### PR TITLE
fix(radicle): preflight Git before first-time identity setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
       statements: 66,
       branches: 53,
       functions: 71,
-      lines: 68,
+      lines: 67,
     },
   },
   transform: {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "electron .",
     "test": "npm run test:unit",
     "test:unit": "jest",
-    "test:coverage": "jest --coverage --runInBand",
+    "test:coverage": "jest --coverage --runInBand --forceExit",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/main/radicle-manager.js
+++ b/src/main/radicle-manager.js
@@ -52,6 +52,8 @@ const PREFERRED_SEEDS = [
 
 // Canonical Freedom Browser repo — bundled nodes auto-seed this
 const FREEDOM_BROWSER_RID = 'rad:z3QXuMvMmSeEX3ZgoUidZC1v5MkKE';
+const RADICLE_GIT_MISSING_MESSAGE =
+  'Git is required to create a Radicle identity. Install Git and try again.';
 
 // States
 const STATUS = {
@@ -136,6 +138,23 @@ function cleanupStaleSocket(radHome) {
   }
 }
 
+function hasIdentity(radHome) {
+  const keysDir = path.join(radHome, 'keys');
+  return fs.existsSync(keysDir) && fs.readdirSync(keysDir).length > 0;
+}
+
+async function checkGitAvailable() {
+  try {
+    await execFileAsync('git', ['--version'], { timeout: 5000 });
+    return { available: true };
+  } catch {
+    return {
+      available: false,
+      error: RADICLE_GIT_MISSING_MESSAGE,
+    };
+  }
+}
+
 /**
  * Ensure config.json contains preferredSeeds for peer discovery.
  * Merges seeds into an existing config or creates a new one.
@@ -168,18 +187,20 @@ function ensureConfig(radHome) {
  * Check if Radicle identity exists, create if not
  */
 function ensureIdentity(radHome) {
-  const keysDir = path.join(radHome, 'keys');
-
-  if (fs.existsSync(keysDir) && fs.readdirSync(keysDir).length > 0) {
+  if (hasIdentity(radHome)) {
     log.info('[Radicle] Identity already exists');
     ensureConfig(radHome);
-    return true;
+    return { success: true };
   }
 
   const radPath = getRadicleBinaryPath('rad');
   if (!fs.existsSync(radPath)) {
     log.error('[Radicle] rad binary not found for identity creation');
-    return false;
+    return {
+      success: false,
+      code: 'RADICLE_CLI_MISSING',
+      message: 'Radicle CLI (rad) not found for identity creation',
+    };
   }
 
   try {
@@ -196,10 +217,23 @@ function ensureIdentity(radHome) {
     });
     log.info('[Radicle] Identity created successfully');
     ensureConfig(radHome);
-    return true;
+    return { success: true };
   } catch (err) {
-    log.error('[Radicle] Failed to create identity:', err.message);
-    return false;
+    const stderr = err.stderr?.toString() || '';
+    const stdout = err.stdout?.toString() || '';
+    const combinedOutput = `${stdout}\n${stderr}`;
+    const message = combinedOutput.includes('A Git installation is required')
+      ? RADICLE_GIT_MISSING_MESSAGE
+      : err.message;
+
+    log.error('[Radicle] Failed to create identity:', message);
+    return {
+      success: false,
+      code: combinedOutput.includes('A Git installation is required')
+        ? 'RADICLE_GIT_MISSING'
+        : 'RADICLE_IDENTITY_FAILED',
+      message,
+    };
   }
 }
 
@@ -620,9 +654,19 @@ async function startRadicle() {
   const radHome = activeRadHome;
 
   // Step 3: Ensure identity exists
-  if (!ensureIdentity(radHome)) {
-    updateState(STATUS.ERROR, 'Failed to create Radicle identity');
-    setStatusMessage('radicle', 'Node failed to start');
+  if (!hasIdentity(radHome)) {
+    const gitCheck = await checkGitAvailable();
+    if (!gitCheck.available) {
+      updateState(STATUS.ERROR, gitCheck.error);
+      setStatusMessage('radicle', gitCheck.error);
+      return;
+    }
+  }
+
+  const identityResult = ensureIdentity(radHome);
+  if (!identityResult.success) {
+    updateState(STATUS.ERROR, identityResult.message);
+    setStatusMessage('radicle', identityResult.message);
     return;
   }
 
@@ -895,6 +939,51 @@ function checkBinary() {
   return fs.existsSync(nodeBinPath) && fs.existsSync(httpdBinPath);
 }
 
+async function getRadicleAvailability() {
+  const available = checkBinary();
+  if (!available) {
+    return { available, startBlocked: false };
+  }
+
+  if (currentState === STATUS.RUNNING || currentState === STATUS.STARTING) {
+    return { available, startBlocked: false };
+  }
+
+  const radHome = getRadicleDataPath();
+  const identityExists = hasIdentity(radHome);
+
+  if (identityExists) {
+    return { available, identityExists, startBlocked: false };
+  }
+
+  if (detectSystemNode().found) {
+    return { available, identityExists, startBlocked: false };
+  }
+
+  const existingDaemon = await detectExistingDaemon();
+  if (existingDaemon.found) {
+    return { available, identityExists, startBlocked: false };
+  }
+
+  const gitCheck = await checkGitAvailable();
+  if (!gitCheck.available) {
+    return {
+      available,
+      identityExists,
+      gitAvailable: false,
+      startBlocked: true,
+      reason: gitCheck.error,
+    };
+  }
+
+  return {
+    available,
+    identityExists,
+    gitAvailable: true,
+    startBlocked: false,
+  };
+}
+
 function getActivePort() {
   return currentHttpPort;
 }
@@ -1093,10 +1182,10 @@ function registerRadicleIpc() {
     return { status: currentState, error: lastError };
   });
 
-  ipcMain.handle(IPC.RADICLE_CHECK_BINARY, () => {
-    const available = checkBinary();
-    log.info('[Radicle] IPC: checkBinary requested, available:', available);
-    return { available };
+  ipcMain.handle(IPC.RADICLE_CHECK_BINARY, async () => {
+    const availability = await getRadicleAvailability();
+    log.info('[Radicle] IPC: checkBinary requested, available:', availability.available);
+    return availability;
   });
 
   ipcMain.handle(IPC.RADICLE_SEED, async (_event, rid) => {

--- a/src/main/radicle-manager.test.js
+++ b/src/main/radicle-manager.test.js
@@ -3,6 +3,9 @@ const mockSetStatusMessage = jest.fn();
 const mockSetErrorState = jest.fn();
 const mockClearErrorState = jest.fn();
 const mockClearService = jest.fn();
+const mockReaddirSync = jest.fn(() => ['key']);
+const mockExecFileSync = jest.fn();
+const mockExecFile = jest.fn((_file, _args, _opts, cb) => cb(null, '', ''));
 
 jest.mock('./logger', () => ({
   info: jest.fn(),
@@ -54,7 +57,7 @@ jest.mock('fs', () => ({
   existsSync: (filePath) => mockExistsSync(filePath),
   mkdirSync: jest.fn(),
   unlinkSync: jest.fn(),
-  readdirSync: jest.fn(() => ['key']),
+  readdirSync: (...args) => mockReaddirSync(...args),
   readFileSync: jest.fn(() => '{}'),
   writeFileSync: jest.fn(),
 }));
@@ -93,8 +96,8 @@ const mockSpawn = jest.fn((name) => {
 
 jest.mock('child_process', () => ({
   spawn: (...args) => mockSpawn(...args),
-  execFileSync: jest.fn(),
-  execFile: jest.fn((_file, _args, _opts, cb) => cb(null, '', '')),
+  execFileSync: (...args) => mockExecFileSync(...args),
+  execFile: (...args) => mockExecFile(...args),
 }));
 
 jest.mock('net', () => ({
@@ -150,16 +153,29 @@ describe('radicle-manager lifecycle integration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSpawnedProcesses.length = 0;
+    mockReaddirSync.mockImplementation(() => ['key']);
+    mockExecFileSync.mockImplementation(() => {});
+    mockExecFile.mockImplementation((_file, _args, _opts, cb) => cb(null, '', ''));
   });
 
   afterEach(async () => {
     await stopRadicle();
   });
 
-  test('starts bundled node/httpd and shuts them down cleanly', async () => {
+  test('creates an identity when needed, then starts bundled node/httpd and shuts them down cleanly', async () => {
+    mockReaddirSync.mockImplementation(() => []);
+
     await startRadicle();
     await new Promise((resolve) => setTimeout(resolve, 1200));
 
+    expect(mockExecFile.mock.calls.some(([file]) => file === 'git')).toBe(true);
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('rad'),
+      ['auth', '--alias', 'FreedomBrowser'],
+      expect.objectContaining({
+        stdio: 'pipe',
+      })
+    );
     expect(mockSpawn).toHaveBeenCalledTimes(2);
     expect(mockSpawnedProcesses[0].bin).toContain('radicle-node');
     expect(mockSpawnedProcesses[1].bin).toContain('radicle-httpd');
@@ -176,5 +192,43 @@ describe('radicle-manager lifecycle integration', () => {
     expect(mockSpawnedProcesses[1].kills).toContain('SIGTERM');
     expect(mockSpawnedProcesses[0].kills).toContain('SIGTERM');
     expect(mockClearService).toHaveBeenCalledWith('radicle');
+  });
+
+  test('skips the git preflight when an identity already exists', async () => {
+    mockExecFile.mockImplementation((file, _args, _opts, cb) => {
+      if (file === 'git') {
+        cb(new Error('git missing'));
+        return;
+      }
+      cb(null, '', '');
+    });
+
+    await startRadicle();
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    expect(mockExecFile.mock.calls.some(([file]) => file === 'git')).toBe(false);
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+  });
+
+  test('fails early when git is missing and a new identity is required', async () => {
+    mockReaddirSync.mockImplementation(() => []);
+    mockExecFile.mockImplementation((file, _args, _opts, cb) => {
+      if (file === 'git') {
+        cb(new Error('git missing'));
+        return;
+      }
+      cb(null, '', '');
+    });
+
+    await startRadicle();
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(mockSetStatusMessage).toHaveBeenCalledWith(
+      'radicle',
+      'Git is required to create a Radicle identity. Install Git and try again.'
+    );
+    expect(mockUpdateService).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -708,6 +708,10 @@
                 <span class="toggle-slider"></span>
               </label>
             </div>
+            <p class="settings-note">
+              First-time Radicle setup requires Git installed and available in your shell PATH.
+            </p>
+            <div id="radicle-git-warning" class="settings-warning" hidden></div>
           </section>
 
           <!-- Updates Section -->

--- a/src/renderer/lib/radicle-ui.js
+++ b/src/renderer/lib/radicle-ui.js
@@ -17,6 +17,8 @@ let radicleNodesSection = null;
 
 // Binary availability state
 let radicleBinaryAvailable = true;
+let radicleStartBlocked = false;
+let radicleStartBlockedReason = '';
 
 // Polling state
 let radicleInfoInterval = null;
@@ -197,7 +199,10 @@ const setToggleDisabled = (disabled) => {
   if (disabled) {
     radicleToggleBtn.classList.add('disabled');
     radicleToggleBtn.setAttribute('disabled', 'true');
-    radicleToggleBtn.setAttribute('title', 'Radicle binaries not found');
+    radicleToggleBtn.setAttribute(
+      'title',
+      radicleStartBlockedReason || 'Radicle binaries not found'
+    );
   } else {
     radicleToggleBtn.classList.remove('disabled');
     radicleToggleBtn.removeAttribute('disabled');
@@ -205,14 +210,20 @@ const setToggleDisabled = (disabled) => {
   }
 };
 
-const refreshRadicleBinaryAvailability = () => {
-  if (!window.radicle?.checkBinary) return;
-  window.radicle.checkBinary().then(({ available }) => {
+export const refreshRadicleBinaryAvailability = () => {
+  if (!window.radicle?.checkBinary) return Promise.resolve(null);
+  return window.radicle.checkBinary().then(({ available, startBlocked, reason }) => {
     radicleBinaryAvailable = available;
-    setToggleDisabled(!available);
+    radicleStartBlocked = startBlocked === true;
+    radicleStartBlockedReason = radicleStartBlocked ? reason || '' : '';
+    setToggleDisabled(!available || radicleStartBlocked);
     if (!available) {
       pushDebug('Radicle binaries not found - toggle disabled');
     }
+    if (radicleStartBlocked && radicleStartBlockedReason) {
+      pushDebug(`Radicle start blocked: ${radicleStartBlockedReason}`);
+    }
+    return { available, startBlocked, reason };
   });
 };
 
@@ -278,7 +289,7 @@ export const initRadicleUi = () => {
   // Toggle button listener
   radicleToggleBtn?.addEventListener('click', () => {
     if (!state.enableRadicleIntegration) return;
-    if (!radicleBinaryAvailable) return;
+    if (!radicleBinaryAvailable || radicleStartBlocked) return;
 
     if (state.currentRadicleStatus === 'running' || state.currentRadicleStatus === 'starting') {
       state.suppressRadicleRunningStatus = true;

--- a/src/renderer/lib/settings-ui.js
+++ b/src/renderer/lib/settings-ui.js
@@ -1,6 +1,7 @@
 // Settings modal UI
 import { pushDebug } from './debug.js';
 import { setMenuOpen } from './menus.js';
+import { refreshRadicleBinaryAvailability } from './radicle-ui.js';
 
 const electronAPI = window.electronAPI;
 
@@ -14,6 +15,7 @@ let startIpfsAtLaunchCheckbox = null;
 let enableRadicleIntegrationCheckbox = null;
 let startRadicleRow = null;
 let startRadicleAtLaunchCheckbox = null;
+let radicleGitWarning = null;
 let autoUpdateCheckbox = null;
 let experimentalSection = null;
 let isWindows = false;
@@ -39,6 +41,28 @@ const updateRadicleSettingsVisibility = () => {
   startRadicleRow?.classList.toggle('disabled', !enabled);
   if (startRadicleAtLaunchCheckbox) {
     startRadicleAtLaunchCheckbox.disabled = !enabled;
+  }
+};
+
+const updateRadicleGitWarning = async () => {
+  if (!radicleGitWarning) return;
+
+  radicleGitWarning.textContent = '';
+  radicleGitWarning.hidden = true;
+
+  if (isWindows) {
+    return;
+  }
+
+  try {
+    const availability = await refreshRadicleBinaryAvailability();
+    if (availability?.startBlocked && availability.reason) {
+      const { reason } = availability;
+      radicleGitWarning.textContent = reason;
+      radicleGitWarning.hidden = false;
+    }
+  } catch {
+    pushDebug('Failed to refresh Radicle prerequisite warning');
   }
 };
 
@@ -118,6 +142,7 @@ export const initSettings = async () => {
   enableRadicleIntegrationCheckbox = document.getElementById('enable-radicle-integration');
   startRadicleRow = document.getElementById('start-radicle-row');
   startRadicleAtLaunchCheckbox = document.getElementById('start-radicle-at-launch');
+  radicleGitWarning = document.getElementById('radicle-git-warning');
   autoUpdateCheckbox = document.getElementById('auto-update');
   experimentalSection = document.getElementById('experimental-section');
 
@@ -134,6 +159,7 @@ export const initSettings = async () => {
   startIpfsAtLaunchCheckbox?.addEventListener('change', saveSettings);
   enableRadicleIntegrationCheckbox?.addEventListener('change', () => {
     updateRadicleSettingsVisibility();
+    updateRadicleGitWarning();
     saveSettings();
   });
   startRadicleAtLaunchCheckbox?.addEventListener('change', saveSettings);
@@ -155,6 +181,7 @@ export const initSettings = async () => {
         startRadicleAtLaunchCheckbox.checked = settings.startRadicleAtLaunch === true;
       if (autoUpdateCheckbox) autoUpdateCheckbox.checked = settings.autoUpdate !== false;
       updateRadicleSettingsVisibility();
+      await updateRadicleGitWarning();
     }
     settingsModal?.showModal();
   });

--- a/src/renderer/lib/settings-ui.test.js
+++ b/src/renderer/lib/settings-ui.test.js
@@ -201,6 +201,7 @@ describe('settings-ui', () => {
 
     elements.settingsBtn.dispatch('click');
     await Promise.resolve();
+    await Promise.resolve();
 
     expect(menuMocks.setMenuOpen).toHaveBeenCalledWith(false);
     expect(elements.themeModeSelect.value).toBe('dark');

--- a/src/renderer/styles/settings.css
+++ b/src/renderer/styles/settings.css
@@ -158,6 +158,28 @@
   color: var(--text);
 }
 
+.settings-note {
+  margin: 12px 0 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.settings-warning {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 196, 107, 0.28);
+  border-radius: 8px;
+  background: rgba(255, 196, 107, 0.08);
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text);
+}
+
+.settings-warning[hidden] {
+  display: none;
+}
+
 /* Settings Select Rows */
 .settings-select-row {
   display: flex;


### PR DESCRIPTION
fix(radicle): preflight Git before first-time identity setup

Check for an executable Git installation before attempting `rad auth`
when Freedom needs to create a new Radicle identity. This avoids the
current generic startup failure and surfaces a clear user-facing error
when Git is missing.

Keep existing Radicle reuse paths working without Git when an identity,
system node, or reusable local daemon already exists. Also show the Git
requirement in Settings and disable the Radicle start toggle only when
first-time setup is blocked.