### PR TITLE
Feature/test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run test coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/
+          if-no-files-found: error

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 31,
-      branches: 26,
+      statements: 32,
+      branches: 27,
       functions: 27,
-      lines: 31,
+      lines: 32,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 36,
-      branches: 31,
-      functions: 31,
-      lines: 37,
+      statements: 39,
+      branches: 34,
+      functions: 33,
+      lines: 40,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 13,
-      branches: 10,
-      functions: 7,
-      lines: 14,
+      statements: 15,
+      branches: 11,
+      functions: 11,
+      lines: 16,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 54,
-      branches: 46,
-      functions: 58,
-      lines: 55,
+      statements: 58,
+      branches: 48,
+      functions: 63,
+      lines: 58,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 60,
-      branches: 50,
-      functions: 65,
-      lines: 61,
+      statements: 64,
+      branches: 52,
+      functions: 68,
+      lines: 65,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 58,
-      branches: 48,
-      functions: 63,
-      lines: 58,
+      statements: 60,
+      branches: 50,
+      functions: 65,
+      lines: 61,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,9 +6,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 53,
-      branches: 44,
-      functions: 55,
-      lines: 53,
+      branches: 45,
+      functions: 56,
+      lines: 54,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 48,
+      statements: 51,
       branches: 43,
-      functions: 40,
-      lines: 49,
+      functions: 52,
+      lines: 51,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,15 @@
 module.exports = {
   testMatch: ['**/*.test.js'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/', '/bee-bin/', '/ipfs-bin/'],
+  collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
+  coverageThreshold: {
+    global: {
+      statements: 13,
+      branches: 10,
+      functions: 7,
+      lines: 14,
+    },
+  },
   transform: {
     '^.+\\.js$': 'babel-jest',
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 29,
-      branches: 25,
-      functions: 26,
-      lines: 30,
+      statements: 31,
+      branches: 26,
+      functions: 27,
+      lines: 31,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 64,
-      branches: 52,
-      functions: 68,
-      lines: 65,
+      statements: 66,
+      branches: 53,
+      functions: 71,
+      lines: 68,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 24,
-      branches: 20,
-      functions: 19,
-      lines: 24,
+      statements: 29,
+      branches: 25,
+      functions: 26,
+      lines: 30,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 51,
-      branches: 43,
-      functions: 52,
-      lines: 51,
+      statements: 53,
+      branches: 44,
+      functions: 55,
+      lines: 53,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 18,
-      branches: 16,
-      functions: 14,
-      lines: 19,
+      statements: 24,
+      branches: 20,
+      functions: 19,
+      lines: 24,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 44,
-      branches: 38,
-      functions: 36,
-      lines: 44,
+      statements: 46,
+      branches: 41,
+      functions: 38,
+      lines: 47,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 41,
-      branches: 36,
-      functions: 34,
-      lines: 42,
+      statements: 44,
+      branches: 38,
+      functions: 36,
+      lines: 44,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 39,
-      branches: 34,
-      functions: 33,
-      lines: 40,
+      statements: 41,
+      branches: 36,
+      functions: 34,
+      lines: 42,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 32,
-      branches: 27,
-      functions: 27,
-      lines: 32,
+      statements: 36,
+      branches: 31,
+      functions: 31,
+      lines: 37,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 53,
-      branches: 45,
-      functions: 56,
-      lines: 54,
+      statements: 54,
+      branches: 46,
+      functions: 58,
+      lines: 55,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 46,
-      branches: 41,
-      functions: 38,
-      lines: 47,
+      statements: 48,
+      branches: 43,
+      functions: 40,
+      lines: 49,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   coverageThreshold: {
     global: {
-      statements: 15,
-      branches: 11,
-      functions: 11,
-      lines: 16,
+      statements: 18,
+      branches: 16,
+      functions: 14,
+      lines: 19,
     },
   },
   transform: {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "main": "src/main/index.js",
   "scripts": {
     "start": "electron .",
-    "test": "jest",
+    "test": "npm run test:unit",
+    "test:unit": "jest",
+    "test:coverage": "jest --coverage --runInBand",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -48,7 +50,6 @@
     "radicle:init": "node scripts/init-radicle.js",
     "radicle:status": "curl -s http://127.0.0.1:8780/api/v1/ | head -c 500",
     "radicle:reset": "rm -rf radicle-data && echo 'Radicle data reset.'",
-    "test:updater": "bash scripts/test-updater.sh",
     "serve:updates": "node scripts/serve-updates.js",
     "start:test-updater": "ENABLE_DEV_UPDATER=true npm start",
     "postinstall": "electron-builder install-app-deps"

--- a/src/main/bee-manager.js
+++ b/src/main/bee-manager.js
@@ -378,13 +378,16 @@ async function startBee() {
         clearTimeout(forceKillTimeout);
         forceKillTimeout = null;
       }
+      if (healthCheckInterval) {
+        clearInterval(healthCheckInterval);
+        healthCheckInterval = null;
+      }
 
       if (currentState !== STATUS.STOPPING) {
         updateState(STATUS.STOPPED, code !== 0 ? `Exited with code ${code}` : null);
       } else {
         updateState(STATUS.STOPPED);
       }
-      if (healthCheckInterval) clearInterval(healthCheckInterval);
       clearService('bee');
 
       if (pendingStart) {
@@ -453,6 +456,10 @@ function stopBee() {
 
     // If we reused an external daemon, just clear state (don't stop it)
     if (currentMode === MODE.REUSED) {
+      if (healthCheckInterval) {
+        clearInterval(healthCheckInterval);
+        healthCheckInterval = null;
+      }
       updateState(STATUS.STOPPED);
       clearService('bee');
       currentMode = MODE.NONE;
@@ -469,6 +476,10 @@ function stopBee() {
 
     // Listen for the process to exit
     const onExit = () => {
+      if (healthCheckInterval) {
+        clearInterval(healthCheckInterval);
+        healthCheckInterval = null;
+      }
       if (forceKillTimeout) {
         clearTimeout(forceKillTimeout);
         forceKillTimeout = null;
@@ -479,10 +490,10 @@ function stopBee() {
     beeProcess.once('close', onExit);
 
     updateState(STATUS.STOPPING);
-    if (healthCheckInterval) clearInterval(healthCheckInterval);
-
-    // Try graceful shutdown via SIGTERM
-    beeProcess.kill('SIGTERM');
+    if (healthCheckInterval) {
+      clearInterval(healthCheckInterval);
+      healthCheckInterval = null;
+    }
 
     // Force kill if it doesn't exit within 5 seconds
     if (forceKillTimeout) clearTimeout(forceKillTimeout);
@@ -493,6 +504,9 @@ function stopBee() {
       }
       forceKillTimeout = null;
     }, 5000);
+
+    // Try graceful shutdown via SIGTERM
+    beeProcess.kill('SIGTERM');
   });
 }
 

--- a/src/main/bee-manager.test.js
+++ b/src/main/bee-manager.test.js
@@ -1,0 +1,524 @@
+const path = require('path');
+const IPC = require('../shared/ipc-channels');
+const {
+  createAppMock,
+  createIpcMainMock,
+  loadMainModule,
+} = require('../../test/helpers/main-process-test-utils');
+
+const PROJECT_ROOT = path.join(__dirname, '..', '..');
+const DEV_BEE_DATA_DIR = path.join(PROJECT_ROOT, 'bee-data');
+
+function flushMicrotasks() {
+  return Promise.resolve().then(() => Promise.resolve());
+}
+
+function createProcessMock(binary, options = {}) {
+  const listeners = new Map();
+  const onceListeners = new Map();
+  const stdoutListeners = new Map();
+  const stderrListeners = new Map();
+
+  const emitAll = (store, event, args) => {
+    for (const handler of store.get(event) || []) {
+      handler(...args);
+    }
+  };
+
+  const proc = {
+    binary,
+    kills: [],
+    stdout: {
+      on: jest.fn((event, handler) => {
+        if (!stdoutListeners.has(event)) {
+          stdoutListeners.set(event, []);
+        }
+        stdoutListeners.get(event).push(handler);
+      }),
+    },
+    stderr: {
+      on: jest.fn((event, handler) => {
+        if (!stderrListeners.has(event)) {
+          stderrListeners.set(event, []);
+        }
+        stderrListeners.get(event).push(handler);
+      }),
+    },
+    on: jest.fn((event, handler) => {
+      if (!listeners.has(event)) {
+        listeners.set(event, []);
+      }
+      listeners.get(event).push(handler);
+    }),
+    once: jest.fn((event, handler) => {
+      if (!onceListeners.has(event)) {
+        onceListeners.set(event, []);
+      }
+      onceListeners.get(event).push(handler);
+    }),
+    emit(event, ...args) {
+      emitAll(listeners, event, args);
+      const oneTimeHandlers = onceListeners.get(event) || [];
+      onceListeners.delete(event);
+      oneTimeHandlers.forEach((handler) => handler(...args));
+    },
+    kill: jest.fn((signal) => {
+      proc.kills.push(signal);
+      if (options.autoCloseOnKill !== false) {
+        proc.emit('close', options.closeCode ?? 0);
+      }
+      return true;
+    }),
+  };
+
+  return proc;
+}
+
+function createSocketClass(portResolver) {
+  const queue = Array.isArray(portResolver) ? [...portResolver] : null;
+
+  return class MockSocket {
+    constructor() {
+      this.handlers = {};
+    }
+
+    setTimeout() {}
+
+    on(event, handler) {
+      this.handlers[event] = handler;
+    }
+
+    destroy() {}
+
+    connect(port, host) {
+      const result = typeof portResolver === 'function'
+        ? portResolver(port, host)
+        : queue && queue.length > 0
+          ? queue.shift()
+          : false;
+
+      if (result === true) {
+        this.handlers.connect?.();
+        return;
+      }
+
+      if (result === 'timeout') {
+        this.handlers.timeout?.();
+        return;
+      }
+
+      this.handlers.error?.(new Error('closed'));
+    }
+  };
+}
+
+function createHttpGetMock(responseResolver) {
+  const resolveResponse = responseResolver || (() => ({ statusCode: 500, body: '' }));
+
+  return jest.fn((url, options, callback) => {
+    let handler = callback;
+    if (typeof options === 'function') {
+      handler = options;
+    }
+
+    const requestHandlers = new Map();
+    const request = {
+      on: jest.fn((event, fn) => {
+        requestHandlers.set(event, fn);
+        return request;
+      }),
+      destroy: jest.fn(),
+      end: jest.fn(),
+    };
+
+    const responseConfig = resolveResponse(url);
+
+    if (responseConfig?.error) {
+      requestHandlers.get('error')?.(responseConfig.error);
+      return request;
+    }
+
+    if (responseConfig?.timeout) {
+      requestHandlers.get('timeout')?.();
+      return request;
+    }
+
+    const responseHandlers = new Map();
+    const response = {
+      statusCode: responseConfig?.statusCode ?? 200,
+      resume: jest.fn(),
+      on: jest.fn((event, fn) => {
+        if (!responseHandlers.has(event)) {
+          responseHandlers.set(event, []);
+        }
+        responseHandlers.get(event).push(fn);
+      }),
+    };
+
+    handler(response);
+
+    const chunks = (() => {
+      if (responseConfig?.body === undefined || responseConfig?.body === null) {
+        return [];
+      }
+      if (typeof responseConfig.body === 'string') {
+        return [responseConfig.body];
+      }
+      return [JSON.stringify(responseConfig.body)];
+    })();
+
+    chunks.forEach((chunk) => {
+      for (const fn of responseHandlers.get('data') || []) {
+        fn(chunk);
+      }
+    });
+    for (const fn of responseHandlers.get('end') || []) {
+      fn();
+    }
+
+    return request;
+  });
+}
+
+function createWindowMock() {
+  return {
+    webContents: {
+      send: jest.fn(),
+    },
+  };
+}
+
+function loadBeeManagerModule(options = {}) {
+  const ipcMain = options.ipcMain || createIpcMainMock();
+  const app = options.app || createAppMock({
+    isPackaged: options.isPackaged ?? false,
+    userDataDir: options.userDataDir || '/tmp/freedom-user-data',
+  });
+  const windows = options.windows || [];
+  const BrowserWindow = {
+    getAllWindows: jest.fn(() => windows),
+  };
+  const log = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  const updateService = jest.fn();
+  const setStatusMessage = jest.fn();
+  const setErrorState = jest.fn();
+  const clearErrorState = jest.fn();
+  const clearService = jest.fn();
+  const spawnedProcesses = [];
+  const execSync = options.execSync || jest.fn();
+  const spawn = jest.fn((binary, args = [], spawnOptions = {}) => {
+    const proc = (options.createProcess || createProcessMock)(binary, options.processOptions || {});
+    proc.args = args;
+    proc.spawnOptions = spawnOptions;
+    spawnedProcesses.push(proc);
+    return proc;
+  });
+
+  const platformMap = {
+    darwin: 'mac',
+    linux: 'linux',
+    win32: 'win',
+  };
+  const platform = platformMap[process.platform] || process.platform;
+  const binaryName = process.platform === 'win32' ? 'bee.exe' : 'bee';
+  const beeBinPath = path.join(PROJECT_ROOT, 'bee-bin', `${platform}-${process.arch}`, binaryName);
+  const dataDir = options.isPackaged
+    ? path.join(options.userDataDir || '/tmp/freedom-user-data', 'bee-data')
+    : DEV_BEE_DATA_DIR;
+  const configPath = path.join(dataDir, 'config.yaml');
+  const keysPath = path.join(dataDir, 'keys');
+
+  const fsMock = {
+    existsSync: jest.fn((target) => {
+      if (typeof options.existsSync === 'function') {
+        return options.existsSync(target);
+      }
+
+      if (target === beeBinPath) return options.binExists !== false;
+      if (target === dataDir) return options.dataDirExists === true;
+      if (target === configPath) return options.configExists === true;
+      if (target === keysPath) return options.keysExist === true;
+      return false;
+    }),
+    mkdirSync: jest.fn(),
+    readFileSync: jest.fn(() => options.configContents || ''),
+    writeFileSync: jest.fn(),
+  };
+  const httpGet = createHttpGetMock(options.httpResponse);
+  const Socket = createSocketClass(options.portSequence || options.portResolver || false);
+  const randomBytes = options.randomBytes || jest.fn(() => Buffer.from('ab'.repeat(32), 'hex'));
+
+  const { mod } = loadMainModule(require.resolve('./bee-manager'), {
+    app,
+    ipcMain,
+    BrowserWindow,
+    extraMocks: {
+      child_process: () => ({
+        spawn,
+        execSync,
+      }),
+      crypto: () => ({
+        randomBytes,
+      }),
+      fs: () => fsMock,
+      http: () => ({
+        get: httpGet,
+      }),
+      net: () => ({
+        Socket,
+      }),
+      [require.resolve('./logger')]: () => log,
+      [require.resolve('./service-registry')]: () => ({
+        MODE: {
+          BUNDLED: 'bundled',
+          REUSED: 'reused',
+          NONE: 'none',
+        },
+        DEFAULTS: {
+          bee: {
+            apiPort: 1633,
+            p2pPort: 1634,
+            fallbackRange: 10,
+          },
+        },
+        updateService,
+        setStatusMessage,
+        setErrorState,
+        clearErrorState,
+        clearService,
+      }),
+    },
+  });
+
+  return {
+    beeBinPath,
+    BrowserWindow,
+    clearErrorState,
+    clearService,
+    configPath,
+    dataDir,
+    execSync,
+    fsMock,
+    httpGet,
+    ipcMain,
+    keysPath,
+    log,
+    mod,
+    randomBytes,
+    setErrorState,
+    setStatusMessage,
+    spawn,
+    spawnedProcesses,
+    updateService,
+    windows,
+  };
+}
+
+describe('bee-manager', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('registers IPC handlers and reports binary availability plus initial status', async () => {
+    const ctx = loadBeeManagerModule({
+      binExists: false,
+    });
+
+    ctx.mod.registerBeeIpc();
+
+    expect([...ctx.ipcMain.handlers.keys()].sort()).toEqual([
+      IPC.BEE_START,
+      IPC.BEE_STOP,
+      IPC.BEE_GET_STATUS,
+      IPC.BEE_CHECK_BINARY,
+    ].sort());
+
+    await expect(ctx.ipcMain.invoke(IPC.BEE_GET_STATUS)).resolves.toEqual({
+      status: 'stopped',
+      error: null,
+    });
+    await expect(ctx.ipcMain.invoke(IPC.BEE_CHECK_BINARY)).resolves.toEqual({
+      available: false,
+    });
+  });
+
+  test('reuses an existing daemon and clears the health-check interval on stop', async () => {
+    const setIntervalSpy = jest.spyOn(global, 'setInterval').mockReturnValue(123);
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval').mockImplementation(() => {});
+    const window = createWindowMock();
+    const ctx = loadBeeManagerModule({
+      windows: [window],
+      portSequence: [true],
+      httpResponse: (url) => {
+        if (url === 'http://127.0.0.1:1633/health') {
+          return {
+            statusCode: 200,
+            body: { version: '2.1.0' },
+          };
+        }
+
+        return { statusCode: 500, body: '' };
+      },
+    });
+
+    await ctx.mod.startBee();
+    await flushMicrotasks();
+
+    expect(ctx.spawn).not.toHaveBeenCalled();
+    expect(ctx.mod.getActivePort()).toBe(1633);
+    expect(ctx.updateService).toHaveBeenCalledWith('bee', {
+      api: 'http://127.0.0.1:1633',
+      gateway: 'http://127.0.0.1:1633',
+      mode: 'reused',
+    });
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('bee', 'Node: localhost:1633');
+    expect(setIntervalSpy).toHaveBeenCalled();
+    expect(window.webContents.send).toHaveBeenCalledWith(IPC.BEE_STATUS_UPDATE, {
+      status: 'starting',
+      error: null,
+    });
+    expect(window.webContents.send).toHaveBeenLastCalledWith(IPC.BEE_STATUS_UPDATE, {
+      status: 'running',
+      error: null,
+    });
+
+    await ctx.mod.stopBee();
+
+    expect(clearIntervalSpy).toHaveBeenCalledWith(123);
+    expect(ctx.clearService).toHaveBeenCalledWith('bee');
+  });
+
+  test('starts a bundled daemon on a fallback port, writes config, and leaves no shutdown timers behind', async () => {
+    jest.useFakeTimers();
+
+    const platformMap = {
+      darwin: 'mac',
+      linux: 'linux',
+      win32: 'win',
+    };
+    const platform = platformMap[process.platform] || process.platform;
+    const binaryName = process.platform === 'win32' ? 'bee.exe' : 'bee';
+    const beeBinPath = path.join(PROJECT_ROOT, 'bee-bin', `${platform}-${process.arch}`, binaryName);
+    const dataDir = DEV_BEE_DATA_DIR;
+    const configPath = path.join(dataDir, 'config.yaml');
+    const keysPath = path.join(dataDir, 'keys');
+    const ctx = loadBeeManagerModule({
+      existsSync: (target) => {
+        if (target === beeBinPath) return true;
+        if (target === dataDir) return false;
+        if (target === configPath) return false;
+        if (target === keysPath) return false;
+        return false;
+      },
+      portSequence: [true, false],
+      httpResponse: (url) => {
+        if (url === 'http://127.0.0.1:1633/health') {
+          return {
+            statusCode: 500,
+            body: '',
+          };
+        }
+        if (url === 'http://127.0.0.1:1634/health') {
+          return {
+            statusCode: 200,
+            body: { version: '2.1.0' },
+          };
+        }
+        return {
+          statusCode: 500,
+          body: '',
+        };
+      },
+    });
+
+    await ctx.mod.startBee();
+    await flushMicrotasks();
+    await jest.advanceTimersByTimeAsync(1000);
+    await flushMicrotasks();
+
+    expect(ctx.fsMock.mkdirSync).toHaveBeenCalledWith(ctx.dataDir, { recursive: true });
+    expect(ctx.randomBytes).toHaveBeenCalledWith(32);
+    expect(ctx.execSync).toHaveBeenCalledWith(`"${ctx.beeBinPath}" init --config="${ctx.configPath}"`);
+    expect(ctx.spawnedProcesses).toHaveLength(1);
+    expect(ctx.spawnedProcesses[0].binary).toBe(ctx.beeBinPath);
+    expect(ctx.spawnedProcesses[0].args).toEqual(['start', `--config=${ctx.configPath}`]);
+    expect(ctx.mod.getActivePort()).toBe(1634);
+    expect(ctx.updateService).toHaveBeenCalledWith('bee', {
+      api: 'http://127.0.0.1:1634',
+      gateway: 'http://127.0.0.1:1634',
+      mode: 'bundled',
+    });
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('bee', 'Fallback Port: 1634');
+
+    const configContent = ctx.fsMock.writeFileSync.mock.calls[0][1];
+    expect(configContent).toContain('api-addr: 127.0.0.1:1634');
+    expect(configContent).toContain(`data-dir: ${ctx.dataDir}`);
+    expect(configContent).toContain(`password: ${'ab'.repeat(32)}`);
+
+    const stopPromise = ctx.mod.stopBee();
+    await flushMicrotasks();
+    await stopPromise;
+
+    expect(ctx.spawnedProcesses[0].kills).toContain('SIGTERM');
+    expect(ctx.clearService).toHaveBeenCalledWith('bee');
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test('preserves an existing Bee password when rewriting config', async () => {
+    jest.useFakeTimers();
+
+    const ctx = loadBeeManagerModule({
+      configExists: true,
+      keysExist: true,
+      configContents: 'api-addr: 127.0.0.1:1633\npassword: keep-me\n',
+      portSequence: [false],
+      httpResponse: (url) => {
+        if (url === 'http://127.0.0.1:1633/health') {
+          return {
+            statusCode: 200,
+            body: { version: '2.1.0' },
+          };
+        }
+        return {
+          statusCode: 500,
+          body: '',
+        };
+      },
+    });
+
+    await ctx.mod.startBee();
+    await flushMicrotasks();
+    await jest.advanceTimersByTimeAsync(1000);
+    await flushMicrotasks();
+
+    const configContent = ctx.fsMock.writeFileSync.mock.calls[0][1];
+    expect(configContent).toContain('password: keep-me');
+    expect(ctx.execSync).not.toHaveBeenCalled();
+
+    await ctx.mod.stopBee();
+  });
+
+  test('fails startup when the Bee binary is missing', async () => {
+    const ctx = loadBeeManagerModule({
+      binExists: false,
+      portSequence: [false],
+      httpResponse: () => ({
+        statusCode: 500,
+        body: '',
+      }),
+    });
+
+    await ctx.mod.startBee();
+    await flushMicrotasks();
+
+    expect(ctx.spawn).not.toHaveBeenCalled();
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('bee', 'Node failed to start');
+  });
+});

--- a/src/main/bookmarks-store.test.js
+++ b/src/main/bookmarks-store.test.js
@@ -1,0 +1,135 @@
+const fs = require('fs');
+const path = require('path');
+const IPC = require('../shared/ipc-channels');
+const defaultBookmarks = require('../../config/default-bookmarks.json');
+const {
+  createIpcMainMock,
+  createTempUserDataDir,
+  loadMainModule,
+  removeTempUserDataDir,
+} = require('../../test/helpers/main-process-test-utils');
+
+function loadBookmarksStore(options = {}) {
+  return loadMainModule(require.resolve('./bookmarks-store'), options);
+}
+
+function getUserBookmarksPath(userDataDir) {
+  return path.join(userDataDir, 'user-bookmarks.json');
+}
+
+describe('bookmarks-store', () => {
+  let userDataDir;
+
+  beforeEach(() => {
+    userDataDir = createTempUserDataDir();
+  });
+
+  afterEach(() => {
+    removeTempUserDataDir(userDataDir);
+  });
+
+  test('falls back to bundled default bookmarks when the user file is missing', async () => {
+    const ipcMain = createIpcMainMock();
+    const { mod } = loadBookmarksStore({ userDataDir, ipcMain });
+
+    mod.registerBookmarksIpc();
+
+    await expect(ipcMain.invoke(IPC.BOOKMARKS_GET)).resolves.toEqual(defaultBookmarks);
+  });
+
+  test('loads user bookmarks before bundled defaults', async () => {
+    const ipcMain = createIpcMainMock();
+    const customBookmarks = [{ label: 'Local', target: 'https://example.com' }];
+
+    fs.writeFileSync(
+      getUserBookmarksPath(userDataDir),
+      JSON.stringify(customBookmarks, null, 2),
+      'utf-8'
+    );
+
+    const { mod } = loadBookmarksStore({ userDataDir, ipcMain });
+    mod.registerBookmarksIpc();
+
+    await expect(ipcMain.invoke(IPC.BOOKMARKS_GET)).resolves.toEqual(customBookmarks);
+  });
+
+  test('adds bookmarks and prevents duplicate targets', async () => {
+    const ipcMain = createIpcMainMock();
+    const bookmark = { label: 'Example', target: 'https://example.com' };
+
+    fs.writeFileSync(getUserBookmarksPath(userDataDir), '[]', 'utf-8');
+
+    const { mod } = loadBookmarksStore({ userDataDir, ipcMain });
+    mod.registerBookmarksIpc();
+
+    await expect(ipcMain.invoke(IPC.BOOKMARKS_ADD, bookmark)).resolves.toBe(true);
+    await expect(ipcMain.invoke(IPC.BOOKMARKS_ADD, bookmark)).resolves.toBe(false);
+
+    expect(
+      JSON.parse(fs.readFileSync(getUserBookmarksPath(userDataDir), 'utf-8'))
+    ).toEqual([bookmark]);
+  });
+
+  test('updates bookmarks and rejects target conflicts', async () => {
+    const ipcMain = createIpcMainMock();
+    const initialBookmarks = [
+      { label: 'One', target: 'https://one.example' },
+      { label: 'Two', target: 'https://two.example' },
+    ];
+
+    fs.writeFileSync(
+      getUserBookmarksPath(userDataDir),
+      JSON.stringify(initialBookmarks, null, 2),
+      'utf-8'
+    );
+
+    const { mod } = loadBookmarksStore({ userDataDir, ipcMain });
+    mod.registerBookmarksIpc();
+
+    await expect(
+      ipcMain.invoke(IPC.BOOKMARKS_UPDATE, {
+        originalTarget: 'https://one.example',
+        bookmark: { label: 'Conflict', target: 'https://two.example' },
+      })
+    ).resolves.toBe(false);
+
+    await expect(
+      ipcMain.invoke(IPC.BOOKMARKS_UPDATE, {
+        originalTarget: 'https://one.example',
+        bookmark: { label: 'Updated', target: 'https://updated.example' },
+      })
+    ).resolves.toBe(true);
+
+    expect(
+      JSON.parse(fs.readFileSync(getUserBookmarksPath(userDataDir), 'utf-8'))
+    ).toEqual([
+      { label: 'Updated', target: 'https://updated.example' },
+      { label: 'Two', target: 'https://two.example' },
+    ]);
+  });
+
+  test('removes bookmarks by target', async () => {
+    const ipcMain = createIpcMainMock();
+    const initialBookmarks = [
+      { label: 'One', target: 'https://one.example' },
+      { label: 'Two', target: 'https://two.example' },
+    ];
+
+    fs.writeFileSync(
+      getUserBookmarksPath(userDataDir),
+      JSON.stringify(initialBookmarks, null, 2),
+      'utf-8'
+    );
+
+    const { mod } = loadBookmarksStore({ userDataDir, ipcMain });
+    mod.registerBookmarksIpc();
+
+    await expect(ipcMain.invoke(IPC.BOOKMARKS_REMOVE, 'https://one.example')).resolves.toBe(
+      true
+    );
+
+    expect(
+      JSON.parse(fs.readFileSync(getUserBookmarksPath(userDataDir), 'utf-8'))
+    ).toEqual([{ label: 'Two', target: 'https://two.example' }]);
+  });
+});

--- a/src/main/github-bridge.test.js
+++ b/src/main/github-bridge.test.js
@@ -1,95 +1,711 @@
-// Mock electron before requiring github-bridge
-jest.mock('electron', () => ({
-  ipcMain: { handle: jest.fn() },
-}));
+const IPC = require('../shared/ipc-channels');
+const { failure, success } = require('./ipc-contract');
+const {
+  createIpcMainMock,
+  loadMainModule,
+} = require('../../test/helpers/main-process-test-utils');
 
-// Mock radicle-manager (required by github-bridge)
-jest.mock('./radicle-manager', () => ({
-  getRadicleBinaryPath: (bin) => `/mock/path/${bin}`,
-  getRadicleDataPath: () => '/mock/radicle-data',
-}));
+function createResponseMock(options = {}) {
+  const listeners = new Map();
 
-const { validateGitHubUrl } = require('./github-bridge');
+  return {
+    statusCode: options.statusCode ?? 200,
+    on: jest.fn((event, handler) => {
+      if (!listeners.has(event)) {
+        listeners.set(event, []);
+      }
+      listeners.get(event).push(handler);
+    }),
+    resume: jest.fn(),
+    emit(event, ...args) {
+      for (const handler of listeners.get(event) || []) {
+        handler(...args);
+      }
+    },
+  };
+}
 
-describe('github-bridge', () => {
-  describe('validateGitHubUrl', () => {
-    test('accepts full HTTPS GitHub URL', () => {
-      const result = validateGitHubUrl('https://github.com/solardev-xyz/freedom-browser');
-      expect(result.success).toBe(true);
-      expect(result.valid).toBe(true);
-      expect(result.owner).toBe('solardev-xyz');
-      expect(result.repo).toBe('freedom-browser');
-      expect(result.cloneUrl).toBe('https://github.com/solardev-xyz/freedom-browser.git');
-    });
+function createRequestMock() {
+  const listeners = new Map();
+  const request = {
+    on: jest.fn((event, handler) => {
+      if (!listeners.has(event)) {
+        listeners.set(event, []);
+      }
+      listeners.get(event).push(handler);
+      return request;
+    }),
+    destroy: jest.fn(),
+    end: jest.fn(),
+    emit(event, ...args) {
+      for (const handler of listeners.get(event) || []) {
+        handler(...args);
+      }
+    },
+  };
 
-    test('accepts GitHub URL with .git suffix', () => {
-      const result = validateGitHubUrl('https://github.com/owner/repo.git');
-      expect(result.valid).toBe(true);
-      expect(result.owner).toBe('owner');
-      expect(result.repo).toBe('repo');
-    });
+  return request;
+}
 
-    test('accepts GitHub URL without protocol', () => {
-      const result = validateGitHubUrl('github.com/owner/repo');
-      expect(result.valid).toBe(true);
-      expect(result.owner).toBe('owner');
-      expect(result.repo).toBe('repo');
-    });
+function matchesRoute(route, url) {
+  if (route.url) {
+    return route.url === url;
+  }
 
-    test('accepts shorthand owner/repo', () => {
-      const result = validateGitHubUrl('owner/repo');
-      expect(result.success).toBe(true);
-      expect(result.valid).toBe(true);
-      expect(result.owner).toBe('owner');
-      expect(result.repo).toBe('repo');
-      expect(result.cloneUrl).toBe('https://github.com/owner/repo.git');
-    });
+  if (route.match instanceof RegExp) {
+    return route.match.test(url);
+  }
 
-    test('accepts URL with trailing slash', () => {
-      const result = validateGitHubUrl('https://github.com/owner/repo/');
-      expect(result.valid).toBe(true);
-      expect(result.owner).toBe('owner');
-      expect(result.repo).toBe('repo');
-    });
+  if (typeof route.match === 'function') {
+    return route.match(url);
+  }
 
-    test('accepts URL with www prefix', () => {
-      const result = validateGitHubUrl('https://www.github.com/owner/repo');
-      expect(result.valid).toBe(true);
-    });
+  return false;
+}
 
-    test('rejects empty input', () => {
-      const result = validateGitHubUrl('');
-      expect(result.valid).toBe(false);
-      expect(result.success).toBe(false);
-      expect(result.error).toEqual({
-        code: 'INVALID_URL',
-        message: 'Please enter a GitHub repository URL',
-        details: { field: 'url' },
+function toBodyChunks(body) {
+  if (body === undefined || body === null) return [];
+  if (typeof body === 'string') return [body];
+  return [JSON.stringify(body)];
+}
+
+function createGetMock(routes = []) {
+  const queue = [...routes];
+
+  return jest.fn((url, options, callback) => {
+    let handler = callback;
+    if (typeof options === 'function') {
+      handler = options;
+    }
+
+    const routeIndex = queue.findIndex((route) => matchesRoute(route, url));
+    if (routeIndex === -1) {
+      throw new Error(`Unexpected GET request: ${url}`);
+    }
+
+    const route = queue.splice(routeIndex, 1)[0];
+    const request = createRequestMock();
+
+    process.nextTick(() => {
+      if (route.error) {
+        request.emit('error', route.error);
+        return;
+      }
+
+      if (route.timeout) {
+        request.emit('timeout');
+        return;
+      }
+
+      const response = createResponseMock(route);
+      handler(response);
+
+      process.nextTick(() => {
+        toBodyChunks(route.body).forEach((chunk) => response.emit('data', chunk));
+        response.emit('end');
       });
     });
 
-    test('rejects null/undefined', () => {
-      expect(validateGitHubUrl(null).valid).toBe(false);
-      expect(validateGitHubUrl(undefined).valid).toBe(false);
+    return request;
+  });
+}
+
+function createRequestFactory(routes = []) {
+  const queue = [...routes];
+
+  return jest.fn((url, _options, callback) => {
+    const routeIndex = queue.findIndex((route) => matchesRoute(route, url));
+    if (routeIndex === -1) {
+      throw new Error(`Unexpected request: ${url}`);
+    }
+
+    const route = queue.splice(routeIndex, 1)[0];
+    const request = createRequestMock();
+
+    request.end.mockImplementation(() => {
+      process.nextTick(() => {
+        if (route.error) {
+          request.emit('error', route.error);
+          return;
+        }
+
+        if (route.timeout) {
+          request.emit('timeout');
+          return;
+        }
+
+        const response = createResponseMock(route);
+        callback(response);
+
+        process.nextTick(() => {
+          toBodyChunks(route.body).forEach((chunk) => response.emit('data', chunk));
+          response.emit('end');
+        });
+      });
     });
 
-    test('rejects non-GitHub URLs', () => {
-      expect(validateGitHubUrl('https://gitlab.com/owner/repo').valid).toBe(false);
+    return request;
+  });
+}
+
+function createSenderMock(options = {}) {
+  return {
+    isDestroyed: jest.fn(() => options.destroyed ?? false),
+    send: jest.fn(),
+  };
+}
+
+function loadGithubBridgeModule(options = {}) {
+  const ipcMain = options.ipcMain || createIpcMainMock();
+  const execFileAsync = options.execFileAsync || jest.fn();
+  const radicleDataPath = options.radicleDataPath || '/mock/radicle-data';
+  const radicleBinDir = options.radicleBinDir || '/mock/radicle/bin';
+  const tempDir = options.tempDir || '/tmp/freedom-bridge-12345';
+  const mapPath = `${radicleDataPath}/github-bridge-map.json`;
+  const fsMock = {
+    existsSync: jest.fn((target) => {
+      if (target === mapPath) return options.mapExists === true;
+      if (target === tempDir) return options.tempDirExists !== false;
+      if (target === `${radicleBinDir}/rad`) return options.radBinaryExists !== false;
+      if (target === `${radicleBinDir}/git-remote-rad`) return options.gitRemoteRadExists !== false;
+      return false;
+    }),
+    readFileSync: jest.fn((target) => {
+      if (target === mapPath) {
+        return options.mapFileContent || '{}';
+      }
+      return '';
+    }),
+    writeFileSync: jest.fn(),
+    mkdtempSync: jest.fn(() => tempDir),
+    rmSync: jest.fn(),
+  };
+  const httpsGet = options.httpsGet || createGetMock(options.httpsGetRoutes);
+  const httpsRequest = options.httpsRequest || createRequestFactory(options.httpsRequestRoutes);
+  const httpGet = options.httpGet || createGetMock(options.httpGetRoutes);
+  const loadSettings = jest.fn(() => options.settings || { enableRadicleIntegration: true });
+  const getRadicleBinaryPath = jest.fn((bin) => `${radicleBinDir}/${bin}`);
+  const getRadicleDataPath = jest.fn(() => radicleDataPath);
+  const getActivePort = jest.fn(() => options.activePort ?? null);
+
+  const { mod } = loadMainModule(require.resolve('./github-bridge'), {
+    ipcMain,
+    extraMocks: {
+      child_process: () => ({ execFile: jest.fn() }),
+      fs: () => fsMock,
+      http: () => ({ get: httpGet }),
+      https: () => ({
+        get: httpsGet,
+        request: httpsRequest,
+      }),
+      os: () => ({
+        tmpdir: jest.fn(() => '/tmp'),
+      }),
+      util: () => ({
+        ...jest.requireActual('util'),
+        promisify: jest.fn(() => execFileAsync),
+      }),
+      [require.resolve('./radicle-manager')]: () => ({
+        getRadicleBinaryPath,
+        getRadicleDataPath,
+        getActivePort,
+      }),
+      [require.resolve('./settings-store')]: () => ({
+        loadSettings,
+      }),
+    },
+  });
+
+  return {
+    execFileAsync,
+    fsMock,
+    getActivePort,
+    getRadicleBinaryPath,
+    getRadicleDataPath,
+    httpGet,
+    httpsGet,
+    httpsRequest,
+    ipcMain,
+    loadSettings,
+    mapPath,
+    mod,
+    tempDir,
+  };
+}
+
+describe('github-bridge', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('validateGitHubUrl', () => {
+    test.each([
+      ['https://github.com/solardev-xyz/freedom-browser', 'solardev-xyz', 'freedom-browser'],
+      ['https://github.com/owner/repo.git', 'owner', 'repo'],
+      ['github.com/owner/repo', 'owner', 'repo'],
+      ['owner/repo', 'owner', 'repo'],
+      ['https://github.com/owner/repo/', 'owner', 'repo'],
+      ['https://www.github.com/owner/repo', 'owner', 'repo'],
+      ['my-org.io/my-repo.js', 'my-org.io', 'my-repo.js'],
+    ])('accepts %s', (url, owner, repo) => {
+      const { mod } = loadGithubBridgeModule();
+
+      expect(mod.validateGitHubUrl(url)).toEqual({
+        ...success(),
+        valid: true,
+        owner,
+        repo,
+        cloneUrl: `https://github.com/${owner}/${repo}.git`,
+      });
     });
 
-    test('rejects URLs with extra path segments', () => {
-      expect(validateGitHubUrl('https://github.com/owner/repo/tree/main').valid).toBe(false);
+    test('rejects empty input', () => {
+      const { mod } = loadGithubBridgeModule();
+
+      expect(mod.validateGitHubUrl('')).toEqual({
+        valid: false,
+        ...failure('INVALID_URL', 'Please enter a GitHub repository URL', { field: 'url' }),
+      });
     });
 
-    test('rejects bare owner without repo', () => {
-      expect(validateGitHubUrl('https://github.com/owner').valid).toBe(false);
+    test.each([
+      null,
+      undefined,
+      'https://gitlab.com/owner/repo',
+      'https://github.com/owner/repo/tree/main',
+      'https://github.com/owner',
+    ])('rejects invalid value %p', (value) => {
+      const { mod } = loadGithubBridgeModule();
+
+      expect(mod.validateGitHubUrl(value).valid).toBe(false);
+    });
+  });
+
+  describe('registerGithubBridgeIpc', () => {
+    test('registers all GitHub bridge IPC handlers', () => {
+      const ctx = loadGithubBridgeModule();
+
+      ctx.mod.registerGithubBridgeIpc();
+
+      expect([...ctx.ipcMain.handlers.keys()].sort()).toEqual([
+        IPC.GITHUB_BRIDGE_IMPORT,
+        IPC.GITHUB_BRIDGE_CHECK_GIT,
+        IPC.GITHUB_BRIDGE_CHECK_PREREQUISITES,
+        IPC.GITHUB_BRIDGE_VALIDATE_URL,
+        IPC.GITHUB_BRIDGE_CHECK_EXISTING,
+      ].sort());
     });
 
-    test('handles owner/repo with dots and hyphens', () => {
-      const result = validateGitHubUrl('my-org.io/my-repo.js');
-      expect(result.valid).toBe(true);
-      expect(result.owner).toBe('my-org.io');
-      expect(result.repo).toBe('my-repo.js');
+    test('gates bridge actions when Radicle integration is disabled', async () => {
+      const ctx = loadGithubBridgeModule({
+        settings: { enableRadicleIntegration: false },
+      });
+
+      ctx.mod.registerGithubBridgeIpc();
+
+      await expect(ctx.ipcMain.invoke(IPC.GITHUB_BRIDGE_CHECK_PREREQUISITES)).resolves.toEqual(
+        failure(
+          'RADICLE_DISABLED',
+          'Radicle integration is disabled. Enable it in Settings > Experimental'
+        )
+      );
+      await expect(
+        ctx.ipcMain.handlers.get(IPC.GITHUB_BRIDGE_IMPORT)({ sender: createSenderMock() }, 'owner/repo')
+      ).resolves.toEqual(
+        failure(
+          'RADICLE_DISABLED',
+          'Radicle integration is disabled. Enable it in Settings > Experimental'
+        )
+      );
+      await expect(ctx.ipcMain.invoke(IPC.GITHUB_BRIDGE_CHECK_EXISTING, 'owner/repo')).resolves.toEqual(
+        failure(
+          'RADICLE_DISABLED',
+          'Radicle integration is disabled. Enable it in Settings > Experimental'
+        )
+      );
+    });
+
+    test('rejects missing URLs before import or existing-bridge lookups', async () => {
+      const ctx = loadGithubBridgeModule();
+
+      ctx.mod.registerGithubBridgeIpc();
+
+      await expect(ctx.ipcMain.handlers.get(IPC.GITHUB_BRIDGE_IMPORT)({}, '')).resolves.toEqual(
+        failure('INVALID_URL', 'Missing GitHub URL', { field: 'url' })
+      );
+      await expect(ctx.ipcMain.invoke(IPC.GITHUB_BRIDGE_CHECK_EXISTING, '')).resolves.toEqual(
+        failure('INVALID_URL', 'Missing GitHub URL', { field: 'url' })
+      );
+    });
+
+    test('checks whether git is available', async () => {
+      const successCtx = loadGithubBridgeModule({
+        execFileAsync: jest.fn().mockResolvedValue({ stdout: 'git version 2.43.0\n' }),
+      });
+
+      successCtx.mod.registerGithubBridgeIpc();
+
+      await expect(successCtx.ipcMain.invoke(IPC.GITHUB_BRIDGE_CHECK_GIT)).resolves.toEqual({
+        available: true,
+        version: 'git version 2.43.0',
+      });
+
+      const failureCtx = loadGithubBridgeModule({
+        execFileAsync: jest.fn().mockRejectedValue(new Error('git missing')),
+      });
+
+      failureCtx.mod.registerGithubBridgeIpc();
+
+      await expect(failureCtx.ipcMain.invoke(IPC.GITHUB_BRIDGE_CHECK_GIT)).resolves.toEqual({
+        available: false,
+        error: 'Git is not installed or not found in PATH',
+      });
+    });
+
+    test('reports prerequisite failures for missing binaries and network timeout', async () => {
+      const missingBinaryCtx = loadGithubBridgeModule({
+        execFileAsync: jest.fn().mockResolvedValue({ stdout: 'git version 2.43.0\n' }),
+        gitRemoteRadExists: false,
+      });
+
+      missingBinaryCtx.mod.registerGithubBridgeIpc();
+
+      await expect(
+        missingBinaryCtx.ipcMain.invoke(IPC.GITHUB_BRIDGE_CHECK_PREREQUISITES)
+      ).resolves.toEqual({
+        ...failure('GIT_REMOTE_RAD_MISSING', 'Radicle Git bridge (git-remote-rad) not found'),
+        step: 'checking-radicle',
+      });
+
+      const networkCtx = loadGithubBridgeModule({
+        execFileAsync: jest.fn().mockResolvedValue({ stdout: 'git version 2.43.0\n' }),
+        httpsRequestRoutes: [{ url: 'https://github.com/', timeout: true }],
+      });
+
+      networkCtx.mod.registerGithubBridgeIpc();
+
+      await expect(networkCtx.ipcMain.invoke(IPC.GITHUB_BRIDGE_CHECK_PREREQUISITES)).resolves.toEqual({
+        ...failure(
+          'NETWORK_UNAVAILABLE',
+          'Network check timed out while reaching GitHub.'
+        ),
+        step: 'checking-network',
+      });
+    });
+
+    test('returns bridge matches loaded from disk', async () => {
+      const ctx = loadGithubBridgeModule({
+        mapExists: true,
+        mapFileContent: JSON.stringify({
+          'openai/project': 'rad:z6mkt4existing123',
+        }),
+      });
+
+      ctx.mod.registerGithubBridgeIpc();
+
+      await expect(
+        ctx.ipcMain.invoke(IPC.GITHUB_BRIDGE_CHECK_EXISTING, 'https://github.com/openai/project')
+      ).resolves.toEqual(
+        success({
+          bridged: true,
+          rid: 'z6mkt4existing123',
+        })
+      );
+      expect(ctx.fsMock.readFileSync).toHaveBeenCalledWith(ctx.mapPath, 'utf8');
+    });
+
+    test('detects legacy bridges from repo descriptions and persists the mapping', async () => {
+      const ctx = loadGithubBridgeModule({
+        activePort: 8780,
+        httpGetRoutes: [
+          {
+            match: /\/api\/v1\/repos\?show=all$/,
+            body: [
+              {
+                rid: 'rad:z6mkt4description123',
+                payloads: {
+                  'xyz.radicle.project': {
+                    data: {
+                      description: 'Imported from github.com/OpenAI/Project',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      ctx.mod.registerGithubBridgeIpc();
+
+      await expect(
+        ctx.ipcMain.invoke(IPC.GITHUB_BRIDGE_CHECK_EXISTING, 'https://github.com/openai/project')
+      ).resolves.toEqual(
+        success({
+          bridged: true,
+          rid: 'z6mkt4description123',
+        })
+      );
+      expect(ctx.fsMock.writeFileSync).toHaveBeenCalledWith(
+        ctx.mapPath,
+        JSON.stringify({ 'openai/project': 'z6mkt4description123' }, null, 2)
+      );
+    });
+
+    test('detects legacy bridges by matching GitHub head SHAs', async () => {
+      const ctx = loadGithubBridgeModule({
+        activePort: 8780,
+        httpGetRoutes: [
+          {
+            match: /\/api\/v1\/repos\?show=all$/,
+            body: [
+              {
+                rid: 'rad:z6mkt4headmatch123',
+                payloads: {
+                  'xyz.radicle.project': {
+                    data: {
+                      name: 'project',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          {
+            match: /\/api\/v1\/repos\/rad:z6mkt4headmatch123\/remotes$/,
+            body: [
+              {
+                heads: {
+                  main: 'abc123',
+                },
+              },
+            ],
+          },
+        ],
+        httpsGetRoutes: [
+          {
+            url: 'https://api.github.com/repos/openai/project',
+            body: {
+              default_branch: 'main',
+            },
+          },
+          {
+            url: 'https://api.github.com/repos/openai/project/commits/main',
+            body: {
+              sha: 'abc123',
+            },
+          },
+        ],
+      });
+
+      ctx.mod.registerGithubBridgeIpc();
+
+      await expect(
+        ctx.ipcMain.invoke(IPC.GITHUB_BRIDGE_CHECK_EXISTING, 'https://github.com/openai/project')
+      ).resolves.toEqual(
+        success({
+          bridged: true,
+          rid: 'z6mkt4headmatch123',
+        })
+      );
+      expect(ctx.fsMock.writeFileSync).toHaveBeenCalledWith(
+        ctx.mapPath,
+        JSON.stringify({ 'openai/project': 'z6mkt4headmatch123' }, null, 2)
+      );
+    });
+
+    test('surfaces import validation failures after emitting progress', async () => {
+      const ctx = loadGithubBridgeModule();
+      const sender = createSenderMock();
+
+      ctx.mod.registerGithubBridgeIpc();
+
+      await expect(
+        ctx.ipcMain.handlers.get(IPC.GITHUB_BRIDGE_IMPORT)({ sender }, 'not a valid url')
+      ).resolves.toEqual({
+        ...failure(
+          'INVALID_URL_FORMAT',
+          'Invalid GitHub URL. Expected: https://github.com/owner/repo or owner/repo',
+          { field: 'url', value: 'not a valid url' }
+        ),
+        step: 'validating',
+      });
+      expect(sender.send).toHaveBeenCalledWith(IPC.GITHUB_BRIDGE_PROGRESS, {
+        step: 'validating',
+        message: 'Validating GitHub URL...',
+      });
+    });
+
+    test('imports a GitHub repository through the registered IPC handler', async () => {
+      const execFileAsync = jest.fn()
+        .mockResolvedValueOnce({ stdout: 'git version 2.43.0\n' })
+        .mockResolvedValueOnce({ stdout: '', stderr: '' })
+        .mockResolvedValueOnce({ stdout: 'develop\n' })
+        .mockResolvedValueOnce({ stdout: 'initialized rad:z6mkt4import123\n', stderr: '' })
+        .mockResolvedValueOnce({ stdout: '', stderr: '' })
+        .mockResolvedValueOnce({ stdout: '', stderr: '' });
+      const ctx = loadGithubBridgeModule({
+        execFileAsync,
+        httpsRequestRoutes: [{ url: 'https://github.com/', statusCode: 200 }],
+        httpsGetRoutes: [
+          {
+            url: 'https://api.github.com/repos/openai/project',
+            body: {
+              description: 'Project description',
+            },
+          },
+        ],
+      });
+      const sender = createSenderMock();
+
+      ctx.mod.registerGithubBridgeIpc();
+
+      await expect(
+        ctx.ipcMain.handlers.get(IPC.GITHUB_BRIDGE_IMPORT)(
+          { sender },
+          'https://github.com/openai/project'
+        )
+      ).resolves.toEqual({
+        ...success(),
+        rid: 'z6mkt4import123',
+        name: 'project',
+        owner: 'openai',
+        description: 'Project description',
+      });
+
+      expect(sender.send.mock.calls).toEqual([
+        [IPC.GITHUB_BRIDGE_PROGRESS, { step: 'validating', message: 'Validating GitHub URL...' }],
+        [IPC.GITHUB_BRIDGE_PROGRESS, { step: 'checking-prereqs', message: 'Checking prerequisites...' }],
+        [IPC.GITHUB_BRIDGE_PROGRESS, { step: 'cloning', message: 'Cloning openai/project...' }],
+        [IPC.GITHUB_BRIDGE_PROGRESS, { step: 'initializing', message: 'Initializing Radicle project...' }],
+        [IPC.GITHUB_BRIDGE_PROGRESS, { step: 'pushing', message: 'Pushing to Radicle network...' }],
+        [IPC.GITHUB_BRIDGE_PROGRESS, { step: 'success', message: 'Repository seeded successfully!' }],
+      ]);
+      expect(execFileAsync).toHaveBeenNthCalledWith(1, 'git', ['--version'], { timeout: 5000 });
+      expect(execFileAsync).toHaveBeenNthCalledWith(2, 'git', [
+        'clone',
+        'https://github.com/openai/project.git',
+        '/tmp/freedom-bridge-12345/project',
+      ], {
+        timeout: 300000,
+      });
+      expect(execFileAsync).toHaveBeenNthCalledWith(3, 'git', ['symbolic-ref', '--short', 'HEAD'], {
+        cwd: '/tmp/freedom-bridge-12345/project',
+        timeout: 5000,
+      });
+      expect(execFileAsync).toHaveBeenNthCalledWith(4, '/mock/radicle/bin/rad', [
+        'init',
+        '--name',
+        'project',
+        '--description',
+        'Project description',
+        '--default-branch',
+        'develop',
+        '--public',
+        '--no-confirm',
+      ], expect.objectContaining({
+        cwd: '/tmp/freedom-bridge-12345/project',
+        timeout: 60000,
+        env: expect.objectContaining({
+          RAD_HOME: '/mock/radicle-data',
+          RAD_PASSPHRASE: '',
+          PATH: expect.stringContaining('/mock/radicle/bin'),
+        }),
+      }));
+      expect(ctx.fsMock.writeFileSync).toHaveBeenCalledWith(
+        ctx.mapPath,
+        JSON.stringify({ 'openai/project': 'z6mkt4import123' }, null, 2)
+      );
+      expect(ctx.fsMock.rmSync).toHaveBeenCalledWith(ctx.tempDir, {
+        recursive: true,
+        force: true,
+      });
+    });
+
+    test('returns an already-bridged failure when rad init reports an existing project', async () => {
+      const execFileAsync = jest.fn()
+        .mockResolvedValueOnce({ stdout: 'git version 2.43.0\n' })
+        .mockResolvedValueOnce({ stdout: '', stderr: '' })
+        .mockResolvedValueOnce({ stdout: 'main\n' })
+        .mockRejectedValueOnce(Object.assign(new Error('project exists'), {
+          stderr: Buffer.from('\u001b[31mproject exists rad:z6mkt4already123\u001b[39m'),
+        }));
+      const ctx = loadGithubBridgeModule({
+        execFileAsync,
+        httpsRequestRoutes: [{ url: 'https://github.com/', statusCode: 200 }],
+        httpsGetRoutes: [
+          {
+            url: 'https://api.github.com/repos/openai/project',
+            body: {
+              description: 'Existing project',
+            },
+          },
+        ],
+      });
+      const sender = createSenderMock();
+
+      ctx.mod.registerGithubBridgeIpc();
+
+      await expect(
+        ctx.ipcMain.handlers.get(IPC.GITHUB_BRIDGE_IMPORT)(
+          { sender },
+          'https://github.com/openai/project'
+        )
+      ).resolves.toEqual({
+        ...failure(
+          'ALREADY_BRIDGED',
+          'This GitHub repository is already bridged to Radicle.',
+          { rid: 'z6mkt4already123' }
+        ),
+        step: 'initializing',
+        rid: 'z6mkt4already123',
+      });
+      expect(ctx.fsMock.writeFileSync).toHaveBeenCalledWith(
+        ctx.mapPath,
+        JSON.stringify({ 'openai/project': 'z6mkt4already123' }, null, 2)
+      );
+      expect(sender.send).not.toHaveBeenCalledWith(IPC.GITHUB_BRIDGE_PROGRESS, {
+        step: 'error',
+        message: expect.any(String),
+      });
+    });
+
+    test('maps repository-not-found import failures to a friendly error and emits progress', async () => {
+      const execFileAsync = jest.fn()
+        .mockResolvedValueOnce({ stdout: 'git version 2.43.0\n' })
+        .mockRejectedValueOnce(Object.assign(new Error('clone failed'), {
+          stderr: Buffer.from('\u001b[31mrepository not found\u001b[39m'),
+        }));
+      const ctx = loadGithubBridgeModule({
+        execFileAsync,
+        httpsRequestRoutes: [{ url: 'https://github.com/', statusCode: 200 }],
+      });
+      const sender = createSenderMock();
+
+      ctx.mod.registerGithubBridgeIpc();
+
+      await expect(
+        ctx.ipcMain.handlers.get(IPC.GITHUB_BRIDGE_IMPORT)(
+          { sender },
+          'https://github.com/openai/project'
+        )
+      ).resolves.toEqual(
+        failure('REPOSITORY_NOT_FOUND', 'GitHub repository not found or not accessible.')
+      );
+      expect(sender.send).toHaveBeenLastCalledWith(IPC.GITHUB_BRIDGE_PROGRESS, {
+        step: 'error',
+        message: 'GitHub repository not found or not accessible.',
+      });
+      expect(ctx.fsMock.rmSync).toHaveBeenCalledWith(ctx.tempDir, {
+        recursive: true,
+        force: true,
+      });
     });
   });
 });

--- a/src/main/history.test.js
+++ b/src/main/history.test.js
@@ -1,0 +1,142 @@
+const IPC = require('../shared/ipc-channels');
+const FakeBetterSqlite3Database = require('../../test/helpers/fake-better-sqlite3');
+const {
+  createIpcMainMock,
+  createTempUserDataDir,
+  loadMainModule,
+  removeTempUserDataDir,
+} = require('../../test/helpers/main-process-test-utils');
+
+function loadHistoryModule(options = {}) {
+  return loadMainModule(require.resolve('./history'), {
+    ...options,
+    extraMocks: {
+      'better-sqlite3': () => FakeBetterSqlite3Database,
+    },
+  });
+}
+
+describe('history', () => {
+  let userDataDir;
+  let historyModule;
+
+  beforeEach(() => {
+    userDataDir = createTempUserDataDir();
+    historyModule = null;
+  });
+
+  afterEach(() => {
+    if (historyModule?.closeDb) {
+      historyModule.closeDb();
+    }
+    removeTempUserDataDir(userDataDir);
+  });
+
+  test('adds history entries and returns them from the database', () => {
+    const { mod } = loadHistoryModule({ userDataDir });
+    historyModule = mod;
+
+    const entry = mod.addHistoryEntry({
+      url: 'https://example.com',
+      title: 'Example',
+      protocol: 'https',
+    });
+
+    expect(entry).toEqual(
+      expect.objectContaining({
+        url: 'https://example.com',
+        title: 'Example',
+        protocol: 'https',
+      })
+    );
+    expect(mod.getHistoryCount()).toBe(1);
+    expect(mod.getAllHistory()).toEqual([
+      expect.objectContaining({
+        url: 'https://example.com',
+        title: 'Example',
+        protocol: 'https',
+        visit_count: 1,
+      }),
+    ]);
+  });
+
+  test('upserts duplicate URLs and increments visit count', () => {
+    const { mod } = loadHistoryModule({ userDataDir });
+    historyModule = mod;
+
+    mod.addHistoryEntry({
+      url: 'https://example.com',
+      title: 'First title',
+      protocol: 'https',
+    });
+    mod.addHistoryEntry({
+      url: 'https://example.com',
+      title: 'Updated title',
+      protocol: 'https',
+    });
+
+    expect(mod.getHistoryCount()).toBe(1);
+    expect(mod.getAllHistory()).toEqual([
+      expect.objectContaining({
+        url: 'https://example.com',
+        title: 'Updated title',
+        visit_count: 2,
+      }),
+    ]);
+  });
+
+  test('searches, removes, and clears history entries', () => {
+    const { mod } = loadHistoryModule({ userDataDir });
+    historyModule = mod;
+
+    mod.addHistoryEntry({
+      url: 'https://example.com',
+      title: 'Example',
+      protocol: 'https',
+    });
+    mod.addHistoryEntry({
+      url: 'https://freedom.browser',
+      title: 'Freedom',
+      protocol: 'https',
+    });
+
+    const searchResults = mod.searchHistory('Freedom');
+    expect(searchResults).toHaveLength(1);
+    expect(searchResults[0].url).toBe('https://freedom.browser');
+
+    expect(mod.removeHistoryEntry(searchResults[0].id)).toBe(true);
+    expect(mod.getHistoryCount()).toBe(1);
+    expect(mod.clearHistory()).toBe(1);
+    expect(mod.getHistoryCount()).toBe(0);
+  });
+
+  test('registers IPC handlers for history workflows', async () => {
+    const ipcMain = createIpcMainMock();
+    const { mod } = loadHistoryModule({ userDataDir, ipcMain });
+    historyModule = mod;
+
+    mod.registerHistoryIpc();
+
+    await expect(ipcMain.invoke(IPC.HISTORY_ADD, {})).resolves.toBeNull();
+
+    const created = await ipcMain.invoke(IPC.HISTORY_ADD, {
+      url: 'https://example.com',
+      title: 'Example',
+      protocol: 'https',
+    });
+    expect(created).toEqual(
+      expect.objectContaining({
+        url: 'https://example.com',
+        title: 'Example',
+      })
+    );
+
+    await expect(ipcMain.invoke(IPC.HISTORY_GET, { limit: 10 })).resolves.toEqual([
+      expect.objectContaining({
+        url: 'https://example.com',
+      }),
+    ]);
+    await expect(ipcMain.invoke(IPC.HISTORY_REMOVE, created.id)).resolves.toBe(true);
+    await expect(ipcMain.invoke(IPC.HISTORY_CLEAR)).resolves.toBe(0);
+  });
+});

--- a/src/main/ipc-handlers.test.js
+++ b/src/main/ipc-handlers.test.js
@@ -1,0 +1,360 @@
+const path = require('path');
+const internalPages = require('../shared/internal-pages.json');
+const IPC = require('../shared/ipc-channels');
+const { failure, success } = require('./ipc-contract');
+const {
+  createIpcMainMock,
+  loadMainModule,
+} = require('../../test/helpers/main-process-test-utils');
+
+function createWindowMock() {
+  return {
+    close: jest.fn(),
+    minimize: jest.fn(),
+    maximize: jest.fn(),
+    unmaximize: jest.fn(),
+    isMaximized: jest.fn(() => false),
+    setFullScreen: jest.fn(),
+    isFullScreen: jest.fn(() => false),
+    setTitle: jest.fn(),
+  };
+}
+
+function loadIpcHandlersModule(options = {}) {
+  const ipcMain = options.ipcMain || createIpcMainMock();
+  const log = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  const loadSettings = jest.fn(() => options.settings || { enableRadicleIntegration: false });
+  const fetchBuffer =
+    options.fetchBuffer || jest.fn().mockResolvedValue(Buffer.from('image-bytes'));
+  const fetchToFile = options.fetchToFile || jest.fn().mockResolvedValue(undefined);
+  const dialog = options.dialog || {
+    showSaveDialog: jest.fn(),
+  };
+  const clipboard = options.clipboard || {
+    writeText: jest.fn(),
+    writeImage: jest.fn(),
+  };
+  const nativeImage = options.nativeImage || {
+    createFromBuffer: jest.fn(() => ({
+      isEmpty: () => false,
+    })),
+  };
+
+  const { mod, app } = loadMainModule(require.resolve('./ipc-handlers'), {
+    ipcMain,
+    dialog,
+    clipboard,
+    nativeImage,
+    extraMocks: {
+      [require.resolve('./logger')]: () => log,
+      [require.resolve('./settings-store')]: () => ({ loadSettings }),
+      [require.resolve('./http-fetch')]: () => ({
+        fetchBuffer,
+        fetchToFile,
+      }),
+    },
+  });
+  const state = require('./state');
+
+  state.activeBzzBases.clear();
+  state.activeIpfsBases.clear();
+  state.activeRadBases.clear();
+
+  return {
+    app,
+    clipboard,
+    dialog,
+    fetchBuffer,
+    fetchToFile,
+    ipcMain,
+    loadSettings,
+    log,
+    mod,
+    nativeImage,
+    state,
+  };
+}
+
+describe('ipc-handlers', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('registers and validates base-url handlers for bzz, ipfs, and radicle', async () => {
+    const ctx = loadIpcHandlersModule({
+      settings: { enableRadicleIntegration: false },
+    });
+
+    ctx.mod.registerBaseIpcHandlers();
+
+    await expect(
+      ctx.ipcMain.invoke(IPC.BZZ_SET_BASE, {
+        webContentsId: 0,
+        baseUrl: 'http://127.0.0.1:1633/bzz/hash/',
+      })
+    ).resolves.toEqual(
+      failure('INVALID_WEB_CONTENTS_ID', 'Invalid webContentsId', { webContentsId: 0 })
+    );
+
+    await expect(
+      ctx.ipcMain.invoke(IPC.BZZ_SET_BASE, {
+        webContentsId: 5,
+      })
+    ).resolves.toEqual(failure('INVALID_BASE_URL', 'Missing baseUrl'));
+
+    await expect(
+      ctx.ipcMain.invoke(IPC.BZZ_SET_BASE, {
+        webContentsId: 5,
+        baseUrl: 'https://swarm-gateway.example/bzz/hash/',
+      })
+    ).resolves.toEqual(
+      failure('INVALID_BASE_URL', 'Base URL must be localhost or 127.0.0.1', {
+        baseUrl: 'https://swarm-gateway.example/bzz/hash/',
+      })
+    );
+    expect(ctx.log.warn).toHaveBeenCalledWith('[ipc] Rejecting non-local bzz base URL');
+
+    await expect(
+      ctx.ipcMain.invoke(IPC.BZZ_SET_BASE, {
+        webContentsId: 5,
+        baseUrl: 'http://127.0.0.1:1633/bzz/hash/',
+      })
+    ).resolves.toEqual(success());
+    expect(ctx.state.activeBzzBases.get(5)?.toString()).toBe('http://127.0.0.1:1633/bzz/hash/');
+
+    await expect(
+      ctx.ipcMain.invoke(IPC.BZZ_CLEAR_BASE, {
+        webContentsId: 5,
+      })
+    ).resolves.toEqual(success());
+    expect(ctx.state.activeBzzBases.has(5)).toBe(false);
+
+    await expect(
+      ctx.ipcMain.invoke(IPC.IPFS_SET_BASE, {
+        webContentsId: 8,
+        baseUrl: 'http://localhost:8080/ipfs/cid/',
+      })
+    ).resolves.toEqual(success());
+    expect(ctx.state.activeIpfsBases.get(8)?.toString()).toBe('http://localhost:8080/ipfs/cid/');
+
+    await expect(
+      ctx.ipcMain.invoke(IPC.IPFS_CLEAR_BASE, {
+        webContentsId: 8,
+      })
+    ).resolves.toEqual(success());
+    expect(ctx.state.activeIpfsBases.has(8)).toBe(false);
+
+    await expect(
+      ctx.ipcMain.invoke(IPC.RAD_SET_BASE, {
+        webContentsId: 12,
+        baseUrl: 'http://127.0.0.1:8780/api/v1/repos/rid/',
+      })
+    ).resolves.toEqual(
+      failure(
+        'RADICLE_DISABLED',
+        'Radicle integration is disabled. Enable it in Settings > Experimental'
+      )
+    );
+
+    const enabledCtx = loadIpcHandlersModule({
+      settings: { enableRadicleIntegration: true },
+    });
+    enabledCtx.mod.registerBaseIpcHandlers();
+
+    await expect(
+      enabledCtx.ipcMain.invoke(IPC.RAD_SET_BASE, {
+        webContentsId: 12,
+        baseUrl: 'http://127.0.0.1:8780/api/v1/repos/rid/',
+      })
+    ).resolves.toEqual(success());
+    expect(enabledCtx.state.activeRadBases.get(12)?.toString()).toBe(
+      'http://127.0.0.1:8780/api/v1/repos/rid/'
+    );
+
+    await expect(
+      enabledCtx.ipcMain.invoke(IPC.RAD_CLEAR_BASE, {
+        webContentsId: 12,
+      })
+    ).resolves.toEqual(success());
+    expect(enabledCtx.state.activeRadBases.has(12)).toBe(false);
+  });
+
+  test('registers window, app, and internal routing handlers', async () => {
+    const onNewWindow = jest.fn();
+    const onSetTitle = jest.fn();
+    const ctx = loadIpcHandlersModule();
+    const win = createWindowMock();
+    const hostWebContents = {
+      send: jest.fn(),
+    };
+    const event = {
+      sender: {
+        getOwnerBrowserWindow: jest.fn(() => win),
+        hostWebContents,
+      },
+    };
+
+    ctx.mod.registerBaseIpcHandlers({
+      onNewWindow,
+      onSetTitle,
+    });
+
+    ctx.ipcMain.emit(IPC.WINDOW_SET_TITLE, event, '  Example Title  ');
+    expect(win.setTitle).toHaveBeenCalledWith('Example Title - Freedom');
+    expect(onSetTitle).toHaveBeenCalledWith('Example Title - Freedom');
+
+    ctx.ipcMain.emit(IPC.WINDOW_CLOSE, event);
+    ctx.ipcMain.emit(IPC.WINDOW_MINIMIZE, event);
+    expect(win.close).toHaveBeenCalled();
+    expect(win.minimize).toHaveBeenCalled();
+
+    ctx.ipcMain.emit(IPC.WINDOW_MAXIMIZE, event);
+    expect(win.maximize).toHaveBeenCalled();
+    win.isMaximized.mockReturnValueOnce(true);
+    ctx.ipcMain.emit(IPC.WINDOW_MAXIMIZE, event);
+    expect(win.unmaximize).toHaveBeenCalled();
+
+    ctx.ipcMain.emit(IPC.WINDOW_TOGGLE_FULLSCREEN, event);
+    expect(win.setFullScreen).toHaveBeenCalledWith(true);
+
+    await expect(ctx.ipcMain.invoke(IPC.WINDOW_GET_PLATFORM)).resolves.toBe(process.platform);
+
+    ctx.ipcMain.emit(IPC.WINDOW_NEW, event);
+    ctx.ipcMain.emit(IPC.WINDOW_NEW_WITH_URL, event, 'https://example.com');
+    expect(onNewWindow).toHaveBeenNthCalledWith(1);
+    expect(onNewWindow).toHaveBeenNthCalledWith(2, 'https://example.com');
+
+    ctx.ipcMain.emit(IPC.APP_SHOW_ABOUT);
+    expect(ctx.app.showAboutPanel).toHaveBeenCalled();
+
+    const preloadPath = await ctx.ipcMain.invoke(IPC.GET_WEBVIEW_PRELOAD_PATH);
+    expect(path.basename(preloadPath)).toBe('webview-preload.js');
+
+    const internalPagesEvent = {};
+    ctx.ipcMain.emit(IPC.GET_INTERNAL_PAGES, internalPagesEvent);
+    expect(internalPagesEvent.returnValue).toEqual(internalPages);
+
+    await ctx.ipcMain.handlers.get(IPC.OPEN_URL_IN_NEW_TAB)(event, 'https://open.example');
+    expect(hostWebContents.send).toHaveBeenCalledWith('tab:new-with-url', 'https://open.example');
+  });
+
+  test('saves images through the dialog workflow', async () => {
+    const ctx = loadIpcHandlersModule();
+    const win = createWindowMock();
+    const event = {
+      sender: {
+        getOwnerBrowserWindow: jest.fn(() => win),
+      },
+    };
+
+    ctx.mod.registerBaseIpcHandlers();
+
+    await expect(ctx.ipcMain.handlers.get(IPC.CONTEXT_MENU_SAVE_IMAGE)(event)).resolves.toEqual({
+      success: false,
+      error: 'No image URL provided',
+    });
+
+    ctx.dialog.showSaveDialog.mockResolvedValueOnce({
+      canceled: true,
+      filePath: undefined,
+    });
+    await expect(
+      ctx.ipcMain.handlers.get(IPC.CONTEXT_MENU_SAVE_IMAGE)(
+        event,
+        'https://example.com/assets/logo.png'
+      )
+    ).resolves.toEqual({
+      success: false,
+      canceled: true,
+    });
+
+    ctx.dialog.showSaveDialog.mockResolvedValueOnce({
+      canceled: false,
+      filePath: '/tmp/logo.png',
+    });
+    await expect(
+      ctx.ipcMain.handlers.get(IPC.CONTEXT_MENU_SAVE_IMAGE)(
+        event,
+        'https://example.com/assets/logo.png'
+      )
+    ).resolves.toEqual({
+      success: true,
+      filePath: '/tmp/logo.png',
+    });
+    expect(ctx.dialog.showSaveDialog).toHaveBeenLastCalledWith(
+      win,
+      expect.objectContaining({
+        defaultPath: 'logo.png',
+      })
+    );
+    expect(ctx.fetchToFile).toHaveBeenCalledWith('https://example.com/assets/logo.png', '/tmp/logo.png');
+  });
+
+  test('copies text and images to the clipboard with error handling', async () => {
+    const emptyImage = {
+      isEmpty: () => true,
+    };
+    const ctx = loadIpcHandlersModule({
+      nativeImage: {
+        createFromBuffer: jest
+          .fn()
+          .mockReturnValueOnce({
+            isEmpty: () => false,
+          })
+          .mockReturnValueOnce(emptyImage),
+      },
+    });
+
+    ctx.mod.registerBaseIpcHandlers();
+
+    await expect(ctx.ipcMain.invoke('clipboard:copy-text', 'hello')).resolves.toEqual({
+      success: true,
+    });
+    expect(ctx.clipboard.writeText).toHaveBeenCalledWith('hello');
+
+    await expect(ctx.ipcMain.invoke('clipboard:copy-text', '')).resolves.toEqual({
+      success: false,
+      error: 'No text provided',
+    });
+
+    await expect(ctx.ipcMain.handlers.get('clipboard:copy-image')({}, undefined)).resolves.toEqual({
+      success: false,
+      error: 'No image URL provided',
+    });
+
+    await expect(
+      ctx.ipcMain.handlers.get('clipboard:copy-image')({}, 'https://example.com/image.png')
+    ).resolves.toEqual({
+      success: true,
+    });
+    expect(ctx.fetchBuffer).toHaveBeenCalledWith('https://example.com/image.png');
+    expect(ctx.clipboard.writeImage).toHaveBeenCalled();
+
+    await expect(
+      ctx.ipcMain.handlers.get('clipboard:copy-image')({}, 'https://example.com/empty.png')
+    ).resolves.toEqual({
+      success: false,
+      error: 'Failed to create image from data',
+    });
+
+    const failingCtx = loadIpcHandlersModule({
+      fetchBuffer: jest.fn().mockRejectedValue(new Error('download failed')),
+    });
+    failingCtx.mod.registerBaseIpcHandlers();
+
+    await expect(
+      failingCtx.ipcMain.handlers.get('clipboard:copy-image')({}, 'https://example.com/error.png')
+    ).resolves.toEqual({
+      success: false,
+      error: 'download failed',
+    });
+    expect(failingCtx.log.error).toHaveBeenCalledWith(
+      '[clipboard] Failed to copy image:',
+      expect.any(Error)
+    );
+  });
+});

--- a/src/main/ipfs-manager.js
+++ b/src/main/ipfs-manager.js
@@ -508,13 +508,16 @@ async function startIpfs() {
         clearTimeout(forceKillTimeout);
         forceKillTimeout = null;
       }
+      if (healthCheckInterval) {
+        clearInterval(healthCheckInterval);
+        healthCheckInterval = null;
+      }
 
       if (currentState !== STATUS.STOPPING) {
         updateState(STATUS.STOPPED, code !== 0 ? `Exited with code ${code}` : null);
       } else {
         updateState(STATUS.STOPPED);
       }
-      if (healthCheckInterval) clearInterval(healthCheckInterval);
       clearService('ipfs');
 
       if (pendingStart) {
@@ -583,6 +586,10 @@ function stopIpfs() {
 
     // If we reused an external daemon, just clear state (don't stop it)
     if (currentMode === MODE.REUSED) {
+      if (healthCheckInterval) {
+        clearInterval(healthCheckInterval);
+        healthCheckInterval = null;
+      }
       updateState(STATUS.STOPPED);
       clearService('ipfs');
       currentMode = MODE.NONE;
@@ -599,6 +606,10 @@ function stopIpfs() {
 
     // Listen for the process to exit
     const onExit = () => {
+      if (healthCheckInterval) {
+        clearInterval(healthCheckInterval);
+        healthCheckInterval = null;
+      }
       if (forceKillTimeout) {
         clearTimeout(forceKillTimeout);
         forceKillTimeout = null;
@@ -609,9 +620,10 @@ function stopIpfs() {
     ipfsProcess.once('close', onExit);
 
     updateState(STATUS.STOPPING);
-    if (healthCheckInterval) clearInterval(healthCheckInterval);
-
-    ipfsProcess.kill('SIGTERM');
+    if (healthCheckInterval) {
+      clearInterval(healthCheckInterval);
+      healthCheckInterval = null;
+    }
 
     if (forceKillTimeout) clearTimeout(forceKillTimeout);
     forceKillTimeout = setTimeout(() => {
@@ -621,6 +633,8 @@ function stopIpfs() {
       }
       forceKillTimeout = null;
     }, 5000);
+
+    ipfsProcess.kill('SIGTERM');
   });
 }
 

--- a/src/main/ipfs-manager.test.js
+++ b/src/main/ipfs-manager.test.js
@@ -1,0 +1,550 @@
+const path = require('path');
+const IPC = require('../shared/ipc-channels');
+const {
+  createAppMock,
+  createIpcMainMock,
+  loadMainModule,
+} = require('../../test/helpers/main-process-test-utils');
+
+const PROJECT_ROOT = path.join(__dirname, '..', '..');
+const DEV_IPFS_DATA_DIR = path.join(PROJECT_ROOT, 'ipfs-data');
+
+function flushMicrotasks() {
+  return Promise.resolve().then(() => Promise.resolve());
+}
+
+function createProcessMock(binary, options = {}) {
+  const listeners = new Map();
+  const onceListeners = new Map();
+  const stdoutListeners = new Map();
+  const stderrListeners = new Map();
+
+  const emitAll = (store, event, args) => {
+    for (const handler of store.get(event) || []) {
+      handler(...args);
+    }
+  };
+
+  const proc = {
+    binary,
+    kills: [],
+    stdout: {
+      on: jest.fn((event, handler) => {
+        if (!stdoutListeners.has(event)) {
+          stdoutListeners.set(event, []);
+        }
+        stdoutListeners.get(event).push(handler);
+      }),
+    },
+    stderr: {
+      on: jest.fn((event, handler) => {
+        if (!stderrListeners.has(event)) {
+          stderrListeners.set(event, []);
+        }
+        stderrListeners.get(event).push(handler);
+      }),
+    },
+    on: jest.fn((event, handler) => {
+      if (!listeners.has(event)) {
+        listeners.set(event, []);
+      }
+      listeners.get(event).push(handler);
+    }),
+    once: jest.fn((event, handler) => {
+      if (!onceListeners.has(event)) {
+        onceListeners.set(event, []);
+      }
+      onceListeners.get(event).push(handler);
+    }),
+    emit(event, ...args) {
+      emitAll(listeners, event, args);
+      const oneTimeHandlers = onceListeners.get(event) || [];
+      onceListeners.delete(event);
+      oneTimeHandlers.forEach((handler) => handler(...args));
+    },
+    emitStdout(data) {
+      emitAll(stdoutListeners, 'data', [data]);
+    },
+    emitStderr(data) {
+      emitAll(stderrListeners, 'data', [data]);
+    },
+    kill: jest.fn((signal) => {
+      proc.kills.push(signal);
+      if (options.autoCloseOnKill !== false) {
+        proc.emit('close', options.closeCode ?? 0);
+      }
+      return true;
+    }),
+  };
+
+  return proc;
+}
+
+function createSocketClass(portResolver) {
+  const queue = Array.isArray(portResolver) ? [...portResolver] : null;
+
+  return class MockSocket {
+    constructor() {
+      this.handlers = {};
+    }
+
+    setTimeout() {}
+
+    on(event, handler) {
+      this.handlers[event] = handler;
+    }
+
+    destroy() {}
+
+    connect(port, host) {
+      const result = typeof portResolver === 'function'
+        ? portResolver(port, host)
+        : queue && queue.length > 0
+          ? queue.shift()
+          : false;
+
+      if (result === true) {
+        this.handlers.connect?.();
+        return;
+      }
+
+      if (result === 'timeout') {
+        this.handlers.timeout?.();
+        return;
+      }
+
+      this.handlers.error?.(new Error('closed'));
+    }
+  };
+}
+
+function createHttpRequestMock(responseResolver) {
+  const resolveResponse = responseResolver || (() => ({ statusCode: 500, body: '' }));
+
+  return jest.fn((options, callback) => {
+    const requestHandlers = new Map();
+    let timeoutHandler = null;
+
+    const request = {
+      on: jest.fn((event, handler) => {
+        requestHandlers.set(event, handler);
+        return request;
+      }),
+      setTimeout: jest.fn((_timeout, handler) => {
+        timeoutHandler = handler;
+        return request;
+      }),
+      destroy: jest.fn(),
+      end: jest.fn(() => {
+        const responseConfig = resolveResponse(options);
+
+        if (responseConfig?.error) {
+          requestHandlers.get('error')?.(responseConfig.error);
+          return;
+        }
+
+        if (responseConfig?.timeoutEvent) {
+          requestHandlers.get('timeout')?.();
+          return;
+        }
+
+        if (responseConfig?.timeoutCallback) {
+          timeoutHandler?.();
+          return;
+        }
+
+        const responseHandlers = new Map();
+        const response = {
+          statusCode: responseConfig?.statusCode ?? 200,
+          resume: jest.fn(),
+          on: jest.fn((event, handler) => {
+            if (!responseHandlers.has(event)) {
+              responseHandlers.set(event, []);
+            }
+            responseHandlers.get(event).push(handler);
+          }),
+        };
+
+        callback(response);
+
+        const chunks = (() => {
+          if (responseConfig?.body === undefined || responseConfig?.body === null) {
+            return [];
+          }
+          if (typeof responseConfig.body === 'string') {
+            return [responseConfig.body];
+          }
+          return [JSON.stringify(responseConfig.body)];
+        })();
+
+        chunks.forEach((chunk) => {
+          for (const handler of responseHandlers.get('data') || []) {
+            handler(chunk);
+          }
+        });
+        for (const handler of responseHandlers.get('end') || []) {
+          handler();
+        }
+      }),
+    };
+
+    return request;
+  });
+}
+
+function createWindowMock() {
+  return {
+    webContents: {
+      send: jest.fn(),
+    },
+  };
+}
+
+function loadIpfsManagerModule(options = {}) {
+  const ipcMain = options.ipcMain || createIpcMainMock();
+  const app = options.app || createAppMock({
+    isPackaged: options.isPackaged ?? false,
+    userDataDir: options.userDataDir || '/tmp/freedom-user-data',
+  });
+  const windows = options.windows || [];
+  const BrowserWindow = {
+    getAllWindows: jest.fn(() => windows),
+  };
+  const log = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  const updateService = jest.fn();
+  const setStatusMessage = jest.fn();
+  const setErrorState = jest.fn();
+  const clearErrorState = jest.fn();
+  const clearService = jest.fn();
+  const spawnedProcesses = [];
+  const execSync = options.execSync || jest.fn();
+  const spawn = jest.fn((binary, args = [], spawnOptions = {}) => {
+    const proc = (options.createProcess || createProcessMock)(binary, options.processOptions || {});
+    proc.args = args;
+    proc.spawnOptions = spawnOptions;
+    spawnedProcesses.push(proc);
+    return proc;
+  });
+
+  const platformMap = {
+    darwin: 'mac',
+    linux: 'linux',
+    win32: 'win',
+  };
+  const platform = platformMap[process.platform] || process.platform;
+  const binaryName = process.platform === 'win32' ? 'ipfs.exe' : 'ipfs';
+  const binPath = path.join(PROJECT_ROOT, 'ipfs-bin', `${platform}-${process.arch}`, binaryName);
+  const dataDir = options.isPackaged
+    ? path.join(options.userDataDir || '/tmp/freedom-user-data', 'ipfs-data')
+    : DEV_IPFS_DATA_DIR;
+  const configPath = path.join(dataDir, 'config');
+  const lockPath = path.join(dataDir, 'repo.lock');
+
+  const fsMock = {
+    existsSync: jest.fn((target) => {
+      if (typeof options.existsSync === 'function') {
+        return options.existsSync(target);
+      }
+
+      if (target === binPath) return options.binExists !== false;
+      if (target === dataDir) return options.dataDirExists === true;
+      if (target === configPath) return options.configExists === true;
+      if (target === lockPath) return options.lockExists === true;
+      return false;
+    }),
+    mkdirSync: jest.fn(),
+    unlinkSync: jest.fn(),
+    readFileSync: jest.fn(() => options.configContents || '{}'),
+    writeFileSync: jest.fn(),
+  };
+
+  const httpRequest = createHttpRequestMock(options.httpResponse);
+  const Socket = createSocketClass(options.portSequence || options.portResolver || false);
+
+  const { mod } = loadMainModule(require.resolve('./ipfs-manager'), {
+    app,
+    ipcMain,
+    BrowserWindow,
+    extraMocks: {
+      child_process: () => ({
+        spawn,
+        execSync,
+      }),
+      fs: () => fsMock,
+      http: () => ({
+        request: httpRequest,
+      }),
+      net: () => ({
+        Socket,
+      }),
+      [require.resolve('./logger')]: () => log,
+      [require.resolve('./service-registry')]: () => ({
+        MODE: {
+          BUNDLED: 'bundled',
+          REUSED: 'reused',
+          NONE: 'none',
+        },
+        DEFAULTS: {
+          ipfs: {
+            apiPort: 5001,
+            gatewayPort: 8080,
+            fallbackRange: 10,
+          },
+        },
+        updateService,
+        setStatusMessage,
+        setErrorState,
+        clearErrorState,
+        clearService,
+      }),
+    },
+  });
+
+  return {
+    app,
+    binPath,
+    BrowserWindow,
+    clearErrorState,
+    clearService,
+    configPath,
+    dataDir,
+    execSync,
+    fsMock,
+    httpRequest,
+    ipcMain,
+    lockPath,
+    log,
+    mod,
+    setErrorState,
+    setStatusMessage,
+    spawn,
+    spawnedProcesses,
+    updateService,
+    windows,
+  };
+}
+
+describe('ipfs-manager', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('registers IPC handlers and reports binary availability plus initial status', async () => {
+    const ctx = loadIpfsManagerModule({
+      binExists: false,
+    });
+
+    ctx.mod.registerIpfsIpc();
+
+    expect([...ctx.ipcMain.handlers.keys()].sort()).toEqual([
+      IPC.IPFS_START,
+      IPC.IPFS_STOP,
+      IPC.IPFS_GET_STATUS,
+      IPC.IPFS_CHECK_BINARY,
+    ].sort());
+
+    await expect(ctx.ipcMain.invoke(IPC.IPFS_GET_STATUS)).resolves.toEqual({
+      status: 'stopped',
+      error: null,
+    });
+    await expect(ctx.ipcMain.invoke(IPC.IPFS_CHECK_BINARY)).resolves.toEqual({
+      available: false,
+    });
+  });
+
+  test('reuses an existing daemon and clears the health-check interval on stop', async () => {
+    const setIntervalSpy = jest.spyOn(global, 'setInterval').mockReturnValue(321);
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval').mockImplementation(() => {});
+    const window = createWindowMock();
+    const ctx = loadIpfsManagerModule({
+      windows: [window],
+      portSequence: [true],
+      httpResponse: (options) => {
+        if (options.port === 5001) {
+          return {
+            statusCode: 200,
+            body: { ID: 'peer-123' },
+          };
+        }
+
+        return { statusCode: 500, body: '' };
+      },
+    });
+
+    await ctx.mod.startIpfs();
+    await flushMicrotasks();
+
+    expect(ctx.spawn).not.toHaveBeenCalled();
+    expect(ctx.mod.getActivePort()).toBe(5001);
+    expect(ctx.mod.getActiveGatewayPort()).toBe(8080);
+    expect(ctx.updateService).toHaveBeenCalledWith('ipfs', {
+      api: 'http://127.0.0.1:5001',
+      gateway: 'http://127.0.0.1:8080',
+      mode: 'reused',
+    });
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('ipfs', 'Node: localhost:5001');
+    expect(setIntervalSpy).toHaveBeenCalled();
+    expect(window.webContents.send).toHaveBeenCalledWith(IPC.IPFS_STATUS_UPDATE, {
+      status: 'starting',
+      error: null,
+    });
+    expect(window.webContents.send).toHaveBeenLastCalledWith(IPC.IPFS_STATUS_UPDATE, {
+      status: 'running',
+      error: null,
+    });
+
+    await ctx.mod.stopIpfs();
+
+    expect(clearIntervalSpy).toHaveBeenCalledWith(321);
+    expect(ctx.clearService).toHaveBeenCalledWith('ipfs');
+  });
+
+  test('starts a bundled daemon on fallback ports, enforces config, and leaves no shutdown timers behind', async () => {
+    jest.useFakeTimers();
+
+    let configExists = false;
+    const platformMap = {
+      darwin: 'mac',
+      linux: 'linux',
+      win32: 'win',
+    };
+    const platform = platformMap[process.platform] || process.platform;
+    const binaryName = process.platform === 'win32' ? 'ipfs.exe' : 'ipfs';
+    const binPath = path.join(PROJECT_ROOT, 'ipfs-bin', `${platform}-${process.arch}`, binaryName);
+    const dataDir = DEV_IPFS_DATA_DIR;
+    const lockPath = path.join(dataDir, 'repo.lock');
+    const configPath = path.join(dataDir, 'config');
+    const execSync = jest.fn(() => {
+      configExists = true;
+    });
+    const ctx = loadIpfsManagerModule({
+      execSync,
+      lockExists: true,
+      existsSync: (target) => {
+        if (target === binPath) return true;
+        if (target === dataDir) return false;
+        if (target === lockPath) return true;
+        if (target === configPath) return configExists;
+        return false;
+      },
+      portSequence: [true, false, true, false],
+      httpResponse: (options) => {
+        if (options.port === 5001) {
+          return {
+            statusCode: 500,
+            body: '',
+          };
+        }
+        if (options.port === 5002) {
+          return {
+            statusCode: 200,
+            body: { ID: 'peer-5002' },
+          };
+        }
+        return {
+          statusCode: 500,
+          body: '',
+        };
+      },
+    });
+
+    await ctx.mod.startIpfs();
+    await flushMicrotasks();
+    await jest.advanceTimersByTimeAsync(1000);
+    await flushMicrotasks();
+
+    expect(ctx.fsMock.mkdirSync).toHaveBeenCalledWith(ctx.dataDir, { recursive: true });
+    expect(ctx.fsMock.unlinkSync).toHaveBeenCalledWith(ctx.lockPath);
+    expect(execSync).toHaveBeenCalledWith(`"${ctx.binPath}" init`, {
+      env: expect.objectContaining({
+        IPFS_PATH: ctx.dataDir,
+      }),
+      stdio: 'pipe',
+    });
+    expect(ctx.spawnedProcesses).toHaveLength(1);
+    expect(ctx.spawnedProcesses[0].binary).toBe(ctx.binPath);
+    expect(ctx.spawnedProcesses[0].args).toEqual(['daemon']);
+    expect(ctx.spawnedProcesses[0].spawnOptions).toEqual({
+      env: expect.objectContaining({
+        IPFS_PATH: ctx.dataDir,
+      }),
+    });
+    expect(ctx.mod.getActivePort()).toBe(5002);
+    expect(ctx.mod.getActiveGatewayPort()).toBe(8081);
+    expect(ctx.updateService).toHaveBeenCalledWith('ipfs', {
+      api: 'http://127.0.0.1:5002',
+      gateway: 'http://127.0.0.1:8081',
+      mode: 'bundled',
+    });
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('ipfs', 'Fallback Port: 5002');
+
+    const writtenConfig = JSON.parse(ctx.fsMock.writeFileSync.mock.calls[0][1]);
+    expect(writtenConfig.Addresses.API).toBe('/ip4/127.0.0.1/tcp/5002');
+    expect(writtenConfig.Addresses.Gateway).toBe('/ip4/127.0.0.1/tcp/8081');
+    expect(writtenConfig.Routing.Type).toBe('autoclient');
+    expect(writtenConfig.DNS.Resolvers).toEqual({
+      '.': 'https://cloudflare-dns.com/dns-query',
+      'eth.': 'https://dns.eth.limo/dns-query',
+    });
+
+    const stopPromise = ctx.mod.stopIpfs();
+    await flushMicrotasks();
+    await stopPromise;
+
+    expect(ctx.spawnedProcesses[0].kills).toContain('SIGTERM');
+    expect(ctx.clearService).toHaveBeenCalledWith('ipfs');
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test('fails startup when the IPFS binary is missing', async () => {
+    const ctx = loadIpfsManagerModule({
+      binExists: false,
+      portSequence: [false],
+      httpResponse: () => ({ statusCode: 500, body: '' }),
+    });
+
+    await ctx.mod.startIpfs();
+    await flushMicrotasks();
+
+    expect(ctx.spawn).not.toHaveBeenCalled();
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('ipfs', 'Node failed to start');
+    expect(ctx.log.error).not.toHaveBeenCalled();
+  });
+
+  test('fails startup when config enforcement cannot parse the repo config', async () => {
+    const ctx = loadIpfsManagerModule({
+      configExists: true,
+      configContents: '{invalid json',
+      portSequence: [false, false],
+      httpResponse: (options) => {
+        if (options.port === 5001) {
+          return {
+            statusCode: 500,
+            body: '',
+          };
+        }
+        return {
+          statusCode: 200,
+          body: { ID: 'peer' },
+        };
+      },
+    });
+
+    await ctx.mod.startIpfs();
+    await flushMicrotasks();
+
+    expect(ctx.spawn).not.toHaveBeenCalled();
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('ipfs', 'Node failed to start');
+    expect(ctx.log.error).toHaveBeenCalledWith(
+      '[IPFS] Failed to enforce config:',
+      expect.any(String)
+    );
+  });
+});

--- a/src/main/logger.js
+++ b/src/main/logger.js
@@ -8,15 +8,24 @@ try {
   // Running outside Electron (e.g., Jest)
 }
 
-// File transport captures everything for post-mortem debugging
-log.transports.file.level = 'info';
+const isTestEnv =
+  process.env.NODE_ENV === 'test' || Boolean(process.env.JEST_WORKER_ID);
 
-// Console transport: production shows only warnings+errors, dev shows all
-// Set DEBUG=1 to enable verbose console output in production
-if (isPackaged && !process.env.DEBUG) {
-  log.transports.console.level = 'warn';
+if (isTestEnv) {
+  // Jest should not try to write to the user's log directory.
+  log.transports.file.level = false;
+  log.transports.console.level = process.env.DEBUG ? 'verbose' : false;
 } else {
-  log.transports.console.level = process.env.DEBUG ? 'verbose' : 'info';
+  // File transport captures everything for post-mortem debugging
+  log.transports.file.level = 'info';
+
+  // Console transport: production shows only warnings+errors, dev shows all
+  // Set DEBUG=1 to enable verbose console output in production
+  if (isPackaged && !process.env.DEBUG) {
+    log.transports.console.level = 'warn';
+  } else {
+    log.transports.console.level = process.env.DEBUG ? 'verbose' : 'info';
+  }
 }
 
 module.exports = log;

--- a/src/main/preload.test.js
+++ b/src/main/preload.test.js
@@ -1,0 +1,272 @@
+const IPC = require('../shared/ipc-channels');
+const {
+  createContextBridgeMock,
+  createIpcRendererMock,
+  loadMainModule,
+} = require('../../test/helpers/main-process-test-utils');
+
+const originalBeeApi = process.env.BEE_API;
+const originalIpfsGateway = process.env.IPFS_GATEWAY;
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+function loadPreloadModule(options = {}) {
+  const internalPages = options.internalPages || {
+    home: 'file:///app/pages/home.html',
+    history: 'file:///app/pages/history.html',
+  };
+  const ipcRenderer =
+    options.ipcRenderer ||
+    createIpcRendererMock({
+      syncResponses: {
+        [IPC.GET_INTERNAL_PAGES]: internalPages,
+      },
+      invokeResponses: {
+        [IPC.BEE_GET_STATUS]: { status: 'running', error: null },
+        [IPC.IPFS_GET_STATUS]: { status: 'stopped', error: null },
+        [IPC.RADICLE_GET_STATUS]: { status: 'error', error: 'offline' },
+        ...(options.invokeResponses || {}),
+      },
+    });
+  const contextBridge = options.contextBridge || createContextBridgeMock();
+
+  if (Object.prototype.hasOwnProperty.call(options, 'beeApiEnv')) {
+    if (options.beeApiEnv == null) {
+      delete process.env.BEE_API;
+    } else {
+      process.env.BEE_API = options.beeApiEnv;
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(options, 'ipfsGatewayEnv')) {
+    if (options.ipfsGatewayEnv == null) {
+      delete process.env.IPFS_GATEWAY;
+    } else {
+      process.env.IPFS_GATEWAY = options.ipfsGatewayEnv;
+    }
+  }
+
+  loadMainModule(require.resolve('./preload'), {
+    ipcRenderer,
+    contextBridge,
+  });
+
+  return {
+    contextBridge,
+    exposures: contextBridge.exposedValues,
+    internalPages,
+    ipcRenderer,
+  };
+}
+
+describe('preload', () => {
+  afterEach(() => {
+    if (originalBeeApi === undefined) {
+      delete process.env.BEE_API;
+    } else {
+      process.env.BEE_API = originalBeeApi;
+    }
+
+    if (originalIpfsGateway === undefined) {
+      delete process.env.IPFS_GATEWAY;
+    } else {
+      process.env.IPFS_GATEWAY = originalIpfsGateway;
+    }
+
+    jest.restoreAllMocks();
+  });
+
+  test('exposes the preload bridges and routes direct wrappers to ipcRenderer', async () => {
+    const { contextBridge, exposures, internalPages, ipcRenderer } = loadPreloadModule({
+      beeApiEnv: 'http://127.0.0.1:1700',
+      ipfsGatewayEnv: 'http://127.0.0.1:9090',
+    });
+
+    expect(contextBridge.exposeInMainWorld).toHaveBeenCalledTimes(8);
+    expect(Object.keys(exposures)).toEqual([
+      'nodeConfig',
+      'internalPages',
+      'electronAPI',
+      'bee',
+      'ipfs',
+      'radicle',
+      'githubBridge',
+      'serviceRegistry',
+    ]);
+    expect(ipcRenderer.sendSync).toHaveBeenCalledWith(IPC.GET_INTERNAL_PAGES);
+    expect(exposures.nodeConfig).toEqual({
+      beeApi: 'http://127.0.0.1:1700',
+      ipfsGateway: 'http://127.0.0.1:9090',
+    });
+    expect(exposures.internalPages).toBe(internalPages);
+
+    const invokeCases = [
+      [exposures.electronAPI, 'setBzzBase', [11, 'http://127.0.0.1:1633/bzz/hash/'], IPC.BZZ_SET_BASE, [{ webContentsId: 11, baseUrl: 'http://127.0.0.1:1633/bzz/hash/' }]],
+      [exposures.electronAPI, 'clearBzzBase', [11], IPC.BZZ_CLEAR_BASE, [{ webContentsId: 11 }]],
+      [exposures.electronAPI, 'setIpfsBase', [21, 'http://127.0.0.1:8080/ipfs/cid/'], IPC.IPFS_SET_BASE, [{ webContentsId: 21, baseUrl: 'http://127.0.0.1:8080/ipfs/cid/' }]],
+      [exposures.electronAPI, 'clearIpfsBase', [21], IPC.IPFS_CLEAR_BASE, [{ webContentsId: 21 }]],
+      [exposures.electronAPI, 'setRadBase', [31, 'http://127.0.0.1:8780/api/v1/repos/rid/'], IPC.RAD_SET_BASE, [{ webContentsId: 31, baseUrl: 'http://127.0.0.1:8780/api/v1/repos/rid/' }]],
+      [exposures.electronAPI, 'clearRadBase', [31], IPC.RAD_CLEAR_BASE, [{ webContentsId: 31 }]],
+      [exposures.electronAPI, 'getPlatform', [], IPC.WINDOW_GET_PLATFORM, []],
+      [exposures.electronAPI, 'getSettings', [], IPC.SETTINGS_GET, []],
+      [exposures.electronAPI, 'saveSettings', [{ theme: 'dark' }], IPC.SETTINGS_SAVE, [{ theme: 'dark' }]],
+      [exposures.electronAPI, 'getBookmarks', [], IPC.BOOKMARKS_GET, []],
+      [exposures.electronAPI, 'addBookmark', [{ label: 'Example', target: 'https://example.com' }], IPC.BOOKMARKS_ADD, [{ label: 'Example', target: 'https://example.com' }]],
+      [exposures.electronAPI, 'updateBookmark', ['https://old.example', { label: 'New', target: 'https://new.example' }], IPC.BOOKMARKS_UPDATE, [{ originalTarget: 'https://old.example', bookmark: { label: 'New', target: 'https://new.example' } }]],
+      [exposures.electronAPI, 'removeBookmark', ['https://example.com'], IPC.BOOKMARKS_REMOVE, ['https://example.com']],
+      [exposures.electronAPI, 'resolveEns', ['myname.box'], IPC.ENS_RESOLVE, [{ name: 'myname.box' }]],
+      [exposures.electronAPI, 'getHistory', [{ limit: 10 }], IPC.HISTORY_GET, [{ limit: 10 }]],
+      [exposures.electronAPI, 'addHistory', [{ url: 'https://example.com' }], IPC.HISTORY_ADD, [{ url: 'https://example.com' }]],
+      [exposures.electronAPI, 'removeHistory', [7], IPC.HISTORY_REMOVE, [7]],
+      [exposures.electronAPI, 'clearHistory', [], IPC.HISTORY_CLEAR, []],
+      [exposures.electronAPI, 'getWebviewPreloadPath', [], IPC.GET_WEBVIEW_PRELOAD_PATH, []],
+      [exposures.electronAPI, 'saveImage', ['https://example.com/image.png'], IPC.CONTEXT_MENU_SAVE_IMAGE, ['https://example.com/image.png']],
+      [exposures.electronAPI, 'copyText', ['hello'], 'clipboard:copy-text', ['hello']],
+      [exposures.electronAPI, 'copyImageFromUrl', ['https://example.com/image.png'], 'clipboard:copy-image', ['https://example.com/image.png']],
+      [exposures.electronAPI, 'getFavicon', ['https://example.com'], IPC.FAVICON_GET, ['https://example.com']],
+      [exposures.electronAPI, 'getCachedFavicon', ['https://example.com'], IPC.FAVICON_GET_CACHED, ['https://example.com']],
+      [exposures.electronAPI, 'fetchFavicon', ['https://example.com'], IPC.FAVICON_FETCH, ['https://example.com']],
+      [exposures.electronAPI, 'fetchFaviconWithKey', ['https://example.com/icon.png', 'icon-key'], IPC.FAVICON_FETCH_WITH_KEY, ['https://example.com/icon.png', 'icon-key']],
+      [exposures.bee, 'start', [], IPC.BEE_START, []],
+      [exposures.bee, 'stop', [], IPC.BEE_STOP, []],
+      [exposures.bee, 'getStatus', [], IPC.BEE_GET_STATUS, []],
+      [exposures.bee, 'checkBinary', [], IPC.BEE_CHECK_BINARY, []],
+      [exposures.ipfs, 'start', [], IPC.IPFS_START, []],
+      [exposures.ipfs, 'stop', [], IPC.IPFS_STOP, []],
+      [exposures.ipfs, 'getStatus', [], IPC.IPFS_GET_STATUS, []],
+      [exposures.ipfs, 'checkBinary', [], IPC.IPFS_CHECK_BINARY, []],
+      [exposures.radicle, 'start', [], IPC.RADICLE_START, []],
+      [exposures.radicle, 'stop', [], IPC.RADICLE_STOP, []],
+      [exposures.radicle, 'getStatus', [], IPC.RADICLE_GET_STATUS, []],
+      [exposures.radicle, 'checkBinary', [], IPC.RADICLE_CHECK_BINARY, []],
+      [exposures.radicle, 'getConnections', [], IPC.RADICLE_GET_CONNECTIONS, []],
+      [exposures.githubBridge, 'import', ['https://github.com/openai/project'], IPC.GITHUB_BRIDGE_IMPORT, ['https://github.com/openai/project']],
+      [exposures.githubBridge, 'checkGit', [], IPC.GITHUB_BRIDGE_CHECK_GIT, []],
+      [exposures.githubBridge, 'checkPrerequisites', [], IPC.GITHUB_BRIDGE_CHECK_PREREQUISITES, []],
+      [exposures.githubBridge, 'validateUrl', ['https://github.com/openai/project'], IPC.GITHUB_BRIDGE_VALIDATE_URL, ['https://github.com/openai/project']],
+      [exposures.githubBridge, 'checkExisting', ['https://github.com/openai/project'], IPC.GITHUB_BRIDGE_CHECK_EXISTING, ['https://github.com/openai/project']],
+      [exposures.serviceRegistry, 'getRegistry', [], IPC.SERVICE_REGISTRY_GET, []],
+    ];
+
+    for (const [target, method, args, channel, expectedArgs] of invokeCases) {
+      ipcRenderer.invoke.mockClear();
+      await target[method](...args);
+      expect(ipcRenderer.invoke).toHaveBeenCalledWith(channel, ...expectedArgs);
+    }
+
+    const sendCases = [
+      [exposures.electronAPI, 'setWindowTitle', ['Title'], IPC.WINDOW_SET_TITLE, ['Title']],
+      [exposures.electronAPI, 'closeWindow', [], IPC.WINDOW_CLOSE, []],
+      [exposures.electronAPI, 'minimizeWindow', [], IPC.WINDOW_MINIMIZE, []],
+      [exposures.electronAPI, 'maximizeWindow', [], IPC.WINDOW_MAXIMIZE, []],
+      [exposures.electronAPI, 'toggleFullscreen', [], IPC.WINDOW_TOGGLE_FULLSCREEN, []],
+      [exposures.electronAPI, 'newWindow', [], IPC.WINDOW_NEW, []],
+      [exposures.electronAPI, 'openUrlInNewWindow', ['https://example.com'], IPC.WINDOW_NEW_WITH_URL, ['https://example.com']],
+      [exposures.electronAPI, 'showAbout', [], IPC.APP_SHOW_ABOUT, []],
+      [exposures.electronAPI, 'updateTabMenuState', [{ canGoBack: true }], 'menu:update-tab-state', [{ canGoBack: true }]],
+      [exposures.electronAPI, 'setBookmarkBarToggleEnabled', [true], 'menu:set-bookmark-bar-toggle-enabled', [true]],
+      [exposures.electronAPI, 'setBookmarkBarChecked', [false], 'menu:set-bookmark-bar-checked', [false]],
+      [exposures.electronAPI, 'restartAndInstallUpdate', [], 'update:restart-and-install', []],
+      [exposures.electronAPI, 'checkForUpdates', [], 'update:check', []],
+    ];
+
+    for (const [target, method, args, channel, expectedArgs] of sendCases) {
+      ipcRenderer.send.mockClear();
+      target[method](...args);
+      expect(ipcRenderer.send).toHaveBeenCalledWith(channel, ...expectedArgs);
+    }
+  });
+
+  test('registers electronAPI, github bridge, and service registry listeners with cleanup', () => {
+    const { exposures, ipcRenderer } = loadPreloadModule();
+
+    const listenerCases = [
+      [exposures.electronAPI, 'onNewTab', 'tab:new', [], []],
+      [exposures.electronAPI, 'onCloseTab', 'tab:close', [], []],
+      [exposures.electronAPI, 'onNewTabWithUrl', 'tab:new-with-url', ['https://example.com', 'named-target'], ['https://example.com', 'named-target']],
+      [exposures.electronAPI, 'onNavigateToUrl', 'navigate-to-url', ['bzz://hash'], ['bzz://hash']],
+      [exposures.electronAPI, 'onLoadUrl', 'tab:load-url', ['https://load.example'], ['https://load.example']],
+      [exposures.electronAPI, 'onToggleDevTools', 'devtools:toggle', [], []],
+      [exposures.electronAPI, 'onCloseDevTools', 'devtools:close', [], []],
+      [exposures.electronAPI, 'onCloseAllDevTools', 'devtools:close-all', [], []],
+      [exposures.electronAPI, 'onFocusAddressBar', 'focus:address-bar', [], []],
+      [exposures.electronAPI, 'onCloseMenus', 'menus:close', [], []],
+      [exposures.electronAPI, 'onReload', 'page:reload', [], []],
+      [exposures.electronAPI, 'onHardReload', 'page:hard-reload', [], []],
+      [exposures.electronAPI, 'onNextTab', 'tab:next', [], []],
+      [exposures.electronAPI, 'onPrevTab', 'tab:prev', [], []],
+      [exposures.electronAPI, 'onMoveTabLeft', 'tab:move-left', [], []],
+      [exposures.electronAPI, 'onMoveTabRight', 'tab:move-right', [], []],
+      [exposures.electronAPI, 'onReopenClosedTab', 'tab:reopen-closed', [], []],
+      [exposures.electronAPI, 'onToggleBookmarkBar', IPC.BOOKMARKS_TOGGLE_BAR, [], []],
+      [exposures.electronAPI, 'onUpdateNotification', 'show-update-notification', [{ version: '1.2.3' }], [{ version: '1.2.3' }]],
+      [exposures.githubBridge, 'onProgress', IPC.GITHUB_BRIDGE_PROGRESS, [{ step: 'cloning' }], [{ step: 'cloning' }]],
+      [exposures.serviceRegistry, 'onUpdate', IPC.SERVICE_REGISTRY_UPDATE, [{ bee: { mode: 'bundled' } }], [{ bee: { mode: 'bundled' } }]],
+    ];
+
+    for (const [target, method, channel, emittedArgs, expectedArgs] of listenerCases) {
+      const callback = jest.fn();
+      const cleanup = target[method](callback);
+      const handler = ipcRenderer.listeners.get(channel)[0];
+
+      ipcRenderer.emit(channel, ...emittedArgs);
+      expect(callback).toHaveBeenCalledWith(...expectedArgs);
+
+      cleanup();
+      expect(ipcRenderer.removeListener).toHaveBeenLastCalledWith(channel, handler);
+    }
+  });
+
+  test('status update wrappers subscribe, fetch current state immediately, and clean up', async () => {
+    const beeStatus = { status: 'running', error: null };
+    const ipfsStatus = { status: 'stopped', error: null };
+    const radicleStatus = { status: 'error', error: 'offline' };
+    const { exposures, ipcRenderer } = loadPreloadModule({
+      invokeResponses: {
+        [IPC.BEE_GET_STATUS]: beeStatus,
+        [IPC.IPFS_GET_STATUS]: ipfsStatus,
+        [IPC.RADICLE_GET_STATUS]: radicleStatus,
+      },
+    });
+
+    const statusCases = [
+      [exposures.bee, IPC.BEE_STATUS_UPDATE, IPC.BEE_GET_STATUS, beeStatus, { status: 'starting', error: null }],
+      [exposures.ipfs, IPC.IPFS_STATUS_UPDATE, IPC.IPFS_GET_STATUS, ipfsStatus, { status: 'running', error: null }],
+      [exposures.radicle, IPC.RADICLE_STATUS_UPDATE, IPC.RADICLE_GET_STATUS, radicleStatus, { status: 'running', error: null }],
+    ];
+
+    for (const [target, updateChannel, getStatusChannel, initialStatus, pushedStatus] of statusCases) {
+      const callback = jest.fn();
+      ipcRenderer.invoke.mockClear();
+      ipcRenderer.removeListener.mockClear();
+
+      const cleanup = target.onStatusUpdate(callback);
+      const handler = ipcRenderer.listeners.get(updateChannel)[0];
+
+      expect(ipcRenderer.invoke).toHaveBeenCalledWith(getStatusChannel);
+      await flushMicrotasks();
+      expect(callback).toHaveBeenCalledWith(initialStatus);
+
+      ipcRenderer.emit(updateChannel, pushedStatus);
+      expect(callback).toHaveBeenLastCalledWith(pushedStatus);
+
+      cleanup();
+      expect(ipcRenderer.removeListener).toHaveBeenCalledWith(updateChannel, handler);
+    }
+  });
+
+  test('uses default gateway env values when overrides are absent', () => {
+    const { exposures } = loadPreloadModule({
+      beeApiEnv: null,
+      ipfsGatewayEnv: null,
+    });
+
+    expect(exposures.nodeConfig).toEqual({
+      beeApi: 'http://127.0.0.1:1633',
+      ipfsGateway: 'http://127.0.0.1:8080',
+    });
+  });
+});

--- a/src/main/radicle-manager.js
+++ b/src/main/radicle-manager.js
@@ -804,6 +804,10 @@ function stopRadicle() {
       if (radicleHttpdProcess) {
         // We spawned httpd against the system node — kill it
         radicleHttpdProcess.once('close', () => {
+          if (healthCheckInterval) {
+            clearInterval(healthCheckInterval);
+            healthCheckInterval = null;
+          }
           if (forceKillTimeout) {
             clearTimeout(forceKillTimeout);
             forceKillTimeout = null;
@@ -814,9 +818,6 @@ function stopRadicle() {
           activeRadHome = null;
           resolve();
         });
-        radicleHttpdProcess.kill('SIGTERM');
-
-        // Force kill if httpd doesn't exit within 5 seconds
         if (forceKillTimeout) clearTimeout(forceKillTimeout);
         forceKillTimeout = setTimeout(() => {
           if (radicleHttpdProcess) {
@@ -825,9 +826,14 @@ function stopRadicle() {
           }
           forceKillTimeout = null;
         }, 5000);
+        radicleHttpdProcess.kill('SIGTERM');
         return;
       }
       // No httpd process (fully external) — just clear state
+      if (healthCheckInterval) {
+        clearInterval(healthCheckInterval);
+        healthCheckInterval = null;
+      }
       updateState(STATUS.STOPPED);
       clearService('radicle');
       currentMode = MODE.NONE;
@@ -852,6 +858,10 @@ function stopRadicle() {
     const checkDone = () => {
       processesExited++;
       if (processesExited >= totalProcesses) {
+        if (healthCheckInterval) {
+          clearInterval(healthCheckInterval);
+          healthCheckInterval = null;
+        }
         if (forceKillTimeout) {
           clearTimeout(forceKillTimeout);
           forceKillTimeout = null;
@@ -860,6 +870,19 @@ function stopRadicle() {
         resolve();
       }
     };
+
+    if (forceKillTimeout) clearTimeout(forceKillTimeout);
+    forceKillTimeout = setTimeout(() => {
+      if (radicleHttpdProcess) {
+        log.warn('[Radicle] Force killing httpd...');
+        radicleHttpdProcess.kill('SIGKILL');
+      }
+      if (radicleNodeProcess) {
+        log.warn('[Radicle] Force killing node...');
+        radicleNodeProcess.kill('SIGKILL');
+      }
+      forceKillTimeout = null;
+    }, 10000);
 
     // Stop httpd first
     if (radicleHttpdProcess) {
@@ -878,20 +901,6 @@ function stopRadicle() {
         }
       }, 500);
     }
-
-    // Force kill if processes don't exit within 10 seconds
-    if (forceKillTimeout) clearTimeout(forceKillTimeout);
-    forceKillTimeout = setTimeout(() => {
-      if (radicleHttpdProcess) {
-        log.warn('[Radicle] Force killing httpd...');
-        radicleHttpdProcess.kill('SIGKILL');
-      }
-      if (radicleNodeProcess) {
-        log.warn('[Radicle] Force killing node...');
-        radicleNodeProcess.kill('SIGKILL');
-      }
-      forceKillTimeout = null;
-    }, 10000);
   });
 }
 

--- a/src/main/radicle-manager.js
+++ b/src/main/radicle-manager.js
@@ -804,6 +804,10 @@ function stopRadicle() {
       if (radicleHttpdProcess) {
         // We spawned httpd against the system node — kill it
         radicleHttpdProcess.once('close', () => {
+          if (forceKillTimeout) {
+            clearTimeout(forceKillTimeout);
+            forceKillTimeout = null;
+          }
           updateState(STATUS.STOPPED);
           clearService('radicle');
           currentMode = MODE.NONE;
@@ -813,11 +817,13 @@ function stopRadicle() {
         radicleHttpdProcess.kill('SIGTERM');
 
         // Force kill if httpd doesn't exit within 5 seconds
-        setTimeout(() => {
+        if (forceKillTimeout) clearTimeout(forceKillTimeout);
+        forceKillTimeout = setTimeout(() => {
           if (radicleHttpdProcess) {
             log.warn('[Radicle] Force killing reused-mode httpd...');
             radicleHttpdProcess.kill('SIGKILL');
           }
+          forceKillTimeout = null;
         }, 5000);
         return;
       }

--- a/src/main/radicle-manager.test.js
+++ b/src/main/radicle-manager.test.js
@@ -1,180 +1,672 @@
-const mockUpdateService = jest.fn();
-const mockSetStatusMessage = jest.fn();
-const mockSetErrorState = jest.fn();
-const mockClearErrorState = jest.fn();
-const mockClearService = jest.fn();
+const path = require('path');
+const IPC = require('../shared/ipc-channels');
+const { failure, success } = require('./ipc-contract');
+const {
+  createAppMock,
+  createIpcMainMock,
+  loadMainModule,
+} = require('../../test/helpers/main-process-test-utils');
 
-jest.mock('./logger', () => ({
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-}));
+const PROJECT_ROOT = path.join(__dirname, '..', '..');
+const DEV_RADICLE_DATA_DIR = path.join(PROJECT_ROOT, 'radicle-data');
+const DEFAULT_HOME_DIR = '/home/test';
 
-jest.mock('electron', () => ({
-  app: {
-    isPackaged: false,
-    getPath: jest.fn(() => '/tmp/freedom-user-data'),
-  },
-  ipcMain: { handle: jest.fn() },
-  BrowserWindow: {
-    getAllWindows: jest.fn(() => []),
-  },
-}));
+function flushMicrotasks() {
+  return Promise.resolve().then(() => Promise.resolve());
+}
 
-jest.mock('./service-registry', () => ({
-  MODE: {
-    BUNDLED: 'bundled',
-    REUSED: 'reused',
-    EXTERNAL: 'external',
-    NONE: 'none',
-  },
-  DEFAULTS: {
-    radicle: {
-      httpPort: 8780,
-      p2pPort: 8776,
-      fallbackRange: 10,
-    },
-  },
-  updateService: mockUpdateService,
-  setStatusMessage: mockSetStatusMessage,
-  setErrorState: mockSetErrorState,
-  clearErrorState: mockClearErrorState,
-  clearService: mockClearService,
-}));
+function createProcessMock(binary, options = {}) {
+  const handlers = new Map();
+  const onceHandlers = new Map();
+  const stdoutHandlers = new Map();
+  const stderrHandlers = new Map();
 
-const mockExistsSync = jest.fn((filePath) => {
-  if (filePath.includes('/.radicle/node/control.sock')) return false; // no system node
-  if (filePath.endsWith('/node/control.sock')) return true; // bundled node socket appears
-  if (filePath.includes('radicle-bin')) return true; // binaries exist
-  if (filePath.endsWith('/config.json')) return false;
-  return true;
-});
+  const emitHandlers = (store, event, args) => {
+    for (const handler of store.get(event) || []) {
+      handler(...args);
+    }
+  };
 
-jest.mock('fs', () => ({
-  existsSync: (filePath) => mockExistsSync(filePath),
-  mkdirSync: jest.fn(),
-  unlinkSync: jest.fn(),
-  readdirSync: jest.fn(() => ['key']),
-  readFileSync: jest.fn(() => '{}'),
-  writeFileSync: jest.fn(),
-}));
-
-const mockSpawnedProcesses = [];
-const mockSpawn = jest.fn((name) => {
-  const handlers = {};
-  const onceHandlers = {};
   const proc = {
-    bin: name,
+    binary,
     kills: [],
     stdout: {
-      on: jest.fn(),
+      on: jest.fn((event, handler) => {
+        if (!stdoutHandlers.has(event)) {
+          stdoutHandlers.set(event, []);
+        }
+        stdoutHandlers.get(event).push(handler);
+      }),
     },
     stderr: {
-      on: jest.fn(),
+      on: jest.fn((event, handler) => {
+        if (!stderrHandlers.has(event)) {
+          stderrHandlers.set(event, []);
+        }
+        stderrHandlers.get(event).push(handler);
+      }),
     },
     on: jest.fn((event, handler) => {
-      handlers[event] = handler;
+      if (!handlers.has(event)) {
+        handlers.set(event, []);
+      }
+      handlers.get(event).push(handler);
     }),
     once: jest.fn((event, handler) => {
-      onceHandlers[event] = handler;
+      if (!onceHandlers.has(event)) {
+        onceHandlers.set(event, []);
+      }
+      onceHandlers.get(event).push(handler);
     }),
+    emit(event, ...args) {
+      emitHandlers(handlers, event, args);
+      const oneTimeHandlers = onceHandlers.get(event) || [];
+      onceHandlers.delete(event);
+      oneTimeHandlers.forEach((handler) => handler(...args));
+    },
+    emitStdout(data) {
+      emitHandlers(stdoutHandlers, 'data', [data]);
+    },
+    emitStderr(data) {
+      emitHandlers(stderrHandlers, 'data', [data]);
+    },
     kill: jest.fn((signal) => {
       proc.kills.push(signal);
-      setTimeout(() => {
-        if (onceHandlers.close) onceHandlers.close(0);
-        if (handlers.close) handlers.close(0);
-      }, 0);
+      if (options.autoCloseOnKill !== false) {
+        proc.emit('close', options.closeCode ?? 0);
+      }
       return true;
     }),
   };
-  mockSpawnedProcesses.push(proc);
+
   return proc;
-});
+}
 
-jest.mock('child_process', () => ({
-  spawn: (...args) => mockSpawn(...args),
-  execFileSync: jest.fn(),
-  execFile: jest.fn((_file, _args, _opts, cb) => cb(null, '', '')),
-}));
+function createSocketClass(portResolver) {
+  const queue = Array.isArray(portResolver) ? [...portResolver] : null;
 
-jest.mock('net', () => ({
-  Socket: class MockSocket {
+  return class MockSocket {
     constructor() {
       this.handlers = {};
     }
+
     setTimeout() {}
+
     on(event, handler) {
       this.handlers[event] = handler;
     }
+
     destroy() {}
-    connect() {
-      setTimeout(() => {
-        if (this.handlers.error) this.handlers.error(new Error('closed'));
-      }, 0);
+
+    connect(port, host) {
+      const result = typeof portResolver === 'function'
+        ? portResolver(port, host)
+        : queue && queue.length > 0
+          ? queue.shift()
+          : false;
+
+      process.nextTick(() => {
+        if (result === true) {
+          this.handlers.connect?.();
+          return;
+        }
+
+        if (result === 'timeout') {
+          this.handlers.timeout?.();
+          return;
+        }
+
+        this.handlers.error?.(new Error('closed'));
+      });
     }
-  },
-}));
+  };
+}
 
-jest.mock('http', () => ({
-  get: jest.fn((_url, _opts, callback) => {
-    const res = {
-      statusCode: 200,
-      resume: jest.fn(),
-      on: jest.fn((event, handler) => {
-        if (event === 'data') {
-          setTimeout(() => handler('{}'), 0);
-        }
-        if (event === 'end') {
-          setTimeout(() => handler(), 0);
-        }
+function createHttpGetMock(responseResolver) {
+  const resolveResponse = responseResolver || (() => ({ statusCode: 200, body: '{}' }));
+
+  return jest.fn((url, options, callback) => {
+    let handler = callback;
+    if (typeof options === 'function') {
+      handler = options;
+    }
+
+    const requestHandlers = new Map();
+    const request = {
+      on: jest.fn((event, fn) => {
+        requestHandlers.set(event, fn);
+        return request;
       }),
-    };
-
-    setTimeout(() => callback(res), 0);
-
-    return {
-      on: jest.fn(),
       end: jest.fn(),
       destroy: jest.fn(),
     };
-  }),
-}));
 
-jest.mock('os', () => ({
-  homedir: jest.fn(() => '/home/test'),
-}));
+    process.nextTick(() => {
+      const responseConfig = resolveResponse(url);
 
-const { startRadicle, stopRadicle } = require('./radicle-manager');
+      if (responseConfig?.error) {
+        requestHandlers.get('error')?.(responseConfig.error);
+        return;
+      }
 
-describe('radicle-manager lifecycle integration', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockSpawnedProcesses.length = 0;
-  });
+      if (responseConfig?.timeout) {
+        requestHandlers.get('timeout')?.();
+        return;
+      }
 
-  afterEach(async () => {
-    await stopRadicle();
-  });
+      const responseHandlers = new Map();
+      const response = {
+        statusCode: responseConfig?.statusCode ?? 200,
+        resume: jest.fn(),
+        on: jest.fn((event, fn) => {
+          if (!responseHandlers.has(event)) {
+            responseHandlers.set(event, []);
+          }
+          responseHandlers.get(event).push(fn);
+        }),
+      };
 
-  test('starts bundled node/httpd and shuts them down cleanly', async () => {
-    await startRadicle();
-    await new Promise((resolve) => setTimeout(resolve, 1200));
+      handler(response);
 
-    expect(mockSpawn).toHaveBeenCalledTimes(2);
-    expect(mockSpawnedProcesses[0].bin).toContain('radicle-node');
-    expect(mockSpawnedProcesses[1].bin).toContain('radicle-httpd');
-    expect(mockUpdateService).toHaveBeenCalledWith('radicle', {
-      api: 'http://127.0.0.1:8780',
-      gateway: 'http://127.0.0.1:8780',
-      mode: 'bundled',
+      process.nextTick(() => {
+        const chunks = (() => {
+          if (responseConfig?.body === undefined || responseConfig?.body === null) {
+            return [];
+          }
+          if (typeof responseConfig.body === 'string') {
+            return [responseConfig.body];
+          }
+          return [JSON.stringify(responseConfig.body)];
+        })();
+
+        for (const chunk of chunks) {
+          for (const fn of responseHandlers.get('data') || []) {
+            fn(chunk);
+          }
+        }
+        for (const fn of responseHandlers.get('end') || []) {
+          fn();
+        }
+      });
     });
 
-    const stopPromise = stopRadicle();
+    return request;
+  });
+}
+
+function createWindowMock() {
+  return {
+    webContents: {
+      send: jest.fn(),
+    },
+  };
+}
+
+function loadRadicleManagerModule(options = {}) {
+  const ipcMain = options.ipcMain || createIpcMainMock();
+  const app = options.app || createAppMock({
+    isPackaged: options.isPackaged ?? false,
+    userDataDir: options.userDataDir || '/tmp/freedom-user-data',
+  });
+  const windows = options.windows || [];
+  const BrowserWindow = {
+    getAllWindows: jest.fn(() => windows),
+  };
+  const log = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  const updateService = jest.fn();
+  const setStatusMessage = jest.fn();
+  const setErrorState = jest.fn();
+  const clearErrorState = jest.fn();
+  const clearService = jest.fn();
+  const execFileSync = options.execFileSync || jest.fn();
+  const execFileAsync = options.execFileAsync || jest.fn().mockResolvedValue({ stdout: '', stderr: '' });
+  const spawnedProcesses = [];
+  const spawn = jest.fn((binary, args = [], spawnOptions = {}) => {
+    const proc = (options.createProcess || createProcessMock)(binary, options.processOptions || {});
+    proc.args = args;
+    proc.spawnOptions = spawnOptions;
+    spawnedProcesses.push(proc);
+    return proc;
+  });
+  const fsMock = {
+    existsSync: jest.fn((target) => {
+      if (typeof options.existsSync === 'function') {
+        return options.existsSync(target);
+      }
+
+      const systemSocketPath = path.join(options.homeDir || DEFAULT_HOME_DIR, '.radicle', 'node', 'control.sock');
+      if (target === systemSocketPath) {
+        return options.systemSocketExists === true;
+      }
+
+      if (target.endsWith(`${path.sep}node${path.sep}control.sock`)) {
+        return options.socketExists !== false;
+      }
+
+      if (target.endsWith(`${path.sep}config.json`)) {
+        return options.configExists === true;
+      }
+
+      if (target.endsWith(`${path.sep}keys`)) {
+        return options.keysDirExists !== false;
+      }
+
+      if (
+        target.endsWith(`${path.sep}rad`) || target.endsWith(`${path.sep}rad.exe`)
+      ) {
+        return options.radBinaryExists !== false;
+      }
+
+      if (
+        target.endsWith(`${path.sep}radicle-node`) || target.endsWith(`${path.sep}radicle-node.exe`)
+      ) {
+        return options.nodeBinaryExists !== false;
+      }
+
+      if (
+        target.endsWith(`${path.sep}radicle-httpd`) || target.endsWith(`${path.sep}radicle-httpd.exe`)
+      ) {
+        return options.httpdBinaryExists !== false;
+      }
+
+      if (target === DEV_RADICLE_DATA_DIR) {
+        return options.radicleDataDirExists === true;
+      }
+
+      return false;
+    }),
+    mkdirSync: jest.fn(),
+    unlinkSync: jest.fn(),
+    readdirSync: jest.fn(() => options.keyFiles || ['key']),
+    readFileSync: jest.fn(() => options.configContents || '{}'),
+    writeFileSync: jest.fn(),
+  };
+  const loadSettings = jest.fn(() => options.settings || { enableRadicleIntegration: true });
+  const httpGet = createHttpGetMock(options.httpResponse);
+  const Socket = createSocketClass(options.portSequence || options.portResolver || false);
+
+  const { mod } = loadMainModule(require.resolve('./radicle-manager'), {
+    app,
+    ipcMain,
+    BrowserWindow,
+    extraMocks: {
+      child_process: () => ({
+        spawn,
+        execFileSync,
+        execFile: jest.fn(),
+      }),
+      fs: () => fsMock,
+      http: () => ({
+        get: httpGet,
+      }),
+      net: () => ({
+        Socket,
+      }),
+      os: () => ({
+        ...jest.requireActual('os'),
+        homedir: jest.fn(() => options.homeDir || DEFAULT_HOME_DIR),
+      }),
+      util: () => ({
+        ...jest.requireActual('util'),
+        promisify: jest.fn(() => execFileAsync),
+      }),
+      [require.resolve('./logger')]: () => log,
+      [require.resolve('./service-registry')]: () => ({
+        MODE: {
+          BUNDLED: 'bundled',
+          REUSED: 'reused',
+          EXTERNAL: 'external',
+          NONE: 'none',
+        },
+        DEFAULTS: {
+          radicle: {
+            httpPort: 8780,
+            p2pPort: 8776,
+            fallbackRange: 10,
+          },
+        },
+        updateService,
+        setStatusMessage,
+        setErrorState,
+        clearErrorState,
+        clearService,
+      }),
+      [require.resolve('./settings-store')]: () => ({
+        loadSettings,
+      }),
+    },
+  });
+
+  return {
+    app,
+    BrowserWindow,
+    clearErrorState,
+    clearService,
+    execFileAsync,
+    execFileSync,
+    fsMock,
+    httpGet,
+    ipcMain,
+    loadSettings,
+    log,
+    mod,
+    setErrorState,
+    setStatusMessage,
+    spawn,
+    spawnedProcesses,
+    updateService,
+    windows,
+  };
+}
+
+describe('radicle-manager', () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('returns the dev binary path and creates the dev data directory on demand', () => {
+    const ctx = loadRadicleManagerModule({
+      radicleDataDirExists: false,
+    });
+    const platformMap = {
+      darwin: 'mac',
+      linux: 'linux',
+      win32: 'win',
+    };
+    const platform = platformMap[process.platform] || process.platform;
+    const binaryName = process.platform === 'win32' ? 'radicle-node.exe' : 'radicle-node';
+
+    expect(ctx.mod.getRadicleBinaryPath('radicle-node')).toBe(
+      path.join(PROJECT_ROOT, 'radicle-bin', `${platform}-${process.arch}`, binaryName)
+    );
+    expect(ctx.mod.getRadicleDataPath()).toBe(DEV_RADICLE_DATA_DIR);
+    expect(ctx.fsMock.mkdirSync).toHaveBeenCalledWith(DEV_RADICLE_DATA_DIR, { recursive: true });
+    expect(ctx.mod.getActiveRadHome()).toBe(DEV_RADICLE_DATA_DIR);
+  });
+
+  test('registers IPC handlers, blocks disabled integration, and validates missing RIDs', async () => {
+    const ctx = loadRadicleManagerModule({
+      settings: { enableRadicleIntegration: false },
+    });
+
+    ctx.mod.registerRadicleIpc();
+
+    expect([...ctx.ipcMain.handlers.keys()].sort()).toEqual([
+      IPC.RADICLE_START,
+      IPC.RADICLE_STOP,
+      IPC.RADICLE_GET_STATUS,
+      IPC.RADICLE_CHECK_BINARY,
+      IPC.RADICLE_SEED,
+      IPC.RADICLE_GET_CONNECTIONS,
+      IPC.RADICLE_GET_REPO_PAYLOAD,
+      IPC.RADICLE_SYNC_REPO,
+    ].sort());
+
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_START)).resolves.toEqual({
+      status: 'stopped',
+      error: 'Radicle integration is disabled. Enable it in Settings > Experimental',
+    });
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_GET_STATUS)).resolves.toEqual({
+      status: 'stopped',
+      error: 'Radicle integration is disabled. Enable it in Settings > Experimental',
+    });
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_SEED, 'z3QXuMvMmSeEX3ZgoUidZC1v5MkKE')).resolves.toEqual(
+      failure(
+        'RADICLE_DISABLED',
+        'Radicle integration is disabled. Enable it in Settings > Experimental'
+      )
+    );
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_GET_CONNECTIONS)).resolves.toEqual(
+      failure(
+        'RADICLE_DISABLED',
+        'Radicle integration is disabled. Enable it in Settings > Experimental',
+        undefined,
+        { count: 0 }
+      )
+    );
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_GET_REPO_PAYLOAD, '')).resolves.toEqual(
+      failure(
+        'RADICLE_DISABLED',
+        'Radicle integration is disabled. Enable it in Settings > Experimental'
+      )
+    );
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_SYNC_REPO, '')).resolves.toEqual(
+      failure(
+        'RADICLE_DISABLED',
+        'Radicle integration is disabled. Enable it in Settings > Experimental'
+      )
+    );
+  });
+
+  test('reports binary availability and validates missing repository IDs when enabled', async () => {
+    const ctx = loadRadicleManagerModule({
+      nodeBinaryExists: false,
+    });
+
+    ctx.mod.registerRadicleIpc();
+
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_CHECK_BINARY)).resolves.toEqual({ available: false });
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_SEED, '')).resolves.toEqual(
+      failure('INVALID_RID', 'Missing Radicle Repository ID', { field: 'rid' })
+    );
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_GET_REPO_PAYLOAD, '')).resolves.toEqual(
+      failure('INVALID_RID', 'Missing Radicle Repository ID', { field: 'rid' })
+    );
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_SYNC_REPO, '')).resolves.toEqual(
+      failure('INVALID_RID', 'Missing Radicle Repository ID', { field: 'rid' })
+    );
+  });
+
+  test('reuses an existing local httpd and serves seed, payload, sync, and connection IPC requests', async () => {
+    jest.spyOn(global, 'setInterval').mockReturnValue(1);
+    jest.spyOn(global, 'clearInterval').mockImplementation(() => {});
+
+    const window = createWindowMock();
+    const execFileAsync = jest.fn((binary, args) => {
+      if (args[0] === 'seed') {
+        return Promise.resolve({ stdout: '', stderr: '' });
+      }
+      if (args[0] === 'inspect') {
+        return Promise.resolve({ stdout: JSON.stringify({ name: 'project' }), stderr: '' });
+      }
+      if (args[0] === 'sync') {
+        return Promise.resolve({ stdout: 'synced\n', stderr: '' });
+      }
+      if (args[0] === 'node' && args[1] === 'status') {
+        return Promise.resolve({
+          stdout: [
+            'Node is running',
+            '│ z6MkgNR111   iris.radicle.xyz:8776   ✓   ↗   1.75 minute(s) │',
+            '│ z6MkgNR222   rosa.radicle.xyz:8776   ✓   ↗   2.10 minute(s) │',
+            '│ z6MkgNR333   local.radicle.xyz:8776   ✗   ↗   0.10 minute(s) │',
+          ].join('\n'),
+          stderr: '',
+        });
+      }
+      throw new Error(`Unexpected execFileAsync call: ${binary} ${args.join(' ')}`);
+    });
+    const ctx = loadRadicleManagerModule({
+      execFileAsync,
+      windows: [window],
+      portSequence: [true],
+      httpResponse: (url) => {
+        if (url === 'http://127.0.0.1:8780/') {
+          return { statusCode: 200, body: { version: '0.1.0' } };
+        }
+        return { statusCode: 404, body: '' };
+      },
+    });
+
+    ctx.mod.registerRadicleIpc();
+
+    await ctx.mod.startRadicle();
+    await flushMicrotasks();
+
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_GET_STATUS)).resolves.toEqual({
+      status: 'running',
+      error: null,
+    });
+    expect(ctx.spawn).not.toHaveBeenCalled();
+    expect(ctx.updateService).toHaveBeenCalledWith('radicle', {
+      api: 'http://127.0.0.1:8780',
+      gateway: 'http://127.0.0.1:8780',
+      mode: 'reused',
+    });
+    expect(window.webContents.send).toHaveBeenCalledWith(IPC.RADICLE_STATUS_UPDATE, {
+      status: 'starting',
+      error: null,
+    });
+    expect(window.webContents.send).toHaveBeenLastCalledWith(IPC.RADICLE_STATUS_UPDATE, {
+      status: 'running',
+      error: null,
+    });
+
+    await expect(
+      ctx.ipcMain.invoke(IPC.RADICLE_SEED, 'z3QXuMvMmSeEX3ZgoUidZC1v5MkKE')
+    ).resolves.toEqual(success());
+    await expect(
+      ctx.ipcMain.invoke(IPC.RADICLE_GET_REPO_PAYLOAD, 'rad://z3QXuMvMmSeEX3ZgoUidZC1v5MkKE')
+    ).resolves.toEqual(success({ payload: { name: 'project' } }));
+    await expect(
+      ctx.ipcMain.invoke(IPC.RADICLE_SYNC_REPO, 'rad:z3QXuMvMmSeEX3ZgoUidZC1v5MkKE')
+    ).resolves.toEqual(success({ output: 'synced\n' }));
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_GET_CONNECTIONS)).resolves.toEqual(
+      success({ count: 2 })
+    );
+
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_SEED, 'not-a-rid')).resolves.toEqual(
+      failure('INVALID_RID', 'Invalid Radicle Repository ID', { rid: 'not-a-rid' })
+    );
+
+    await ctx.mod.stopRadicle();
+  });
+
+  test('starts a bundled node on a fallback port after a conflict and stops both processes cleanly', async () => {
+    const execFileAsync = jest.fn().mockResolvedValue({ stdout: '', stderr: '' });
+    const ctx = loadRadicleManagerModule({
+      execFileAsync,
+      configExists: false,
+      keyFiles: [],
+      portSequence: [true, false],
+      httpResponse: (url) => {
+        if (url === 'http://127.0.0.1:8780/') {
+          return { statusCode: 503, body: '' };
+        }
+        if (url === 'http://127.0.0.1:8781/') {
+          return { statusCode: 200, body: {} };
+        }
+        return { statusCode: 404, body: '' };
+      },
+    });
+
+    await ctx.mod.startRadicle();
+    await flushMicrotasks();
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await flushMicrotasks();
+
+    expect(ctx.execFileSync).toHaveBeenCalledWith(
+      expect.stringContaining(`${path.sep}rad`),
+      ['auth', '--alias', 'FreedomBrowser'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          RAD_HOME: DEV_RADICLE_DATA_DIR,
+          RAD_PASSPHRASE: '',
+        }),
+        stdio: 'pipe',
+      })
+    );
+    expect(ctx.fsMock.writeFileSync).toHaveBeenCalledWith(
+      path.join(DEV_RADICLE_DATA_DIR, 'config.json'),
+      JSON.stringify({
+        preferredSeeds: [
+          'z6MkrLMMsiPWUcNPHcRajuMi9mDfYckSoJyPwwnknocNYPm7@iris.radicle.xyz:8776',
+          'z6Mkmqogy2qEM2ummccUthFEaaHvyYmYBYh3dbe9W4ebScxo@rosa.radicle.xyz:8776',
+        ],
+        node: {
+          alias: 'FreedomBrowser',
+        },
+      }, null, 2)
+    );
+    expect(ctx.spawnedProcesses).toHaveLength(2);
+    expect(ctx.spawnedProcesses[0].binary).toContain('radicle-node');
+    expect(ctx.spawnedProcesses[1].binary).toContain('radicle-httpd');
+    expect(ctx.spawnedProcesses[1].args).toEqual(['--listen', '127.0.0.1:8781']);
+    expect(ctx.updateService).toHaveBeenCalledWith('radicle', {
+      api: 'http://127.0.0.1:8781',
+      gateway: 'http://127.0.0.1:8781',
+      mode: 'bundled',
+    });
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('radicle', 'Fallback Port: 8781');
+    expect(ctx.mod.getActivePort()).toBe(8781);
+
+    const stopPromise = ctx.mod.stopRadicle();
     await new Promise((resolve) => setTimeout(resolve, 600));
+    await flushMicrotasks();
     await stopPromise;
 
-    expect(mockSpawnedProcesses[1].kills).toContain('SIGTERM');
-    expect(mockSpawnedProcesses[0].kills).toContain('SIGTERM');
-    expect(mockClearService).toHaveBeenCalledWith('radicle');
+    expect(ctx.spawnedProcesses[1].kills).toContain('SIGTERM');
+    expect(ctx.spawnedProcesses[0].kills).toContain('SIGTERM');
+    expect(ctx.clearService).toHaveBeenCalledWith('radicle');
+  });
+
+  test('starts httpd against a detected system node and stops only that spawned process', async () => {
+    const ctx = loadRadicleManagerModule({
+      systemSocketExists: true,
+      portSequence: [true, false],
+      httpResponse: (url) => {
+        if (url === 'http://127.0.0.1:8780/') {
+          return { statusCode: 503, body: '' };
+        }
+        if (url === 'http://127.0.0.1:8781/') {
+          return { statusCode: 200, body: {} };
+        }
+        return { statusCode: 404, body: '' };
+      },
+    });
+
+    await ctx.mod.startRadicle();
+    await flushMicrotasks();
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await flushMicrotasks();
+
+    expect(ctx.spawnedProcesses).toHaveLength(1);
+    expect(ctx.spawnedProcesses[0].binary).toContain('radicle-httpd');
+    expect(ctx.spawnedProcesses[0].args).toEqual(['--listen', '127.0.0.1:8781']);
+    expect(ctx.updateService).toHaveBeenCalledWith('radicle', {
+      api: 'http://127.0.0.1:8781',
+      gateway: 'http://127.0.0.1:8781',
+      mode: 'reused',
+    });
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('radicle', 'System node: localhost:8781');
+    expect(ctx.mod.getActiveRadHome()).toBe(path.join(DEFAULT_HOME_DIR, '.radicle'));
+
+    const stopPromise = ctx.mod.stopRadicle();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await stopPromise;
+
+    expect(ctx.spawnedProcesses[0].kills).toContain('SIGTERM');
+    expect(ctx.clearService).toHaveBeenCalledWith('radicle');
+  });
+
+  test('fails startup when identity creation cannot complete', async () => {
+    const ctx = loadRadicleManagerModule({
+      keyFiles: [],
+      radBinaryExists: false,
+      portSequence: [false],
+      httpResponse: () => ({ statusCode: 404, body: '' }),
+    });
+
+    await ctx.mod.startRadicle();
+    await flushMicrotasks();
+
+    expect(ctx.spawn).not.toHaveBeenCalled();
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('radicle', 'Node failed to start');
+    expect(ctx.log.error).toHaveBeenCalledWith('[Radicle] rad binary not found for identity creation');
   });
 });

--- a/src/main/service-registry.test.js
+++ b/src/main/service-registry.test.js
@@ -1,0 +1,135 @@
+const IPC = require('../shared/ipc-channels');
+const {
+  createIpcMainMock,
+  loadMainModule,
+} = require('../../test/helpers/main-process-test-utils');
+
+function loadServiceRegistry(options = {}) {
+  return loadMainModule(require.resolve('./service-registry'), options);
+}
+
+describe('service-registry', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('returns default service URLs when registry is empty', () => {
+    const { mod } = loadServiceRegistry();
+
+    expect(mod.getIpfsApiUrl()).toBe('http://127.0.0.1:5001');
+    expect(mod.getIpfsGatewayUrl()).toBe('http://127.0.0.1:8080');
+    expect(mod.getBeeApiUrl()).toBe('http://127.0.0.1:1633');
+    expect(mod.getBeeGatewayUrl()).toBe('http://127.0.0.1:1633');
+    expect(mod.getRadicleApiUrl()).toBe('http://127.0.0.1:8780');
+  });
+
+  test('updates a service and broadcasts the new registry state', () => {
+    const firstWindow = { webContents: { send: jest.fn() } };
+    const closingWindow = {
+      webContents: {
+        send: jest.fn(() => {
+          throw new Error('window closing');
+        }),
+      },
+    };
+    const { mod } = loadServiceRegistry({ windows: [firstWindow, closingWindow] });
+
+    mod.updateService('ipfs', {
+      api: 'http://127.0.0.1:5999',
+      gateway: 'http://127.0.0.1:8999',
+      mode: mod.MODE.EXTERNAL,
+    });
+
+    expect(mod.getService('ipfs')).toEqual(
+      expect.objectContaining({
+        api: 'http://127.0.0.1:5999',
+        gateway: 'http://127.0.0.1:8999',
+        mode: mod.MODE.EXTERNAL,
+      })
+    );
+    expect(firstWindow.webContents.send).toHaveBeenCalledWith(
+      IPC.SERVICE_REGISTRY_UPDATE,
+      expect.objectContaining({
+        ipfs: expect.objectContaining({
+          api: 'http://127.0.0.1:5999',
+          gateway: 'http://127.0.0.1:8999',
+          mode: mod.MODE.EXTERNAL,
+        }),
+      })
+    );
+    expect(closingWindow.webContents.send).toHaveBeenCalled();
+  });
+
+  test('temporary messages override status and auto-clear back to the permanent message', () => {
+    const { mod } = loadServiceRegistry();
+
+    mod.setStatusMessage('bee', 'Bee ready');
+    mod.setTempStatusMessage('bee', 'Reconnecting', 50);
+
+    expect(mod.getDisplayMessage('bee')).toBe('Reconnecting');
+
+    jest.advanceTimersByTime(50);
+
+    expect(mod.getDisplayMessage('bee')).toBe('Bee ready');
+  });
+
+  test('error state can be cleared back to the permanent status message', () => {
+    const { mod } = loadServiceRegistry();
+
+    mod.setStatusMessage('radicle', 'Running');
+    mod.setErrorState('radicle', 'Connection failed');
+    expect(mod.getDisplayMessage('radicle')).toBe('Connection failed');
+
+    mod.clearErrorState('radicle');
+    expect(mod.getDisplayMessage('radicle')).toBe('Running');
+  });
+
+  test('clearService resets service state back to defaults', () => {
+    const { mod } = loadServiceRegistry();
+
+    mod.updateService('bee', {
+      api: 'http://127.0.0.1:1999',
+      gateway: 'http://127.0.0.1:1999',
+      mode: mod.MODE.BUNDLED,
+    });
+    mod.setStatusMessage('bee', 'Online');
+
+    mod.clearService('bee');
+
+    expect(mod.getService('bee')).toEqual({
+      api: null,
+      gateway: null,
+      mode: mod.MODE.NONE,
+      statusMessage: null,
+      tempMessage: null,
+      tempMessageTimeout: null,
+    });
+  });
+
+  test('registers an IPC handler that returns the current registry state', async () => {
+    const ipcMain = createIpcMainMock();
+    const { mod } = loadServiceRegistry({ ipcMain });
+
+    mod.updateService('radicle', {
+      api: 'http://127.0.0.1:8781',
+      gateway: 'http://127.0.0.1:8781',
+      mode: mod.MODE.REUSED,
+    });
+    mod.registerServiceRegistryIpc();
+
+    await expect(ipcMain.invoke(IPC.SERVICE_REGISTRY_GET)).resolves.toEqual(
+      expect.objectContaining({
+        radicle: expect.objectContaining({
+          api: 'http://127.0.0.1:8781',
+          gateway: 'http://127.0.0.1:8781',
+          mode: mod.MODE.REUSED,
+        }),
+      })
+    );
+  });
+});

--- a/src/main/settings-store.test.js
+++ b/src/main/settings-store.test.js
@@ -1,0 +1,107 @@
+const fs = require('fs');
+const path = require('path');
+const IPC = require('../shared/ipc-channels');
+const {
+  createIpcMainMock,
+  createTempUserDataDir,
+  loadMainModule,
+  removeTempUserDataDir,
+} = require('../../test/helpers/main-process-test-utils');
+
+function loadSettingsStore(options = {}) {
+  return loadMainModule(require.resolve('./settings-store'), options);
+}
+
+describe('settings-store', () => {
+  let userDataDir;
+
+  beforeEach(() => {
+    userDataDir = createTempUserDataDir();
+  });
+
+  afterEach(() => {
+    removeTempUserDataDir(userDataDir);
+  });
+
+  test('loads defaults and applies the system theme when no file exists', () => {
+    const { mod, nativeTheme } = loadSettingsStore({ userDataDir });
+
+    expect(mod.loadSettings()).toEqual({
+      theme: 'system',
+      enableRadicleIntegration: false,
+      startBeeAtLaunch: true,
+      startIpfsAtLaunch: true,
+      startRadicleAtLaunch: false,
+      autoUpdate: true,
+      showBookmarkBar: false,
+    });
+    expect(nativeTheme.themeSource).toBe('system');
+  });
+
+  test('merges persisted settings with defaults and applies the saved theme', () => {
+    fs.writeFileSync(
+      path.join(userDataDir, 'settings.json'),
+      JSON.stringify({ theme: 'dark', autoUpdate: false }),
+      'utf-8'
+    );
+
+    const { mod, nativeTheme } = loadSettingsStore({ userDataDir });
+
+    expect(mod.loadSettings()).toEqual(
+      expect.objectContaining({
+        theme: 'dark',
+        autoUpdate: false,
+        startBeeAtLaunch: true,
+        showBookmarkBar: false,
+      })
+    );
+    expect(nativeTheme.themeSource).toBe('dark');
+  });
+
+  test('falls back to defaults when the settings file is invalid', () => {
+    fs.writeFileSync(path.join(userDataDir, 'settings.json'), '{not-valid-json', 'utf-8');
+
+    const { mod, nativeTheme } = loadSettingsStore({ userDataDir });
+
+    expect(mod.loadSettings()).toEqual(
+      expect.objectContaining({
+        theme: 'system',
+        autoUpdate: true,
+      })
+    );
+    expect(nativeTheme.themeSource).toBe('system');
+  });
+
+  test('saveSettings persists a merged payload and updates the theme', () => {
+    const { mod, nativeTheme } = loadSettingsStore({ userDataDir });
+
+    expect(mod.saveSettings({ theme: 'light', autoUpdate: false })).toBe(true);
+
+    expect(
+      JSON.parse(fs.readFileSync(path.join(userDataDir, 'settings.json'), 'utf-8'))
+    ).toEqual(
+      expect.objectContaining({
+        theme: 'light',
+        autoUpdate: false,
+        startBeeAtLaunch: true,
+      })
+    );
+    expect(nativeTheme.themeSource).toBe('light');
+  });
+
+  test('registers IPC handlers for loading and saving settings', async () => {
+    const ipcMain = createIpcMainMock();
+    const { mod, nativeTheme } = loadSettingsStore({ userDataDir, ipcMain });
+
+    mod.registerSettingsIpc();
+
+    await expect(ipcMain.invoke(IPC.SETTINGS_GET)).resolves.toEqual(
+      expect.objectContaining({
+        theme: 'system',
+      })
+    );
+    await expect(ipcMain.invoke(IPC.SETTINGS_SAVE, { theme: 'dark' })).resolves.toBe(true);
+
+    expect(nativeTheme.themeSource).toBe('dark');
+  });
+});

--- a/src/main/webcontents-setup.test.js
+++ b/src/main/webcontents-setup.test.js
@@ -1,0 +1,230 @@
+const {
+  loadMainModule,
+} = require('../../test/helpers/main-process-test-utils');
+
+function createContentsMock(options = {}) {
+  const listeners = new Map();
+  const onceListeners = new Map();
+  let currentUrl = options.url || 'https://example.com';
+
+  const contents = {
+    id: options.id || 7,
+    getType: jest.fn(() => options.type || 'webview'),
+    getURL: jest.fn(() => currentUrl),
+    setURL(url) {
+      currentUrl = url;
+    },
+    on: jest.fn((event, handler) => {
+      if (!listeners.has(event)) {
+        listeners.set(event, []);
+      }
+      listeners.get(event).push(handler);
+    }),
+    once: jest.fn((event, handler) => {
+      if (!onceListeners.has(event)) {
+        onceListeners.set(event, []);
+      }
+      onceListeners.get(event).push(handler);
+    }),
+    emit(event, ...args) {
+      for (const handler of listeners.get(event) || []) {
+        handler(...args);
+      }
+
+      const oneTimeHandlers = onceListeners.get(event) || [];
+      onceListeners.delete(event);
+      oneTimeHandlers.forEach((handler) => handler(...args));
+    },
+    insertCSS: jest.fn(() => Promise.resolve()),
+    setWindowOpenHandler: jest.fn((handler) => {
+      contents.windowOpenHandler = handler;
+    }),
+    windowOpenHandler: null,
+  };
+
+  return contents;
+}
+
+function loadWebContentsSetupModule(options = {}) {
+  const log = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  const BrowserWindow = options.BrowserWindow || {
+    getAllWindows: jest.fn(() => options.windows || []),
+  };
+  const { app, mod } = loadMainModule(require.resolve('./webcontents-setup'), {
+    BrowserWindow,
+    extraMocks: {
+      [require.resolve('./logger')]: () => log,
+    },
+  });
+  const state = require('./state');
+
+  state.activeBzzBases.clear();
+  state.activeIpfsBases.clear();
+  state.activeRadBases.clear();
+
+  return {
+    app,
+    BrowserWindow,
+    log,
+    mod,
+    state,
+  };
+}
+
+describe('webcontents-setup', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('injects light defaults for external webviews and clears active protocol bases on destroy', async () => {
+    const ctx = loadWebContentsSetupModule();
+    const contents = createContentsMock({
+      id: 14,
+      type: 'webview',
+      url: 'https://example.com/articles/1',
+    });
+
+    ctx.state.activeBzzBases.set(contents.id, new URL('http://127.0.0.1:1633/bzz/hash/'));
+    ctx.state.activeIpfsBases.set(contents.id, new URL('http://127.0.0.1:8080/ipfs/cid/'));
+    ctx.state.activeRadBases.set(contents.id, new URL('http://127.0.0.1:8780/api/v1/repos/rid/'));
+
+    ctx.mod.registerWebContentsHandlers();
+    ctx.app.emit('web-contents-created', {}, contents);
+
+    contents.emit('dom-ready');
+    expect(contents.insertCSS).toHaveBeenCalledWith(
+      'html, body { background-color: #fff; color: #000; color-scheme: light; }',
+      {
+        cssOrigin: 'user',
+      }
+    );
+
+    contents.emit('destroyed');
+    expect(ctx.state.activeBzzBases.has(contents.id)).toBe(false);
+    expect(ctx.state.activeIpfsBases.has(contents.id)).toBe(false);
+    expect(ctx.state.activeRadBases.has(contents.id)).toBe(false);
+  });
+
+  test('skips css injection for internal file pages and intercepts external window opens', () => {
+    const parentWindow = {
+      webContents: {
+        id: 1,
+        send: jest.fn(),
+      },
+    };
+    const ctx = loadWebContentsSetupModule({
+      windows: [parentWindow],
+    });
+    const contents = createContentsMock({
+      id: 22,
+      type: 'webview',
+      url: 'file:///app/pages/home.html',
+    });
+
+    ctx.mod.registerWebContentsHandlers();
+    ctx.app.emit('web-contents-created', {}, contents);
+
+    contents.emit('dom-ready');
+    expect(contents.insertCSS).not.toHaveBeenCalled();
+
+    const namedResult = contents.windowOpenHandler({
+      url: 'https://github.com/openai/project',
+      frameName: 'named-tab',
+    });
+    expect(namedResult).toEqual({ action: 'deny' });
+    expect(parentWindow.webContents.send).toHaveBeenCalledWith(
+      'tab:new-with-url',
+      'https://github.com/openai/project',
+      'named-tab'
+    );
+
+    const blankResult = contents.windowOpenHandler({
+      url: 'https://example.com',
+      frameName: '_blank',
+    });
+    expect(blankResult).toEqual({ action: 'deny' });
+    expect(parentWindow.webContents.send).toHaveBeenLastCalledWith(
+      'tab:new-with-url',
+      'https://example.com',
+      null
+    );
+    expect(ctx.log.info).toHaveBeenCalledWith(
+      expect.stringContaining('intercepted new window request')
+    );
+  });
+
+  test('intercepts custom protocol navigation and logs renderer lifecycle failures', () => {
+    const parentWindow = {
+      webContents: {
+        id: 2,
+        send: jest.fn(),
+      },
+    };
+    const ctx = loadWebContentsSetupModule({
+      windows: [parentWindow],
+    });
+    const contents = createContentsMock({
+      id: 33,
+      type: 'webview',
+      url: 'https://example.com',
+    });
+    const event = {
+      preventDefault: jest.fn(),
+    };
+
+    ctx.mod.registerWebContentsHandlers();
+    ctx.app.emit('web-contents-created', {}, contents);
+
+    contents.emit('will-navigate', event, 'bzz://0123456789abcdef');
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(parentWindow.webContents.send).toHaveBeenCalledWith(
+      'navigate-to-url',
+      'bzz://0123456789abcdef'
+    );
+    expect(ctx.log.info).toHaveBeenCalledWith(
+      expect.stringContaining('intercepted custom protocol navigation')
+    );
+
+    const httpEvent = {
+      preventDefault: jest.fn(),
+    };
+    contents.emit('will-navigate', httpEvent, 'https://example.com/next');
+    expect(httpEvent.preventDefault).not.toHaveBeenCalled();
+
+    const crashDetails = { reason: 'crashed' };
+    contents.emit('render-process-gone', {}, crashDetails);
+    contents.emit('crashed');
+    contents.emit('unresponsive');
+    contents.emit('responsive');
+
+    expect(ctx.log.error).toHaveBeenCalledWith(
+      '[webcontents:33:webview] render-process-gone',
+      crashDetails
+    );
+    expect(ctx.log.error).toHaveBeenCalledWith('[webcontents:33:webview] crashed event (legacy)');
+    expect(ctx.log.warn).toHaveBeenCalledWith('[webcontents:33:webview] became unresponsive');
+    expect(ctx.log.warn).toHaveBeenCalledWith('[webcontents:33:webview] responsive again');
+  });
+
+  test('registers global process failure handlers on the app', () => {
+    const ctx = loadWebContentsSetupModule();
+
+    ctx.mod.registerWebContentsHandlers();
+
+    ctx.app.emit('child-process-gone', {}, { type: 'GPU', reason: 'crashed' });
+    ctx.app.emit('render-process-gone', {}, { id: 99, reason: 'oom' });
+
+    expect(ctx.log.error).toHaveBeenCalledWith('[child-process-gone]', {
+      type: 'GPU',
+      reason: 'crashed',
+    });
+    expect(ctx.log.error).toHaveBeenCalledWith('[render-process-gone-global]', {
+      id: 99,
+      reason: 'oom',
+    });
+  });
+});

--- a/src/main/webview-preload.test.js
+++ b/src/main/webview-preload.test.js
@@ -1,0 +1,298 @@
+const IPC = require('../shared/ipc-channels');
+const {
+  createContextBridgeMock,
+  createIpcRendererMock,
+} = require('../../test/helpers/main-process-test-utils');
+
+const originalWindow = global.window;
+const originalDocument = global.document;
+const originalNavigator = global.navigator;
+const originalLocation = global.location;
+
+const internalPages = {
+  routable: {
+    home: 'home.html',
+    history: 'history.html',
+    links: 'links.html',
+    'protocol-test': 'protocol-test.html',
+  },
+  other: ['error.html', 'rad-browser.html'],
+};
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+function loadWebviewPreloadModule(options = {}) {
+  jest.resetModules();
+
+  const contextBridge = createContextBridgeMock();
+  const ipcRenderer = createIpcRendererMock({
+    syncResponses: {
+      [IPC.GET_INTERNAL_PAGES]: internalPages,
+    },
+    invokeResponses: {
+      [IPC.HISTORY_GET]: [{ url: 'https://example.com' }],
+      [IPC.SETTINGS_GET]: { theme: 'dark' },
+      [IPC.BOOKMARKS_GET]: [{ target: 'https://example.com' }],
+      [IPC.RADICLE_GET_STATUS]: { status: 'running' },
+      ...(options.invokeResponses || {}),
+    },
+  });
+  ipcRenderer.sendToHost = jest.fn();
+
+  const documentHandlers = {};
+  const body = { tagName: 'BODY' };
+  const document = {
+    title: options.title || 'Internal Page',
+    body,
+    addEventListener: jest.fn((event, handler) => {
+      documentHandlers[event] = handler;
+    }),
+    execCommand: jest.fn(),
+  };
+  const location = options.location || {
+    href: 'file:///app/pages/history.html',
+    protocol: 'file:',
+    pathname: '/app/pages/history.html',
+  };
+  const selectionText = options.selectionText || '';
+  const selection = {
+    toString: jest.fn(() => selectionText),
+  };
+  const clipboard = {
+    writeText: jest.fn().mockResolvedValue(undefined),
+  };
+
+  global.document = document;
+  global.window = {
+    location,
+    getSelection: jest.fn(() => selection),
+  };
+  global.location = location;
+  global.navigator = {
+    clipboard,
+  };
+
+  jest.doMock('electron', () => ({
+    contextBridge,
+    ipcRenderer,
+  }));
+
+  require(require.resolve('./webview-preload'));
+
+  return {
+    clipboard,
+    contextBridge,
+    document,
+    documentHandlers,
+    exposures: contextBridge.exposedValues,
+    ipcRenderer,
+    location,
+  };
+}
+
+describe('webview-preload', () => {
+  let consoleLogSpy;
+  let consoleWarnSpy;
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.navigator = originalNavigator;
+    global.location = originalLocation;
+    jest.restoreAllMocks();
+  });
+
+  test('exposes guarded freedomAPI methods for allowed internal pages', async () => {
+    const { contextBridge, exposures, ipcRenderer } = loadWebviewPreloadModule({
+      location: {
+        href: 'file:///app/pages/error.html?url=https%3A%2F%2Fexample.com',
+        protocol: 'file:',
+        pathname: '/app/pages/error.html',
+      },
+    });
+
+    expect(contextBridge.exposeInMainWorld).toHaveBeenCalledWith(
+      'freedomAPI',
+      expect.any(Object)
+    );
+    expect(ipcRenderer.sendSync).toHaveBeenCalledWith(IPC.GET_INTERNAL_PAGES);
+
+    const invokeCases = [
+      ['getHistory', [{ limit: 10 }], IPC.HISTORY_GET, [{ limit: 10 }]],
+      ['addHistory', [{ url: 'https://example.com' }], IPC.HISTORY_ADD, [{ url: 'https://example.com' }]],
+      ['removeHistory', [5], IPC.HISTORY_REMOVE, [5]],
+      ['clearHistory', [], IPC.HISTORY_CLEAR, []],
+      ['getSettings', [], IPC.SETTINGS_GET, []],
+      ['getBookmarks', [], IPC.BOOKMARKS_GET, []],
+      ['openInNewTab', ['https://example.com'], IPC.OPEN_URL_IN_NEW_TAB, ['https://example.com']],
+      ['getCachedFavicon', ['https://example.com'], IPC.FAVICON_GET_CACHED, ['https://example.com']],
+      ['seedRadicle', ['z3abc'], IPC.RADICLE_SEED, ['z3abc']],
+      ['getRadicleStatus', [], IPC.RADICLE_GET_STATUS, []],
+      ['getRadicleRepoPayload', ['z3abc'], IPC.RADICLE_GET_REPO_PAYLOAD, ['z3abc']],
+      ['syncRadicleRepo', ['z3abc'], IPC.RADICLE_SYNC_REPO, ['z3abc']],
+    ];
+
+    for (const [method, args, channel, expectedArgs] of invokeCases) {
+      ipcRenderer.invoke.mockClear();
+      await exposures.freedomAPI[method](...args);
+      expect(ipcRenderer.invoke).toHaveBeenCalledWith(channel, ...expectedArgs);
+    }
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('[webview-preload] Loaded (freedomAPI + context menu)');
+  });
+
+  test('blocks freedomAPI access on non-internal pages', async () => {
+    const { exposures, ipcRenderer } = loadWebviewPreloadModule({
+      location: {
+        href: 'https://example.com/articles/1',
+        protocol: 'https:',
+        pathname: '/articles/1',
+      },
+    });
+
+    await expect(exposures.freedomAPI.getHistory({ limit: 5 })).rejects.toThrow(
+      'freedomAPI is only available on internal pages'
+    );
+    expect(ipcRenderer.invoke).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '[freedomAPI] blocked "getHistory" on non-internal page: https://example.com/articles/1'
+    );
+  });
+
+  test('collects rich context menu data and forwards it to the host renderer', () => {
+    const { documentHandlers, ipcRenderer } = loadWebviewPreloadModule({
+      selectionText: 'Selected text',
+      title: 'Article Title',
+      location: {
+        href: 'https://example.com/articles/1',
+        protocol: 'https:',
+        pathname: '/articles/1',
+      },
+    });
+    const editableContainer = {
+      tagName: 'DIV',
+      isContentEditable: true,
+      parentElement: { tagName: 'BODY' },
+    };
+    const link = {
+      tagName: 'A',
+      href: 'https://linked.example',
+      textContent: 'Read more',
+      parentElement: editableContainer,
+    };
+    const image = {
+      tagName: 'IMG',
+      src: 'https://linked.example/cover.png',
+      alt: 'Cover image',
+      parentElement: link,
+    };
+    const event = {
+      clientX: 12,
+      clientY: 34,
+      target: image,
+      preventDefault: jest.fn(),
+    };
+
+    documentHandlers.contextmenu(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(ipcRenderer.sendToHost).toHaveBeenCalledWith('context-menu', {
+      x: 12,
+      y: 34,
+      pageUrl: 'https://example.com/articles/1',
+      pageTitle: 'Article Title',
+      linkUrl: 'https://linked.example',
+      linkText: 'Read more',
+      selectedText: 'Selected text',
+      imageSrc: 'https://linked.example/cover.png',
+      imageAlt: 'Cover image',
+      isEditable: true,
+      mediaType: 'image',
+    });
+  });
+
+  test('detects video and audio media sources in the context menu handler', () => {
+    const { documentHandlers, ipcRenderer } = loadWebviewPreloadModule({
+      location: {
+        href: 'https://example.com/media',
+        protocol: 'https:',
+        pathname: '/media',
+      },
+    });
+    const body = global.document.body;
+    const video = {
+      tagName: 'VIDEO',
+      src: '',
+      querySelector: jest.fn((selector) =>
+        selector === 'source' ? { src: 'https://cdn.example/video.mp4' } : null
+      ),
+      parentElement: body,
+    };
+    const audio = {
+      tagName: 'AUDIO',
+      src: 'https://cdn.example/audio.mp3',
+      querySelector: jest.fn(() => null),
+      parentElement: body,
+    };
+
+    documentHandlers.contextmenu({
+      clientX: 1,
+      clientY: 2,
+      target: video,
+      preventDefault: jest.fn(),
+    });
+    expect(ipcRenderer.sendToHost).toHaveBeenLastCalledWith(
+      'context-menu',
+      expect.objectContaining({
+        mediaType: 'video',
+        mediaSrc: 'https://cdn.example/video.mp4',
+      })
+    );
+
+    documentHandlers.contextmenu({
+      clientX: 3,
+      clientY: 4,
+      target: audio,
+      preventDefault: jest.fn(),
+    });
+    expect(ipcRenderer.sendToHost).toHaveBeenLastCalledWith(
+      'context-menu',
+      expect.objectContaining({
+        mediaType: 'audio',
+        mediaSrc: 'https://cdn.example/audio.mp3',
+      })
+    );
+  });
+
+  test('handles context menu actions through execCommand and clipboard APIs', async () => {
+    const { clipboard, document, ipcRenderer } = loadWebviewPreloadModule();
+
+    ipcRenderer.emit('context-menu-action', 'copy');
+    ipcRenderer.emit('context-menu-action', 'cut');
+    ipcRenderer.emit('context-menu-action', 'paste');
+    ipcRenderer.emit('context-menu-action', 'select-all');
+    ipcRenderer.emit('context-menu-action', 'copy-text', { text: 'Copied text' });
+    await flushMicrotasks();
+
+    expect(document.execCommand).toHaveBeenNthCalledWith(1, 'copy');
+    expect(document.execCommand).toHaveBeenNthCalledWith(2, 'cut');
+    expect(document.execCommand).toHaveBeenNthCalledWith(3, 'paste');
+    expect(document.execCommand).toHaveBeenNthCalledWith(4, 'selectAll');
+    expect(clipboard.writeText).toHaveBeenCalledWith('Copied text');
+
+    clipboard.writeText.mockRejectedValueOnce(new Error('clipboard failed'));
+    ipcRenderer.emit('context-menu-action', 'copy-text', { text: 'Failure case' });
+    await flushMicrotasks();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(Error));
+  });
+});

--- a/src/renderer/lib/autocomplete-utils.js
+++ b/src/renderer/lib/autocomplete-utils.js
@@ -1,0 +1,160 @@
+export const extractRootDomain = (url) => {
+  try {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      const parsed = new URL(url);
+      return `${parsed.protocol}//${parsed.host}`;
+    }
+
+    if (url.startsWith('bzz://') || url.startsWith('ipfs://') || url.startsWith('ipns://')) {
+      const match = url.match(/^([a-z]+:\/\/[^\/]+)/);
+      return match ? match[1] : null;
+    }
+
+    if (url.includes('.eth') || url.includes('.box')) {
+      const match = url.match(/^([a-zA-Z0-9-]+\.(?:eth|box))/);
+      return match ? match[1] : null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+export const detectSuggestionProtocol = (url) => {
+  if (!url) return 'http';
+  if (url.startsWith('bzz://') || url.includes('.eth') || url.includes('.box')) return 'swarm';
+  if (url.startsWith('ipfs://')) return 'ipfs';
+  if (url.startsWith('ipns://')) return 'ipns';
+  if (url.startsWith('https://')) return 'https';
+  return 'http';
+};
+
+export const scoreSuggestion = (item, query) => {
+  const url = (item.url || item.target || '').toLowerCase();
+  const title = (item.title || item.label || '').toLowerCase();
+  const q = query.toLowerCase();
+
+  let score = 0;
+
+  if (url.startsWith(q)) score += 100;
+  else if (url.includes(q)) score += 50;
+
+  if (title.startsWith(q)) score += 80;
+  else if (title.includes(q)) score += 30;
+
+  if (item.visit_count) {
+    score += Math.min(Math.log(item.visit_count + 1) * 10, 50);
+  }
+
+  if (item.isBookmark) score += 20;
+
+  return score;
+};
+
+export const generateSuggestions = (
+  query,
+  { openTabs = [], historyItems = [], bookmarks = [] } = {}
+) => {
+  if (!query || query.length < 1) return [];
+
+  const q = query.toLowerCase();
+  const results = new Map();
+  const rootDomains = new Set();
+
+  for (const tab of openTabs) {
+    const url = tab.url || '';
+    const title = tab.title || '';
+
+    if (!url || url.includes('/pages/home.html') || url.includes('/pages/')) continue;
+
+    if (url.toLowerCase().includes(q) || title.toLowerCase().includes(q)) {
+      const score = 200 + scoreSuggestion({ url, title }, query);
+      results.set(url, {
+        url,
+        title,
+        protocol: detectSuggestionProtocol(url),
+        score,
+        type: 'tab',
+        tabId: tab.id,
+        isActive: tab.isActive,
+      });
+    }
+  }
+
+  for (const item of historyItems) {
+    const url = item.url || '';
+    const title = item.title || '';
+
+    if (url.toLowerCase().includes(q) || title.toLowerCase().includes(q)) {
+      const score = scoreSuggestion(item, query);
+      if (score > 0) {
+        if (!results.has(url)) {
+          results.set(url, {
+            url,
+            title,
+            protocol: detectSuggestionProtocol(url),
+            score,
+            type: 'history',
+            visit_count: item.visit_count || 1,
+          });
+        }
+
+        const root = extractRootDomain(url);
+        if (root && root !== url && !rootDomains.has(root)) {
+          rootDomains.add(root);
+          if (root.toLowerCase().includes(q) && !results.has(root)) {
+            results.set(root, {
+              url: root,
+              title: root,
+              protocol: detectSuggestionProtocol(root),
+              score: score * 0.8,
+              type: 'history',
+              visit_count: item.visit_count || 1,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  for (const item of bookmarks) {
+    const url = item.target || '';
+    const title = item.label || '';
+
+    if (url.toLowerCase().includes(q) || title.toLowerCase().includes(q)) {
+      const score = scoreSuggestion({ ...item, url, title, isBookmark: true }, query);
+      const existing = results.get(url);
+      if (!existing || (existing.type !== 'tab' && existing.score < score)) {
+        results.set(url, {
+          url,
+          title,
+          protocol: detectSuggestionProtocol(url),
+          score,
+          type: existing?.type === 'tab' ? 'tab' : 'bookmark',
+          tabId: existing?.tabId,
+        });
+      }
+    }
+  }
+
+  return Array.from(results.values())
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 8);
+};
+
+export const getPlaceholderLetter = (url) => {
+  try {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      const host = new URL(url).host;
+      return host
+        .replace(/^www\./, '')
+        .charAt(0)
+        .toUpperCase();
+    }
+
+    return url.charAt(0).toUpperCase();
+  } catch {
+    return '?';
+  }
+};

--- a/src/renderer/lib/autocomplete-utils.test.js
+++ b/src/renderer/lib/autocomplete-utils.test.js
@@ -1,0 +1,159 @@
+import {
+  detectSuggestionProtocol,
+  extractRootDomain,
+  generateSuggestions,
+  getPlaceholderLetter,
+  scoreSuggestion,
+} from './autocomplete-utils.js';
+
+describe('autocomplete-utils', () => {
+  describe('extractRootDomain', () => {
+    test('extracts the origin from http urls', () => {
+      expect(extractRootDomain('https://example.com/docs/page')).toBe('https://example.com');
+    });
+
+    test('extracts protocol roots from dweb urls', () => {
+      expect(extractRootDomain('ipfs://bafy123/path/to/file')).toBe('ipfs://bafy123');
+      expect(extractRootDomain('bzz://abcdef/path')).toBe('bzz://abcdef');
+    });
+
+    test('extracts ens roots', () => {
+      expect(extractRootDomain('vitalik.eth/about')).toBe('vitalik.eth');
+      expect(extractRootDomain('name.box/docs')).toBe('name.box');
+    });
+
+    test('returns null for unsupported inputs', () => {
+      expect(extractRootDomain('not a url')).toBeNull();
+      expect(extractRootDomain('')).toBeNull();
+    });
+  });
+
+  describe('detectSuggestionProtocol', () => {
+    test('maps suggestion protocols for icons', () => {
+      expect(detectSuggestionProtocol('bzz://hash')).toBe('swarm');
+      expect(detectSuggestionProtocol('vitalik.eth')).toBe('swarm');
+      expect(detectSuggestionProtocol('ipfs://cid')).toBe('ipfs');
+      expect(detectSuggestionProtocol('ipns://name')).toBe('ipns');
+      expect(detectSuggestionProtocol('https://example.com')).toBe('https');
+      expect(detectSuggestionProtocol('http://example.com')).toBe('http');
+    });
+  });
+
+  describe('scoreSuggestion', () => {
+    test('prefers strong url matches, visit count, and bookmarks', () => {
+      const plain = scoreSuggestion({ url: 'https://example.com/docs', title: 'Docs' }, 'exa');
+      const bookmark = scoreSuggestion(
+        {
+          url: 'https://example.com/docs',
+          title: 'Docs',
+          visit_count: 20,
+          isBookmark: true,
+        },
+        'exa'
+      );
+
+      expect(bookmark).toBeGreaterThan(plain);
+    });
+  });
+
+  describe('generateSuggestions', () => {
+    test('prioritizes open tabs over history and bookmarks', () => {
+      const suggestions = generateSuggestions('exa', {
+        openTabs: [
+          {
+            id: 7,
+            url: 'https://example.com/tab',
+            title: 'Example Tab',
+            isActive: true,
+          },
+        ],
+        historyItems: [
+          {
+            url: 'https://example.com/history',
+            title: 'Example History',
+            visit_count: 10,
+          },
+        ],
+        bookmarks: [{ target: 'https://example.com/bookmark', label: 'Example Bookmark' }],
+      });
+
+      expect(suggestions[0]).toEqual(
+        expect.objectContaining({
+          type: 'tab',
+          tabId: 7,
+          url: 'https://example.com/tab',
+        })
+      );
+    });
+
+    test('adds root-domain suggestions for matching history deeplinks', () => {
+      const suggestions = generateSuggestions('freedom', {
+        historyItems: [
+          {
+            url: 'https://freedom.dev/docs/testing',
+            title: 'Freedom docs',
+            visit_count: 3,
+          },
+        ],
+      });
+
+      expect(suggestions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ url: 'https://freedom.dev/docs/testing' }),
+          expect.objectContaining({ url: 'https://freedom.dev' }),
+        ])
+      );
+    });
+
+    test('dedupes bookmark entries when history already contains the same url', () => {
+      const suggestions = generateSuggestions('docs', {
+        historyItems: [
+          {
+            url: 'https://example.com/docs',
+            title: 'History Docs',
+            visit_count: 1,
+          },
+        ],
+        bookmarks: [
+          {
+            target: 'https://example.com/docs',
+            label: 'Bookmarked Docs',
+          },
+        ],
+      });
+
+      expect(suggestions.filter((item) => item.url === 'https://example.com/docs')).toHaveLength(1);
+      expect(suggestions[0]).toEqual(
+        expect.objectContaining({
+          type: 'bookmark',
+          title: 'Bookmarked Docs',
+        })
+      );
+    });
+
+    test('skips internal page tabs and limits results to 8 entries', () => {
+      const suggestions = generateSuggestions('match', {
+        openTabs: [
+          { id: 1, url: 'file:///app/pages/home.html', title: 'Home' },
+          { id: 2, url: 'https://match.example/1', title: 'One' },
+        ],
+        historyItems: Array.from({ length: 10 }, (_, index) => ({
+          url: `https://match.example/${index + 2}`,
+          title: `Match ${index + 2}`,
+          visit_count: index + 1,
+        })),
+      });
+
+      expect(suggestions).toHaveLength(8);
+      expect(suggestions.some((item) => item.url.includes('/pages/home.html'))).toBe(false);
+    });
+  });
+
+  describe('getPlaceholderLetter', () => {
+    test('uses host initials for http urls and raw first letters otherwise', () => {
+      expect(getPlaceholderLetter('https://www.example.com/path')).toBe('E');
+      expect(getPlaceholderLetter('ipfs://bafy123')).toBe('I');
+      expect(getPlaceholderLetter('')).toBe('');
+    });
+  });
+});

--- a/src/renderer/lib/autocomplete.js
+++ b/src/renderer/lib/autocomplete.js
@@ -4,6 +4,10 @@ import { getOpenTabs, switchTab, hideTabContextMenu } from './tabs.js';
 import { closeMenus } from './menus.js';
 import { hideBookmarkContextMenu } from './bookmarks-ui.js';
 import { showMenuBackdrop, hideMenuBackdrop } from './menu-backdrop.js';
+import {
+  generateSuggestions as generateAutocompleteSuggestions,
+  getPlaceholderLetter,
+} from './autocomplete-utils.js';
 
 const electronAPI = window.electronAPI;
 
@@ -50,174 +54,12 @@ export const refreshCache = async () => {
   }
 };
 
-/**
- * Extract root domain from a URL
- */
-const extractRootDomain = (url) => {
-  try {
-    // Handle protocol-prefixed URLs
-    if (url.startsWith('http://') || url.startsWith('https://')) {
-      const parsed = new URL(url);
-      return `${parsed.protocol}//${parsed.host}`;
-    }
-    // Handle bzz://, ipfs://, ipns://
-    if (url.startsWith('bzz://') || url.startsWith('ipfs://') || url.startsWith('ipns://')) {
-      const match = url.match(/^([a-z]+:\/\/[^\/]+)/);
-      return match ? match[1] : null;
-    }
-    // Handle .eth and .box domains (ENS)
-    if (url.includes('.eth') || url.includes('.box')) {
-      const match = url.match(/^([a-zA-Z0-9-]+\.(?:eth|box))/);
-      return match ? match[1] : null;
-    }
-    return null;
-  } catch {
-    return null;
-  }
-};
-
-/**
- * Detect protocol from URL for icon display
- */
-const detectProtocol = (url) => {
-  if (!url) return 'http';
-  if (url.startsWith('bzz://') || url.includes('.eth') || url.includes('.box')) return 'swarm';
-  if (url.startsWith('ipfs://')) return 'ipfs';
-  if (url.startsWith('ipns://')) return 'ipns';
-  if (url.startsWith('https://')) return 'https';
-  return 'http';
-};
-
-/**
- * Score and rank suggestions based on query match
- */
-const scoreSuggestion = (item, query) => {
-  const url = (item.url || item.target || '').toLowerCase();
-  const title = (item.title || item.label || '').toLowerCase();
-  const q = query.toLowerCase();
-
-  let score = 0;
-
-  // URL matching
-  if (url.startsWith(q)) score += 100;
-  else if (url.includes(q)) score += 50;
-
-  // Title matching
-  if (title.startsWith(q)) score += 80;
-  else if (title.includes(q)) score += 30;
-
-  // Visit count bonus (for history items)
-  if (item.visit_count) {
-    score += Math.min(Math.log(item.visit_count + 1) * 10, 50);
-  }
-
-  // Bookmark bonus
-  if (item.isBookmark) score += 20;
-
-  return score;
-};
-
-/**
- * Generate suggestions from query
- */
-const generateSuggestions = (query) => {
-  if (!query || query.length < 1) return [];
-
-  const q = query.toLowerCase();
-  const results = new Map(); // Use Map to dedupe by URL
-  const rootDomains = new Set(); // Track which root domains we've added
-
-  // Process open tabs first (highest priority)
-  const openTabs = getOpenTabs();
-  for (const tab of openTabs) {
-    const url = tab.url || '';
-    const title = tab.title || '';
-
-    // Skip home page and internal pages
-    if (!url || url.includes('/pages/home.html') || url.includes('/pages/')) continue;
-
-    if (url.toLowerCase().includes(q) || title.toLowerCase().includes(q)) {
-      const score = 200 + scoreSuggestion({ url, title }, query); // High base score for tabs
-      results.set(url, {
-        url,
-        title,
-        protocol: detectProtocol(url),
-        score,
-        type: 'tab',
-        tabId: tab.id,
-        isActive: tab.isActive,
-      });
-    }
-  }
-
-  // Process history
-  for (const item of historyCache) {
-    const url = item.url || '';
-    const title = item.title || '';
-
-    // Check if matches
-    if (url.toLowerCase().includes(q) || title.toLowerCase().includes(q)) {
-      const score = scoreSuggestion(item, query);
-      if (score > 0) {
-        // Don't overwrite tab entries
-        if (!results.has(url)) {
-          results.set(url, {
-            url,
-            title,
-            protocol: detectProtocol(url),
-            score,
-            type: 'history',
-            visit_count: item.visit_count || 1,
-          });
-        }
-
-        // Extract and add root domain if this is a deeplink
-        const root = extractRootDomain(url);
-        if (root && root !== url && !rootDomains.has(root)) {
-          rootDomains.add(root);
-          // Only add root if it also matches the query
-          if (root.toLowerCase().includes(q) && !results.has(root)) {
-            results.set(root, {
-              url: root,
-              title: root,
-              protocol: detectProtocol(root),
-              score: score * 0.8, // Slightly lower than the deeplink
-              type: 'history',
-              visit_count: item.visit_count || 1,
-            });
-          }
-        }
-      }
-    }
-  }
-
-  // Process bookmarks
-  for (const item of bookmarksCache) {
-    const url = item.target || '';
-    const title = item.label || '';
-
-    if (url.toLowerCase().includes(q) || title.toLowerCase().includes(q)) {
-      const score = scoreSuggestion({ ...item, url, title, isBookmark: true }, query);
-      const existing = results.get(url);
-      // Only add if no tab/history entry or if this scores higher
-      if (!existing || (existing.type !== 'tab' && existing.score < score)) {
-        results.set(url, {
-          url,
-          title,
-          protocol: detectProtocol(url),
-          score,
-          type: existing?.type === 'tab' ? 'tab' : 'bookmark', // Preserve tab type
-          tabId: existing?.tabId,
-        });
-      }
-    }
-  }
-
-  // Sort by score (highest first) and limit to 8
-  return Array.from(results.values())
-    .sort((a, b) => b.score - a.score)
-    .slice(0, 8);
-};
+const generateSuggestions = (query) =>
+  generateAutocompleteSuggestions(query, {
+    openTabs: getOpenTabs(),
+    historyItems: historyCache,
+    bookmarks: bookmarksCache,
+  });
 
 /**
  * Get badge for item type
@@ -230,24 +72,6 @@ const getTypeBadge = (item) => {
     return '<span class="autocomplete-type">★</span>';
   }
   return '';
-};
-
-/**
- * Get first letter for placeholder
- */
-const getPlaceholderLetter = (url) => {
-  try {
-    if (url.startsWith('http://') || url.startsWith('https://')) {
-      const host = new URL(url).host;
-      return host
-        .replace(/^www\./, '')
-        .charAt(0)
-        .toUpperCase();
-    }
-    return url.charAt(0).toUpperCase();
-  } catch {
-    return '?';
-  }
 };
 
 /**

--- a/src/renderer/lib/autocomplete.test.js
+++ b/src/renderer/lib/autocomplete.test.js
@@ -1,0 +1,558 @@
+const originalWindow = global.window;
+const originalDocument = global.document;
+const originalNavigator = global.navigator;
+
+const escapeHtml = (value) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const createClassList = (initialClasses = []) => {
+  const classes = new Set(initialClasses);
+
+  return {
+    add: jest.fn((className) => {
+      classes.add(className);
+    }),
+    remove: jest.fn((className) => {
+      classes.delete(className);
+    }),
+    toggle: jest.fn((className, force) => {
+      if (force === undefined) {
+        if (classes.has(className)) {
+          classes.delete(className);
+          return false;
+        }
+
+        classes.add(className);
+        return true;
+      }
+
+      if (force) {
+        classes.add(className);
+      } else {
+        classes.delete(className);
+      }
+
+      return force;
+    }),
+    contains: jest.fn((className) => classes.has(className)),
+  };
+};
+
+const createElement = (initialClasses = []) => {
+  const handlers = {};
+
+  return {
+    handlers,
+    classList: createClassList(initialClasses),
+    dataset: {},
+    innerHTML: '',
+    value: '',
+    addEventListener: jest.fn((event, handler) => {
+      handlers[event] = handler;
+    }),
+    blur: jest.fn(),
+    querySelectorAll: jest.fn(() => []),
+  };
+};
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const loadAutocompleteModule = async (options = {}) => {
+  jest.resetModules();
+
+  const {
+    openTabs = [{ id: 11, title: 'Open Tab', url: 'https://tab.example' }],
+    history = [{ title: 'History Entry', url: 'https://history.example' }],
+    bookmarks = [{ title: 'Bookmark Entry', url: 'https://bookmark.example' }],
+    suggestionResolver = (query) => [
+      {
+        title: `Tab Result ${query}`,
+        url: 'https://tab.example',
+        protocol: 'https',
+        type: 'tab',
+        tabId: 11,
+      },
+      {
+        title: `Bookmark <Result> ${query}`,
+        url: 'ipfs://bookmark',
+        protocol: 'ipfs',
+        type: 'bookmark',
+      },
+    ],
+    faviconBehavior = async (url) => {
+      if (url === 'https://tab.example') {
+        return 'data:image/png;base64,tab';
+      }
+      if (url === 'ipfs://bookmark') {
+        throw new Error('favicon fetch failed');
+      }
+      return null;
+    },
+    includeElements = true,
+  } = options;
+
+  let renderedItems = [];
+  let iconContainers = [];
+  const createdImages = [];
+  const documentHandlers = {};
+  const windowHandlers = {};
+  const dropdown = createElement(['hidden']);
+  const addressInput = createElement();
+  const webviewElement = createElement();
+  const electronAPI = {
+    getHistory: jest.fn().mockResolvedValue(history),
+    getBookmarks: jest.fn().mockResolvedValue(bookmarks),
+    getCachedFavicon: jest.fn((url) => faviconBehavior(url)),
+  };
+  const tabsMocks = {
+    getOpenTabs: jest.fn(() => openTabs),
+    switchTab: jest.fn(),
+    hideTabContextMenu: jest.fn(),
+  };
+  const menusMocks = {
+    closeMenus: jest.fn(),
+  };
+  const bookmarkUiMocks = {
+    hideBookmarkContextMenu: jest.fn(),
+  };
+  const backdropMocks = {
+    showMenuBackdrop: jest.fn(),
+    hideMenuBackdrop: jest.fn(),
+  };
+  const debugMocks = {
+    pushDebug: jest.fn(),
+  };
+  const autocompleteUtilsMocks = {
+    generateSuggestions: jest.fn((query, data) => {
+      const suggestions = suggestionResolver(query, data);
+
+      renderedItems = suggestions.map(() => ({
+        classList: createClassList(),
+        scrollIntoView: jest.fn(),
+      }));
+
+      iconContainers = suggestions.map((item) => {
+        const placeholder = {
+          replaceWith: jest.fn(),
+        };
+        const protocolBadge = {
+          classList: createClassList([`protocol-${item.protocol}`]),
+          style: {},
+        };
+
+        return {
+          dataset: {
+            faviconUrl: item.url,
+          },
+          placeholder,
+          protocolBadge,
+          querySelector: jest.fn((selector) => {
+            if (selector === '.autocomplete-icon-placeholder') {
+              return placeholder;
+            }
+            if (selector === '.autocomplete-protocol-badge') {
+              return protocolBadge;
+            }
+            return null;
+          }),
+        };
+      });
+
+      iconContainers.push({
+        dataset: {},
+        querySelector: jest.fn(() => null),
+      });
+
+      return suggestions;
+    }),
+    getPlaceholderLetter: jest.fn(() => 'A'),
+  };
+
+  dropdown.querySelectorAll = jest.fn((selector) => {
+    if (selector === '.autocomplete-item') {
+      return renderedItems;
+    }
+    if (selector === '.autocomplete-icon-container') {
+      return iconContainers;
+    }
+    return [];
+  });
+
+  global.window = {
+    electronAPI,
+    addEventListener: jest.fn((event, handler) => {
+      windowHandlers[event] = handler;
+    }),
+  };
+
+  global.document = {
+    getElementById: jest.fn((id) => {
+      if (!includeElements) return null;
+      if (id === 'autocomplete-dropdown') return dropdown;
+      if (id === 'address-input') return addressInput;
+      if (id === 'bzz-webview') return webviewElement;
+      return null;
+    }),
+    createElement: jest.fn((tagName) => {
+      if (tagName === 'div') {
+        let innerHTML = '';
+
+        return {
+          set textContent(value) {
+            innerHTML = escapeHtml(String(value));
+          },
+          get innerHTML() {
+            return innerHTML;
+          },
+        };
+      }
+
+      if (tagName === 'img') {
+        const image = {
+          className: '',
+          src: '',
+          alt: '',
+          onerror: null,
+          replaceWith: jest.fn(),
+        };
+
+        createdImages.push(image);
+        return image;
+      }
+
+      return {};
+    }),
+    addEventListener: jest.fn((event, handler) => {
+      documentHandlers[event] = handler;
+    }),
+  };
+
+  global.navigator = {
+    clipboard: {
+      writeText: jest.fn(),
+    },
+  };
+
+  jest.doMock('./debug.js', () => debugMocks);
+  jest.doMock('./tabs.js', () => tabsMocks);
+  jest.doMock('./menus.js', () => menusMocks);
+  jest.doMock('./bookmarks-ui.js', () => bookmarkUiMocks);
+  jest.doMock('./menu-backdrop.js', () => backdropMocks);
+  jest.doMock('./autocomplete-utils.js', () => autocompleteUtilsMocks);
+
+  const mod = await import('./autocomplete.js');
+
+  return {
+    mod,
+    dropdown,
+    addressInput,
+    webviewElement,
+    createdImages,
+    renderedItems: () => renderedItems,
+    iconContainers: () => iconContainers,
+    documentHandlers,
+    windowHandlers,
+    electronAPI,
+    tabsMocks,
+    menusMocks,
+    bookmarkUiMocks,
+    backdropMocks,
+    debugMocks,
+    autocompleteUtilsMocks,
+  };
+};
+
+describe('autocomplete', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.navigator = originalNavigator;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('logs an error when required elements are missing', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { mod } = await loadAutocompleteModule({ includeElements: false });
+
+    mod.initAutocomplete();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[Autocomplete] Required elements not found');
+  });
+
+  test('refreshes cache, renders suggestions, escapes html, and loads favicons', async () => {
+    jest.useFakeTimers();
+
+    const {
+      mod,
+      dropdown,
+      addressInput,
+      createdImages,
+      iconContainers,
+      electronAPI,
+      menusMocks,
+      tabsMocks,
+      bookmarkUiMocks,
+      backdropMocks,
+      debugMocks,
+      autocompleteUtilsMocks,
+    } = await loadAutocompleteModule({
+      suggestionResolver: (query) => [
+        {
+          title: `<b>${query}</b>`,
+          url: 'https://tab.example',
+          protocol: 'https',
+          type: 'tab',
+          tabId: 11,
+        },
+        {
+          title: 'Bookmark Result',
+          url: 'ipfs://bookmark',
+          protocol: 'ipfs',
+          type: 'bookmark',
+        },
+      ],
+    });
+
+    mod.initAutocomplete();
+    await flushMicrotasks();
+
+    expect(debugMocks.pushDebug).toHaveBeenCalledWith(
+      '[Autocomplete] Cache refreshed: 1 history, 1 bookmarks'
+    );
+    expect(debugMocks.pushDebug).toHaveBeenCalledWith('[Autocomplete] Initialized');
+
+    addressInput.value = 'example';
+    addressInput.handlers.input();
+    jest.runAllTimers();
+    await flushMicrotasks();
+
+    expect(autocompleteUtilsMocks.generateSuggestions).toHaveBeenCalledWith('example', {
+      openTabs: [{ id: 11, title: 'Open Tab', url: 'https://tab.example' }],
+      historyItems: [{ title: 'History Entry', url: 'https://history.example' }],
+      bookmarks: [{ title: 'Bookmark Entry', url: 'https://bookmark.example' }],
+    });
+    expect(dropdown.innerHTML).toContain('&lt;b&gt;example&lt;/b&gt;');
+    expect(dropdown.innerHTML).toContain('tab-badge');
+    expect(dropdown.innerHTML).toContain('★');
+    expect(menusMocks.closeMenus).toHaveBeenCalled();
+    expect(tabsMocks.hideTabContextMenu).toHaveBeenCalled();
+    expect(bookmarkUiMocks.hideBookmarkContextMenu).toHaveBeenCalled();
+    expect(backdropMocks.showMenuBackdrop).toHaveBeenCalled();
+    expect(dropdown.classList.remove).toHaveBeenCalledWith('hidden');
+
+    expect(electronAPI.getCachedFavicon).toHaveBeenCalledWith('https://tab.example');
+    expect(electronAPI.getCachedFavicon).toHaveBeenCalledWith('ipfs://bookmark');
+    expect(createdImages).toHaveLength(1);
+    expect(iconContainers()[0].placeholder.replaceWith).toHaveBeenCalledWith(createdImages[0]);
+    expect(iconContainers()[0].protocolBadge.style.display).toBe('none');
+
+    createdImages[0].onerror();
+
+    expect(createdImages[0].replaceWith).toHaveBeenCalledWith(iconContainers()[0].placeholder);
+    expect(iconContainers()[0].protocolBadge.style.display).toBe('block');
+  });
+
+  test('supports keyboard navigation for switching tabs, navigating, tab completion, and escape', async () => {
+    jest.useFakeTimers();
+
+    const { mod, dropdown, addressInput, tabsMocks, backdropMocks } =
+      await loadAutocompleteModule({
+        suggestionResolver: () => [
+          {
+            title: 'Open Tab',
+            url: 'https://tab.example',
+            protocol: 'https',
+            type: 'tab',
+            tabId: 11,
+          },
+          {
+            title: 'Navigate Here',
+            url: 'https://navigate.example',
+            protocol: 'https',
+            type: 'history',
+          },
+        ],
+      });
+    const onNavigate = jest.fn();
+
+    mod.setOnNavigate(onNavigate);
+    mod.initAutocomplete();
+    await flushMicrotasks();
+
+    addressInput.value = 'nav';
+    addressInput.handlers.keydown({
+      key: 'ArrowDown',
+      preventDefault: jest.fn(),
+    });
+    jest.runAllTimers();
+    await flushMicrotasks();
+
+    addressInput.handlers.keydown({
+      key: 'ArrowDown',
+      preventDefault: jest.fn(),
+    });
+
+    expect(dropdown.querySelectorAll('.autocomplete-item')[0].classList.toggle).toHaveBeenCalledWith(
+      'selected',
+      true
+    );
+    expect(dropdown.querySelectorAll('.autocomplete-item')[0].scrollIntoView).toHaveBeenCalledWith({
+      block: 'nearest',
+    });
+
+    addressInput.handlers.keydown({
+      key: 'Enter',
+      preventDefault: jest.fn(),
+    });
+
+    expect(tabsMocks.switchTab).toHaveBeenCalledWith(11);
+    expect(addressInput.blur).toHaveBeenCalled();
+    expect(backdropMocks.hideMenuBackdrop).toHaveBeenCalled();
+
+    addressInput.value = 'nav';
+    addressInput.handlers.input();
+    jest.runAllTimers();
+    await flushMicrotasks();
+
+    addressInput.handlers.keydown({
+      key: 'ArrowUp',
+      preventDefault: jest.fn(),
+    });
+    addressInput.handlers.keydown({
+      key: 'Tab',
+      preventDefault: jest.fn(),
+    });
+
+    expect(addressInput.value).toBe('https://navigate.example');
+
+    addressInput.value = 'nav';
+    addressInput.handlers.input();
+    jest.runAllTimers();
+    await flushMicrotasks();
+
+    addressInput.handlers.keydown({
+      key: 'ArrowUp',
+      preventDefault: jest.fn(),
+    });
+    addressInput.handlers.keydown({
+      key: 'Enter',
+      preventDefault: jest.fn(),
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('https://navigate.example');
+    expect(addressInput.value).toBe('https://navigate.example');
+
+    addressInput.value = 'nav';
+    addressInput.handlers.input();
+    jest.runAllTimers();
+    await flushMicrotasks();
+
+    addressInput.handlers.keydown({
+      key: 'Escape',
+      preventDefault: jest.fn(),
+    });
+
+    expect(dropdown.classList.add).toHaveBeenCalledWith('hidden');
+  });
+
+  test('handles click selection, empty queries, blur interactions, and refresh errors', async () => {
+    jest.useFakeTimers();
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const {
+      mod,
+      dropdown,
+      addressInput,
+      webviewElement,
+      windowHandlers,
+      tabsMocks,
+      electronAPI,
+    } = await loadAutocompleteModule({
+      suggestionResolver: () => [
+        {
+          title: 'Open Tab',
+          url: 'https://tab.example',
+          protocol: 'https',
+          type: 'tab',
+          tabId: 11,
+        },
+        {
+          title: 'Navigate Here',
+          url: 'https://navigate.example',
+          protocol: 'https',
+          type: 'history',
+        },
+      ],
+    });
+    const onNavigate = jest.fn();
+
+    mod.setOnNavigate(onNavigate);
+    mod.initAutocomplete();
+    await flushMicrotasks();
+
+    addressInput.value = '';
+    addressInput.handlers.input();
+    expect(dropdown.classList.add).toHaveBeenCalledWith('hidden');
+
+    addressInput.value = 'navigate';
+    addressInput.handlers.input();
+    jest.runAllTimers();
+    await flushMicrotasks();
+
+    dropdown.handlers.click({
+      target: {
+        closest: jest.fn(() => ({
+          dataset: {
+            tabId: '11',
+          },
+        })),
+      },
+    });
+    expect(tabsMocks.switchTab).toHaveBeenCalledWith(11);
+
+    addressInput.value = 'navigate';
+    addressInput.handlers.input();
+    jest.runAllTimers();
+    await flushMicrotasks();
+
+    dropdown.handlers.click({
+      target: {
+        closest: jest.fn(() => ({
+          dataset: {
+            url: 'https://navigate.example',
+          },
+        })),
+      },
+    });
+    expect(onNavigate).toHaveBeenCalledWith('https://navigate.example');
+
+    dropdown.handlers.click({
+      target: {
+        closest: jest.fn(() => null),
+      },
+    });
+
+    webviewElement.handlers.focus();
+    webviewElement.handlers.mousedown();
+    windowHandlers.blur();
+
+    expect(dropdown.classList.add).toHaveBeenCalledWith('hidden');
+
+    electronAPI.getHistory.mockRejectedValueOnce(new Error('history unavailable'));
+    await mod.refreshCache();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[Autocomplete] Failed to refresh cache:',
+      expect.any(Error)
+    );
+  });
+});

--- a/src/renderer/lib/bee-ui.test.js
+++ b/src/renderer/lib/bee-ui.test.js
@@ -1,0 +1,294 @@
+const { createDocument, createElement } = require('../../../test/helpers/fake-dom.js');
+
+const originalWindow = global.window;
+const originalDocument = global.document;
+const originalFetch = global.fetch;
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const loadBeeModule = async (options = {}) => {
+  jest.resetModules();
+
+  const state = {
+    beeMenuOpen: options.beeMenuOpen ?? false,
+    currentBeeStatus: options.currentBeeStatus || 'stopped',
+    beePeersInterval: null,
+    beeVisibleInterval: null,
+    beeVersionFetched: options.beeVersionFetched ?? false,
+    beeVersionValue: options.beeVersionValue || '',
+    suppressRunningStatus: options.suppressRunningStatus ?? false,
+    registry: {
+      bee: {
+        api: 'http://bee.test',
+        mode: options.mode || 'none',
+        statusMessage: options.statusMessage ?? null,
+        tempMessage: options.tempMessage ?? null,
+      },
+    },
+  };
+  const buildBeeUrl = jest.fn((endpoint) => `http://bee.test${endpoint}`);
+  const getDisplayMessage = jest.fn(() => {
+    return state.registry.bee.tempMessage || state.registry.bee.statusMessage;
+  });
+  const debugMocks = {
+    pushDebug: jest.fn(),
+  };
+  const beeToggleBtn = createElement('button');
+  const beeToggleSwitch = createElement('div');
+  const beePeersCount = createElement('span');
+  const beeNetworkPeers = createElement('span');
+  const beeVersionText = createElement('span');
+  const beeInfoPanel = createElement('div', {
+    classes: ['bee-info'],
+  });
+  const beeStatusRow = createElement('div');
+  const beeStatusLabel = createElement('span');
+  const beeStatusValue = createElement('span');
+  const body = createElement('body');
+  body.appendChild(beeInfoPanel);
+  const document = createDocument({
+    body,
+    elementsById: {
+      'bee-toggle-btn': beeToggleBtn,
+      'bee-toggle-switch': beeToggleSwitch,
+      'bee-peers-count': beePeersCount,
+      'bee-network-peers': beeNetworkPeers,
+      'bee-version-text': beeVersionText,
+      'bee-status-row': beeStatusRow,
+      'bee-status-label': beeStatusLabel,
+      'bee-status-value': beeStatusValue,
+    },
+  });
+  let statusHandler = null;
+  const beeApi =
+    options.windowBee === false
+      ? undefined
+      : {
+          checkBinary: jest
+            .fn()
+            .mockResolvedValue({ available: options.binaryAvailable ?? true }),
+          start: jest
+            .fn()
+            .mockResolvedValue(options.startResult || { status: 'running', error: null }),
+          stop: jest
+            .fn()
+            .mockResolvedValue(options.stopResult || { status: 'stopped', error: null }),
+          getStatus: jest
+            .fn()
+            .mockResolvedValue(options.statusResult || { status: 'stopped', error: null }),
+          onStatusUpdate: jest.fn((handler) => {
+            statusHandler = handler;
+          }),
+        };
+  let intervalId = 1;
+  const setIntervalMock = jest.spyOn(global, 'setInterval').mockImplementation(() => intervalId++);
+  const clearIntervalMock = jest.spyOn(global, 'clearInterval').mockImplementation(() => {});
+
+  global.fetch =
+    options.fetchImpl ||
+    jest.fn(async (url) => {
+      if (url.endsWith('/peers')) {
+        return {
+          ok: true,
+          json: async () => ({ peers: [{ id: 'a' }, { id: 'b' }] }),
+        };
+      }
+      if (url.endsWith('/topology')) {
+        return {
+          ok: true,
+          json: async () => ({
+            bins: {
+              '0': { population: 3 },
+              '1': { population: 4 },
+            },
+          }),
+        };
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ version: '2.3.4-abcdef' }),
+      };
+    });
+  global.window = {
+    bee: beeApi,
+  };
+  global.document = document;
+
+  jest.doMock('./state.js', () => ({
+    state,
+    buildBeeUrl,
+    getDisplayMessage,
+  }));
+  jest.doMock('./debug.js', () => debugMocks);
+
+  const mod = await import('./bee-ui.js');
+
+  return {
+    mod,
+    state,
+    buildBeeUrl,
+    getDisplayMessage,
+    debugMocks,
+    setIntervalMock,
+    clearIntervalMock,
+    beeApi,
+    getStatusHandler: () => statusHandler,
+    elements: {
+      beeToggleBtn,
+      beeToggleSwitch,
+      beePeersCount,
+      beeNetworkPeers,
+      beeVersionText,
+      beeInfoPanel,
+      beeStatusRow,
+      beeStatusLabel,
+      beeStatusValue,
+    },
+  };
+};
+
+describe('bee-ui', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  test('starts and stops Bee info polling and populates stats', async () => {
+    const ctx = await loadBeeModule({
+      beeMenuOpen: true,
+      currentBeeStatus: 'running',
+      windowBee: false,
+    });
+
+    ctx.mod.initBeeUi();
+    ctx.mod.startBeeInfoPolling();
+    await flushMicrotasks();
+
+    expect(ctx.buildBeeUrl).toHaveBeenCalledWith('/peers');
+    expect(ctx.buildBeeUrl).toHaveBeenCalledWith('/topology');
+    expect(ctx.buildBeeUrl).toHaveBeenCalledWith('/health');
+    expect(ctx.elements.beeInfoPanel.classList.contains('visible')).toBe(true);
+    expect(ctx.elements.beePeersCount.textContent).toBe('2');
+    expect(ctx.elements.beeNetworkPeers.textContent).toBe('7');
+    expect(ctx.elements.beeVersionText.textContent).toBe('2.3.4');
+    expect(ctx.state.beeVersionFetched).toBe(true);
+    expect(ctx.state.beePeersInterval).toBe(1);
+    expect(ctx.state.beeVisibleInterval).toBe(2);
+    expect(ctx.setIntervalMock).toHaveBeenCalledWith(expect.any(Function), 500);
+    expect(ctx.setIntervalMock).toHaveBeenCalledWith(expect.any(Function), 1000);
+
+    ctx.mod.stopBeeInfoPolling();
+
+    expect(ctx.clearIntervalMock).toHaveBeenCalledWith(1);
+    expect(ctx.clearIntervalMock).toHaveBeenCalledWith(2);
+    expect(ctx.state.beePeersInterval).toBeNull();
+    expect(ctx.state.beeVisibleInterval).toBeNull();
+    expect(ctx.elements.beeInfoPanel.classList.contains('visible')).toBe(false);
+    expect(ctx.elements.beePeersCount.textContent).toBe('0');
+    expect(ctx.elements.beeNetworkPeers.textContent).toBe('0');
+    expect(ctx.elements.beeVersionText.textContent).toBe('2.3.4');
+
+    ctx.mod.resetBeeVersion();
+    expect(ctx.state.beeVersionFetched).toBe(false);
+    expect(ctx.state.beeVersionValue).toBe('');
+    expect(ctx.elements.beeVersionText.textContent).toBe('');
+  });
+
+  test('updates Bee status lines, toggle state, and running transitions', async () => {
+    const ctx = await loadBeeModule({
+      beeMenuOpen: true,
+      currentBeeStatus: 'stopped',
+      statusMessage: 'Swarm: Connected',
+      windowBee: false,
+    });
+
+    ctx.mod.initBeeUi();
+    ctx.mod.updateBeeStatusLine();
+
+    expect(ctx.getDisplayMessage).toHaveBeenCalledWith('bee');
+    expect(ctx.elements.beeStatusLabel.textContent).toBe('Swarm:');
+    expect(ctx.elements.beeStatusValue.textContent).toBe('Connected');
+    expect(ctx.elements.beeStatusRow.classList.contains('visible')).toBe(true);
+
+    ctx.state.registry.bee.mode = 'reused';
+    ctx.mod.updateBeeToggleState();
+    expect(ctx.elements.beeToggleBtn.classList.contains('external')).toBe(true);
+    expect(ctx.elements.beeToggleBtn.getAttribute('title')).toBe(
+      'Using existing node — cannot be controlled from Freedom'
+    );
+
+    ctx.state.registry.bee.mode = 'none';
+    ctx.mod.updateBeeToggleState();
+    expect(ctx.elements.beeToggleBtn.classList.contains('external')).toBe(false);
+
+    ctx.mod.updateBeeUi('starting');
+    expect(ctx.elements.beeToggleSwitch.classList.contains('running')).toBe(true);
+    expect(ctx.state.currentBeeStatus).toBe('starting');
+
+    ctx.state.suppressRunningStatus = true;
+    ctx.elements.beeToggleSwitch.classList.remove('running');
+    ctx.mod.updateBeeUi('running');
+    expect(ctx.elements.beeToggleSwitch.classList.contains('running')).toBe(false);
+
+    ctx.mod.updateBeeUi('error', 'offline');
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('Bee Error: offline');
+
+    ctx.mod.updateBeeUi('stopped');
+    expect(ctx.elements.beeStatusRow.classList.contains('visible')).toBe(false);
+  });
+
+  test('initializes Bee controls, handles binary availability, and toggles start and stop', async () => {
+    const ctx = await loadBeeModule({
+      beeMenuOpen: true,
+      currentBeeStatus: 'stopped',
+      binaryAvailable: false,
+      statusResult: { status: 'stopped', error: null },
+    });
+
+    ctx.mod.initBeeUi();
+    await flushMicrotasks();
+
+    expect(ctx.beeApi.checkBinary).toHaveBeenCalled();
+    expect(ctx.elements.beeToggleBtn.classList.contains('disabled')).toBe(true);
+    expect(ctx.elements.beeToggleBtn.getAttribute('disabled')).toBe('true');
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('Swarm binary not found - toggle disabled');
+    expect(ctx.beeApi.onStatusUpdate).toHaveBeenCalledWith(expect.any(Function));
+    expect(ctx.beeApi.getStatus).toHaveBeenCalled();
+    expect(ctx.setIntervalMock).toHaveBeenCalledWith(expect.any(Function), 5000);
+
+    ctx.elements.beeToggleBtn.dispatch('click');
+    expect(ctx.beeApi.start).not.toHaveBeenCalled();
+
+    ctx.beeApi.checkBinary.mockResolvedValueOnce({ available: true });
+    ctx.mod.initBeeUi();
+    await flushMicrotasks();
+
+    ctx.elements.beeToggleBtn.dispatch('click');
+    await flushMicrotasks();
+
+    expect(ctx.beeApi.start).toHaveBeenCalled();
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('User toggled Swarm On');
+    expect(ctx.elements.beeToggleSwitch.classList.contains('running')).toBe(true);
+    expect(ctx.state.currentBeeStatus).toBe('running');
+
+    const statusHandler = ctx.getStatusHandler();
+    statusHandler({
+      status: 'error',
+      error: 'offline',
+    });
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('Bee Status Update: error (offline)');
+
+    ctx.state.currentBeeStatus = 'running';
+    ctx.elements.beeToggleBtn.dispatch('click');
+    await flushMicrotasks();
+
+    expect(ctx.beeApi.stop).toHaveBeenCalled();
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('User toggled Swarm Off');
+  });
+});

--- a/src/renderer/lib/bookmarks-ui.test.js
+++ b/src/renderer/lib/bookmarks-ui.test.js
@@ -1,0 +1,489 @@
+const { createDocument, createElement, FakeElement } = require('../../../test/helpers/fake-dom.js');
+
+const originalWindow = global.window;
+const originalDocument = global.document;
+const originalAlert = global.alert;
+const originalConfirm = global.confirm;
+const originalPrompt = global.prompt;
+const originalRequestAnimationFrame = global.requestAnimationFrame;
+const originalResizeObserver = global.ResizeObserver;
+const originalHTMLElement = global.HTMLElement;
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createResizeObserver = () => {
+  const instances = [];
+  const ResizeObserver = jest.fn(function ResizeObserver(callback) {
+    this.callback = callback;
+    this.observe = jest.fn();
+    this.disconnect = jest.fn();
+    instances.push(this);
+  });
+
+  return {
+    ResizeObserver,
+    instances,
+  };
+};
+
+const loadBookmarksModule = async (options = {}) => {
+  jest.resetModules();
+
+  let storedBookmarks = (options.initialBookmarks || []).map((bookmark) => ({ ...bookmark }));
+  const activeTabRef = {
+    current: options.activeTab || {
+      id: 1,
+      title: 'Active Page',
+      isLoading: false,
+    },
+  };
+  const resizeObserverState = createResizeObserver();
+  const windowHandlers = {};
+  const bookmarksBar = createElement('div', {
+    classes: ['bookmarks'],
+    rect: {
+      left: 0,
+      top: 0,
+      right: 140,
+      bottom: 40,
+      width: 140,
+      height: 40,
+    },
+  });
+  const body = createElement('body');
+  body.appendChild(bookmarksBar);
+  const addBookmarkBtn = createElement('button', { classes: ['hidden'] });
+  const addBookmarkModal = createElement('dialog');
+  const addBookmarkForm = createElement('form');
+  const closeAddBookmarkBtn = createElement('button');
+  const bookmarkLabelInput = createElement('input');
+  const bookmarkTargetInput = createElement('input');
+  const bookmarkModalTitle = createElement('div');
+  const bookmarkSubmitBtn = createElement('button');
+  const addressInput = createElement('input', {
+    value: options.addressValue || 'https://active.example',
+  });
+  const webviewElement = createElement('webview');
+  const document = createDocument({
+    body,
+    elementsById: {
+      'add-bookmark-btn': addBookmarkBtn,
+      'add-bookmark-modal': addBookmarkModal,
+      'add-bookmark-form': addBookmarkForm,
+      'close-add-bookmark': closeAddBookmarkBtn,
+      'bookmark-label': bookmarkLabelInput,
+      'bookmark-target': bookmarkTargetInput,
+      'bookmark-modal-title': bookmarkModalTitle,
+      'bookmark-submit-btn': bookmarkSubmitBtn,
+      'address-input': addressInput,
+      'bzz-webview': webviewElement,
+    },
+    createElementOverride: (tagName) => {
+      if (tagName === 'button') {
+        return createElement(tagName, {
+          rect: {
+            left: 0,
+            top: 0,
+            right: 60,
+            bottom: 24,
+            width: 60,
+            height: 24,
+          },
+        });
+      }
+
+      if (tagName === 'div') {
+        return createElement(tagName, {
+          rect: {
+            left: 0,
+            top: 0,
+            right: 140,
+            bottom: 40,
+            width: 140,
+            height: 40,
+          },
+        });
+      }
+
+      return createElement(tagName);
+    },
+  });
+  const electronAPI = {
+    getBookmarks:
+      options.getBookmarks ||
+      jest.fn().mockImplementation(async () => storedBookmarks.map((bookmark) => ({ ...bookmark }))),
+    getCachedFavicon:
+      options.getCachedFavicon ||
+      jest.fn().mockImplementation(async (target) => options.cachedFavicons?.[target] || null),
+    addBookmark:
+      options.addBookmark ||
+      jest.fn().mockImplementation(async (bookmark) => {
+        if (options.addBookmarkResult === false) return false;
+        if (storedBookmarks.some((item) => item.target === bookmark.target)) return false;
+        storedBookmarks.push({ ...bookmark });
+        return true;
+      }),
+    updateBookmark:
+      options.updateBookmark ||
+      jest.fn().mockImplementation(async (originalTarget, bookmark) => {
+        if (options.updateBookmarkResult === false) return false;
+        if (
+          storedBookmarks.some(
+            (item) => item.target === bookmark.target && item.target !== originalTarget
+          )
+        ) {
+          return false;
+        }
+
+        const index = storedBookmarks.findIndex((item) => item.target === originalTarget);
+        if (index === -1) return false;
+        storedBookmarks[index] = { ...bookmark };
+        return true;
+      }),
+    removeBookmark:
+      options.removeBookmark ||
+      jest.fn().mockImplementation(async (target) => {
+        storedBookmarks = storedBookmarks.filter((item) => item.target !== target);
+        return true;
+      }),
+  };
+  const debugMocks = {
+    pushDebug: jest.fn(),
+  };
+  const tabsMocks = {
+    getActiveTab: jest.fn(() => activeTabRef.current),
+    hideTabContextMenu: jest.fn(),
+  };
+  const menuMocks = {
+    closeMenus: jest.fn(),
+  };
+  const menuBackdropMocks = {
+    showMenuBackdrop: jest.fn(),
+    hideMenuBackdrop: jest.fn(),
+  };
+
+  addBookmarkModal.showModal = jest.fn();
+  addBookmarkModal.close = jest.fn(() => {
+    addBookmarkModal.dispatch('close', { target: addBookmarkModal });
+  });
+  bookmarkLabelInput.focus = jest.fn();
+  bookmarkLabelInput.select = jest.fn();
+
+  global.window = {
+    electronAPI,
+    innerWidth: 500,
+    innerHeight: 400,
+    addEventListener: jest.fn((event, handler) => {
+      windowHandlers[event] = handler;
+    }),
+  };
+  global.document = document;
+  global.alert = jest.fn();
+  global.confirm = jest.fn(() => options.confirmResult ?? true);
+  global.prompt = jest.fn(() => options.promptResult ?? null);
+  global.requestAnimationFrame = jest.fn((callback) => callback());
+  global.ResizeObserver = resizeObserverState.ResizeObserver;
+  global.HTMLElement = FakeElement;
+
+  jest.doMock('./debug.js', () => debugMocks);
+  jest.doMock('./tabs.js', () => tabsMocks);
+  jest.doMock('./menus.js', () => menuMocks);
+  jest.doMock('./menu-backdrop.js', () => menuBackdropMocks);
+
+  const mod = await import('./bookmarks-ui.js');
+
+  return {
+    mod,
+    electronAPI,
+    debugMocks,
+    tabsMocks,
+    menuMocks,
+    menuBackdropMocks,
+    windowHandlers,
+    resizeObserverInstances: resizeObserverState.instances,
+    activeTabRef,
+    getStoredBookmarks: () => storedBookmarks.map((bookmark) => ({ ...bookmark })),
+    elements: {
+      bookmarksBar,
+      addBookmarkBtn,
+      addBookmarkModal,
+      addBookmarkForm,
+      closeAddBookmarkBtn,
+      bookmarkLabelInput,
+      bookmarkTargetInput,
+      bookmarkModalTitle,
+      bookmarkSubmitBtn,
+      addressInput,
+      webviewElement,
+    },
+    helpers: {
+      getBookmarksInner: () => bookmarksBar.querySelector('.bookmarks-inner'),
+      getOverflowButton: () => bookmarksBar.querySelector('.bookmarks-overflow-btn'),
+      getOverflowMenu: () => document.body.querySelector('.bookmarks-overflow-menu'),
+      getContextMenu: () => document.body.querySelector('.context-menu'),
+    },
+  };
+};
+
+describe('bookmarks-ui', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.alert = originalAlert;
+    global.confirm = originalConfirm;
+    global.prompt = originalPrompt;
+    global.requestAnimationFrame = originalRequestAnimationFrame;
+    global.ResizeObserver = originalResizeObserver;
+    global.HTMLElement = originalHTMLElement;
+    jest.restoreAllMocks();
+  });
+
+  test('loads bookmarks, renders overflow items, and loads bookmark targets on click', async () => {
+    const onLoadTarget = jest.fn();
+    const onContextMenuOpening = jest.fn();
+    const ctx = await loadBookmarksModule({
+      initialBookmarks: [
+        { label: 'Alpha', target: 'https://alpha.example' },
+        { label: 'Beta', target: 'https://beta.example' },
+        { label: 'Gamma', target: 'https://gamma.example' },
+      ],
+      cachedFavicons: {
+        'https://alpha.example': 'data:image/png;base64,alpha',
+      },
+    });
+
+    ctx.mod.setOnLoadTarget(onLoadTarget);
+    ctx.mod.setOnBookmarkContextMenuOpening(onContextMenuOpening);
+    ctx.mod.initBookmarks();
+    await ctx.mod.loadBookmarks();
+    await flushMicrotasks();
+
+    const bookmarksInner = ctx.helpers.getBookmarksInner();
+    const overflowBtn = ctx.helpers.getOverflowButton();
+    const overflowMenu = ctx.helpers.getOverflowMenu();
+    const firstBookmark = bookmarksInner.children[0];
+    const firstIconContainer = firstBookmark.children[0];
+    const firstFavicon = firstIconContainer.children[0];
+
+    expect(bookmarksInner.querySelectorAll('.bookmark')).toHaveLength(3);
+    expect(ctx.electronAPI.getCachedFavicon).toHaveBeenCalledWith('https://alpha.example');
+    expect(firstFavicon.src).toBe('data:image/png;base64,alpha');
+    expect(firstIconContainer.dataset.state).toBe('favicon');
+    expect(overflowBtn.classList.contains('visible')).toBe(true);
+    expect(overflowMenu.children).toHaveLength(1);
+    expect(ctx.resizeObserverInstances[0].observe).toHaveBeenCalledWith(ctx.elements.bookmarksBar);
+
+    overflowBtn.dispatch('click', {
+      stopPropagation: jest.fn(),
+    });
+
+    expect(ctx.menuMocks.closeMenus).toHaveBeenCalled();
+    expect(ctx.tabsMocks.hideTabContextMenu).toHaveBeenCalled();
+    expect(onContextMenuOpening).toHaveBeenCalled();
+    expect(ctx.menuBackdropMocks.showMenuBackdrop).toHaveBeenCalled();
+    expect(overflowMenu.classList.contains('hidden')).toBe(false);
+
+    const overflowBookmark = overflowMenu.children[0];
+    overflowMenu.dispatch('click', {
+      target: overflowBookmark.children[1],
+    });
+
+    expect(ctx.elements.addressInput.value).toBe('https://gamma.example');
+    expect(onLoadTarget).toHaveBeenCalledWith('https://gamma.example');
+    expect(overflowMenu.classList.contains('hidden')).toBe(true);
+    expect(ctx.menuBackdropMocks.hideMenuBackdrop).toHaveBeenCalled();
+  });
+
+  test('updates add bookmark button visibility and bookmark state', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const ctx = await loadBookmarksModule({
+      initialBookmarks: [{ label: 'Saved', target: 'https://saved.example' }],
+      addressValue: 'https://saved.example',
+      activeTab: {
+        id: 1,
+        title: 'Saved Page',
+        isLoading: true,
+      },
+    });
+
+    ctx.mod.initBookmarks();
+
+    await ctx.mod.updateBookmarkButtonVisibility();
+    expect(ctx.elements.addBookmarkBtn.classList.contains('hidden')).toBe(true);
+
+    ctx.activeTabRef.current.isLoading = false;
+    await ctx.mod.updateBookmarkButtonVisibility();
+    expect(ctx.elements.addBookmarkBtn.classList.contains('hidden')).toBe(false);
+    expect(ctx.elements.addBookmarkBtn.classList.contains('bookmarked')).toBe(true);
+
+    ctx.electronAPI.getBookmarks.mockRejectedValueOnce(new Error('status failed'));
+    await ctx.mod.updateBookmarkButtonVisibility();
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to check bookmark status',
+      expect.any(Error)
+    );
+    expect(ctx.elements.addBookmarkBtn.classList.contains('bookmarked')).toBe(false);
+
+    ctx.elements.addressInput.value = 'file:///internal-page.html';
+    await ctx.mod.updateBookmarkButtonVisibility();
+    expect(ctx.elements.addBookmarkBtn.classList.contains('hidden')).toBe(true);
+  });
+
+  test('opens the add bookmark modal and saves a new bookmark', async () => {
+    const ctx = await loadBookmarksModule({
+      addressValue: 'https://new.example',
+      activeTab: {
+        id: 1,
+        title: 'Readable Title',
+        isLoading: false,
+      },
+    });
+
+    ctx.mod.initBookmarks();
+
+    ctx.elements.addBookmarkBtn.dispatch('click');
+    await flushMicrotasks();
+
+    expect(ctx.elements.addBookmarkModal.showModal).toHaveBeenCalled();
+    expect(ctx.elements.bookmarkLabelInput.value).toBe('Readable Title');
+    expect(ctx.elements.bookmarkTargetInput.value).toBe('https://new.example');
+    expect(ctx.elements.bookmarkTargetInput.readOnly).toBe(true);
+    expect(ctx.elements.bookmarkModalTitle.textContent).toBe('Add Bookmark');
+    expect(ctx.elements.bookmarkSubmitBtn.textContent).toBe('Add Bookmark');
+    expect(ctx.elements.bookmarkLabelInput.focus).toHaveBeenCalled();
+    expect(ctx.elements.bookmarkLabelInput.select).toHaveBeenCalled();
+
+    ctx.elements.bookmarkLabelInput.value = 'Saved Bookmark';
+    ctx.elements.addBookmarkForm.dispatch('submit', {
+      preventDefault: jest.fn(),
+    });
+    await flushMicrotasks();
+
+    expect(ctx.electronAPI.addBookmark).toHaveBeenCalledWith({
+      label: 'Saved Bookmark',
+      target: 'https://new.example',
+    });
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('Bookmark added: Saved Bookmark');
+    expect(ctx.elements.addBookmarkModal.close).toHaveBeenCalled();
+    expect(ctx.getStoredBookmarks()).toContainEqual({
+      label: 'Saved Bookmark',
+      target: 'https://new.example',
+    });
+    await ctx.mod.updateBookmarkButtonVisibility();
+    expect(ctx.elements.addBookmarkBtn.classList.contains('bookmarked')).toBe(true);
+  });
+
+  test('removes existing bookmarks from the add button and supports context-menu edit/delete', async () => {
+    const onContextMenuOpening = jest.fn();
+    const ctx = await loadBookmarksModule({
+      initialBookmarks: [
+        { label: 'Old Label', target: 'https://old.example' },
+        { label: 'Other', target: 'https://other.example' },
+      ],
+      addressValue: 'https://old.example',
+      activeTab: {
+        id: 1,
+        title: 'Old Label',
+        isLoading: false,
+      },
+      confirmResult: true,
+    });
+
+    ctx.mod.setOnBookmarkContextMenuOpening(onContextMenuOpening);
+    ctx.mod.initBookmarks();
+    await ctx.mod.loadBookmarks();
+    await flushMicrotasks();
+
+    ctx.elements.addBookmarkBtn.dispatch('click');
+    await flushMicrotasks();
+
+    expect(global.confirm).toHaveBeenCalledWith('Remove bookmark "Old Label"?');
+    expect(ctx.electronAPI.removeBookmark).toHaveBeenCalledWith('https://old.example');
+    expect(ctx.elements.addBookmarkModal.showModal).not.toHaveBeenCalled();
+
+    await ctx.mod.loadBookmarks();
+    await flushMicrotasks();
+
+    const bookmarksInner = ctx.helpers.getBookmarksInner();
+    const contextMenu = ctx.helpers.getContextMenu();
+    const remainingBookmark = bookmarksInner.children[0];
+
+    contextMenu.setRect({
+      right: 520,
+      bottom: 420,
+      width: 120,
+      height: 50,
+    });
+
+    bookmarksInner.dispatch('contextmenu', {
+      clientX: 490,
+      clientY: 390,
+      preventDefault: jest.fn(),
+      target: remainingBookmark.children[1],
+    });
+
+    expect(ctx.menuMocks.closeMenus).toHaveBeenCalled();
+    expect(ctx.tabsMocks.hideTabContextMenu).toHaveBeenCalled();
+    expect(onContextMenuOpening).toHaveBeenCalled();
+    expect(ctx.menuBackdropMocks.showMenuBackdrop).toHaveBeenCalled();
+    expect(contextMenu.classList.contains('hidden')).toBe(false);
+    expect(contextMenu.style.left).toBe('372px');
+    expect(contextMenu.style.top).toBe('342px');
+
+    contextMenu.dispatch('click', {
+      target: {
+        dataset: {
+          action: 'edit',
+        },
+      },
+    });
+    await flushMicrotasks();
+
+    expect(ctx.elements.addBookmarkModal.showModal).toHaveBeenCalledTimes(1);
+    expect(ctx.elements.bookmarkLabelInput.value).toBe('Other');
+    expect(ctx.elements.bookmarkTargetInput.value).toBe('https://other.example');
+    expect(ctx.elements.bookmarkTargetInput.readOnly).toBe(false);
+    expect(ctx.elements.bookmarkModalTitle.textContent).toBe('Edit Bookmark');
+    expect(ctx.elements.bookmarkSubmitBtn.textContent).toBe('Save');
+
+    ctx.elements.bookmarkLabelInput.value = 'Renamed';
+    ctx.elements.bookmarkTargetInput.value = 'https://renamed.example';
+    ctx.elements.addBookmarkForm.dispatch('submit', {
+      preventDefault: jest.fn(),
+    });
+    await flushMicrotasks();
+
+    expect(ctx.electronAPI.updateBookmark).toHaveBeenCalledWith('https://other.example', {
+      label: 'Renamed',
+      target: 'https://renamed.example',
+    });
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('Bookmark updated: Renamed');
+
+    await ctx.mod.loadBookmarks();
+    await flushMicrotasks();
+
+    const renamedBookmark = ctx.helpers.getBookmarksInner().children[0];
+    ctx.helpers.getBookmarksInner().dispatch('contextmenu', {
+      clientX: 120,
+      clientY: 140,
+      preventDefault: jest.fn(),
+      target: renamedBookmark.children[1],
+    });
+
+    contextMenu.dispatch('click', {
+      target: {
+        dataset: {
+          action: 'delete',
+        },
+      },
+    });
+    await flushMicrotasks();
+
+    expect(ctx.electronAPI.removeBookmark).toHaveBeenCalledWith('https://renamed.example');
+    expect(ctx.getStoredBookmarks()).toHaveLength(0);
+    expect(ctx.menuBackdropMocks.hideMenuBackdrop).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/lib/debug.js
+++ b/src/renderer/lib/debug.js
@@ -1,6 +1,14 @@
 // Debug logging - outputs to console (visible in App Developer Tools)
 
 export const pushDebug = (message) => {
+  const isTestEnv =
+    typeof process !== 'undefined' &&
+    (process.env.NODE_ENV === 'test' || Boolean(process.env.JEST_WORKER_ID));
+
+  if (isTestEnv && !process.env.DEBUG) {
+    return;
+  }
+
   const timestamp = new Date().toLocaleTimeString();
   console.log(`[${timestamp}] ${message}`);
 };

--- a/src/renderer/lib/github-bridge-ui.test.js
+++ b/src/renderer/lib/github-bridge-ui.test.js
@@ -1,0 +1,348 @@
+const { createDocument, createElement } = require('../../../test/helpers/fake-dom.js');
+
+const originalWindow = global.window;
+const originalDocument = global.document;
+const originalNavigator = global.navigator;
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createStep = (step) =>
+  createElement('div', {
+    classes: ['ghb-step'],
+    dataset: { step },
+  });
+
+const loadGithubBridgeModule = async (options = {}) => {
+  jest.resetModules();
+
+  const state = {
+    enableRadicleIntegration: options.enableRadicleIntegration ?? true,
+    currentRadicleStatus: options.currentRadicleStatus || 'running',
+  };
+  const bridgeBtn = createElement('button', {
+    classes: ['hidden'],
+  });
+  const panel = createElement('div', {
+    classes: ['hidden'],
+  });
+  const closeBtn = createElement('button');
+  const importBtn = createElement('button');
+  const browseBtn = createElement('button');
+  const retryBtn = createElement('button');
+  const copyBtn = createElement('button');
+  const repoNameEl = createElement('div');
+  const ridEl = createElement('div');
+  const errorDetailEl = createElement('div');
+  const prereqTextEl = createElement('div');
+  const prereqErrorState = createElement('section', { classes: ['hidden'] });
+  const readyState = createElement('section', { classes: ['hidden'] });
+  const importingState = createElement('section', { classes: ['hidden'] });
+  const successState = createElement('section', { classes: ['hidden'] });
+  const errorState = createElement('section', { classes: ['hidden'] });
+  const cloningStep = createStep('cloning');
+  const initializingStep = createStep('initializing');
+  const pushingStep = createStep('pushing');
+  const addressInput = createElement('input', {
+    value: options.addressValue || 'https://github.com/openai/project',
+  });
+  const body = createElement('body');
+
+  importingState.appendChild(cloningStep);
+  importingState.appendChild(initializingStep);
+  importingState.appendChild(pushingStep);
+  panel.appendChild(closeBtn);
+  panel.appendChild(importBtn);
+  panel.appendChild(browseBtn);
+  panel.appendChild(retryBtn);
+  panel.appendChild(copyBtn);
+  panel.appendChild(repoNameEl);
+  panel.appendChild(ridEl);
+  panel.appendChild(errorDetailEl);
+  panel.appendChild(prereqTextEl);
+  panel.appendChild(prereqErrorState);
+  panel.appendChild(readyState);
+  panel.appendChild(importingState);
+  panel.appendChild(successState);
+  panel.appendChild(errorState);
+  body.appendChild(panel);
+
+  const document = createDocument({
+    body,
+    elementsById: {
+      'github-bridge-btn': bridgeBtn,
+      'github-bridge-panel': panel,
+      'ghb-close': closeBtn,
+      'ghb-import-btn': importBtn,
+      'ghb-browse-btn': browseBtn,
+      'ghb-retry-btn': retryBtn,
+      'ghb-copy-rid': copyBtn,
+      'ghb-repo-name': repoNameEl,
+      'ghb-rid': ridEl,
+      'ghb-error-detail': errorDetailEl,
+      'ghb-prereq-text': prereqTextEl,
+      'ghb-prereq-error': prereqErrorState,
+      'ghb-ready': readyState,
+      'ghb-importing': importingState,
+      'ghb-success': successState,
+      'ghb-error': errorState,
+      'address-input': addressInput,
+    },
+  });
+  let progressHandler = null;
+  const progressCleanup = jest.fn();
+  const githubBridge = {
+    checkExisting:
+      options.checkExisting ||
+      jest.fn().mockResolvedValue({ success: true, bridged: false, rid: '' }),
+    checkPrerequisites:
+      options.checkPrerequisites || jest.fn().mockResolvedValue({ success: true }),
+    onProgress:
+      options.onProgress ||
+      jest.fn((handler) => {
+        progressHandler = handler;
+        return progressCleanup;
+      }),
+    import:
+      options.importFn ||
+      jest.fn().mockResolvedValue({ success: true, rid: 'z123' }),
+  };
+  const windowHandlers = {};
+  const clipboard = {
+    writeText: jest.fn().mockResolvedValue(undefined),
+  };
+  const electronAPI = {
+    copyText: jest.fn(),
+  };
+  const setTimeoutMock = jest.spyOn(global, 'setTimeout').mockImplementation((fn) => {
+    fn();
+    return 1;
+  });
+
+  global.window = {
+    githubBridge,
+    electronAPI,
+    addEventListener: jest.fn((event, handler) => {
+      windowHandlers[event] = handler;
+    }),
+  };
+  global.document = document;
+  global.navigator = {
+    clipboard,
+  };
+
+  jest.doMock('./state.js', () => ({ state }));
+
+  const mod = await import('./github-bridge-ui.js');
+
+  return {
+    mod,
+    state,
+    githubBridge,
+    progressCleanup,
+    getProgressHandler: () => progressHandler,
+    clipboard,
+    electronAPI,
+    windowHandlers,
+    setTimeoutMock,
+    documentHandlers: document.handlers,
+    elements: {
+      bridgeBtn,
+      panel,
+      closeBtn,
+      importBtn,
+      browseBtn,
+      retryBtn,
+      copyBtn,
+      repoNameEl,
+      ridEl,
+      errorDetailEl,
+      prereqTextEl,
+      prereqErrorState,
+      readyState,
+      importingState,
+      successState,
+      errorState,
+      cloningStep,
+      initializingStep,
+      pushingStep,
+      addressInput,
+    },
+  };
+};
+
+describe('github-bridge-ui', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.navigator = originalNavigator;
+    jest.restoreAllMocks();
+  });
+
+  test('updates icon visibility for GitHub URLs and bridged repositories', async () => {
+    const ctx = await loadGithubBridgeModule();
+
+    ctx.mod.initGithubBridgeUi();
+    await ctx.mod.updateGithubBridgeIcon();
+
+    expect(ctx.githubBridge.checkExisting).toHaveBeenCalledWith('https://github.com/openai/project');
+    expect(ctx.elements.bridgeBtn.classList.contains('hidden')).toBe(false);
+
+    ctx.githubBridge.checkExisting.mockResolvedValueOnce({
+      success: true,
+      bridged: true,
+      rid: 'zknown',
+    });
+    await ctx.mod.updateGithubBridgeIcon();
+    expect(ctx.elements.bridgeBtn.classList.contains('hidden')).toBe(true);
+
+    ctx.elements.addressInput.value = 'https://example.com/not-github';
+    await ctx.mod.updateGithubBridgeIcon();
+    expect(ctx.elements.bridgeBtn.classList.contains('hidden')).toBe(true);
+
+    ctx.state.enableRadicleIntegration = false;
+    ctx.windowHandlers['settings:updated']();
+    await flushMicrotasks();
+    expect(ctx.elements.bridgeBtn.classList.contains('hidden')).toBe(true);
+  });
+
+  test('opens the panel, imports successfully, and supports browse and copy actions', async () => {
+    const ctx = await loadGithubBridgeModule();
+    const onOpenRadicleUrl = jest.fn();
+
+    ctx.mod.initGithubBridgeUi();
+    ctx.mod.setOnOpenRadicleUrl(onOpenRadicleUrl);
+    await ctx.mod.updateGithubBridgeIcon();
+    ctx.githubBridge.import.mockImplementation(async () => {
+      const progressHandler = ctx.getProgressHandler();
+      progressHandler({ step: 'cloning' });
+      progressHandler({ step: 'pushing' });
+      progressHandler({ step: 'success' });
+      return { success: true, rid: 'zsuccess' };
+    });
+    ctx.elements.bridgeBtn.dispatch('click', {
+      stopPropagation: jest.fn(),
+    });
+    await flushMicrotasks();
+
+    expect(ctx.elements.panel.classList.contains('hidden')).toBe(false);
+    expect(ctx.elements.repoNameEl.textContent).toBe('openai/project');
+    expect(ctx.elements.readyState.classList.contains('hidden')).toBe(false);
+    expect(ctx.elements.prereqErrorState.classList.contains('hidden')).toBe(true);
+
+    ctx.elements.importBtn.dispatch('click');
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(ctx.githubBridge.checkPrerequisites).toHaveBeenCalled();
+    expect(ctx.githubBridge.import).toHaveBeenCalledWith('https://github.com/openai/project');
+    expect(ctx.progressCleanup).toHaveBeenCalled();
+    expect(ctx.elements.cloningStep.classList.contains('done')).toBe(true);
+    expect(ctx.elements.pushingStep.classList.contains('done')).toBe(true);
+    expect(ctx.elements.successState.classList.contains('hidden')).toBe(false);
+    expect(ctx.elements.ridEl.textContent).toBe('rad:zsuccess');
+
+    ctx.elements.browseBtn.dispatch('click');
+    expect(onOpenRadicleUrl).toHaveBeenCalledWith('rad://zsuccess');
+    expect(ctx.elements.panel.classList.contains('hidden')).toBe(true);
+
+    ctx.elements.copyBtn.dispatch('click');
+    expect(ctx.clipboard.writeText).toHaveBeenCalledWith('rad:zsuccess');
+    expect(ctx.setTimeoutMock).toHaveBeenCalledWith(expect.any(Function), 1000);
+  });
+
+  test('shows prereq and import errors and supports retry', async () => {
+    const ctx = await loadGithubBridgeModule({
+      enableRadicleIntegration: false,
+    });
+
+    ctx.mod.initGithubBridgeUi();
+    ctx.elements.bridgeBtn.dispatch('click', {
+      stopPropagation: jest.fn(),
+    });
+
+    expect(ctx.elements.prereqErrorState.classList.contains('hidden')).toBe(false);
+    expect(ctx.elements.prereqTextEl.textContent).toBe(
+      'Radicle integration is disabled. Enable it in Settings > Experimental'
+    );
+
+    ctx.state.enableRadicleIntegration = true;
+    ctx.state.currentRadicleStatus = 'running';
+    ctx.githubBridge.import.mockResolvedValueOnce({
+      success: false,
+      error: 'remote rejected',
+      step: 'pushing',
+    });
+
+    await ctx.mod.updateGithubBridgeIcon();
+    ctx.elements.bridgeBtn.dispatch('click', {
+      stopPropagation: jest.fn(),
+    });
+    await flushMicrotasks();
+
+    ctx.elements.importBtn.dispatch('click');
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(ctx.elements.errorState.classList.contains('hidden')).toBe(false);
+    expect(ctx.elements.errorDetailEl.textContent).toBe('remote rejected');
+    expect(ctx.elements.pushingStep.classList.contains('error')).toBe(true);
+
+    ctx.elements.retryBtn.dispatch('click');
+    expect(ctx.elements.readyState.classList.contains('hidden')).toBe(false);
+    expect(ctx.elements.pushingStep.classList.contains('error')).toBe(false);
+  });
+
+  test('handles already-bridged imports, copy fallback, and panel close shortcuts', async () => {
+    const ctx = await loadGithubBridgeModule({
+      importFn: jest.fn().mockResolvedValue({
+        success: false,
+        error: {
+          code: 'ALREADY_BRIDGED',
+          details: {
+            rid: 'zexisting',
+          },
+        },
+      }),
+    });
+
+    ctx.clipboard.writeText.mockRejectedValueOnce(new Error('clipboard unavailable'));
+
+    ctx.mod.initGithubBridgeUi();
+    await ctx.mod.updateGithubBridgeIcon();
+
+    ctx.elements.bridgeBtn.dispatch('click', {
+      stopPropagation: jest.fn(),
+    });
+    await flushMicrotasks();
+
+    ctx.elements.importBtn.dispatch('click');
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(ctx.elements.successState.classList.contains('hidden')).toBe(false);
+    expect(ctx.elements.ridEl.textContent).toBe('rad:zexisting');
+    expect(ctx.elements.bridgeBtn.classList.contains('hidden')).toBe(true);
+
+    ctx.elements.copyBtn.dispatch('click');
+    await flushMicrotasks();
+    expect(ctx.electronAPI.copyText).toHaveBeenCalledWith('rad:zexisting');
+
+    ctx.documentHandlers.keydown({
+      key: 'Escape',
+    });
+    expect(ctx.elements.panel.classList.contains('hidden')).toBe(true);
+
+    ctx.elements.bridgeBtn.classList.remove('hidden');
+    ctx.elements.bridgeBtn.dispatch('click', {
+      stopPropagation: jest.fn(),
+    });
+    await flushMicrotasks();
+    ctx.documentHandlers.click({
+      target: createElement('div'),
+    });
+    expect(ctx.elements.panel.classList.contains('hidden')).toBe(true);
+  });
+});

--- a/src/renderer/lib/ipfs-ui.test.js
+++ b/src/renderer/lib/ipfs-ui.test.js
@@ -1,0 +1,293 @@
+const { createDocument, createElement } = require('../../../test/helpers/fake-dom.js');
+
+const originalWindow = global.window;
+const originalDocument = global.document;
+const originalFetch = global.fetch;
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const loadIpfsModule = async (options = {}) => {
+  jest.resetModules();
+
+  const state = {
+    beeMenuOpen: options.beeMenuOpen ?? false,
+    currentIpfsStatus: options.currentIpfsStatus || 'stopped',
+    ipfsPeersInterval: null,
+    ipfsVersionFetched: options.ipfsVersionFetched ?? false,
+    ipfsVersionValue: options.ipfsVersionValue || '',
+    suppressIpfsRunningStatus: options.suppressIpfsRunningStatus ?? false,
+    registry: {
+      ipfs: {
+        api: 'http://ipfs.test',
+        mode: options.mode || 'none',
+        statusMessage: options.statusMessage ?? null,
+        tempMessage: options.tempMessage ?? null,
+      },
+    },
+  };
+  const buildIpfsApiUrl = jest.fn((endpoint) => `http://ipfs.test${endpoint}`);
+  const getDisplayMessage = jest.fn(() => {
+    return state.registry.ipfs.tempMessage || state.registry.ipfs.statusMessage;
+  });
+  const debugMocks = {
+    pushDebug: jest.fn(),
+  };
+  const ipfsToggleBtn = createElement('button');
+  const ipfsToggleSwitch = createElement('div');
+  const ipfsPeersCount = createElement('span');
+  const ipfsBandwidthDown = createElement('span');
+  const ipfsBandwidthUp = createElement('span');
+  const ipfsVersionText = createElement('span');
+  const ipfsInfoPanel = createElement('div', {
+    classes: ['ipfs-info'],
+  });
+  const ipfsStatusRow = createElement('div');
+  const ipfsStatusLabel = createElement('span');
+  const ipfsStatusValue = createElement('span');
+  const body = createElement('body');
+  body.appendChild(ipfsInfoPanel);
+  const document = createDocument({
+    body,
+    elementsById: {
+      'ipfs-toggle-btn': ipfsToggleBtn,
+      'ipfs-toggle-switch': ipfsToggleSwitch,
+      'ipfs-peers-count': ipfsPeersCount,
+      'ipfs-bandwidth-down': ipfsBandwidthDown,
+      'ipfs-bandwidth-up': ipfsBandwidthUp,
+      'ipfs-version-text': ipfsVersionText,
+      'ipfs-status-row': ipfsStatusRow,
+      'ipfs-status-label': ipfsStatusLabel,
+      'ipfs-status-value': ipfsStatusValue,
+    },
+  });
+  let statusHandler = null;
+  const ipfsApi =
+    options.windowIpfs === false
+      ? undefined
+      : {
+          checkBinary: jest
+            .fn()
+            .mockResolvedValue({ available: options.binaryAvailable ?? true }),
+          start: jest
+            .fn()
+            .mockResolvedValue(options.startResult || { status: 'running', error: null }),
+          stop: jest
+            .fn()
+            .mockResolvedValue(options.stopResult || { status: 'stopped', error: null }),
+          getStatus: jest
+            .fn()
+            .mockResolvedValue(options.statusResult || { status: 'stopped', error: null }),
+          onStatusUpdate: jest.fn((handler) => {
+            statusHandler = handler;
+          }),
+        };
+  let intervalId = 1;
+  const setIntervalMock = jest.spyOn(global, 'setInterval').mockImplementation(() => intervalId++);
+  const clearIntervalMock = jest.spyOn(global, 'clearInterval').mockImplementation(() => {});
+
+  global.fetch =
+    options.fetchImpl ||
+    jest.fn(async (url) => {
+      if (url.endsWith('/api/v0/swarm/peers')) {
+        return {
+          ok: true,
+          json: async () => ({ Peers: [{ id: 'a' }, { id: 'b' }, { id: 'c' }] }),
+        };
+      }
+      if (url.endsWith('/api/v0/stats/bw')) {
+        return {
+          ok: true,
+          json: async () => ({
+            RateIn: 1536,
+            RateOut: 1048576,
+          }),
+        };
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ AgentVersion: 'kubo/0.28.0-rc1/' }),
+      };
+    });
+  global.window = {
+    ipfs: ipfsApi,
+  };
+  global.document = document;
+
+  jest.doMock('./state.js', () => ({
+    state,
+    buildIpfsApiUrl,
+    getDisplayMessage,
+  }));
+  jest.doMock('./debug.js', () => debugMocks);
+
+  const mod = await import('./ipfs-ui.js');
+
+  return {
+    mod,
+    state,
+    buildIpfsApiUrl,
+    getDisplayMessage,
+    debugMocks,
+    setIntervalMock,
+    clearIntervalMock,
+    ipfsApi,
+    getStatusHandler: () => statusHandler,
+    elements: {
+      ipfsToggleBtn,
+      ipfsToggleSwitch,
+      ipfsPeersCount,
+      ipfsBandwidthDown,
+      ipfsBandwidthUp,
+      ipfsVersionText,
+      ipfsInfoPanel,
+      ipfsStatusRow,
+      ipfsStatusLabel,
+      ipfsStatusValue,
+    },
+  };
+};
+
+describe('ipfs-ui', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  test('starts and stops IPFS info polling and populates stats', async () => {
+    const ctx = await loadIpfsModule({
+      beeMenuOpen: true,
+      currentIpfsStatus: 'running',
+      windowIpfs: false,
+    });
+
+    ctx.mod.initIpfsUi();
+    ctx.mod.startIpfsInfoPolling();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(ctx.buildIpfsApiUrl).toHaveBeenCalledWith('/api/v0/swarm/peers');
+    expect(ctx.buildIpfsApiUrl).toHaveBeenCalledWith('/api/v0/stats/bw');
+    expect(ctx.buildIpfsApiUrl).toHaveBeenCalledWith('/api/v0/id');
+    expect(ctx.elements.ipfsInfoPanel.classList.contains('visible')).toBe(true);
+    expect(ctx.elements.ipfsPeersCount.textContent).toBe('3');
+    expect(ctx.elements.ipfsBandwidthDown.textContent).toBe('↓1.5 KB/s');
+    expect(ctx.elements.ipfsBandwidthUp.textContent).toBe('↑1.0 MB/s');
+    expect(ctx.elements.ipfsVersionText.textContent).toBe('0.28.0');
+    expect(ctx.state.ipfsVersionFetched).toBe(true);
+    expect(ctx.state.ipfsPeersInterval).toBe(1);
+    expect(ctx.setIntervalMock).toHaveBeenCalledWith(expect.any(Function), 1000);
+
+    ctx.mod.stopIpfsInfoPolling();
+
+    expect(ctx.clearIntervalMock).toHaveBeenCalledWith(1);
+    expect(ctx.state.ipfsPeersInterval).toBeNull();
+    expect(ctx.elements.ipfsInfoPanel.classList.contains('visible')).toBe(false);
+    expect(ctx.elements.ipfsPeersCount.textContent).toBe('0');
+    expect(ctx.elements.ipfsBandwidthDown.textContent).toBe('');
+    expect(ctx.elements.ipfsBandwidthUp.textContent).toBe('');
+    expect(ctx.elements.ipfsVersionText.textContent).toBe('0.28.0');
+
+    ctx.mod.resetIpfsVersion();
+    expect(ctx.state.ipfsVersionFetched).toBe(false);
+    expect(ctx.state.ipfsVersionValue).toBe('');
+    expect(ctx.elements.ipfsVersionText.textContent).toBe('');
+  });
+
+  test('updates IPFS status lines, toggle state, and running transitions', async () => {
+    const ctx = await loadIpfsModule({
+      beeMenuOpen: true,
+      currentIpfsStatus: 'stopped',
+      statusMessage: 'IPFS: Connected',
+      windowIpfs: false,
+    });
+
+    ctx.mod.initIpfsUi();
+    ctx.mod.updateIpfsStatusLine();
+
+    expect(ctx.getDisplayMessage).toHaveBeenCalledWith('ipfs');
+    expect(ctx.elements.ipfsStatusLabel.textContent).toBe('IPFS:');
+    expect(ctx.elements.ipfsStatusValue.textContent).toBe('Connected');
+    expect(ctx.elements.ipfsStatusRow.classList.contains('visible')).toBe(true);
+
+    ctx.state.registry.ipfs.mode = 'reused';
+    ctx.mod.updateIpfsToggleState();
+    expect(ctx.elements.ipfsToggleBtn.classList.contains('external')).toBe(true);
+    expect(ctx.elements.ipfsToggleBtn.getAttribute('title')).toBe(
+      'Using existing node — cannot be controlled from Freedom'
+    );
+
+    ctx.state.registry.ipfs.mode = 'none';
+    ctx.mod.updateIpfsToggleState();
+    expect(ctx.elements.ipfsToggleBtn.classList.contains('external')).toBe(false);
+
+    ctx.mod.updateIpfsUi('starting');
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+    expect(ctx.state.currentIpfsStatus).toBe('starting');
+
+    ctx.state.suppressIpfsRunningStatus = true;
+    ctx.elements.ipfsToggleSwitch.classList.remove('running');
+    ctx.mod.updateIpfsUi('running');
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
+
+    ctx.mod.updateIpfsUi('error', 'offline');
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('IPFS Error: offline');
+
+    ctx.mod.updateIpfsUi('stopped');
+    expect(ctx.elements.ipfsStatusRow.classList.contains('visible')).toBe(false);
+  });
+
+  test('initializes IPFS controls, handles binary availability, and toggles start and stop', async () => {
+    const ctx = await loadIpfsModule({
+      beeMenuOpen: true,
+      currentIpfsStatus: 'stopped',
+      binaryAvailable: false,
+      statusResult: { status: 'stopped', error: null },
+    });
+
+    ctx.mod.initIpfsUi();
+    await flushMicrotasks();
+
+    expect(ctx.ipfsApi.checkBinary).toHaveBeenCalled();
+    expect(ctx.elements.ipfsToggleBtn.classList.contains('disabled')).toBe(true);
+    expect(ctx.elements.ipfsToggleBtn.getAttribute('disabled')).toBe('true');
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('IPFS binary not found - toggle disabled');
+    expect(ctx.ipfsApi.onStatusUpdate).toHaveBeenCalledWith(expect.any(Function));
+    expect(ctx.ipfsApi.getStatus).toHaveBeenCalled();
+    expect(ctx.setIntervalMock).toHaveBeenCalledWith(expect.any(Function), 5000);
+
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    expect(ctx.ipfsApi.start).not.toHaveBeenCalled();
+
+    ctx.ipfsApi.checkBinary.mockResolvedValueOnce({ available: true });
+    ctx.mod.initIpfsUi();
+    await flushMicrotasks();
+
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    await flushMicrotasks();
+
+    expect(ctx.ipfsApi.start).toHaveBeenCalled();
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('User toggled IPFS On');
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+    expect(ctx.state.currentIpfsStatus).toBe('running');
+
+    const statusHandler = ctx.getStatusHandler();
+    statusHandler({
+      status: 'error',
+      error: 'offline',
+    });
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('IPFS Status Update: error (offline)');
+
+    ctx.state.currentIpfsStatus = 'running';
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    await flushMicrotasks();
+
+    expect(ctx.ipfsApi.stop).toHaveBeenCalled();
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('User toggled IPFS Off');
+  });
+});

--- a/src/renderer/lib/menu-backdrop.test.js
+++ b/src/renderer/lib/menu-backdrop.test.js
@@ -1,0 +1,52 @@
+describe('menu-backdrop', () => {
+  const originalDocument = global.document;
+
+  const loadModule = async (backdrop) => {
+    jest.resetModules();
+    global.document = {
+      getElementById: jest.fn((id) => (id === 'menu-backdrop' ? backdrop : null)),
+    };
+    return import('./menu-backdrop.js');
+  };
+
+  afterEach(() => {
+    global.document = originalDocument;
+  });
+
+  test('initializes the backdrop and closes menus on mousedown', async () => {
+    const closeAllMenus = jest.fn();
+    let mousedownHandler = null;
+    const backdrop = {
+      addEventListener: jest.fn((event, handler) => {
+        if (event === 'mousedown') {
+          mousedownHandler = handler;
+        }
+      }),
+      classList: {
+        add: jest.fn(),
+        remove: jest.fn(),
+      },
+    };
+
+    const mod = await loadModule(backdrop);
+    mod.initMenuBackdrop(closeAllMenus);
+    mod.showMenuBackdrop();
+    mod.hideMenuBackdrop();
+    mousedownHandler();
+
+    expect(backdrop.addEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function));
+    expect(backdrop.classList.remove).toHaveBeenCalledWith('hidden');
+    expect(backdrop.classList.add).toHaveBeenCalledWith('hidden');
+    expect(closeAllMenus).toHaveBeenCalled();
+  });
+
+  test('handles missing backdrop elements safely', async () => {
+    const mod = await loadModule(null);
+
+    expect(() => {
+      mod.initMenuBackdrop(jest.fn());
+      mod.showMenuBackdrop();
+      mod.hideMenuBackdrop();
+    }).not.toThrow();
+  });
+});

--- a/src/renderer/lib/menus.test.js
+++ b/src/renderer/lib/menus.test.js
@@ -1,0 +1,314 @@
+const originalWindow = global.window;
+const originalDocument = global.document;
+
+const createElement = () => {
+  const handlers = {};
+
+  return {
+    handlers,
+    classList: {
+      toggle: jest.fn(),
+      add: jest.fn(),
+      remove: jest.fn(),
+    },
+    dataset: {},
+    textContent: '',
+    setAttribute: jest.fn(),
+    addEventListener: jest.fn((event, handler) => {
+      handlers[event] = handler;
+    }),
+    contains: jest.fn(() => false),
+    blur: jest.fn(),
+    print: jest.fn(),
+  };
+};
+
+const loadMenusModule = async ({ platform = 'darwin', webview } = {}) => {
+  jest.resetModules();
+
+  const menuButton = createElement();
+  const menuDropdown = createElement();
+  const historyBtn = createElement();
+  const newTabMenuBtn = createElement();
+  const newWindowMenuBtn = createElement();
+  const zoomOutBtn = createElement();
+  const zoomInBtn = createElement();
+  const zoomLevelDisplay = createElement();
+  const fullscreenBtn = createElement();
+  const printBtn = createElement();
+  const devtoolsBtn = createElement();
+  const aboutBtn = createElement();
+  const checkUpdatesBtn = createElement();
+  const beeMenuButton = createElement();
+  const beeMenuDropdown = createElement();
+  const webviewElement = createElement();
+  const beePeersCount = createElement();
+  const beeNetworkPeers = createElement();
+  const beeVersionText = createElement();
+  const beeInfoPanel = createElement();
+
+  const shortcutEls = [
+    { dataset: { shortcut: 'CmdOrCtrl+Shift+T' }, textContent: '' },
+    { dataset: { shortcut: 'Alt+CmdOrCtrl+I' }, textContent: '' },
+  ];
+
+  const documentHandlers = {};
+  const windowHandlers = {};
+  const electronAPI = {
+    getPlatform: jest.fn().mockResolvedValue(platform),
+    newWindow: jest.fn(),
+    toggleFullscreen: jest.fn(),
+    showAbout: jest.fn(),
+    checkForUpdates: jest.fn(),
+  };
+  const tabsMocks = {
+    hideTabContextMenu: jest.fn(),
+    getActiveWebview: jest.fn(() => webview || null),
+  };
+  const bookmarkMocks = {
+    hideBookmarkContextMenu: jest.fn(),
+    hideOverflowMenu: jest.fn(),
+  };
+  const backdropMocks = {
+    showMenuBackdrop: jest.fn(),
+    hideMenuBackdrop: jest.fn(),
+  };
+  const beeUiMocks = {
+    startBeeInfoPolling: jest.fn(),
+    stopBeeInfoPolling: jest.fn(),
+  };
+  const ipfsUiMocks = {
+    startIpfsInfoPolling: jest.fn(),
+    stopIpfsInfoPolling: jest.fn(),
+  };
+  const radicleUiMocks = {
+    startRadicleInfoPolling: jest.fn(),
+    stopRadicleInfoPolling: jest.fn(),
+  };
+
+  global.window = {
+    electronAPI,
+    nodeConfig: {},
+    addEventListener: jest.fn((event, handler) => {
+      windowHandlers[event] = handler;
+    }),
+  };
+
+  global.document = {
+    getElementById: jest.fn((id) => {
+      const map = {
+        'menu-button': menuButton,
+        'menu-dropdown': menuDropdown,
+        'history-btn': historyBtn,
+        'new-tab-menu-btn': newTabMenuBtn,
+        'new-window-menu-btn': newWindowMenuBtn,
+        'zoom-out-btn': zoomOutBtn,
+        'zoom-in-btn': zoomInBtn,
+        'zoom-level': zoomLevelDisplay,
+        'fullscreen-btn': fullscreenBtn,
+        'print-btn': printBtn,
+        'devtools-btn': devtoolsBtn,
+        'about-btn': aboutBtn,
+        'check-updates-btn': checkUpdatesBtn,
+        'bee-menu-button': beeMenuButton,
+        'bee-menu-dropdown': beeMenuDropdown,
+        'bzz-webview': webviewElement,
+        'bee-peers-count': beePeersCount,
+        'bee-network-peers': beeNetworkPeers,
+        'bee-version-text': beeVersionText,
+      };
+
+      return map[id] || null;
+    }),
+    querySelector: jest.fn((selector) => (selector === '.bee-info' ? beeInfoPanel : null)),
+    querySelectorAll: jest.fn(() => shortcutEls),
+    addEventListener: jest.fn((event, handler) => {
+      documentHandlers[event] = handler;
+    }),
+  };
+
+  jest.doMock('./tabs.js', () => tabsMocks);
+  jest.doMock('./bookmarks-ui.js', () => bookmarkMocks);
+  jest.doMock('./menu-backdrop.js', () => backdropMocks);
+  jest.doMock('./bee-ui.js', () => beeUiMocks);
+  jest.doMock('./ipfs-ui.js', () => ipfsUiMocks);
+  jest.doMock('./radicle-ui.js', () => radicleUiMocks);
+
+  const menus = await import('./menus.js');
+  const stateModule = await import('./state.js');
+
+  return {
+    menus,
+    state: stateModule.state,
+    elements: {
+      menuButton,
+      menuDropdown,
+      historyBtn,
+      newTabMenuBtn,
+      newWindowMenuBtn,
+      zoomOutBtn,
+      zoomInBtn,
+      zoomLevelDisplay,
+      fullscreenBtn,
+      printBtn,
+      devtoolsBtn,
+      aboutBtn,
+      checkUpdatesBtn,
+      beeMenuButton,
+      beeMenuDropdown,
+      webviewElement,
+      beePeersCount,
+      beeNetworkPeers,
+      beeVersionText,
+      beeInfoPanel,
+      shortcutEls,
+    },
+    handlers: {
+      documentHandlers,
+      windowHandlers,
+    },
+    mocks: {
+      electronAPI,
+      tabsMocks,
+      bookmarkMocks,
+      backdropMocks,
+      beeUiMocks,
+      ipfsUiMocks,
+      radicleUiMocks,
+    },
+  };
+};
+
+describe('menus', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+  });
+
+  test('formats shortcuts and toggles the main menu state', async () => {
+    const webview = {
+      getZoomFactor: jest.fn(() => 1.25),
+    };
+    const { menus, state, elements, mocks } = await loadMenusModule({ webview });
+    const onMenuOpening = jest.fn();
+
+    menus.setOnMenuOpening(onMenuOpening);
+    menus.initMenus();
+    await Promise.resolve();
+
+    expect(elements.shortcutEls[0].textContent).toBe('⌘⇧T');
+    expect(elements.shortcutEls[1].textContent).toBe('⌥⌘I');
+
+    elements.menuButton.handlers.click();
+
+    expect(state.menuOpen).toBe(true);
+    expect(elements.menuDropdown.classList.toggle).toHaveBeenCalledWith('open', true);
+    expect(elements.menuButton.setAttribute).toHaveBeenCalledWith('aria-expanded', 'true');
+    expect(mocks.tabsMocks.hideTabContextMenu).toHaveBeenCalled();
+    expect(mocks.bookmarkMocks.hideBookmarkContextMenu).toHaveBeenCalled();
+    expect(mocks.bookmarkMocks.hideOverflowMenu).toHaveBeenCalled();
+    expect(mocks.backdropMocks.showMenuBackdrop).toHaveBeenCalled();
+    expect(onMenuOpening).toHaveBeenCalled();
+    expect(elements.zoomLevelDisplay.textContent).toBe('125%');
+
+    menus.closeMenus();
+
+    expect(state.menuOpen).toBe(false);
+    expect(elements.menuDropdown.classList.toggle).toHaveBeenCalledWith('open', false);
+  });
+
+  test('handles menu actions and zoom controls through registered click handlers', async () => {
+    let zoomFactor = 1;
+    const webview = {
+      getZoomFactor: jest.fn(() => zoomFactor),
+      setZoomFactor: jest.fn((next) => {
+        zoomFactor = next;
+      }),
+      print: jest.fn(),
+      isDevToolsOpened: jest
+        .fn()
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true),
+      openDevTools: jest.fn(),
+      closeDevTools: jest.fn(),
+    };
+    const { menus, elements, mocks } = await loadMenusModule({ platform: 'win32', webview });
+    const onNewTab = jest.fn();
+    const onOpenHistory = jest.fn();
+
+    menus.setOnNewTab(onNewTab);
+    menus.setOnOpenHistory(onOpenHistory);
+    menus.initMenus();
+    await Promise.resolve();
+
+    elements.newTabMenuBtn.handlers.click();
+    elements.newWindowMenuBtn.handlers.click();
+    elements.historyBtn.handlers.click();
+    elements.zoomInBtn.handlers.click();
+    elements.zoomOutBtn.handlers.click();
+    elements.fullscreenBtn.handlers.click();
+    elements.printBtn.handlers.click();
+    elements.devtoolsBtn.handlers.click();
+    elements.devtoolsBtn.handlers.click();
+    elements.aboutBtn.handlers.click();
+    elements.checkUpdatesBtn.handlers.click();
+
+    expect(onNewTab).toHaveBeenCalled();
+    expect(mocks.electronAPI.newWindow).toHaveBeenCalled();
+    expect(onOpenHistory).toHaveBeenCalled();
+    expect(webview.setZoomFactor).toHaveBeenCalledWith(1.1);
+    expect(webview.setZoomFactor).toHaveBeenCalledWith(1);
+    expect(mocks.electronAPI.toggleFullscreen).toHaveBeenCalled();
+    expect(webview.print).toHaveBeenCalled();
+    expect(webview.openDevTools).toHaveBeenCalled();
+    expect(webview.closeDevTools).toHaveBeenCalled();
+    expect(mocks.electronAPI.showAbout).toHaveBeenCalled();
+    expect(mocks.electronAPI.checkForUpdates).toHaveBeenCalled();
+  });
+
+  test('opens and closes the bee menu while managing polling and backdrop state', async () => {
+    const { menus, state, elements, mocks } = await loadMenusModule();
+
+    menus.initMenus();
+    state.beeVersionFetched = true;
+    state.beeVersionValue = '1.2.3';
+    elements.beePeersCount.textContent = '5';
+    elements.beeNetworkPeers.textContent = '8';
+
+    menus.setBeeMenuOpen(true);
+
+    expect(state.beeMenuOpen).toBe(true);
+    expect(elements.beeMenuDropdown.classList.toggle).toHaveBeenCalledWith('open', true);
+    expect(mocks.beeUiMocks.startBeeInfoPolling).toHaveBeenCalled();
+    expect(mocks.ipfsUiMocks.startIpfsInfoPolling).toHaveBeenCalled();
+    expect(mocks.radicleUiMocks.startRadicleInfoPolling).toHaveBeenCalled();
+    expect(mocks.backdropMocks.showMenuBackdrop).toHaveBeenCalled();
+
+    menus.setBeeMenuOpen(false);
+
+    expect(state.beeMenuOpen).toBe(false);
+    expect(mocks.beeUiMocks.stopBeeInfoPolling).toHaveBeenCalled();
+    expect(mocks.ipfsUiMocks.stopIpfsInfoPolling).toHaveBeenCalled();
+    expect(mocks.radicleUiMocks.stopRadicleInfoPolling).toHaveBeenCalled();
+    expect(elements.beePeersCount.textContent).toBe('0');
+    expect(elements.beeNetworkPeers.textContent).toBe('0');
+    expect(elements.beeVersionText.textContent).toBe('1.2.3');
+    expect(elements.beeInfoPanel.classList.remove).toHaveBeenCalledWith('visible');
+    expect(mocks.backdropMocks.hideMenuBackdrop).toHaveBeenCalled();
+  });
+
+  test('closes menus on outside clicks, webview interaction, and window blur', async () => {
+    const { menus, state, elements, handlers } = await loadMenusModule();
+
+    menus.initMenus();
+    menus.setMenuOpen(true);
+    menus.setBeeMenuOpen(true);
+
+    handlers.documentHandlers.click({ target: {} });
+    elements.webviewElement.handlers.focus();
+    handlers.windowHandlers.blur();
+
+    expect(state.menuOpen).toBe(false);
+    expect(state.beeMenuOpen).toBe(false);
+  });
+});

--- a/src/renderer/lib/navigation-utils-helpers.test.js
+++ b/src/renderer/lib/navigation-utils-helpers.test.js
@@ -1,0 +1,182 @@
+const originalWindow = global.window;
+
+const loadNavigationUtils = async (internalPages = {}) => {
+  jest.resetModules();
+  global.window = {
+    location: { href: 'file:///app/index.html' },
+    internalPages: { routable: internalPages },
+  };
+
+  return import('./navigation-utils.js');
+};
+
+describe('navigation-utils extracted helpers', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+  });
+
+  test('applies ens suffixes and extracts ens resolution metadata', async () => {
+    const mod = await loadNavigationUtils();
+
+    expect(mod.applyEnsSuffix('https://example.com/base/', '/docs?q=1')).toBe(
+      'https://example.com/docs?q=1'
+    );
+    expect(mod.applyEnsSuffix('not-a-url', '/docs')).toBe('not-a-url/docs');
+
+    expect(mod.extractEnsResolutionMetadata('bzz://abcdef/path', 'name.eth')).toEqual({
+      knownEnsPairs: [['abcdef', 'name.eth']],
+      resolvedProtocol: 'swarm',
+    });
+    expect(mod.extractEnsResolutionMetadata('ipfs://QmHash/path', 'name.eth')).toEqual({
+      knownEnsPairs: [['QmHash', 'name.eth']],
+      resolvedProtocol: 'ipfs',
+    });
+    expect(mod.extractEnsResolutionMetadata('ipns://docs.example/path', 'name.eth')).toEqual({
+      knownEnsPairs: [['docs.example', 'name.eth']],
+      resolvedProtocol: 'ipfs',
+    });
+    expect(mod.extractEnsResolutionMetadata('https://example.com', 'name.eth')).toEqual({
+      knownEnsPairs: [],
+      resolvedProtocol: null,
+    });
+  });
+
+  test('derives display addresses with ens preservation and radicle conversion', async () => {
+    const mod = await loadNavigationUtils();
+
+    expect(
+      mod.deriveDisplayAddress({
+        url: 'http://127.0.0.1:1633/bzz/abcdef/path',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+        ipfsRoutePrefix: 'http://127.0.0.1:8080/ipfs/',
+        ipnsRoutePrefix: 'http://127.0.0.1:8080/ipns/',
+        radicleApiPrefix: 'http://127.0.0.1:8780/api/v1/repos/',
+        knownEnsNames: new Map([['abcdef', 'name.eth']]),
+      })
+    ).toBe('ens://name.eth/path');
+
+    expect(
+      mod.deriveDisplayAddress({
+        url: 'http://127.0.0.1:8780/api/v1/repos/zabc123/tree/main',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+        ipfsRoutePrefix: 'http://127.0.0.1:8080/ipfs/',
+        ipnsRoutePrefix: 'http://127.0.0.1:8080/ipns/',
+        radicleApiPrefix: 'http://127.0.0.1:8780/api/v1/repos/',
+      })
+    ).toBe('rad://zabc123/tree/main');
+  });
+
+  test('builds view-source navigation for dweb and gateway urls', async () => {
+    const mod = await loadNavigationUtils();
+
+    expect(
+      mod.buildViewSourceNavigation({
+        value: 'view-source:bzz://abcdef/path',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+        ipfsRoutePrefix: 'http://127.0.0.1:8080/ipfs/',
+        ipnsRoutePrefix: 'http://127.0.0.1:8080/ipns/',
+      })
+    ).toEqual({
+      addressValue: 'view-source:bzz://abcdef/path',
+      loadUrl: 'view-source:http://127.0.0.1:1633/bzz/abcdef/path',
+    });
+
+    expect(
+      mod.buildViewSourceNavigation({
+        value: 'view-source:http://127.0.0.1:1633/bzz/abcdef/docs',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+        ipfsRoutePrefix: 'http://127.0.0.1:8080/ipfs/',
+        ipnsRoutePrefix: 'http://127.0.0.1:8080/ipns/',
+        knownEnsNames: new Map([['abcdef', 'name.eth']]),
+      })
+    ).toEqual({
+      addressValue: 'view-source:ens://name.eth/docs',
+      loadUrl: 'view-source:http://127.0.0.1:1633/bzz/abcdef/docs',
+    });
+  });
+
+  test('derives switched tab display values for loading, internal pages, and view-source', async () => {
+    const mod = await loadNavigationUtils({
+      history: 'history.html',
+    });
+
+    expect(
+      mod.deriveSwitchedTabDisplay({
+        url: 'https://loading.example',
+        isLoading: true,
+        addressBarSnapshot: 'typed value',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+      })
+    ).toBe('typed value');
+
+    expect(
+      mod.deriveSwitchedTabDisplay({
+        url: 'file:///app/pages/history.html',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+      })
+    ).toBe('freedom://history');
+
+    expect(
+      mod.deriveSwitchedTabDisplay({
+        url: 'view-source:http://127.0.0.1:1633/bzz/abcdef/docs',
+        isViewingSource: true,
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+        ipfsRoutePrefix: 'http://127.0.0.1:8080/ipfs/',
+        ipnsRoutePrefix: 'http://127.0.0.1:8080/ipns/',
+        knownEnsNames: new Map([['abcdef', 'name.eth']]),
+      })
+    ).toBe('view-source:ens://name.eth/docs');
+
+    expect(
+      mod.deriveSwitchedTabDisplay({
+        url: 'file:///app/pages/home.html',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+      })
+    ).toBe('');
+  });
+
+  test('computes bookmark bar state and extracts original urls from error pages', async () => {
+    const mod = await loadNavigationUtils();
+
+    expect(
+      mod.getBookmarkBarState({
+        url: '',
+        bookmarkBarOverride: false,
+        homeUrl: 'file:///app/pages/home.html',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+      })
+    ).toEqual({
+      isHomePage: true,
+      visible: true,
+    });
+
+    expect(
+      mod.getBookmarkBarState({
+        url: 'https://example.com',
+        bookmarkBarOverride: true,
+        homeUrl: 'file:///app/pages/home.html',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+      })
+    ).toEqual({
+      isHomePage: false,
+      visible: true,
+    });
+
+    expect(
+      mod.getOriginalUrlFromErrorPage(
+        'file:///app/pages/error.html?error=offline&url=https%3A%2F%2Fexample.com',
+        'file:///app/pages/error.html'
+      )
+    ).toBe('https://example.com');
+    expect(mod.getOriginalUrlFromErrorPage('https://example.com', 'file:///app/pages/error.html')).toBeNull();
+    expect(mod.getOriginalUrlFromErrorPage('not-a-url/error.html?', 'file:///app/pages/error.html')).toBeNull();
+  });
+});

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -1,3 +1,6 @@
+import { applyEnsNamePreservation, deriveDisplayValue } from './url-utils.js';
+import { getInternalPageName } from './page-urls.js';
+
 export const resolveProtocolIconType = ({
   value = '',
   ensProtocols = new Map(),
@@ -51,4 +54,197 @@ export const getRadicleDisplayUrl = (url) => {
     // Ignore parse errors.
   }
   return null;
+};
+
+export const applyEnsSuffix = (targetUri, suffix = '') => {
+  if (!suffix) {
+    return targetUri;
+  }
+
+  try {
+    return new URL(suffix, targetUri).toString();
+  } catch {
+    return `${targetUri.replace(/\/+$/, '')}${suffix}`;
+  }
+};
+
+export const extractEnsResolutionMetadata = (targetUri, ensName) => {
+  const knownEnsPairs = [];
+  let resolvedProtocol = null;
+
+  const bzzMatch = targetUri.match(/^bzz:\/\/([a-fA-F0-9]+)/);
+  if (bzzMatch) {
+    knownEnsPairs.push([bzzMatch[1].toLowerCase(), ensName]);
+    resolvedProtocol = 'swarm';
+  }
+
+  const ipfsMatch = targetUri.match(/^ipfs:\/\/([A-Za-z0-9]+)/);
+  if (ipfsMatch) {
+    knownEnsPairs.push([ipfsMatch[1], ensName]);
+    resolvedProtocol = 'ipfs';
+  }
+
+  const ipnsMatch = targetUri.match(/^ipns:\/\/([A-Za-z0-9.-]+)/);
+  if (ipnsMatch) {
+    knownEnsPairs.push([ipnsMatch[1], ensName]);
+    resolvedProtocol = 'ipfs';
+  }
+
+  return {
+    knownEnsPairs,
+    resolvedProtocol,
+  };
+};
+
+export const deriveDisplayAddress = ({
+  url = '',
+  bzzRoutePrefix,
+  homeUrlNormalized,
+  ipfsRoutePrefix = null,
+  ipnsRoutePrefix = null,
+  radicleApiPrefix = null,
+  knownEnsNames = new Map(),
+} = {}) => {
+  const display = deriveDisplayValue(
+    url,
+    bzzRoutePrefix,
+    homeUrlNormalized,
+    ipfsRoutePrefix,
+    ipnsRoutePrefix,
+    radicleApiPrefix
+  );
+
+  return applyEnsNamePreservation(display, knownEnsNames);
+};
+
+export const buildViewSourceNavigation = ({
+  value = '',
+  bzzRoutePrefix,
+  homeUrlNormalized,
+  ipfsRoutePrefix = null,
+  ipnsRoutePrefix = null,
+  radicleApiPrefix = null,
+  knownEnsNames = new Map(),
+} = {}) => {
+  const innerUrl = value.startsWith('view-source:') ? value.slice(12) : value;
+
+  const bzzMatch = innerUrl.match(/^bzz:\/\/([a-fA-F0-9]+)(\/.*)?$/);
+  if (bzzMatch) {
+    const hash = bzzMatch[1];
+    const path = bzzMatch[2] || '/';
+    return {
+      addressValue: value,
+      loadUrl: `view-source:${bzzRoutePrefix}${hash}${path}`,
+    };
+  }
+
+  const ipfsMatch = innerUrl.match(/^ipfs:\/\/([A-Za-z0-9]+)(\/.*)?$/);
+  if (ipfsMatch) {
+    const cid = ipfsMatch[1];
+    const path = ipfsMatch[2] || '';
+    return {
+      addressValue: value,
+      loadUrl: `view-source:${ipfsRoutePrefix}${cid}${path}`,
+    };
+  }
+
+  const ipnsMatch = innerUrl.match(/^ipns:\/\/([A-Za-z0-9.-]+)(\/.*)?$/);
+  if (ipnsMatch) {
+    const name = ipnsMatch[1];
+    const path = ipnsMatch[2] || '';
+    return {
+      addressValue: value,
+      loadUrl: `view-source:${ipnsRoutePrefix}${name}${path}`,
+    };
+  }
+
+  const displayInner = deriveDisplayAddress({
+    url: innerUrl,
+    bzzRoutePrefix,
+    homeUrlNormalized,
+    ipfsRoutePrefix,
+    ipnsRoutePrefix,
+    radicleApiPrefix,
+    knownEnsNames,
+  });
+
+  return {
+    addressValue: `view-source:${displayInner || innerUrl}`,
+    loadUrl: value,
+  };
+};
+
+export const deriveSwitchedTabDisplay = ({
+  url = '',
+  isLoading = false,
+  addressBarSnapshot = '',
+  isViewingSource = false,
+  bzzRoutePrefix,
+  homeUrlNormalized,
+  ipfsRoutePrefix = null,
+  ipnsRoutePrefix = null,
+  radicleApiPrefix = null,
+  knownEnsNames = new Map(),
+} = {}) => {
+  if (isLoading && addressBarSnapshot) {
+    return addressBarSnapshot;
+  }
+
+  const urlToDerive = url.startsWith('view-source:') ? url.slice(12) : url;
+  const internalPageName = getInternalPageName(urlToDerive);
+  if (internalPageName && internalPageName !== 'home') {
+    return `freedom://${internalPageName}`;
+  }
+
+  let display = deriveDisplayAddress({
+    url: urlToDerive,
+    bzzRoutePrefix,
+    homeUrlNormalized,
+    ipfsRoutePrefix,
+    ipnsRoutePrefix,
+    radicleApiPrefix,
+    knownEnsNames,
+  });
+
+  if (display === homeUrlNormalized) {
+    display = '';
+  }
+
+  if (isViewingSource && display) {
+    return `view-source:${display}`;
+  }
+
+  return display;
+};
+
+export const getBookmarkBarState = ({
+  url = '',
+  bookmarkBarOverride = false,
+  homeUrl = '',
+  homeUrlNormalized = '',
+} = {}) => {
+  const isHomePage = url === homeUrlNormalized || url === homeUrl || !url;
+
+  return {
+    isHomePage,
+    visible: isHomePage || bookmarkBarOverride,
+  };
+};
+
+export const getOriginalUrlFromErrorPage = (url, errorUrlBase = '') => {
+  if (!url) {
+    return null;
+  }
+
+  const isErrorPage =
+    (errorUrlBase && url.startsWith(errorUrlBase)) || url.includes('/error.html?');
+  if (!isErrorPage) {
+    return null;
+  }
+
+  try {
+    return new URL(url).searchParams.get('url');
+  } catch {
+    return null;
+  }
 };

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -1,0 +1,54 @@
+export const resolveProtocolIconType = ({
+  value = '',
+  ensProtocols = new Map(),
+  enableRadicleIntegration = false,
+  currentPageSecure = false,
+} = {}) => {
+  const normalizedValue = value.toLowerCase();
+  let protocol = 'http';
+
+  if (normalizedValue.startsWith('ens://') || normalizedValue.endsWith('.eth') || normalizedValue.endsWith('.box')) {
+    const ensName = normalizedValue.startsWith('ens://')
+      ? normalizedValue.slice(6).split('/')[0]
+      : normalizedValue.split('/')[0];
+    protocol = ensProtocols.get(ensName) || 'http';
+  } else if (normalizedValue.startsWith('bzz://')) {
+    protocol = 'swarm';
+  } else if (normalizedValue.startsWith('ipfs://')) {
+    protocol = 'ipfs';
+  } else if (normalizedValue.startsWith('ipns://')) {
+    protocol = 'ipns';
+  } else if (normalizedValue.startsWith('rad://') && enableRadicleIntegration) {
+    protocol = 'radicle';
+  } else if (normalizedValue.startsWith('freedom://')) {
+    protocol = null;
+  } else if (normalizedValue.startsWith('https://') || currentPageSecure) {
+    protocol = 'https';
+  }
+
+  return protocol;
+};
+
+export const buildRadicleDisabledUrl = (baseHref, inputValue = '') => {
+  const errorUrl = new URL('pages/rad-browser.html', baseHref);
+  errorUrl.searchParams.set('error', 'disabled');
+  if (inputValue) {
+    errorUrl.searchParams.set('input', inputValue);
+  }
+  return errorUrl.toString();
+};
+
+export const getRadicleDisplayUrl = (url) => {
+  if (!url || !url.includes('rad-browser.html')) return null;
+  try {
+    const parsed = new URL(url);
+    const rid = parsed.searchParams.get('rid');
+    const path = parsed.searchParams.get('path') || '';
+    if (rid) {
+      return `rad://${rid}${path}`;
+    }
+  } catch {
+    // Ignore parse errors.
+  }
+  return null;
+};

--- a/src/renderer/lib/navigation-utils.test.js
+++ b/src/renderer/lib/navigation-utils.test.js
@@ -1,12 +1,24 @@
-import {
-  buildRadicleDisabledUrl,
-  getRadicleDisplayUrl,
-  resolveProtocolIconType,
-} from './navigation-utils.js';
+const originalWindow = global.window;
+
+const loadNavigationUtils = async () => {
+  jest.resetModules();
+  global.window = {
+    location: { href: 'file:///app/index.html' },
+    internalPages: { routable: {} },
+  };
+
+  return import('./navigation-utils.js');
+};
 
 describe('navigation-utils', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+  });
+
   describe('resolveProtocolIconType', () => {
-    test('defaults to http and handles dweb protocols', () => {
+    test('defaults to http and handles dweb protocols', async () => {
+      const { resolveProtocolIconType } = await loadNavigationUtils();
+
       expect(resolveProtocolIconType({ value: '' })).toBe('http');
       expect(resolveProtocolIconType({ value: 'bzz://hash' })).toBe('swarm');
       expect(resolveProtocolIconType({ value: 'ipfs://cid' })).toBe('ipfs');
@@ -14,7 +26,9 @@ describe('navigation-utils', () => {
       expect(resolveProtocolIconType({ value: 'https://example.com' })).toBe('https');
     });
 
-    test('maps ens names through resolved protocols', () => {
+    test('maps ens names through resolved protocols', async () => {
+      const { resolveProtocolIconType } = await loadNavigationUtils();
+
       expect(
         resolveProtocolIconType({
           value: 'ens://vitalik.eth',
@@ -29,7 +43,9 @@ describe('navigation-utils', () => {
       ).toBe('http');
     });
 
-    test('hides icons for internal pages and gates radicle on settings', () => {
+    test('hides icons for internal pages and gates radicle on settings', async () => {
+      const { resolveProtocolIconType } = await loadNavigationUtils();
+
       expect(resolveProtocolIconType({ value: 'freedom://history' })).toBeNull();
       expect(resolveProtocolIconType({ value: 'rad://rid' })).toBe('http');
       expect(
@@ -40,7 +56,9 @@ describe('navigation-utils', () => {
       ).toBe('radicle');
     });
 
-    test('prefers secure icon when the page is marked secure', () => {
+    test('prefers secure icon when the page is marked secure', async () => {
+      const { resolveProtocolIconType } = await loadNavigationUtils();
+
       expect(
         resolveProtocolIconType({
           value: 'example.com',
@@ -51,7 +69,9 @@ describe('navigation-utils', () => {
   });
 
   describe('buildRadicleDisabledUrl', () => {
-    test('creates a rad-browser disabled url and preserves input', () => {
+    test('creates a rad-browser disabled url and preserves input', async () => {
+      const { buildRadicleDisabledUrl } = await loadNavigationUtils();
+
       expect(buildRadicleDisabledUrl('file:///app/index.html')).toBe(
         'file:///app/pages/rad-browser.html?error=disabled'
       );
@@ -62,7 +82,9 @@ describe('navigation-utils', () => {
   });
 
   describe('getRadicleDisplayUrl', () => {
-    test('reconstructs rad urls from rad-browser pages', () => {
+    test('reconstructs rad urls from rad-browser pages', async () => {
+      const { getRadicleDisplayUrl } = await loadNavigationUtils();
+
       expect(
         getRadicleDisplayUrl('file:///app/pages/rad-browser.html?rid=zabc123&path=/tree/main')
       ).toBe('rad://zabc123/tree/main');

--- a/src/renderer/lib/navigation-utils.test.js
+++ b/src/renderer/lib/navigation-utils.test.js
@@ -1,0 +1,74 @@
+import {
+  buildRadicleDisabledUrl,
+  getRadicleDisplayUrl,
+  resolveProtocolIconType,
+} from './navigation-utils.js';
+
+describe('navigation-utils', () => {
+  describe('resolveProtocolIconType', () => {
+    test('defaults to http and handles dweb protocols', () => {
+      expect(resolveProtocolIconType({ value: '' })).toBe('http');
+      expect(resolveProtocolIconType({ value: 'bzz://hash' })).toBe('swarm');
+      expect(resolveProtocolIconType({ value: 'ipfs://cid' })).toBe('ipfs');
+      expect(resolveProtocolIconType({ value: 'ipns://name' })).toBe('ipns');
+      expect(resolveProtocolIconType({ value: 'https://example.com' })).toBe('https');
+    });
+
+    test('maps ens names through resolved protocols', () => {
+      expect(
+        resolveProtocolIconType({
+          value: 'ens://vitalik.eth',
+          ensProtocols: new Map([['vitalik.eth', 'ipfs']]),
+        })
+      ).toBe('ipfs');
+      expect(
+        resolveProtocolIconType({
+          value: 'vitalik.eth/docs',
+          ensProtocols: new Map(),
+        })
+      ).toBe('http');
+    });
+
+    test('hides icons for internal pages and gates radicle on settings', () => {
+      expect(resolveProtocolIconType({ value: 'freedom://history' })).toBeNull();
+      expect(resolveProtocolIconType({ value: 'rad://rid' })).toBe('http');
+      expect(
+        resolveProtocolIconType({
+          value: 'rad://rid',
+          enableRadicleIntegration: true,
+        })
+      ).toBe('radicle');
+    });
+
+    test('prefers secure icon when the page is marked secure', () => {
+      expect(
+        resolveProtocolIconType({
+          value: 'example.com',
+          currentPageSecure: true,
+        })
+      ).toBe('https');
+    });
+  });
+
+  describe('buildRadicleDisabledUrl', () => {
+    test('creates a rad-browser disabled url and preserves input', () => {
+      expect(buildRadicleDisabledUrl('file:///app/index.html')).toBe(
+        'file:///app/pages/rad-browser.html?error=disabled'
+      );
+      expect(buildRadicleDisabledUrl('file:///app/index.html', 'rad://zabc')).toBe(
+        'file:///app/pages/rad-browser.html?error=disabled&input=rad%3A%2F%2Fzabc'
+      );
+    });
+  });
+
+  describe('getRadicleDisplayUrl', () => {
+    test('reconstructs rad urls from rad-browser pages', () => {
+      expect(
+        getRadicleDisplayUrl('file:///app/pages/rad-browser.html?rid=zabc123&path=/tree/main')
+      ).toBe('rad://zabc123/tree/main');
+      expect(getRadicleDisplayUrl('file:///app/pages/rad-browser.html?path=/tree/main')).toBeNull();
+      expect(getRadicleDisplayUrl('https://example.com')).toBeNull();
+      expect(getRadicleDisplayUrl('not-a-url')).toBeNull();
+    });
+  });
+});

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -4,7 +4,14 @@ import { pushDebug } from './debug.js';
 import { updateBookmarkButtonVisibility } from './bookmarks-ui.js';
 import { updateGithubBridgeIcon } from './github-bridge-ui.js';
 import {
+  applyEnsSuffix,
   buildRadicleDisabledUrl,
+  buildViewSourceNavigation,
+  deriveDisplayAddress,
+  deriveSwitchedTabDisplay,
+  extractEnsResolutionMetadata,
+  getBookmarkBarState,
+  getOriginalUrlFromErrorPage,
   getRadicleDisplayUrl,
   resolveProtocolIconType,
 } from './navigation-utils.js';
@@ -16,7 +23,6 @@ import {
   deriveBzzBaseFromUrl,
   deriveIpfsBaseFromUrl,
   deriveRadBaseFromUrl,
-  applyEnsNamePreservation,
 } from './url-utils.js';
 import {
   getActiveWebview,
@@ -78,6 +84,18 @@ const setLoading = (isLoading) => {
   setTabLoading(isLoading);
   updateBookmarkButtonVisibility();
   updateGithubBridgeIcon();
+};
+
+const storeEnsResolutionMetadata = (targetUri, ensName, { trackProtocol = true } = {}) => {
+  const { knownEnsPairs, resolvedProtocol } = extractEnsResolutionMetadata(targetUri, ensName);
+
+  for (const [key, name] of knownEnsPairs) {
+    state.knownEnsNames.set(key, name);
+  }
+
+  if (trackProtocol && resolvedProtocol) {
+    state.ensProtocols.set(ensName, resolvedProtocol);
+  }
 };
 
 // Track certificate status for current page
@@ -252,43 +270,24 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null) 
             return;
           }
           // Build target URI with path suffix
-          let targetUri = result.uri;
-          if (ens.suffix) {
-            try {
-              const composed = new URL(ens.suffix, targetUri);
-              targetUri = composed.toString();
-            } catch {
-              targetUri = `${targetUri.replace(/\/+$/, '')}${ens.suffix}`;
-            }
-          }
+          const targetUri = applyEnsSuffix(result.uri, ens.suffix);
+          storeEnsResolutionMetadata(targetUri, ens.name, { trackProtocol: false });
 
-          // Store ENS name mapping
-          const bzzMatch = targetUri.match(/^bzz:\/\/([a-fA-F0-9]+)/);
-          if (bzzMatch) {
-            state.knownEnsNames.set(bzzMatch[1].toLowerCase(), ens.name);
-          }
-          const ipfsMatch = targetUri.match(/^ipfs:\/\/([A-Za-z0-9]+)/);
-          if (ipfsMatch) {
-            state.knownEnsNames.set(ipfsMatch[1], ens.name);
-          }
-          const ipnsMatch = targetUri.match(/^ipns:\/\/([A-Za-z0-9.-]+)/);
-          if (ipnsMatch) {
-            state.knownEnsNames.set(ipnsMatch[1], ens.name);
-          }
+          const { loadUrl } = buildViewSourceNavigation({
+            value: `view-source:${targetUri}`,
+            bzzRoutePrefix: state.bzzRoutePrefix,
+            homeUrlNormalized,
+            ipfsRoutePrefix: state.ipfsRoutePrefix,
+            ipnsRoutePrefix: state.ipnsRoutePrefix,
+            radicleApiPrefix: state.radicleApiPrefix,
+            knownEnsNames: state.knownEnsNames,
+          });
 
-          // Convert dweb URI to gateway URL
-          let gatewayUrl;
-          if (result.protocol === 'bzz' && bzzMatch) {
-            gatewayUrl = `${state.bzzRoutePrefix}${targetUri.slice(6)}`; // Remove 'bzz://'
-          } else if (result.protocol === 'ipfs' && ipfsMatch) {
-            gatewayUrl = `${state.ipfsRoutePrefix}${targetUri.slice(7)}`; // Remove 'ipfs://'
-          } else if (result.protocol === 'ipns' && ipnsMatch) {
-            gatewayUrl = `${state.ipnsRoutePrefix}${targetUri.slice(7)}`; // Remove 'ipns://'
-          } else {
+          if (loadUrl === `view-source:${targetUri}`) {
             alert(`Unsupported protocol: ${result.protocol}`);
             return;
           }
-          capturedWebview.loadURL(`view-source:${gatewayUrl}`);
+          capturedWebview.loadURL(loadUrl);
         })
         .catch((err) => {
           setLoading(false);
@@ -297,56 +296,18 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null) 
       return;
     }
 
-    // Check for bzz:// URLs
-    const bzzMatch = innerUrl.match(/^bzz:\/\/([a-fA-F0-9]+)(\/.*)?$/);
-    if (bzzMatch) {
-      const hash = bzzMatch[1];
-      const path = bzzMatch[2] || '/';
-      const gatewayUrl = `${state.bzzRoutePrefix}${hash}${path}`;
-      addressInput.value = value;
-      updateProtocolIcon();
-      webview.loadURL(`view-source:${gatewayUrl}`);
-      return;
-    }
-
-    // Check for ipfs:// URLs
-    const ipfsMatch = innerUrl.match(/^ipfs:\/\/([A-Za-z0-9]+)(\/.*)?$/);
-    if (ipfsMatch) {
-      const cid = ipfsMatch[1];
-      const path = ipfsMatch[2] || '';
-      const gatewayUrl = `${state.ipfsRoutePrefix}${cid}${path}`;
-      addressInput.value = value;
-      updateProtocolIcon();
-      webview.loadURL(`view-source:${gatewayUrl}`);
-      return;
-    }
-
-    // Check for ipns:// URLs
-    const ipnsMatch = innerUrl.match(/^ipns:\/\/([A-Za-z0-9.-]+)(\/.*)?$/);
-    if (ipnsMatch) {
-      const name = ipnsMatch[1];
-      const path = ipnsMatch[2] || '';
-      const gatewayUrl = `${state.ipnsRoutePrefix}${name}${path}`;
-      addressInput.value = value;
-      updateProtocolIcon();
-      webview.loadURL(`view-source:${gatewayUrl}`);
-      return;
-    }
-
-    // For other URLs (http/https, already gateway URLs), load directly
-    let displayInner = deriveDisplayValue(
-      innerUrl,
-      state.bzzRoutePrefix,
+    const viewSourceNavigation = buildViewSourceNavigation({
+      value,
+      bzzRoutePrefix: state.bzzRoutePrefix,
       homeUrlNormalized,
-      state.ipfsRoutePrefix,
-      state.ipnsRoutePrefix,
-      state.radicleApiPrefix
-    );
-    displayInner = applyEnsNamePreservation(displayInner, state.knownEnsNames);
-    const displayUrl = `view-source:${displayInner || innerUrl}`;
-    addressInput.value = displayUrl;
+      ipfsRoutePrefix: state.ipfsRoutePrefix,
+      ipnsRoutePrefix: state.ipnsRoutePrefix,
+      radicleApiPrefix: state.radicleApiPrefix,
+      knownEnsNames: state.knownEnsNames,
+    });
+    addressInput.value = viewSourceNavigation.addressValue;
     updateProtocolIcon();
-    webview.loadURL(value);
+    webview.loadURL(viewSourceNavigation.loadUrl);
     return;
   }
 
@@ -401,38 +362,11 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null) 
           return;
         }
 
-        let targetUri = result.uri;
-        if (ens.suffix) {
-          try {
-            const composed = new URL(ens.suffix, targetUri);
-            targetUri = composed.toString();
-          } catch {
-            targetUri = `${targetUri.replace(/\/+$/, '')}${ens.suffix}`;
-          }
-        }
+        const targetUri = applyEnsSuffix(result.uri, ens.suffix);
 
         pushDebug(`ENS resolved: ${ens.name} -> ${targetUri}`);
 
-        // Store ENS name mapping for Swarm
-        const bzzMatch = targetUri.match(/^bzz:\/\/([a-fA-F0-9]+)/);
-        if (bzzMatch) {
-          state.knownEnsNames.set(bzzMatch[1].toLowerCase(), ens.name);
-          state.ensProtocols.set(ens.name, 'swarm');
-        }
-
-        // Store ENS name mapping for IPFS
-        const ipfsMatch = targetUri.match(/^ipfs:\/\/([A-Za-z0-9]+)/);
-        if (ipfsMatch) {
-          state.knownEnsNames.set(ipfsMatch[1], ens.name);
-          state.ensProtocols.set(ens.name, 'ipfs');
-        }
-
-        // Store ENS name mapping for IPNS
-        const ipnsMatch = targetUri.match(/^ipns:\/\/([A-Za-z0-9.-]+)/);
-        if (ipnsMatch) {
-          state.knownEnsNames.set(ipnsMatch[1], ens.name);
-          state.ensProtocols.set(ens.name, 'ipfs'); // IPNS uses IPFS icon
-        }
+        storeEnsResolutionMetadata(targetUri, ens.name);
 
         // Pass captured webview to ensure we load in the correct tab
         loadTarget(
@@ -622,14 +556,15 @@ export const loadHomePage = () => {
 // Shared error-page retry logic used by both reload variants and the reload button
 const retryErrorPageOrReload = (webview, hard) => {
   const current = webview.getURL();
+  const originalUrl = getOriginalUrlFromErrorPage(current, errorUrlBase);
+  if (originalUrl) {
+    pushDebug(`Retrying original URL from error page: ${originalUrl}`);
+    loadTarget(originalUrl);
+    return;
+  }
   if (current.startsWith(errorUrlBase) || current.includes('/error.html?')) {
     try {
-      const originalUrl = new URL(current).searchParams.get('url');
-      if (originalUrl) {
-        pushDebug(`Retrying original URL from error page: ${originalUrl}`);
-        loadTarget(originalUrl);
-        return;
-      }
+      new URL(current);
     } catch (err) {
       pushDebug(`[Nav] Could not extract original URL from error page: ${err.message}`);
     }
@@ -682,15 +617,15 @@ const handleNavigationEvent = (event) => {
       if (event.url === homeUrl || event.url === homeUrlNormalized) {
         return;
       }
-      let displayInner = deriveDisplayValue(
-        event.url,
-        state.bzzRoutePrefix,
+      const displayInner = deriveDisplayAddress({
+        url: event.url,
+        bzzRoutePrefix: state.bzzRoutePrefix,
         homeUrlNormalized,
-        state.ipfsRoutePrefix,
-        state.ipnsRoutePrefix,
-        state.radicleApiPrefix
-      );
-      displayInner = applyEnsNamePreservation(displayInner, state.knownEnsNames);
+        ipfsRoutePrefix: state.ipfsRoutePrefix,
+        ipnsRoutePrefix: state.ipnsRoutePrefix,
+        radicleApiPrefix: state.radicleApiPrefix,
+        knownEnsNames: state.knownEnsNames,
+      });
       const displayUrl = `view-source:${displayInner || event.url}`;
       addressInput.value = displayUrl;
       pushDebug(`[AddressBar] View source: ${displayUrl}`);
@@ -763,15 +698,15 @@ const handleNavigationEvent = (event) => {
       }
       electronAPI?.setWindowTitle?.('Error');
     } else {
-      let derived = deriveDisplayValue(
-        event.url,
-        state.bzzRoutePrefix,
+      const derived = deriveDisplayAddress({
+        url: event.url,
+        bzzRoutePrefix: state.bzzRoutePrefix,
         homeUrlNormalized,
-        state.ipfsRoutePrefix,
-        state.ipnsRoutePrefix,
-        state.radicleApiPrefix
-      );
-      derived = applyEnsNamePreservation(derived, state.knownEnsNames);
+        ipfsRoutePrefix: state.ipfsRoutePrefix,
+        ipnsRoutePrefix: state.ipnsRoutePrefix,
+        radicleApiPrefix: state.radicleApiPrefix,
+        knownEnsNames: state.knownEnsNames,
+      });
 
       // Don't clear address bar if navigating to about:blank and it has a value
       // (happens during "open in new window" before loadTarget runs)
@@ -810,17 +745,20 @@ const handleNavigationEvent = (event) => {
 // Like Chrome: bookmark bar always shows on new tab page; toggle only affects other pages
 const updateBookmarkBarState = (url) => {
   if (!bookmarksBar) return;
-  const isHomePage = url === homeUrlNormalized || url === homeUrl || !url;
-  if (isHomePage) {
+  const bookmarkBarState = getBookmarkBarState({
+    url,
+    bookmarkBarOverride,
+    homeUrl,
+    homeUrlNormalized,
+  });
+  if (bookmarkBarState.visible) {
     // Always show on new tab page regardless of toggle
-    bookmarksBar.classList.remove('hidden');
-  } else if (bookmarkBarOverride) {
     bookmarksBar.classList.remove('hidden');
   } else {
     bookmarksBar.classList.add('hidden');
   }
   // Disable the menu item on the new tab page (toggle has no effect there)
-  electronAPI?.setBookmarkBarToggleEnabled?.(!isHomePage);
+  electronAPI?.setBookmarkBarToggleEnabled?.(!bookmarkBarState.isHomePage);
 };
 
 // Toggle bookmark bar visibility and persist to settings
@@ -971,38 +909,11 @@ export const initNavigation = () => {
             return;
           }
 
-          let targetUri = result.uri;
-          if (ens.suffix) {
-            try {
-              const composed = new URL(ens.suffix, targetUri);
-              targetUri = composed.toString();
-            } catch {
-              targetUri = `${targetUri.replace(/\/+$/, '')}${ens.suffix}`;
-            }
-          }
+          const targetUri = applyEnsSuffix(result.uri, ens.suffix);
 
           pushDebug(`ENS resolved: ${ens.name} -> ${targetUri}`);
 
-          // Store ENS name mapping for Swarm
-          const bzzMatch = targetUri.match(/^bzz:\/\/([a-fA-F0-9]+)/);
-          if (bzzMatch) {
-            state.knownEnsNames.set(bzzMatch[1].toLowerCase(), ens.name);
-            state.ensProtocols.set(ens.name, 'swarm');
-          }
-
-          // Store ENS name mapping for IPFS
-          const ipfsMatch = targetUri.match(/^ipfs:\/\/([A-Za-z0-9]+)/);
-          if (ipfsMatch) {
-            state.knownEnsNames.set(ipfsMatch[1], ens.name);
-            state.ensProtocols.set(ens.name, 'ipfs');
-          }
-
-          // Store ENS name mapping for IPNS
-          const ipnsMatch = targetUri.match(/^ipns:\/\/([A-Za-z0-9.-]+)/);
-          if (ipnsMatch) {
-            state.knownEnsNames.set(ipnsMatch[1], ens.name);
-            state.ensProtocols.set(ens.name, 'ipfs'); // IPNS uses IPFS icon
-          }
+          storeEnsResolutionMetadata(targetUri, ens.name);
 
           // Pass captured webview to ensure we load in the correct tab
           loadTarget(targetUri, 'ens://' + ens.name + (ens.suffix || ''), capturedWebview);
@@ -1221,34 +1132,18 @@ export const initNavigation = () => {
 
           // If tab is loading, prefer addressBarSnapshot (what user typed/was shown)
           // Otherwise derive from the actual URL
-          let display;
-          if (isLoading && tabNavState.addressBarSnapshot) {
-            display = tabNavState.addressBarSnapshot;
-          } else {
-            // Handle view-source URLs - derive display from inner URL
-            const urlToDerive = url.startsWith('view-source:') ? url.slice(12) : url;
-            // Check for internal pages first
-            const switchedInternalPage = getInternalPageName(urlToDerive);
-            if (switchedInternalPage && switchedInternalPage !== 'home') {
-              display = `freedom://${switchedInternalPage}`;
-            } else {
-              display = deriveDisplayValue(
-                urlToDerive,
-                state.bzzRoutePrefix,
-                homeUrlNormalized,
-                state.ipfsRoutePrefix,
-                state.ipnsRoutePrefix,
-                state.radicleApiPrefix
-              );
-              // Apply ENS name preservation to show ens:// URLs instead of resolved bzz/ipfs URLs
-              display = applyEnsNamePreservation(display, state.knownEnsNames);
-            }
-            if (display === homeUrlNormalized) display = '';
-            // Prepend view-source: for view-source tabs
-            if (isViewingSource && display) {
-              display = `view-source:${display}`;
-            }
-          }
+          const display = deriveSwitchedTabDisplay({
+            url,
+            isLoading,
+            addressBarSnapshot: tabNavState.addressBarSnapshot,
+            isViewingSource,
+            bzzRoutePrefix: state.bzzRoutePrefix,
+            homeUrlNormalized,
+            ipfsRoutePrefix: state.ipfsRoutePrefix,
+            ipnsRoutePrefix: state.ipnsRoutePrefix,
+            radicleApiPrefix: state.radicleApiPrefix,
+            knownEnsNames: state.knownEnsNames,
+          });
           // Don't clear address bar if it has a value and we're on about:blank
           // (happens during "open in new window" before loadTarget runs)
           if (url === 'about:blank' && addressInput.value) {

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -4,6 +4,11 @@ import { pushDebug } from './debug.js';
 import { updateBookmarkButtonVisibility } from './bookmarks-ui.js';
 import { updateGithubBridgeIcon } from './github-bridge-ui.js';
 import {
+  buildRadicleDisabledUrl,
+  getRadicleDisplayUrl,
+  resolveProtocolIconType,
+} from './navigation-utils.js';
+import {
   formatBzzUrl,
   formatIpfsUrl,
   formatRadicleUrl,
@@ -82,30 +87,12 @@ let currentPageSecure = false;
 const updateProtocolIcon = () => {
   if (!protocolIcon) return;
 
-  const value = (addressInput?.value || '').toLowerCase();
-  let protocol = 'http'; // Default to HTTP/globe icon
-
-  if (value.startsWith('ens://') || value.endsWith('.eth') || value.endsWith('.box')) {
-    // For ENS names, show the underlying protocol icon
-    const ensName = value.startsWith('ens://') ? value.slice(6).split('/')[0] : value.split('/')[0];
-    const resolvedProtocol = state.ensProtocols.get(ensName);
-    protocol = resolvedProtocol || 'http'; // Fallback to http if not yet resolved
-  } else if (value.startsWith('bzz://')) {
-    protocol = 'swarm';
-  } else if (value.startsWith('ipfs://')) {
-    protocol = 'ipfs';
-  } else if (value.startsWith('ipns://')) {
-    protocol = 'ipns';
-  } else if (value.startsWith('rad://') && state.enableRadicleIntegration) {
-    protocol = 'radicle';
-  } else if (value.startsWith('freedom://')) {
-    // Internal pages - no icon
-    protocol = null;
-  } else if (value.startsWith('https://') || currentPageSecure) {
-    // HTTPS pages without certificate errors
-    protocol = 'https';
-  }
-  // For empty or any other input, use default 'http'
+  const protocol = resolveProtocolIconType({
+    value: addressInput?.value || '',
+    ensProtocols: state.ensProtocols,
+    enableRadicleIntegration: state.enableRadicleIntegration,
+    currentPageSecure,
+  });
 
   if (protocol) {
     protocolIcon.setAttribute('data-protocol', protocol);
@@ -232,15 +219,6 @@ const syncRadBase = (nextBase) => {
     .catch((err) => {
       console.error('Failed to sync rad base', err);
     });
-};
-
-const buildRadicleDisabledUrl = (inputValue = '') => {
-  const errorUrl = new URL('pages/rad-browser.html', window.location.href);
-  errorUrl.searchParams.set('error', 'disabled');
-  if (inputValue) {
-    errorUrl.searchParams.set('input', inputValue);
-  }
-  return errorUrl.toString();
 };
 
 export const loadTarget = (value, displayOverride = null, targetWebview = null) => {
@@ -476,7 +454,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null) 
   if (value.trim().toLowerCase().startsWith('rad:') || value.trim().toLowerCase().startsWith('rad://')) {
     if (!state.enableRadicleIntegration) {
       pushDebug(RADICLE_DISABLED_MESSAGE);
-      const disabledUrl = buildRadicleDisabledUrl(value.trim());
+      const disabledUrl = buildRadicleDisabledUrl(window.location.href, value.trim());
       addressInput.value = value.trim();
       navState.pendingNavigationUrl = disabledUrl;
       navState.hasNavigatedDuringCurrentLoad = false;
@@ -676,22 +654,6 @@ export const hardReloadPage = () => {
   const webview = getActiveWebview();
   if (!webview) return;
   retryErrorPageOrReload(webview, true);
-};
-
-// Convert rad-browser.html URL back to rad:// format
-const getRadicleDisplayUrl = (url) => {
-  if (!url || !url.includes('rad-browser.html')) return null;
-  try {
-    const parsed = new URL(url);
-    const rid = parsed.searchParams.get('rid');
-    const path = parsed.searchParams.get('path') || '';
-    if (rid) {
-      return `rad://${rid}${path}`;
-    }
-  } catch {
-    // Ignore parse errors
-  }
-  return null;
 };
 
 const handleNavigationEvent = (event) => {

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -1,0 +1,551 @@
+const { createDocument, createElement, FakeElement } = require('../../../test/helpers/fake-dom.js');
+
+const originalWindow = global.window;
+const originalDocument = global.document;
+const originalAlert = global.alert;
+const originalHTMLElement = global.HTMLElement;
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createWebview = (initialUrl = 'https://active.example', options = {}) => {
+  const webview = createElement('webview');
+  webview._currentUrl = initialUrl;
+  webview.loadURL = jest.fn((url) => {
+    webview._currentUrl = url;
+  });
+  webview.reload = jest.fn();
+  webview.reloadIgnoringCache = jest.fn();
+  webview.stop = jest.fn();
+  webview.goBack = jest.fn();
+  webview.goForward = jest.fn();
+  webview.canGoBack = jest.fn(() => options.canGoBack ?? false);
+  webview.canGoForward = jest.fn(() => options.canGoForward ?? false);
+  webview.getURL = jest.fn(() => webview._currentUrl);
+  webview.getWebContentsId = jest.fn(() => options.webContentsId ?? 7);
+  return webview;
+};
+
+const createTab = (id, url, overrides = {}) => {
+  const webview = overrides.webview || createWebview(url, { webContentsId: id + 10 });
+  const navigationState = {
+    currentPageUrl: url,
+    pendingNavigationUrl: '',
+    pendingTitleForUrl: '',
+    hasNavigatedDuringCurrentLoad: false,
+    isWebviewLoading: false,
+    currentBzzBase: null,
+    currentIpfsBase: null,
+    currentRadBase: null,
+    addressBarSnapshot: '',
+    cachedWebContentsId: null,
+    resolvingWebContentsId: null,
+    ...overrides.navigationState,
+  };
+
+  return {
+    id,
+    title: overrides.title || `Tab ${id}`,
+    url,
+    isLoading: overrides.isLoading || false,
+    favicon: overrides.favicon || null,
+    webview,
+    navigationState,
+  };
+};
+
+const loadNavigationModule = async (options = {}) => {
+  jest.resetModules();
+
+  const homeUrl = 'file:///app/pages/home.html';
+  const historyUrl = 'file:///app/pages/history.html';
+  const errorUrlBase = 'file:///app/pages/error.html';
+  const state = {
+    bzzRoutePrefix: 'https://gateway.example/bzz/',
+    ipfsRoutePrefix: 'https://gateway.example/ipfs/',
+    ipnsRoutePrefix: 'https://gateway.example/ipns/',
+    radicleApiPrefix: 'http://127.0.0.1:8780/api/v1/repos/',
+    radicleBase: 'http://127.0.0.1:8780',
+    enableRadicleIntegration: options.enableRadicleIntegration || false,
+    currentRadicleStatus: options.currentRadicleStatus || 'running',
+    knownEnsNames: new Map(),
+    ensProtocols: new Map(),
+  };
+  const debugMocks = {
+    pushDebug: jest.fn(),
+  };
+  const bookmarksUiMocks = {
+    updateBookmarkButtonVisibility: jest.fn(),
+  };
+  const githubBridgeUiMocks = {
+    updateGithubBridgeIcon: jest.fn(),
+  };
+  const activeRef = {};
+  const tabsRef = { list: [] };
+  const tabsMocks = {
+    webviewEventHandler: null,
+    getActiveWebview: jest.fn(() => activeRef.tab?.webview || null),
+    getActiveTab: jest.fn(() => activeRef.tab || null),
+    getActiveTabState: jest.fn(() => activeRef.tab?.navigationState || null),
+    setWebviewEventHandler: jest.fn((handler) => {
+      tabsMocks.webviewEventHandler = handler;
+    }),
+    updateActiveTabTitle: jest.fn(),
+    updateTabFavicon: jest.fn(),
+    setTabLoading: jest.fn(),
+    getTabs: jest.fn(() => tabsRef.list),
+  };
+  const navigationUtilsMocks = {
+    applyEnsSuffix: jest.fn((targetUri, suffix = '') => `${targetUri}${suffix}`),
+    buildRadicleDisabledUrl: jest.fn(() => 'file:///app/pages/rad-browser.html?error=disabled'),
+    buildViewSourceNavigation: jest.fn(({ value }) => ({
+      addressValue: `display:${value}`,
+      loadUrl: `load:${value}`,
+    })),
+    deriveDisplayAddress: jest.fn(({ url }) => `display:${url}`),
+    deriveSwitchedTabDisplay: jest.fn(
+      ({ url, isLoading, addressBarSnapshot }) =>
+        (isLoading && addressBarSnapshot) || (url ? `switched:${url}` : '')
+    ),
+    extractEnsResolutionMetadata: jest.fn(() => ({
+      knownEnsPairs: [],
+      resolvedProtocol: null,
+    })),
+    getBookmarkBarState: jest.fn(({ url, bookmarkBarOverride }) => {
+      const isHomePage = !url || url === homeUrl;
+      return {
+        isHomePage,
+        visible: isHomePage || bookmarkBarOverride,
+      };
+    }),
+    getOriginalUrlFromErrorPage: jest.fn((url) => {
+      if (!url.includes('error.html')) return null;
+      try {
+        return new URL(url).searchParams.get('url');
+      } catch {
+        return null;
+      }
+    }),
+    getRadicleDisplayUrl: jest.fn((url) =>
+      url.includes('rad-browser.html?rid=') ? 'rad://zrepo123' : null
+    ),
+    resolveProtocolIconType: jest.fn(({ value, currentPageSecure }) => {
+      if (currentPageSecure) return 'https';
+      if (value?.startsWith('bzz://')) return 'swarm';
+      if (value?.startsWith('rad://') && state.enableRadicleIntegration) return 'radicle';
+      return value ? 'http' : 'http';
+    }),
+  };
+  const urlUtilsMocks = {
+    formatBzzUrl: jest.fn((input, prefix) => {
+      if (!input.startsWith('bzz://')) return null;
+      const hashAndPath = input.slice(6);
+      const hash = hashAndPath.split('/')[0];
+      return {
+        targetUrl: `${prefix}${hashAndPath}`,
+        displayValue: input,
+        baseUrl: `${prefix}${hash}/`,
+      };
+    }),
+    formatIpfsUrl: jest.fn((input, prefix) => {
+      if (!input.startsWith('ipfs://')) return null;
+      return {
+        targetUrl: `${prefix}${input.slice(7)}`,
+        displayValue: input,
+        baseUrl: `${prefix}${input.slice(7).split('/')[0]}/`,
+      };
+    }),
+    formatRadicleUrl: jest.fn((input) => {
+      if (!input.startsWith('rad://')) return null;
+      return {
+        targetUrl: 'file:///app/pages/rad-browser.html?rid=zrepo123',
+        displayValue: input,
+      };
+    }),
+    deriveDisplayValue: jest.fn((url) => `display:${url}`),
+    deriveBzzBaseFromUrl: jest.fn((url) => (url.includes('/bzz/') ? 'https://gateway.example/bzz/hash/' : null)),
+    deriveIpfsBaseFromUrl: jest.fn(() => null),
+    deriveRadBaseFromUrl: jest.fn(() => null),
+  };
+  const pageUrlsMocks = {
+    homeUrl,
+    homeUrlNormalized: homeUrl,
+    errorUrlBase,
+    internalPages: {
+      history: historyUrl,
+    },
+    detectProtocol: jest.fn(() => 'https'),
+    isHistoryRecordable: jest.fn((displayUrl, internalUrl) => {
+      return (
+        Boolean(displayUrl) &&
+        !displayUrl.startsWith('freedom://') &&
+        !displayUrl.startsWith('view-source:') &&
+        !internalUrl.includes('/error.html')
+      );
+    }),
+    getInternalPageName: jest.fn((url) => (url === historyUrl ? 'history' : null)),
+    parseEnsInput: jest.fn(() => null),
+  };
+  const settingsState = options.initialSettings || { showBookmarkBar: true };
+  const electronHandlers = {};
+  const electronAPI = {
+    getSettings: jest.fn().mockResolvedValue({ ...settingsState }),
+    saveSettings: jest.fn().mockResolvedValue(true),
+    setBookmarkBarChecked: jest.fn(),
+    setBookmarkBarToggleEnabled: jest.fn(),
+    setWindowTitle: jest.fn(),
+    fetchFaviconWithKey: jest.fn().mockResolvedValue('data:image/png;base64,favicon'),
+    addHistory: jest.fn().mockResolvedValue(undefined),
+    setBzzBase: jest.fn(),
+    clearBzzBase: jest.fn(),
+    setIpfsBase: jest.fn(),
+    clearIpfsBase: jest.fn(),
+    setRadBase: jest.fn(),
+    clearRadBase: jest.fn(),
+    onToggleBookmarkBar: jest.fn((handler) => {
+      electronHandlers.toggleBookmarkBar = handler;
+    }),
+  };
+
+  const addressInput = createElement('input');
+  const navForm = createElement('form');
+  const backBtn = createElement('button');
+  const forwardBtn = createElement('button');
+  const reloadBtn = createElement('button');
+  const homeBtn = createElement('button');
+  const bookmarksBar = createElement('div', { classes: ['hidden'] });
+  const protocolIcon = createElement('div');
+  const document = createDocument({
+    elementsById: {
+      'address-input': addressInput,
+      'nav-form': navForm,
+      'back-btn': backBtn,
+      'forward-btn': forwardBtn,
+      'reload-btn': reloadBtn,
+      'home-btn': homeBtn,
+      'protocol-icon': protocolIcon,
+    },
+  });
+
+  addressInput.focus = jest.fn();
+  addressInput.blur = jest.fn();
+  addressInput.select = jest.fn();
+  protocolIcon.removeAttribute = jest.fn((name) => {
+    delete protocolIcon.attributes[name];
+  });
+  document.querySelector = jest.fn((selector) => {
+    if (selector === '.bookmarks') return bookmarksBar;
+    return null;
+  });
+  document.activeElement = null;
+
+  const windowHandlers = {};
+  global.window = {
+    electronAPI,
+    location: {
+      href: 'file:///app/index.html',
+    },
+    addEventListener: jest.fn((event, handler) => {
+      windowHandlers[event] = handler;
+    }),
+  };
+  global.document = document;
+  global.alert = jest.fn();
+  global.HTMLElement = FakeElement;
+
+  const firstTab =
+    options.firstTab ||
+    createTab(1, 'https://active.example', {
+      title: 'Active Tab',
+      webview: createWebview('https://active.example', {
+        canGoBack: true,
+        canGoForward: true,
+        webContentsId: 21,
+      }),
+    });
+  tabsRef.list = options.tabs || [firstTab];
+  activeRef.tab = options.activeTab || firstTab;
+
+  jest.doMock('./state.js', () => ({ state }));
+  jest.doMock('./debug.js', () => debugMocks);
+  jest.doMock('./bookmarks-ui.js', () => bookmarksUiMocks);
+  jest.doMock('./github-bridge-ui.js', () => githubBridgeUiMocks);
+  jest.doMock('./tabs.js', () => tabsMocks);
+  jest.doMock('./navigation-utils.js', () => navigationUtilsMocks);
+  jest.doMock('./url-utils.js', () => urlUtilsMocks);
+  jest.doMock('./page-urls.js', () => pageUrlsMocks);
+
+  const mod = await import('./navigation.js');
+
+  return {
+    mod,
+    state,
+    debugMocks,
+    bookmarksUiMocks,
+    githubBridgeUiMocks,
+    tabsMocks,
+    navigationUtilsMocks,
+    urlUtilsMocks,
+    pageUrlsMocks,
+    electronAPI,
+    electronHandlers,
+    activeRef,
+    tabsRef,
+    windowHandlers,
+    elements: {
+      addressInput,
+      navForm,
+      backBtn,
+      forwardBtn,
+      reloadBtn,
+      homeBtn,
+      bookmarksBar,
+      protocolIcon,
+    },
+  };
+};
+
+describe('navigation', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.alert = originalAlert;
+    global.HTMLElement = originalHTMLElement;
+    jest.restoreAllMocks();
+  });
+
+  test('initializes navigation controls and public entrypoints', async () => {
+    const ctx = await loadNavigationModule({
+      initialSettings: { showBookmarkBar: true },
+    });
+
+    await ctx.mod.initNavigation();
+    await flushMicrotasks();
+
+    expect(ctx.electronAPI.getSettings).toHaveBeenCalled();
+    expect(ctx.electronAPI.setBookmarkBarChecked).toHaveBeenCalledWith(true);
+
+    ctx.elements.addressInput.value = 'bzz://abcdef';
+    ctx.elements.addressInput.dispatch('focus');
+    ctx.elements.addressInput.dispatch('focusin');
+    ctx.elements.addressInput.dispatch('input');
+
+    expect(ctx.elements.addressInput.select).toHaveBeenCalled();
+    expect(ctx.activeRef.tab.navigationState.addressBarSnapshot).toBe('bzz://abcdef');
+    expect(ctx.navigationUtilsMocks.resolveProtocolIconType).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: 'bzz://abcdef',
+      })
+    );
+    expect(ctx.elements.protocolIcon.getAttribute('data-protocol')).toBe('swarm');
+
+    ctx.elements.backBtn.dispatch('click');
+    ctx.elements.forwardBtn.dispatch('click');
+
+    expect(ctx.activeRef.tab.webview.goBack).toHaveBeenCalled();
+    expect(ctx.activeRef.tab.webview.goForward).toHaveBeenCalled();
+
+    ctx.elements.homeBtn.dispatch('click');
+
+    expect(ctx.activeRef.tab.webview.loadURL).toHaveBeenCalledWith(ctx.pageUrlsMocks.homeUrl);
+    expect(ctx.tabsMocks.updateActiveTabTitle).toHaveBeenCalledWith('New Tab');
+    expect(ctx.electronAPI.setWindowTitle).toHaveBeenCalledWith('');
+    expect(ctx.tabsMocks.updateTabFavicon).toHaveBeenCalledWith(ctx.activeRef.tab.id, null);
+
+    await ctx.mod.toggleBookmarkBar();
+    expect(ctx.electronAPI.setBookmarkBarChecked).toHaveBeenLastCalledWith(false);
+    expect(ctx.electronAPI.saveSettings).toHaveBeenCalledWith({
+      showBookmarkBar: false,
+    });
+  });
+
+  test('handles reload retry, escape restore, keyboard shortcuts, and settings refresh', async () => {
+    const ctx = await loadNavigationModule({
+      initialSettings: { showBookmarkBar: false },
+    });
+
+    await ctx.mod.initNavigation();
+
+    ctx.activeRef.tab.navigationState.isWebviewLoading = true;
+    ctx.activeRef.tab.navigationState.currentPageUrl = 'https://current.example';
+    ctx.activeRef.tab.navigationState.hasNavigatedDuringCurrentLoad = false;
+    ctx.elements.addressInput.value = 'working';
+
+    const addressEscapeEvent = {
+      key: 'Escape',
+      preventDefault: jest.fn(),
+    };
+    ctx.elements.addressInput.dispatch('keydown', addressEscapeEvent);
+
+    expect(addressEscapeEvent.preventDefault).toHaveBeenCalled();
+    expect(ctx.activeRef.tab.webview.stop).toHaveBeenCalled();
+    expect(ctx.elements.addressInput.value).toBe('display:https://current.example');
+    expect(ctx.elements.reloadBtn.dataset.state).toBe('reload');
+    expect(ctx.elements.addressInput.blur).toHaveBeenCalled();
+
+    const blurTarget = createElement('button');
+    blurTarget.blur = jest.fn();
+    global.document.activeElement = blurTarget;
+    ctx.activeRef.tab.navigationState.isWebviewLoading = true;
+    ctx.windowHandlers.keydown({
+      key: 'Escape',
+      preventDefault: jest.fn(),
+    });
+    expect(blurTarget.blur).toHaveBeenCalled();
+
+    ctx.activeRef.tab.navigationState.isWebviewLoading = false;
+    ctx.activeRef.tab.webview.getURL.mockReturnValue(
+      'file:///app/pages/error.html?url=https%3A%2F%2Fretry.example'
+    );
+    ctx.elements.reloadBtn.dispatch('click', {
+      shiftKey: false,
+    });
+    expect(ctx.activeRef.tab.webview.loadURL).toHaveBeenCalledWith('https://retry.example');
+
+    ctx.activeRef.tab.webview.getURL.mockReturnValue('https://active.example');
+    ctx.windowHandlers.keydown({
+      ctrlKey: true,
+      metaKey: false,
+      shiftKey: false,
+      altKey: false,
+      key: 'r',
+      preventDefault: jest.fn(),
+    });
+    ctx.windowHandlers.keydown({
+      ctrlKey: true,
+      metaKey: false,
+      shiftKey: true,
+      altKey: false,
+      key: 'r',
+      preventDefault: jest.fn(),
+    });
+    expect(ctx.activeRef.tab.webview.reload).toHaveBeenCalled();
+    expect(ctx.activeRef.tab.webview.reloadIgnoringCache).toHaveBeenCalled();
+
+    ctx.state.enableRadicleIntegration = false;
+    ctx.elements.addressInput.value = 'rad://zrepo123';
+    ctx.mod.onSettingsChanged();
+    expect(ctx.activeRef.tab.webview.loadURL).toHaveBeenCalledWith(
+      'file:///app/pages/rad-browser.html?error=disabled'
+    );
+  });
+
+  test('processes webview lifecycle events and records history', async () => {
+    const ctx = await loadNavigationModule();
+    const onHistoryRecorded = jest.fn();
+
+    ctx.mod.setOnHistoryRecorded(onHistoryRecorded);
+    await ctx.mod.initNavigation();
+
+    ctx.tabsMocks.webviewEventHandler('did-start-loading', { tabId: ctx.activeRef.tab.id });
+
+    expect(ctx.tabsMocks.setTabLoading).toHaveBeenCalledWith(true);
+    expect(ctx.elements.reloadBtn.dataset.state).toBe('stop');
+
+    ctx.elements.addressInput.value = 'https://recorded.example';
+    ctx.activeRef.tab.title = 'Recorded Title';
+
+    ctx.tabsMocks.webviewEventHandler('did-stop-loading', {
+      url: 'https://loaded.example',
+    });
+    await flushMicrotasks();
+
+    expect(ctx.tabsMocks.setTabLoading).toHaveBeenLastCalledWith(false);
+    expect(ctx.elements.reloadBtn.dataset.state).toBe('reload');
+    expect(ctx.electronAPI.fetchFaviconWithKey).toHaveBeenCalledWith(
+      'https://loaded.example',
+      'https://recorded.example'
+    );
+    expect(ctx.tabsMocks.updateTabFavicon).toHaveBeenCalledWith(
+      ctx.activeRef.tab.id,
+      'https://recorded.example'
+    );
+    expect(ctx.electronAPI.addHistory).toHaveBeenCalledWith({
+      url: 'https://recorded.example',
+      title: 'Recorded Title',
+      protocol: 'https',
+    });
+    expect(onHistoryRecorded).toHaveBeenCalled();
+
+    ctx.tabsMocks.webviewEventHandler('did-fail-load', {
+      event: {
+        errorCode: -105,
+        errorDescription: 'ERR_NAME_NOT_RESOLVED',
+        validatedURL: 'https://bad.example',
+      },
+    });
+    expect(ctx.activeRef.tab.webview.loadURL).toHaveBeenCalledWith(
+      'file:///app/pages/error.html?error=ERR_NAME_NOT_RESOLVED&url=https%3A%2F%2Fbad.example'
+    );
+
+    ctx.tabsMocks.webviewEventHandler('certificate-error', {
+      event: { error: 'CERT_INVALID' },
+    });
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('Certificate error: CERT_INVALID');
+
+    ctx.tabsMocks.webviewEventHandler('dom-ready', {});
+    await flushMicrotasks();
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('Webview ready.');
+  });
+
+  test('restores tab state on tab switches and updates navigation display', async () => {
+    const secondTab = createTab(2, 'https://second.example', {
+      title: 'Second Tab',
+      isLoading: true,
+      navigationState: {
+        addressBarSnapshot: 'typed second',
+        currentBzzBase: 'https://gateway.example/bzz/hash/',
+      },
+      webview: createWebview('https://second.example', {
+        webContentsId: 22,
+      }),
+    });
+    const thirdTab = createTab(3, 'file:///app/pages/home.html', {
+      title: 'Home Tab',
+      webview: createWebview('file:///app/pages/home.html', {
+        webContentsId: 23,
+      }),
+    });
+    const ctx = await loadNavigationModule({
+      tabs: [createTab(1, 'https://first.example'), secondTab, thirdTab],
+      activeTab: createTab(1, 'https://first.example'),
+    });
+
+    ctx.tabsRef.list = [ctx.activeRef.tab, secondTab, thirdTab];
+    await ctx.mod.initNavigation();
+
+    ctx.elements.addressInput.value = 'saved snapshot';
+    ctx.tabsMocks.webviewEventHandler('tab-switched', {
+      tabId: ctx.activeRef.tab.id,
+      tab: ctx.activeRef.tab,
+      isNewTab: false,
+    });
+    ctx.elements.addressInput.value = 'saved snapshot';
+
+    ctx.activeRef.tab = secondTab;
+    ctx.tabsMocks.webviewEventHandler('tab-switched', {
+      tabId: secondTab.id,
+      tab: secondTab,
+      isNewTab: false,
+    });
+    await flushMicrotasks();
+
+    expect(ctx.tabsRef.list[0].navigationState.addressBarSnapshot).toBe('saved snapshot');
+    expect(ctx.elements.addressInput.value).toBe('typed second');
+    expect(ctx.tabsMocks.setTabLoading).toHaveBeenLastCalledWith(true);
+    expect(ctx.elements.reloadBtn.dataset.state).toBe('stop');
+    expect(ctx.tabsMocks.updateTabFavicon).toHaveBeenCalledWith(secondTab.id, 'typed second');
+
+    ctx.navigationUtilsMocks.deriveSwitchedTabDisplay.mockReturnValueOnce('');
+    ctx.activeRef.tab = thirdTab;
+    ctx.tabsMocks.webviewEventHandler('tab-switched', {
+      tabId: thirdTab.id,
+      tab: thirdTab,
+      isNewTab: true,
+    });
+
+    expect(ctx.elements.addressInput.focus).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/lib/page-context-menu.test.js
+++ b/src/renderer/lib/page-context-menu.test.js
@@ -1,0 +1,506 @@
+const originalWindow = global.window;
+const originalDocument = global.document;
+const originalNavigator = global.navigator;
+const originalRequestAnimationFrame = global.requestAnimationFrame;
+const originalCustomEvent = global.CustomEvent;
+
+const createClassList = (initialClasses = []) => {
+  const classes = new Set(initialClasses);
+
+  return {
+    add: jest.fn((className) => {
+      classes.add(className);
+    }),
+    remove: jest.fn((className) => {
+      classes.delete(className);
+    }),
+    toggle: jest.fn((className, force) => {
+      if (force === undefined) {
+        if (classes.has(className)) {
+          classes.delete(className);
+          return false;
+        }
+        classes.add(className);
+        return true;
+      }
+
+      if (force) {
+        classes.add(className);
+      } else {
+        classes.delete(className);
+      }
+
+      return force;
+    }),
+    contains: jest.fn((className) => classes.has(className)),
+  };
+};
+
+const createElement = (initialClasses = []) => {
+  const handlers = {};
+
+  return {
+    handlers,
+    classList: createClassList(initialClasses),
+    style: {},
+    dataset: {},
+    disabled: false,
+    addEventListener: jest.fn((event, handler) => {
+      handlers[event] = handler;
+    }),
+    querySelector: jest.fn(() => null),
+    querySelectorAll: jest.fn(() => []),
+    getBoundingClientRect: jest.fn(() => ({
+      left: 0,
+      top: 0,
+      right: 120,
+      bottom: 120,
+      width: 120,
+      height: 120,
+    })),
+    contains: jest.fn(() => false),
+  };
+};
+
+const loadPageContextMenuModule = async (options = {}) => {
+  jest.resetModules();
+
+  const {
+    activeWebview = {
+      canGoBack: jest.fn(() => true),
+      canGoForward: jest.fn(() => false),
+      goBack: jest.fn(),
+      goForward: jest.fn(),
+      reloadIgnoringCache: jest.fn(),
+      openDevTools: jest.fn(),
+      send: jest.fn(),
+    },
+    menuRect = {
+      left: 0,
+      top: 0,
+      right: 850,
+      bottom: 650,
+      width: 120,
+      height: 100,
+    },
+  } = options;
+
+  const pageGroup = createElement();
+  const selectionGroup = createElement();
+  const linkGroup = createElement();
+  const imageGroup = createElement();
+  const backBtn = createElement();
+  const forwardBtn = createElement();
+  const pageContextMenu = createElement(['hidden']);
+  const webviewContainer = {
+    querySelector: jest.fn(() => activeWebview),
+  };
+  const documentHandlers = {};
+  const windowHandlers = {};
+  const electronAPI = {
+    openUrlInNewWindow: jest.fn(),
+    copyText: jest.fn(),
+    saveImage: jest.fn(),
+    copyImageFromUrl: jest.fn(),
+  };
+  const selectorMap = {
+    '[data-group="page"]': pageGroup,
+    '[data-group="selection"]': selectionGroup,
+    '[data-group="link"]': linkGroup,
+    '[data-group="image"]': imageGroup,
+    '[data-action="back"]': backBtn,
+    '[data-action="forward"]': forwardBtn,
+  };
+  const pushDebug = jest.fn();
+  const backdrop = {
+    showMenuBackdrop: jest.fn(),
+    hideMenuBackdrop: jest.fn(),
+  };
+  const urlUtils = {
+    deriveDisplayValue: jest.fn((url) => `derived:${url}`),
+    applyEnsNamePreservation: jest.fn((display) => `ens:${display}`),
+  };
+
+  pageContextMenu.querySelectorAll = jest.fn((selector) => {
+    if (selector === '.context-menu-group') {
+      return [pageGroup, selectionGroup, linkGroup, imageGroup];
+    }
+
+    return [];
+  });
+  pageContextMenu.querySelector = jest.fn((selector) => selectorMap[selector] || null);
+  pageContextMenu.getBoundingClientRect = jest.fn(() => menuRect);
+
+  global.window = {
+    electronAPI,
+    nodeConfig: {},
+    innerWidth: 800,
+    innerHeight: 600,
+    addEventListener: jest.fn((event, handler) => {
+      windowHandlers[event] = handler;
+    }),
+  };
+
+  global.document = {
+    getElementById: jest.fn((id) => {
+      if (id === 'page-context-menu') return pageContextMenu;
+      if (id === 'webview-container') return webviewContainer;
+      return null;
+    }),
+    addEventListener: jest.fn((event, handler) => {
+      documentHandlers[event] = handler;
+    }),
+    dispatchEvent: jest.fn(),
+  };
+
+  global.navigator = {
+    clipboard: {
+      writeText: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+  global.requestAnimationFrame = jest.fn((callback) => {
+    callback();
+    return 1;
+  });
+  global.CustomEvent = jest.fn((type, init) => ({
+    type,
+    detail: init.detail,
+  }));
+
+  jest.doMock('./debug.js', () => ({
+    pushDebug,
+  }));
+  jest.doMock('./menu-backdrop.js', () => backdrop);
+  jest.doMock('./url-utils.js', () => urlUtils);
+
+  const mod = await import('./page-context-menu.js');
+  const stateModule = await import('./state.js');
+
+  stateModule.state.knownEnsNames = new Map([['cid', 'name.eth']]);
+
+  return {
+    mod,
+    state: stateModule.state,
+    pageContextMenu,
+    pageGroup,
+    selectionGroup,
+    linkGroup,
+    imageGroup,
+    backBtn,
+    forwardBtn,
+    activeWebview,
+    webviewContainer,
+    documentHandlers,
+    windowHandlers,
+    electronAPI,
+    pushDebug,
+    backdrop,
+    urlUtils,
+  };
+};
+
+const triggerMenuAction = async (pageContextMenu, action, itemOverrides = {}) => {
+  const item = {
+    disabled: false,
+    dataset: { action },
+    ...itemOverrides,
+  };
+  const target = {
+    closest: jest.fn(() => item),
+  };
+
+  pageContextMenu.handlers.click({ target });
+  await Promise.resolve();
+
+  return item;
+};
+
+describe('page-context-menu', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.navigator = originalNavigator;
+    global.requestAnimationFrame = originalRequestAnimationFrame;
+    global.CustomEvent = originalCustomEvent;
+    jest.restoreAllMocks();
+  });
+
+  test('handles missing initialization targets safely', async () => {
+    jest.resetModules();
+
+    global.window = {
+      electronAPI: {},
+      nodeConfig: {},
+      innerWidth: 800,
+      innerHeight: 600,
+      addEventListener: jest.fn(),
+    };
+    global.document = {
+      getElementById: jest.fn(() => null),
+      addEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    };
+    global.navigator = {
+      clipboard: {
+        writeText: jest.fn(),
+      },
+    };
+    global.requestAnimationFrame = jest.fn((callback) => {
+      callback();
+      return 1;
+    });
+    global.CustomEvent = jest.fn((type, init) => ({
+      type,
+      detail: init.detail,
+    }));
+
+    jest.doMock('./debug.js', () => ({
+      pushDebug: jest.fn(),
+    }));
+    jest.doMock('./menu-backdrop.js', () => ({
+      showMenuBackdrop: jest.fn(),
+      hideMenuBackdrop: jest.fn(),
+    }));
+    jest.doMock('./url-utils.js', () => ({
+      deriveDisplayValue: jest.fn((url) => url),
+      applyEnsNamePreservation: jest.fn((display) => display),
+    }));
+
+    const mod = await import('./page-context-menu.js');
+
+    expect(() => {
+      mod.showPageContextMenu(10, 20, { pageUrl: 'https://example.com' });
+      mod.hidePageContextMenu();
+      mod.setupWebviewContextMenu(null);
+    }).not.toThrow();
+
+    await expect(mod.initPageContextMenu()).resolves.toBeUndefined();
+  });
+
+  test('shows the correct group, updates navigation state, and repositions on screen bounds', async () => {
+    const activeWebview = {
+      canGoBack: jest.fn(() => true),
+      canGoForward: jest.fn(() => false),
+      goBack: jest.fn(),
+      goForward: jest.fn(),
+      reloadIgnoringCache: jest.fn(),
+      openDevTools: jest.fn(),
+      send: jest.fn(),
+    };
+    const { mod, pageContextMenu, pageGroup, selectionGroup, linkGroup, imageGroup, backBtn, forwardBtn, backdrop, pushDebug } =
+      await loadPageContextMenuModule({ activeWebview });
+
+    await mod.initPageContextMenu();
+
+    expect(pushDebug).toHaveBeenCalledWith('[PageContextMenu] Initialized');
+
+    mod.showPageContextMenu(790, 590, { imageSrc: 'https://example.com/image.png' });
+
+    expect(imageGroup.classList.add).toHaveBeenCalledWith('visible');
+    expect(backBtn.disabled).toBe(false);
+    expect(forwardBtn.disabled).toBe(true);
+    expect(backdrop.showMenuBackdrop).toHaveBeenCalled();
+    expect(pageContextMenu.classList.remove).toHaveBeenCalledWith('hidden');
+    expect(pageContextMenu.style.left).toBe('672px');
+    expect(pageContextMenu.style.top).toBe('492px');
+
+    mod.showPageContextMenu(20, 30, { linkUrl: 'https://example.com/link' });
+    mod.showPageContextMenu(5, 6, { selectedText: 'selected text' });
+    mod.showPageContextMenu(1, 2, { pageUrl: 'https://example.com/page' });
+
+    expect(linkGroup.classList.add).toHaveBeenCalledWith('visible');
+    expect(selectionGroup.classList.add).toHaveBeenCalledWith('visible');
+    expect(pageGroup.classList.add).toHaveBeenCalledWith('visible');
+
+    pageContextMenu.getBoundingClientRect.mockReturnValueOnce({
+      left: 0,
+      top: 0,
+      right: 30,
+      bottom: 40,
+      width: 20,
+      height: 20,
+    });
+    mod.showPageContextMenu(5, 6, { pageUrl: 'https://example.com/clamped' });
+
+    expect(pageContextMenu.style.left).toBe('8px');
+    expect(pageContextMenu.style.top).toBe('8px');
+
+    activeWebview.canGoBack.mockImplementation(() => {
+      throw new Error('no back state');
+    });
+    activeWebview.canGoForward.mockImplementation(() => {
+      throw new Error('no forward state');
+    });
+
+    mod.showPageContextMenu(100, 110, { pageUrl: 'https://example.com/page' });
+
+    expect(backBtn.disabled).toBe(true);
+    expect(forwardBtn.disabled).toBe(true);
+  });
+
+  test('dispatches page and link actions through menu clicks', async () => {
+    const { mod, pageContextMenu, activeWebview, electronAPI, pushDebug, backdrop, urlUtils } =
+      await loadPageContextMenuModule();
+
+    await mod.initPageContextMenu();
+
+    const context = {
+      pageUrl: 'https://example.com/page',
+      linkUrl: 'https://example.com/link',
+    };
+
+    mod.showPageContextMenu(20, 30, context);
+    await triggerMenuAction(pageContextMenu, 'back');
+    expect(activeWebview.goBack).toHaveBeenCalled();
+
+    mod.showPageContextMenu(20, 30, context);
+    activeWebview.canGoForward.mockReturnValue(true);
+    await triggerMenuAction(pageContextMenu, 'forward');
+    expect(activeWebview.goForward).toHaveBeenCalled();
+
+    mod.showPageContextMenu(20, 30, context);
+    await triggerMenuAction(pageContextMenu, 'reload');
+    expect(activeWebview.reloadIgnoringCache).toHaveBeenCalled();
+
+    mod.showPageContextMenu(20, 30, context);
+    await triggerMenuAction(pageContextMenu, 'view-source');
+    expect(global.document.dispatchEvent).toHaveBeenCalledWith({
+      type: 'open-url-new-tab',
+      detail: { url: 'view-source:https://example.com/page' },
+    });
+
+    mod.showPageContextMenu(20, 30, context);
+    await triggerMenuAction(pageContextMenu, 'inspect');
+    expect(activeWebview.openDevTools).toHaveBeenCalled();
+
+    mod.showPageContextMenu(20, 30, context);
+    await triggerMenuAction(pageContextMenu, 'open-link-new-tab');
+    expect(global.document.dispatchEvent).toHaveBeenCalledWith({
+      type: 'open-url-new-tab',
+      detail: { url: 'https://example.com/link' },
+    });
+
+    mod.showPageContextMenu(20, 30, context);
+    await triggerMenuAction(pageContextMenu, 'open-link-new-window');
+    expect(urlUtils.deriveDisplayValue).toHaveBeenCalledWith(
+      'https://example.com/link',
+      expect.any(String),
+      '',
+      expect.any(String),
+      expect.any(String)
+    );
+    expect(electronAPI.openUrlInNewWindow).toHaveBeenCalledWith(
+      'ens:derived:https://example.com/link'
+    );
+
+    mod.showPageContextMenu(20, 30, context);
+    await triggerMenuAction(pageContextMenu, 'copy-link');
+    expect(electronAPI.copyText).toHaveBeenCalledWith('ens:derived:https://example.com/link');
+    expect(pushDebug).toHaveBeenCalledWith('Copied link: ens:derived:https://example.com/link');
+    expect(backdrop.hideMenuBackdrop).toHaveBeenCalled();
+  });
+
+  test('handles selection and image actions, including clipboard and native fallbacks', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { mod, pageContextMenu, activeWebview, electronAPI, pushDebug, urlUtils } =
+      await loadPageContextMenuModule();
+
+    await mod.initPageContextMenu();
+
+    mod.showPageContextMenu(20, 30, { selectedText: 'copied selection' });
+    await triggerMenuAction(pageContextMenu, 'copy');
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith('copied selection');
+    expect(pushDebug).toHaveBeenCalledWith('Copied selected text');
+
+    global.navigator.clipboard.writeText.mockRejectedValueOnce(new Error('clipboard blocked'));
+    mod.showPageContextMenu(20, 30, { selectedText: 'fallback selection' });
+    await triggerMenuAction(pageContextMenu, 'copy');
+    expect(activeWebview.send).toHaveBeenCalledWith('context-menu-action', 'copy');
+
+    mod.showPageContextMenu(20, 30, { imageSrc: 'https://example.com/image.png' });
+    await triggerMenuAction(pageContextMenu, 'open-image-new-tab');
+    expect(global.document.dispatchEvent).toHaveBeenCalledWith({
+      type: 'open-url-new-tab',
+      detail: { url: 'https://example.com/image.png' },
+    });
+
+    electronAPI.saveImage.mockResolvedValueOnce({
+      success: true,
+      filePath: '/tmp/image.png',
+    });
+    mod.showPageContextMenu(20, 30, { imageSrc: 'https://example.com/image.png' });
+    await triggerMenuAction(pageContextMenu, 'save-image');
+    expect(pushDebug).toHaveBeenCalledWith('Image saved to: /tmp/image.png');
+
+    electronAPI.saveImage.mockResolvedValueOnce({
+      error: 'disk full',
+    });
+    mod.showPageContextMenu(20, 30, { imageSrc: 'https://example.com/image.png' });
+    await triggerMenuAction(pageContextMenu, 'save-image');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to save image:', 'disk full');
+
+    electronAPI.copyImageFromUrl.mockResolvedValueOnce({
+      success: true,
+    });
+    mod.showPageContextMenu(20, 30, { imageSrc: 'https://example.com/image.png' });
+    await triggerMenuAction(pageContextMenu, 'copy-image');
+    expect(pushDebug).toHaveBeenCalledWith('Copied image to clipboard');
+
+    electronAPI.copyImageFromUrl.mockResolvedValueOnce({
+      error: 'copy failed',
+    });
+    mod.showPageContextMenu(20, 30, { imageSrc: 'https://example.com/image.png' });
+    await triggerMenuAction(pageContextMenu, 'copy-image');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to copy image:', 'copy failed');
+
+    urlUtils.applyEnsNamePreservation.mockReturnValueOnce('');
+    mod.showPageContextMenu(20, 30, { imageSrc: 'https://example.com/image.png' });
+    await triggerMenuAction(pageContextMenu, 'copy-image-address');
+    expect(electronAPI.copyText).toHaveBeenCalledWith('https://example.com/image.png');
+  });
+
+  test('closes on outside interactions and wires webview ipc context-menu events', async () => {
+    const { mod, pageContextMenu, documentHandlers, windowHandlers, backdrop } =
+      await loadPageContextMenuModule();
+
+    await mod.initPageContextMenu();
+
+    mod.showPageContextMenu(20, 30, { pageUrl: 'https://example.com/page' });
+    pageContextMenu.contains.mockReturnValueOnce(false);
+    documentHandlers.click({ target: {} });
+    expect(pageContextMenu.classList.add).toHaveBeenCalledWith('hidden');
+    expect(backdrop.hideMenuBackdrop).toHaveBeenCalled();
+
+    mod.showPageContextMenu(20, 30, { pageUrl: 'https://example.com/page' });
+    windowHandlers.blur();
+    expect(pageContextMenu.classList.add).toHaveBeenCalledWith('hidden');
+
+    const webviewHandlers = {};
+    const webview = {
+      addEventListener: jest.fn((event, handler) => {
+        webviewHandlers[event] = handler;
+      }),
+      getBoundingClientRect: jest.fn(() => ({
+        left: 25,
+        top: 35,
+      })),
+    };
+
+    mod.setupWebviewContextMenu(webview);
+    pageContextMenu.getBoundingClientRect.mockReturnValueOnce({
+      left: 0,
+      top: 0,
+      right: 60,
+      bottom: 70,
+      width: 25,
+      height: 25,
+    });
+    webviewHandlers['ipc-message']({
+      channel: 'context-menu',
+      args: [{ x: 10, y: 15, pageUrl: 'https://example.com/from-webview' }],
+    });
+
+    expect(pageContextMenu.style.left).toBe('35px');
+    expect(pageContextMenu.style.top).toBe('50px');
+  });
+});

--- a/src/renderer/lib/page-urls.test.js
+++ b/src/renderer/lib/page-urls.test.js
@@ -1,0 +1,82 @@
+describe('page-urls', () => {
+  const originalWindow = global.window;
+
+  const loadModule = async (internalPages = {}) => {
+    jest.resetModules();
+    global.window = {
+      location: { href: 'file:///app/index.html' },
+      internalPages: { routable: internalPages },
+    };
+    return import('./page-urls.js');
+  };
+
+  afterEach(() => {
+    global.window = originalWindow;
+  });
+
+  test('builds internal page urls from window.internalPages', async () => {
+    const routablePages = {
+      history: 'history.html',
+    };
+    routablePages['protocol-test'] = 'protocol-test.html';
+
+    const mod = await loadModule(routablePages);
+
+    expect(mod.internalPages).toEqual({
+      history: 'file:///app/pages/history.html',
+      'protocol-test': 'file:///app/pages/protocol-test.html',
+    });
+    expect(mod.homeUrl).toBe('file:///app/pages/home.html');
+    expect(mod.errorUrlBase).toBe('file:///app/pages/error.html');
+  });
+
+  test('detects protocols for history recording', async () => {
+    const mod = await loadModule();
+
+    expect(mod.detectProtocol('ens://vitalik.eth')).toBe('ens');
+    expect(mod.detectProtocol('bzz://hash')).toBe('swarm');
+    expect(mod.detectProtocol('ipfs://cid')).toBe('ipfs');
+    expect(mod.detectProtocol('ipns://name')).toBe('ipns');
+    expect(mod.detectProtocol('rad://rid')).toBe('radicle');
+    expect(mod.detectProtocol('https://example.com')).toBe('https');
+    expect(mod.detectProtocol('http://example.com')).toBe('http');
+    expect(mod.detectProtocol('')).toBe('unknown');
+  });
+
+  test('filters non-recordable history entries', async () => {
+    const mod = await loadModule();
+
+    expect(mod.isHistoryRecordable('', 'https://example.com')).toBe(false);
+    expect(mod.isHistoryRecordable('freedom://history', 'file:///app/pages/history.html')).toBe(false);
+    expect(mod.isHistoryRecordable('view-source:https://example.com', 'view-source:https://example.com')).toBe(false);
+    expect(mod.isHistoryRecordable('https://example.com', 'file:///app/pages/error.html')).toBe(false);
+    expect(mod.isHistoryRecordable('https://example.com', mod.homeUrl)).toBe(false);
+    expect(mod.isHistoryRecordable('https://example.com', 'https://example.com')).toBe(true);
+  });
+
+  test('maps internal page urls back to freedom:// names', async () => {
+    const mod = await loadModule({
+      history: 'history.html',
+      links: 'links.html',
+    });
+
+    expect(mod.getInternalPageName('file:///app/pages/history.html')).toBe('history');
+    expect(mod.getInternalPageName('file:///app/pages/links.html')).toBe('links');
+    expect(mod.getInternalPageName('https://example.com')).toBeNull();
+  });
+
+  test('parses ens inputs with prefixes, paths, and invalid names', async () => {
+    const mod = await loadModule();
+
+    expect(mod.parseEnsInput('ens://Vitalik.ETH/docs?q=1')).toEqual({
+      name: 'vitalik.eth',
+      suffix: '/docs?q=1',
+    });
+    expect(mod.parseEnsInput('name.box#top')).toEqual({
+      name: 'name.box',
+      suffix: '#top',
+    });
+    expect(mod.parseEnsInput('example.com')).toBeNull();
+    expect(mod.parseEnsInput('')).toBeNull();
+  });
+});

--- a/src/renderer/lib/radicle-ui.test.js
+++ b/src/renderer/lib/radicle-ui.test.js
@@ -1,0 +1,313 @@
+const { createDocument, createElement } = require('../../../test/helpers/fake-dom.js');
+
+const originalWindow = global.window;
+const originalDocument = global.document;
+const originalFetch = global.fetch;
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const loadRadicleModule = async (options = {}) => {
+  jest.resetModules();
+
+  const state = {
+    beeMenuOpen: options.beeMenuOpen ?? false,
+    enableRadicleIntegration: options.enableRadicleIntegration ?? true,
+    currentRadicleStatus: options.currentRadicleStatus || 'stopped',
+    radicleVersionFetched: options.radicleVersionFetched ?? false,
+    radicleVersionValue: options.radicleVersionValue || '',
+    suppressRadicleRunningStatus: options.suppressRadicleRunningStatus ?? false,
+    registry: {
+      radicle: {
+        api: 'http://radicle.test',
+        mode: options.mode || 'none',
+        statusMessage: options.statusMessage ?? null,
+        tempMessage: options.tempMessage ?? null,
+      },
+    },
+  };
+  const buildRadicleUrl = jest.fn((endpoint) => `http://radicle.test${endpoint}`);
+  const getDisplayMessage = jest.fn(() => {
+    return state.registry.radicle.tempMessage || state.registry.radicle.statusMessage;
+  });
+  const debugMocks = {
+    pushDebug: jest.fn(),
+  };
+  const radicleToggleBtn = createElement('button');
+  const radicleToggleSwitch = createElement('div');
+  const radiclePeersCount = createElement('span');
+  const radicleReposCount = createElement('span');
+  const radicleVersionText = createElement('span');
+  const radicleNodeId = createElement('span');
+  const radicleInfoPanel = createElement('div', {
+    classes: ['radicle-info'],
+  });
+  const radicleStatusRow = createElement('div');
+  const radicleStatusLabel = createElement('span');
+  const radicleStatusValue = createElement('span');
+  const radicleNodesSection = createElement('section');
+  const body = createElement('body');
+  body.appendChild(radicleInfoPanel);
+  const document = createDocument({
+    body,
+    elementsById: {
+      'radicle-toggle-btn': radicleToggleBtn,
+      'radicle-toggle-switch': radicleToggleSwitch,
+      'radicle-peers-count': radiclePeersCount,
+      'radicle-repos-count': radicleReposCount,
+      'radicle-version-text': radicleVersionText,
+      'radicle-node-id': radicleNodeId,
+      'radicle-status-row': radicleStatusRow,
+      'radicle-status-label': radicleStatusLabel,
+      'radicle-status-value': radicleStatusValue,
+      'radicle-nodes-section': radicleNodesSection,
+    },
+  });
+  let statusHandler = null;
+  const windowHandlers = {};
+  const radicleApi =
+    options.windowRadicle === false
+      ? undefined
+      : {
+          checkBinary: jest
+            .fn()
+            .mockResolvedValue({ available: options.binaryAvailable ?? true }),
+          getConnections: jest
+            .fn()
+            .mockResolvedValue(options.connectionsResult || { success: true, count: 5 }),
+          start: jest
+            .fn()
+            .mockResolvedValue(options.startResult || { status: 'running', error: null }),
+          stop: jest
+            .fn()
+            .mockResolvedValue(options.stopResult || { status: 'stopped', error: null }),
+          getStatus: jest
+            .fn()
+            .mockResolvedValue(options.statusResult || { status: 'stopped', error: null }),
+          onStatusUpdate: jest.fn((handler) => {
+            statusHandler = handler;
+          }),
+        };
+  let intervalId = 1;
+  const setIntervalMock = jest.spyOn(global, 'setInterval').mockImplementation(() => intervalId++);
+  const clearIntervalMock = jest.spyOn(global, 'clearInterval').mockImplementation(() => {});
+
+  global.fetch =
+    options.fetchImpl ||
+    jest.fn(async (url) => {
+      if (url.endsWith('/api/v1/stats')) {
+        return {
+          ok: true,
+          json: async () => ({ repos: { total: 7 } }),
+        };
+      }
+      if (url.endsWith('/api/v1/node')) {
+        return {
+          ok: true,
+          json: async () => ({ id: 'rad123456789abcdef1234' }),
+        };
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ version: '1.2.3-buildhash' }),
+      };
+    });
+  global.window = {
+    radicle: radicleApi,
+    addEventListener: jest.fn((event, handler) => {
+      windowHandlers[event] = handler;
+    }),
+  };
+  global.document = document;
+
+  jest.doMock('./state.js', () => ({
+    state,
+    buildRadicleUrl,
+    getDisplayMessage,
+  }));
+  jest.doMock('./debug.js', () => debugMocks);
+
+  const mod = await import('./radicle-ui.js');
+
+  return {
+    mod,
+    state,
+    buildRadicleUrl,
+    getDisplayMessage,
+    debugMocks,
+    setIntervalMock,
+    clearIntervalMock,
+    radicleApi,
+    windowHandlers,
+    getStatusHandler: () => statusHandler,
+    elements: {
+      radicleToggleBtn,
+      radicleToggleSwitch,
+      radiclePeersCount,
+      radicleReposCount,
+      radicleVersionText,
+      radicleNodeId,
+      radicleInfoPanel,
+      radicleStatusRow,
+      radicleStatusLabel,
+      radicleStatusValue,
+      radicleNodesSection,
+    },
+  };
+};
+
+describe('radicle-ui', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  test('starts and stops Radicle info polling and populates stats', async () => {
+    const ctx = await loadRadicleModule({
+      beeMenuOpen: true,
+      enableRadicleIntegration: true,
+      currentRadicleStatus: 'running',
+      windowRadicle: true,
+      statusResult: { status: 'running', error: null },
+    });
+
+    ctx.mod.initRadicleUi();
+    ctx.mod.startRadicleInfoPolling();
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(ctx.radicleApi.getConnections).toHaveBeenCalled();
+    expect(ctx.buildRadicleUrl).toHaveBeenCalledWith('/api/v1/stats');
+    expect(ctx.buildRadicleUrl).toHaveBeenCalledWith('/api/v1/node');
+    expect(ctx.buildRadicleUrl).toHaveBeenCalledWith('/');
+    expect(ctx.elements.radicleInfoPanel.classList.contains('visible')).toBe(true);
+    expect(ctx.elements.radiclePeersCount.textContent).toBe('5');
+    expect(ctx.elements.radicleReposCount.textContent).toBe('7');
+    expect(ctx.elements.radicleVersionText.textContent).toBe('1.2.3');
+    expect(ctx.elements.radicleNodeId.textContent).toBe('rad12345...1234');
+    expect(ctx.elements.radicleNodeId.title).toBe('rad123456789abcdef1234');
+    expect(ctx.state.radicleVersionFetched).toBe(true);
+    expect(ctx.setIntervalMock).toHaveBeenCalledWith(expect.any(Function), 2000);
+
+    ctx.mod.stopRadicleInfoPolling();
+
+    expect(ctx.clearIntervalMock).toHaveBeenCalled();
+    expect(ctx.elements.radicleInfoPanel.classList.contains('visible')).toBe(false);
+    expect(ctx.elements.radiclePeersCount.textContent).toBe('0');
+    expect(ctx.elements.radicleReposCount.textContent).toBe('');
+    expect(ctx.elements.radicleVersionText.textContent).toBe('1.2.3');
+    expect(ctx.elements.radicleNodeId.textContent).toBe('');
+  });
+
+  test('updates Radicle status lines, toggle state, and running transitions', async () => {
+    const ctx = await loadRadicleModule({
+      beeMenuOpen: true,
+      enableRadicleIntegration: true,
+      currentRadicleStatus: 'stopped',
+      statusMessage: 'Radicle: Connected',
+      windowRadicle: false,
+    });
+
+    ctx.mod.initRadicleUi();
+    ctx.mod.updateRadicleStatusLine();
+
+    expect(ctx.getDisplayMessage).toHaveBeenCalledWith('radicle');
+    expect(ctx.elements.radicleStatusLabel.textContent).toBe('Radicle:');
+    expect(ctx.elements.radicleStatusValue.textContent).toBe('Connected');
+    expect(ctx.elements.radicleStatusRow.classList.contains('visible')).toBe(true);
+
+    ctx.state.registry.radicle.mode = 'reused';
+    ctx.mod.updateRadicleToggleState();
+    expect(ctx.elements.radicleToggleBtn.classList.contains('external')).toBe(true);
+
+    ctx.state.registry.radicle.mode = 'none';
+    ctx.mod.updateRadicleToggleState();
+    expect(ctx.elements.radicleToggleBtn.classList.contains('external')).toBe(false);
+
+    ctx.mod.updateRadicleUi('starting');
+    expect(ctx.elements.radicleToggleSwitch.classList.contains('running')).toBe(true);
+    expect(ctx.state.currentRadicleStatus).toBe('starting');
+
+    ctx.state.suppressRadicleRunningStatus = true;
+    ctx.elements.radicleToggleSwitch.classList.remove('running');
+    ctx.mod.updateRadicleUi('running');
+    expect(ctx.elements.radicleToggleSwitch.classList.contains('running')).toBe(false);
+
+    ctx.mod.updateRadicleUi('error', 'offline');
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('Radicle Error: offline');
+
+    ctx.mod.updateRadicleUi('stopped');
+    expect(ctx.elements.radicleStatusRow.classList.contains('visible')).toBe(false);
+  });
+
+  test('initializes Radicle controls and reacts to settings changes and toggle actions', async () => {
+    const ctx = await loadRadicleModule({
+      beeMenuOpen: true,
+      enableRadicleIntegration: false,
+      currentRadicleStatus: 'stopped',
+      binaryAvailable: false,
+      statusResult: { status: 'stopped', error: null },
+    });
+
+    ctx.radicleApi.checkBinary
+      .mockResolvedValueOnce({ available: false })
+      .mockResolvedValueOnce({ available: true });
+
+    ctx.mod.initRadicleUi();
+    await flushMicrotasks();
+
+    expect(ctx.elements.radicleNodesSection.classList.contains('hidden')).toBe(true);
+    expect(ctx.elements.radicleToggleBtn.classList.contains('disabled')).toBe(true);
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith(
+      'Radicle binaries not found - toggle disabled'
+    );
+    expect(ctx.radicleApi.onStatusUpdate).toHaveBeenCalledWith(expect.any(Function));
+    expect(ctx.radicleApi.getStatus).toHaveBeenCalled();
+    expect(ctx.setIntervalMock).toHaveBeenCalledWith(expect.any(Function), 5000);
+
+    ctx.elements.radicleToggleBtn.dispatch('click');
+    expect(ctx.radicleApi.start).not.toHaveBeenCalled();
+
+    ctx.windowHandlers['settings:updated']({
+      detail: {
+        enableRadicleIntegration: true,
+      },
+    });
+    await flushMicrotasks();
+
+    expect(ctx.state.enableRadicleIntegration).toBe(true);
+    expect(ctx.elements.radicleNodesSection.classList.contains('hidden')).toBe(false);
+    expect(ctx.radicleApi.checkBinary).toHaveBeenCalledTimes(2);
+    expect(ctx.elements.radicleToggleBtn.classList.contains('disabled')).toBe(false);
+
+    ctx.elements.radicleToggleBtn.dispatch('click');
+    await flushMicrotasks();
+
+    expect(ctx.radicleApi.start).toHaveBeenCalled();
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('User toggled Radicle On');
+    expect(ctx.elements.radicleToggleSwitch.classList.contains('running')).toBe(true);
+    expect(ctx.state.currentRadicleStatus).toBe('running');
+
+    const statusHandler = ctx.getStatusHandler();
+    statusHandler({
+      status: 'error',
+      error: 'offline',
+    });
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith(
+      'Radicle Status Update: error (offline)'
+    );
+
+    ctx.state.currentRadicleStatus = 'running';
+    ctx.elements.radicleToggleBtn.dispatch('click');
+    await flushMicrotasks();
+
+    expect(ctx.radicleApi.stop).toHaveBeenCalled();
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('User toggled Radicle Off');
+  });
+});

--- a/src/renderer/lib/settings-ui.test.js
+++ b/src/renderer/lib/settings-ui.test.js
@@ -1,0 +1,303 @@
+const { createDocument, createElement } = require('../../../test/helpers/fake-dom.js');
+
+const originalWindow = global.window;
+const originalDocument = global.document;
+const originalCustomEvent = global.CustomEvent;
+
+const createCheckbox = () => {
+  const checkbox = createElement('input');
+  checkbox.checked = false;
+  checkbox.disabled = false;
+  return checkbox;
+};
+
+const loadSettingsModule = async (options = {}) => {
+  jest.resetModules();
+
+  const {
+    platform = 'darwin',
+    settingsResponses = [
+      {
+        theme: 'system',
+        startBeeAtLaunch: true,
+        startIpfsAtLaunch: true,
+        enableRadicleIntegration: false,
+        startRadicleAtLaunch: false,
+        autoUpdate: true,
+      },
+    ],
+    saveSettingsResult = true,
+    prefersDark = true,
+  } = options;
+
+  const settingsQueue = [...settingsResponses];
+  const settingsBtn = createElement('button');
+  const settingsModal = createElement('dialog');
+  const closeSettingsBtn = createElement('button');
+  const themeModeSelect = createElement('select');
+  const startBeeAtLaunchCheckbox = createCheckbox();
+  const startIpfsAtLaunchCheckbox = createCheckbox();
+  const enableRadicleIntegrationCheckbox = createCheckbox();
+  const startRadicleRow = createElement('div');
+  const startRadicleAtLaunchCheckbox = createCheckbox();
+  const autoUpdateCheckbox = createCheckbox();
+  const experimentalSection = createElement('section');
+  const mediaQueryList = {
+    matches: prefersDark,
+    addEventListener: jest.fn(),
+  };
+  const document = createDocument({
+    elementsById: {
+      'settings-btn': settingsBtn,
+      'settings-modal': settingsModal,
+      'close-settings': closeSettingsBtn,
+      'theme-mode': themeModeSelect,
+      'start-bee-at-launch': startBeeAtLaunchCheckbox,
+      'start-ipfs-at-launch': startIpfsAtLaunchCheckbox,
+      'enable-radicle-integration': enableRadicleIntegrationCheckbox,
+      'start-radicle-row': startRadicleRow,
+      'start-radicle-at-launch': startRadicleAtLaunchCheckbox,
+      'auto-update': autoUpdateCheckbox,
+      'experimental-section': experimentalSection,
+    },
+  });
+  const settingsUpdatedEvents = [];
+  const radicleStopResult = {
+    catch: jest.fn(),
+  };
+  const electronAPI = {
+    getSettings: jest.fn().mockImplementation(async () => {
+      if (settingsQueue.length === 0) {
+        return settingsResponses[settingsResponses.length - 1] || null;
+      }
+      return settingsQueue.shift();
+    }),
+    saveSettings: jest.fn().mockImplementation(async () => saveSettingsResult),
+    getPlatform: jest.fn().mockResolvedValue(platform),
+  };
+  const debugMocks = {
+    pushDebug: jest.fn(),
+  };
+  const menuMocks = {
+    setMenuOpen: jest.fn(),
+  };
+
+  settingsModal.showModal = jest.fn();
+  settingsModal.close = jest.fn();
+  document.documentElement = {
+    setAttribute: jest.fn(),
+    removeAttribute: jest.fn(),
+  };
+
+  global.window = {
+    electronAPI,
+    matchMedia: jest.fn(() => mediaQueryList),
+    dispatchEvent: jest.fn((event) => {
+      settingsUpdatedEvents.push(event);
+    }),
+    radicle: {
+      stop: jest.fn(() => radicleStopResult),
+    },
+  };
+  global.document = document;
+  global.CustomEvent = jest.fn((type, init) => ({
+    type,
+    detail: init.detail,
+  }));
+
+  jest.doMock('./debug.js', () => debugMocks);
+  jest.doMock('./menus.js', () => menuMocks);
+
+  const mod = await import('./settings-ui.js');
+
+  return {
+    mod,
+    elements: {
+      settingsBtn,
+      settingsModal,
+      closeSettingsBtn,
+      themeModeSelect,
+      startBeeAtLaunchCheckbox,
+      startIpfsAtLaunchCheckbox,
+      enableRadicleIntegrationCheckbox,
+      startRadicleRow,
+      startRadicleAtLaunchCheckbox,
+      autoUpdateCheckbox,
+      experimentalSection,
+    },
+    electronAPI,
+    mediaQueryList,
+    settingsUpdatedEvents,
+    radicleStopResult,
+    debugMocks,
+    menuMocks,
+    documentElement: document.documentElement,
+  };
+};
+
+describe('settings-ui', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.CustomEvent = originalCustomEvent;
+    jest.restoreAllMocks();
+  });
+
+  test('applies light and dark themes and reacts to system theme changes', async () => {
+    const { mod, mediaQueryList, documentElement, electronAPI } = await loadSettingsModule({
+      settingsResponses: [
+        {
+          theme: 'system',
+          enableRadicleIntegration: true,
+        },
+      ],
+      prefersDark: true,
+    });
+
+    mod.applyTheme('light');
+    expect(documentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'light');
+
+    mod.applyTheme('dark');
+    expect(documentElement.removeAttribute).toHaveBeenCalledWith('data-theme');
+
+    await mod.initTheme();
+
+    expect(electronAPI.getSettings).toHaveBeenCalledTimes(1);
+    expect(documentElement.removeAttribute).toHaveBeenCalledWith('data-theme');
+    expect(mediaQueryList.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+
+    mediaQueryList.matches = false;
+    mediaQueryList.addEventListener.mock.calls[0][1]();
+
+    expect(documentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'light');
+  });
+
+  test('initializes settings modal and saves updated settings successfully', async () => {
+    const onSettingsChanged = jest.fn();
+    const { mod, elements, electronAPI, settingsUpdatedEvents, radicleStopResult, debugMocks, menuMocks, documentElement } =
+      await loadSettingsModule({
+        platform: 'darwin',
+        settingsResponses: [
+          {
+            theme: 'dark',
+            enableRadicleIntegration: true,
+          },
+          {
+            theme: 'dark',
+            startBeeAtLaunch: true,
+            startIpfsAtLaunch: false,
+            enableRadicleIntegration: true,
+            startRadicleAtLaunch: true,
+            autoUpdate: false,
+          },
+        ],
+        saveSettingsResult: true,
+        prefersDark: true,
+      });
+
+    mod.setOnSettingsChanged(onSettingsChanged);
+    await mod.initTheme();
+    await mod.initSettings();
+
+    elements.settingsBtn.dispatch('click');
+    await Promise.resolve();
+
+    expect(menuMocks.setMenuOpen).toHaveBeenCalledWith(false);
+    expect(elements.themeModeSelect.value).toBe('dark');
+    expect(elements.startBeeAtLaunchCheckbox.checked).toBe(true);
+    expect(elements.startIpfsAtLaunchCheckbox.checked).toBe(false);
+    expect(elements.enableRadicleIntegrationCheckbox.checked).toBe(true);
+    expect(elements.startRadicleAtLaunchCheckbox.checked).toBe(true);
+    expect(elements.autoUpdateCheckbox.checked).toBe(false);
+    expect(elements.startRadicleAtLaunchCheckbox.disabled).toBe(false);
+    expect(elements.settingsModal.showModal).toHaveBeenCalled();
+
+    elements.themeModeSelect.value = 'light';
+    elements.startBeeAtLaunchCheckbox.checked = false;
+    elements.startIpfsAtLaunchCheckbox.checked = true;
+    elements.enableRadicleIntegrationCheckbox.checked = false;
+    elements.startRadicleAtLaunchCheckbox.checked = true;
+    elements.autoUpdateCheckbox.checked = true;
+    elements.enableRadicleIntegrationCheckbox.dispatch('change');
+    await Promise.resolve();
+
+    expect(elements.startRadicleRow.classList.toggle).toHaveBeenCalledWith('disabled', true);
+    expect(elements.startRadicleAtLaunchCheckbox.disabled).toBe(true);
+    expect(electronAPI.saveSettings).toHaveBeenCalledWith({
+      theme: 'light',
+      startBeeAtLaunch: false,
+      startIpfsAtLaunch: true,
+      enableRadicleIntegration: false,
+      startRadicleAtLaunch: true,
+      autoUpdate: true,
+    });
+    expect(global.window.radicle.stop).toHaveBeenCalled();
+    expect(radicleStopResult.catch).toHaveBeenCalledWith(expect.any(Function));
+    expect(debugMocks.pushDebug).toHaveBeenCalledWith('Settings saved');
+    expect(documentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'light');
+    expect(settingsUpdatedEvents).toContainEqual({
+      type: 'settings:updated',
+      detail: {
+        theme: 'light',
+        startBeeAtLaunch: false,
+        startIpfsAtLaunch: true,
+        enableRadicleIntegration: false,
+        startRadicleAtLaunch: true,
+        autoUpdate: true,
+      },
+    });
+    expect(onSettingsChanged).toHaveBeenCalled();
+  });
+
+  test('handles windows-specific settings behavior and failed saves', async () => {
+    const { mod, elements, electronAPI, debugMocks } = await loadSettingsModule({
+      platform: 'win32',
+      settingsResponses: [
+        {
+          theme: 'system',
+          enableRadicleIntegration: false,
+        },
+        {
+          theme: 'system',
+          startBeeAtLaunch: false,
+          startIpfsAtLaunch: false,
+          enableRadicleIntegration: true,
+          startRadicleAtLaunch: true,
+          autoUpdate: true,
+        },
+      ],
+      saveSettingsResult: false,
+      prefersDark: false,
+    });
+
+    await mod.initTheme();
+    await mod.initSettings();
+
+    expect(elements.experimentalSection.style.display).toBe('none');
+
+    elements.settingsBtn.dispatch('click');
+    await Promise.resolve();
+
+    elements.enableRadicleIntegrationCheckbox.checked = true;
+    elements.startRadicleAtLaunchCheckbox.checked = true;
+    elements.autoUpdateCheckbox.checked = false;
+    elements.autoUpdateCheckbox.dispatch('change');
+    await Promise.resolve();
+
+    expect(electronAPI.saveSettings).toHaveBeenCalledWith({
+      theme: 'system',
+      startBeeAtLaunch: false,
+      startIpfsAtLaunch: false,
+      enableRadicleIntegration: false,
+      startRadicleAtLaunch: false,
+      autoUpdate: false,
+    });
+    expect(debugMocks.pushDebug).toHaveBeenCalledWith('Failed to save settings');
+
+    elements.closeSettingsBtn.dispatch('click');
+    expect(elements.settingsModal.close).toHaveBeenCalledTimes(1);
+
+    elements.settingsModal.dispatch('click', { target: elements.settingsModal });
+    expect(elements.settingsModal.close).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/renderer/lib/state.test.js
+++ b/src/renderer/lib/state.test.js
@@ -1,0 +1,75 @@
+describe('renderer state', () => {
+  const originalWindow = global.window;
+
+  const loadModule = async (nodeConfig = {}) => {
+    jest.resetModules();
+    global.window = { nodeConfig };
+    return import('./state.js');
+  };
+
+  afterEach(() => {
+    global.window = originalWindow;
+  });
+
+  test('builds route prefixes from defaults or window config', async () => {
+    const defaults = await loadModule();
+    expect(defaults.state.bzzRoutePrefix).toBe('http://127.0.0.1:1633/bzz/');
+    expect(defaults.state.ipfsRoutePrefix).toBe('http://127.0.0.1:8080/ipfs/');
+    expect(defaults.state.ipnsRoutePrefix).toBe('http://127.0.0.1:8080/ipns/');
+    expect(defaults.state.radicleApiPrefix).toBe('http://127.0.0.1:8780/api/v1/repos/');
+
+    const custom = await loadModule({
+      beeApi: 'http://127.0.0.1:1733/',
+      ipfsGateway: 'http://127.0.0.1:8181/',
+    });
+    expect(custom.state.bzzRoutePrefix).toBe('http://127.0.0.1:1733/bzz/');
+    expect(custom.state.ipfsRoutePrefix).toBe('http://127.0.0.1:8181/ipfs/');
+    expect(custom.state.ipnsRoutePrefix).toBe('http://127.0.0.1:8181/ipns/');
+  });
+
+  test('builds service urls from registry values or fallbacks', async () => {
+    const mod = await loadModule();
+
+    expect(mod.buildBeeUrl('/health')).toBe('http://127.0.0.1:1633/health');
+    expect(mod.buildIpfsApiUrl('/api/v0/id')).toBe('http://127.0.0.1:5001/api/v0/id');
+    expect(mod.buildRadicleUrl('/api/v1')).toBe('http://127.0.0.1:8780/api/v1');
+
+    mod.updateRegistry({
+      bee: { api: 'http://127.0.0.1:1999', gateway: 'http://127.0.0.1:1999' },
+      ipfs: { api: 'http://127.0.0.1:5999', gateway: 'http://127.0.0.1:8999' },
+      radicle: { api: 'http://127.0.0.1:8781', gateway: 'http://127.0.0.1:8781' },
+    });
+
+    expect(mod.buildBeeUrl('/health')).toBe('http://127.0.0.1:1999/health');
+    expect(mod.buildIpfsApiUrl('/api/v0/id')).toBe('http://127.0.0.1:5999/api/v0/id');
+    expect(mod.buildRadicleUrl('/api/v1')).toBe('http://127.0.0.1:8781/api/v1');
+    expect(mod.state.beeBase).toBe('http://127.0.0.1:1999');
+    expect(mod.state.ipfsBase).toBe('http://127.0.0.1:8999');
+    expect(mod.state.ipfsApiBase).toBe('http://127.0.0.1:5999');
+    expect(mod.state.radicleBase).toBe('http://127.0.0.1:8781');
+  });
+
+  test('normalizes the radicle feature flag and service display messages', async () => {
+    const mod = await loadModule();
+
+    mod.setRadicleIntegrationEnabled(true);
+    expect(mod.state.enableRadicleIntegration).toBe(true);
+
+    mod.setRadicleIntegrationEnabled('yes');
+    expect(mod.state.enableRadicleIntegration).toBe(false);
+
+    mod.updateRegistry({
+      ...mod.state.registry,
+      bee: {
+        api: null,
+        gateway: null,
+        mode: 'none',
+        statusMessage: 'Ready',
+        tempMessage: 'Starting',
+      },
+    });
+
+    expect(mod.getDisplayMessage('bee')).toBe('Starting');
+    expect(mod.getDisplayMessage('missing')).toBeNull();
+  });
+});

--- a/src/renderer/lib/tabs-ui.test.js
+++ b/src/renderer/lib/tabs-ui.test.js
@@ -1,0 +1,564 @@
+const { createDocument, createElement } = require('../../../test/helpers/fake-dom.js');
+
+const originalWindow = global.window;
+const originalDocument = global.document;
+
+const HOME_URL = 'freedom://home';
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createElectronApi = () => {
+  const handlers = {};
+  const register = (name) =>
+    jest.fn((callback) => {
+      handlers[name] = callback;
+    });
+
+  return {
+    handlers,
+    api: {
+      setWindowTitle: jest.fn(),
+      updateTabMenuState: jest.fn(),
+      closeWindow: jest.fn(),
+      getWebviewPreloadPath: jest.fn().mockResolvedValue('/tmp/webview-preload.js'),
+      getCachedFavicon: jest.fn().mockResolvedValue('data:image/png;base64,favicon'),
+      onNewTab: register('newTab'),
+      onCloseTab: register('closeTab'),
+      onNewTabWithUrl: register('newTabWithUrl'),
+      onNavigateToUrl: register('navigateToUrl'),
+      onLoadUrl: register('loadUrl'),
+      onToggleDevTools: register('toggleDevTools'),
+      onCloseDevTools: register('closeDevTools'),
+      onCloseAllDevTools: register('closeAllDevTools'),
+      onFocusAddressBar: register('focusAddressBar'),
+      onReload: register('reload'),
+      onHardReload: register('hardReload'),
+      onNextTab: register('nextTab'),
+      onPrevTab: register('prevTab'),
+      onMoveTabLeft: register('moveTabLeft'),
+      onMoveTabRight: register('moveTabRight'),
+      onReopenClosedTab: register('reopenClosedTab'),
+    },
+  };
+};
+
+const createWebview = (createdWebviews) => {
+  const webview = createElement('webview');
+  const addEventListener = webview.addEventListener.bind(webview);
+  const removeEventListener = webview.removeEventListener.bind(webview);
+
+  webview.addEventListener = jest.fn((event, handler) => {
+    addEventListener(event, handler);
+  });
+  webview.removeEventListener = jest.fn((event, handler) => {
+    removeEventListener(event, handler);
+  });
+  webview._devToolsOpen = false;
+  webview.getURL = jest.fn(() => webview.src || 'about:blank');
+  webview.canGoBack = jest.fn(() => false);
+  webview.canGoForward = jest.fn(() => false);
+  webview.goBack = jest.fn();
+  webview.goForward = jest.fn();
+  webview.reloadIgnoringCache = jest.fn();
+  webview.send = jest.fn();
+  webview.print = jest.fn();
+  webview.openDevTools = jest.fn(() => {
+    webview._devToolsOpen = true;
+  });
+  webview.closeDevTools = jest.fn(() => {
+    webview._devToolsOpen = false;
+  });
+  webview.isDevToolsOpened = jest.fn(() => webview._devToolsOpen);
+  createdWebviews.push(webview);
+  return webview;
+};
+
+const buildTabContextMenu = () => {
+  const tabContextMenu = createElement('div', { classes: ['hidden'] });
+  const actions = {};
+
+  ['close', 'close-others', 'close-right', 'pin'].forEach((action) => {
+    const button = createElement('button');
+    button.dataset.action = action;
+    tabContextMenu.appendChild(button);
+    actions[action] = button;
+  });
+
+  return {
+    tabContextMenu,
+    actions,
+  };
+};
+
+const loadTabsModule = async (options = {}) => {
+  jest.resetModules();
+
+  const createdWebviews = [];
+  const { api: electronAPI, handlers: electronHandlers } = createElectronApi();
+  const tabBar = createElement('div');
+  const newTabBtn = createElement('button');
+  const webviewContainer = createElement('div');
+  const bzzWebview = createElement('webview');
+  const addressInput = createElement('input');
+  const { tabContextMenu, actions } = buildTabContextMenu();
+  const document = createDocument({
+    elementsById: {
+      'tab-bar': tabBar,
+      'new-tab-btn': newTabBtn,
+      'webview-container': webviewContainer,
+      'tab-context-menu': tabContextMenu,
+      'bzz-webview': bzzWebview,
+      'address-input': addressInput,
+    },
+    createElementOverride: (tagName) => {
+      if (tagName === 'webview') {
+        return createWebview(createdWebviews);
+      }
+      return createElement(tagName);
+    },
+  });
+  const windowHandlers = {};
+  const debugMocks = {
+    pushDebug: jest.fn(),
+  };
+  const menuMocks = {
+    closeMenus: jest.fn(),
+  };
+  const bookmarksMocks = {
+    hideBookmarkContextMenu: jest.fn(),
+  };
+  const backdropMocks = {
+    showMenuBackdrop: jest.fn(),
+    hideMenuBackdrop: jest.fn(),
+  };
+  const pageContextMenuMocks = {
+    setupWebviewContextMenu: jest.fn(),
+  };
+
+  addressInput.focus = jest.fn();
+  addressInput.select = jest.fn();
+  addressInput.blur = jest.fn();
+
+  global.window = {
+    electronAPI,
+    innerWidth: 800,
+    innerHeight: 600,
+    location: {
+      href: 'file:///app/index.html',
+      search: options.search || '',
+    },
+    addEventListener: jest.fn((event, handler) => {
+      windowHandlers[event] = handler;
+    }),
+  };
+
+  global.document = document;
+
+  jest.doMock('./debug.js', () => debugMocks);
+  jest.doMock('./menus.js', () => menuMocks);
+  jest.doMock('./bookmarks-ui.js', () => bookmarksMocks);
+  jest.doMock('./menu-backdrop.js', () => backdropMocks);
+  jest.doMock('./page-context-menu.js', () => pageContextMenuMocks);
+  jest.doMock('./page-urls.js', () => ({
+    homeUrl: HOME_URL,
+  }));
+
+  const mod = await import('./tabs.js');
+
+  return {
+    mod,
+    electronAPI,
+    electronHandlers,
+    createdWebviews,
+    elements: {
+      tabBar,
+      newTabBtn,
+      webviewContainer,
+      tabContextMenu,
+      bzzWebview,
+      addressInput,
+      closeBtn: actions.close,
+      closeOthersBtn: actions['close-others'],
+      closeRightBtn: actions['close-right'],
+      pinBtn: actions.pin,
+    },
+    windowHandlers,
+    documentHandlers: document.handlers,
+    debugMocks,
+    menuMocks,
+    bookmarksMocks,
+    backdropMocks,
+    pageContextMenuMocks,
+  };
+};
+
+const findTabElement = (tabBar, tabId) =>
+  tabBar.children.find((child) => child.dataset.tabId === tabId) || null;
+
+describe('tabs ui behavior', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('initializes tabs and supports tab lifecycle helpers', async () => {
+    const { mod, electronAPI, createdWebviews, pageContextMenuMocks } = await loadTabsModule();
+    const onWebviewEvent = jest.fn();
+
+    mod.setWebviewEventHandler(onWebviewEvent);
+    await mod.initTabs();
+
+    expect(electronAPI.getWebviewPreloadPath).toHaveBeenCalled();
+    expect(createdWebviews[0].getAttribute('preload')).toBe('file:///tmp/webview-preload.js');
+    expect(pageContextMenuMocks.setupWebviewContextMenu).toHaveBeenCalledWith(createdWebviews[0]);
+    expect(mod.getTabs()).toHaveLength(1);
+    expect(mod.getActiveTab().url).toBe(HOME_URL);
+
+    const initialTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+    const thirdTab = mod.createTab('https://third.example');
+
+    mod.setTabLoading(true, secondTab.id);
+    expect(mod.getTabs().find((tab) => tab.id === secondTab.id).isLoading).toBe(true);
+
+    mod.switchTab(secondTab.id);
+    expect(mod.getActiveTab()).toBe(secondTab);
+    expect(mod.getActiveWebview()).toBe(secondTab.webview);
+    expect(mod.getActiveTabState()).toBe(secondTab.navigationState);
+
+    mod.updateActiveTabTitle('Updated Title');
+    expect(mod.getActiveTab().title).toBe('Updated Title');
+    expect(electronAPI.setWindowTitle).toHaveBeenCalledWith('New Tab');
+    expect(onWebviewEvent).toHaveBeenCalledWith(
+      'tab-switched',
+      expect.objectContaining({ tabId: secondTab.id, isNewTab: false })
+    );
+
+    mod.moveTab('left');
+    expect(mod.getTabs().map((tab) => tab.id)).toEqual([secondTab.id, initialTab.id, thirdTab.id]);
+
+    mod.switchToNextTab();
+    expect(mod.getActiveTab().id).toBe(initialTab.id);
+
+    mod.switchToPrevTab();
+    expect(mod.getActiveTab().id).toBe(secondTab.id);
+
+    expect(mod.getOpenTabs()).toEqual([
+      { id: secondTab.id, url: secondTab.url, title: secondTab.title, isActive: true },
+      { id: initialTab.id, url: initialTab.url, title: initialTab.title, isActive: false },
+      { id: thirdTab.id, url: thirdTab.url, title: thirdTab.title, isActive: false },
+    ]);
+  });
+
+  test('updates favicons and manages devtools state', async () => {
+    const { mod, electronAPI, debugMocks } = await loadTabsModule();
+
+    await mod.initTabs();
+    const firstTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+
+    await mod.updateTabFavicon(firstTab.id, '');
+    expect(firstTab.favicon).toBeNull();
+
+    await mod.updateTabFavicon(firstTab.id, 'freedom://history');
+    expect(firstTab.favicon).toBeNull();
+
+    await mod.updateTabFavicon(firstTab.id, 'https://favicon.example');
+    expect(firstTab.favicon).toBe('data:image/png;base64,favicon');
+    expect(electronAPI.getCachedFavicon).toHaveBeenCalledWith('https://favicon.example');
+
+    electronAPI.getCachedFavicon.mockRejectedValueOnce(new Error('cache miss'));
+    await mod.updateTabFavicon(firstTab.id, 'https://error.example');
+    expect(debugMocks.pushDebug).toHaveBeenCalledWith(
+      '[Tabs] Favicon cache lookup failed: cache miss'
+    );
+
+    mod.switchTab(firstTab.id);
+    mod.toggleDevTools();
+    mod.toggleDevTools();
+
+    expect(firstTab.webview.openDevTools).toHaveBeenCalled();
+    expect(firstTab.webview.closeDevTools).toHaveBeenCalled();
+    expect(debugMocks.pushDebug).toHaveBeenCalledWith('DevTools opened');
+    expect(debugMocks.pushDebug).toHaveBeenCalledWith('DevTools closed');
+
+    firstTab.webview._devToolsOpen = true;
+    mod.closeDevTools();
+    expect(firstTab.webview.closeDevTools).toHaveBeenCalledTimes(2);
+
+    secondTab.webview._devToolsOpen = true;
+    secondTab.webview.closeDevTools.mockImplementationOnce(() => {
+      throw new Error('close failed');
+    });
+    mod.closeAllDevTools();
+
+    expect(secondTab.webview.closeDevTools).toHaveBeenCalled();
+    expect(debugMocks.pushDebug).toHaveBeenCalledWith('[Tabs] closeDevTools failed: close failed');
+    expect(debugMocks.pushDebug).toHaveBeenCalledWith('All DevTools closed');
+  });
+
+  test('updates tab state from webview events', async () => {
+    const { mod, electronAPI, debugMocks } = await loadTabsModule();
+    const onWebviewEvent = jest.fn();
+
+    mod.setWebviewEventHandler(onWebviewEvent);
+    await mod.initTabs();
+
+    const activeTab = mod.getActiveTab();
+    const { webview } = activeTab;
+
+    webview.getURL.mockReturnValue('https://loaded.example');
+    webview.dispatch('did-start-loading');
+    expect(activeTab.isLoading).toBe(true);
+
+    webview.dispatch('did-stop-loading');
+    expect(activeTab.isLoading).toBe(false);
+    expect(activeTab.url).toBe('https://loaded.example');
+    expect(onWebviewEvent).toHaveBeenCalledWith(
+      'did-stop-loading',
+      expect.objectContaining({ tabId: activeTab.id, url: 'https://loaded.example' })
+    );
+
+    webview.dispatch('did-fail-load', { errorCode: -1 });
+    webview.dispatch('did-navigate-in-page', { url: 'https://loaded.example#hash' });
+    webview.dispatch('dom-ready');
+
+    activeTab.favicon = 'data:favicon';
+    activeTab.title = 'Old Title';
+    webview.getURL.mockReturnValue('view-source:https://loaded.example');
+    webview.dispatch('did-navigate', { url: 'https://loaded.example' });
+    expect(activeTab.isViewingSource).toBe(true);
+    expect(activeTab.favicon).toBeNull();
+
+    webview.getURL.mockReturnValue(HOME_URL);
+    webview.dispatch('did-navigate', { url: HOME_URL });
+    expect(activeTab.title).toBe('New Tab');
+    expect(electronAPI.setWindowTitle).toHaveBeenCalledWith('');
+
+    activeTab.title = 'Still New Tab';
+    webview.dispatch('page-title-updated', { title: 'Ignored Home Title' });
+    expect(activeTab.title).toBe('New Tab');
+
+    activeTab.isViewingSource = true;
+    activeTab.title = 'view-source:https://loaded.example';
+    webview.getURL.mockReturnValue('view-source:https://loaded.example');
+    webview.dispatch('page-title-updated', { title: 'Source Title' });
+    expect(activeTab.title).toBe('view-source:https://loaded.example');
+
+    activeTab.isViewingSource = false;
+    webview.getURL.mockReturnValue('https://loaded.example');
+    webview.dispatch('page-title-updated', { title: 'Loaded Title' });
+    expect(activeTab.title).toBe('Loaded Title');
+    expect(electronAPI.setWindowTitle).toHaveBeenCalledWith('Loaded Title');
+
+    webview.dispatch('console-message', {
+      level: 2,
+      message: 'hello',
+      sourceId: 'index.js',
+      line: 12,
+    });
+    webview.dispatch('certificate-error', { certificate: 'bad-cert' });
+    expect(activeTab.hasCertError).toBe(true);
+    expect(onWebviewEvent).toHaveBeenCalledWith(
+      'certificate-error',
+      expect.objectContaining({ tabId: activeTab.id, event: { certificate: 'bad-cert' } })
+    );
+    expect(debugMocks.pushDebug).toHaveBeenCalledWith('Console level-2: hello (index.js:12)');
+  });
+
+  test('closes and reopens tabs and closes the window when the last tab is removed', async () => {
+    const firstLoad = await loadTabsModule();
+    await firstLoad.mod.initTabs();
+
+    const reopenTab = firstLoad.mod.createTab('https://reopen.example');
+    firstLoad.mod.closeTab(reopenTab.id);
+    expect(firstLoad.mod.getTabs()).toHaveLength(1);
+
+    firstLoad.mod.reopenLastClosedTab();
+    expect(firstLoad.mod.getTabs()).toHaveLength(2);
+    expect(firstLoad.mod.getActiveTab().url).toBe('https://reopen.example');
+
+    const lastWindowLoad = await loadTabsModule();
+    await lastWindowLoad.mod.initTabs();
+
+    const onlyTab = lastWindowLoad.mod.getActiveTab();
+    lastWindowLoad.mod.closeTab(onlyTab.id);
+
+    expect(lastWindowLoad.electronAPI.closeWindow).toHaveBeenCalled();
+    expect(lastWindowLoad.mod.getActiveTab()).toBeNull();
+  });
+
+  test('wires context menu, keyboard shortcuts, and ipc entrypoints', async () => {
+    jest.useFakeTimers();
+
+    const {
+      mod,
+      electronHandlers,
+      elements,
+      windowHandlers,
+      documentHandlers,
+      menuMocks,
+      bookmarksMocks,
+      backdropMocks,
+      debugMocks,
+    } = await loadTabsModule();
+    const onContextMenuOpening = jest.fn();
+    const onLoadTarget = jest.fn();
+    const onReload = jest.fn();
+    const onHardReload = jest.fn();
+
+    mod.setOnContextMenuOpening(onContextMenuOpening);
+    mod.setLoadTargetHandler(onLoadTarget);
+    mod.setReloadHandler(onReload);
+    mod.setHardReloadHandler(onHardReload);
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+    mod.createTab('https://third.example');
+    const firstTabEl = findTabElement(elements.tabBar, firstTab.id);
+    const secondTabEl = findTabElement(elements.tabBar, secondTab.id);
+
+    elements.tabContextMenu.setRect({
+      right: 900,
+      bottom: 640,
+      width: 120,
+      height: 40,
+    });
+
+    secondTabEl.dispatch('contextmenu', {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      clientX: 790,
+      clientY: 590,
+    });
+
+    expect(menuMocks.closeMenus).toHaveBeenCalled();
+    expect(bookmarksMocks.hideBookmarkContextMenu).toHaveBeenCalled();
+    expect(onContextMenuOpening).toHaveBeenCalled();
+    expect(backdropMocks.showMenuBackdrop).toHaveBeenCalled();
+    expect(elements.pinBtn.textContent).toBe('Pin Tab');
+    expect(elements.closeRightBtn.disabled).toBe(false);
+    expect(elements.closeOthersBtn.disabled).toBe(false);
+    expect(elements.tabContextMenu.style.left).toBe('672px');
+    expect(elements.tabContextMenu.style.top).toBe('552px');
+
+    elements.tabContextMenu.dispatch('click', { target: elements.pinBtn });
+    expect(mod.getTabs().find((tab) => tab.id === secondTab.id).pinned).toBe(true);
+
+    firstTabEl.dispatch('contextmenu', {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      clientX: 20,
+      clientY: 30,
+    });
+    elements.tabContextMenu.dispatch('click', { target: elements.closeRightBtn });
+    expect(mod.getTabs().map((tab) => tab.id)).toEqual([secondTab.id, firstTab.id]);
+
+    firstTabEl.dispatch('contextmenu', {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      clientX: 20,
+      clientY: 30,
+    });
+    documentHandlers.click({ target: createElement('div') });
+    expect(backdropMocks.hideMenuBackdrop).toHaveBeenCalled();
+
+    firstTabEl.dispatch('contextmenu', {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      clientX: 20,
+      clientY: 30,
+    });
+    windowHandlers.blur();
+    elements.bzzWebview.dispatch('focus');
+    elements.bzzWebview.dispatch('mousedown');
+
+    elements.newTabBtn.dispatch('click');
+    expect(mod.getTabs()).toHaveLength(3);
+
+    electronHandlers.newTab();
+    expect(mod.getTabs()).toHaveLength(4);
+
+    const activeTab = mod.getActiveTab();
+    activeTab.pinned = true;
+    electronHandlers.closeTab();
+    expect(mod.getTabs()).toHaveLength(4);
+
+    electronHandlers.newTabWithUrl('https://named-target.example', 'named-target');
+    expect(mod.getActiveTab().url).toBe('https://named-target.example');
+    const beforeReuseCount = mod.getTabs().length;
+    electronHandlers.newTabWithUrl('https://reuse-target.example', 'named-target');
+    jest.runOnlyPendingTimers();
+    await flushMicrotasks();
+    expect(mod.getTabs()).toHaveLength(beforeReuseCount);
+    expect(onLoadTarget).toHaveBeenCalledWith('https://reuse-target.example');
+
+    electronHandlers.newTabWithUrl('ipfs://cid', 'ipfs-target');
+    jest.runOnlyPendingTimers();
+    await flushMicrotasks();
+    expect(onLoadTarget).toHaveBeenCalledWith('ipfs://cid');
+
+    electronHandlers.navigateToUrl('https://navigate.example');
+    electronHandlers.loadUrl('https://load.example');
+    expect(onLoadTarget).toHaveBeenCalledWith('https://navigate.example');
+    expect(onLoadTarget).toHaveBeenCalledWith('https://load.example');
+
+    electronHandlers.focusAddressBar();
+    expect(elements.addressInput.focus).toHaveBeenCalled();
+    expect(elements.addressInput.select).toHaveBeenCalled();
+
+    electronHandlers.reload();
+    electronHandlers.hardReload();
+    expect(onReload).toHaveBeenCalled();
+    expect(onHardReload).toHaveBeenCalled();
+
+    mod.switchTab(firstTab.id);
+    const orderedTabs = mod.getTabs();
+    const firstIndex = orderedTabs.findIndex((tab) => tab.id === firstTab.id);
+    const expectedNextTabId = orderedTabs[(firstIndex + 1) % orderedTabs.length].id;
+    windowHandlers.keydown({
+      ctrlKey: true,
+      shiftKey: false,
+      metaKey: false,
+      key: 'Tab',
+      preventDefault: jest.fn(),
+    });
+    expect(mod.getActiveTab().id).toBe(expectedNextTabId);
+
+    windowHandlers.keydown({
+      ctrlKey: true,
+      shiftKey: true,
+      metaKey: false,
+      key: 'Tab',
+      preventDefault: jest.fn(),
+    });
+    expect(mod.getActiveTab().id).toBe(firstTab.id);
+
+    const devtoolsOpenBefore = firstTab.webview.openDevTools.mock.calls.length;
+    const devtoolsCloseBefore = firstTab.webview.closeDevTools.mock.calls.length;
+    windowHandlers.keydown({
+      ctrlKey: true,
+      shiftKey: true,
+      metaKey: false,
+      key: 'I',
+      preventDefault: jest.fn(),
+    });
+    windowHandlers.keydown({
+      ctrlKey: false,
+      shiftKey: false,
+      metaKey: false,
+      key: 'F12',
+      preventDefault: jest.fn(),
+    });
+    expect(firstTab.webview.openDevTools.mock.calls.length).toBe(devtoolsOpenBefore + 1);
+    expect(firstTab.webview.closeDevTools.mock.calls.length).toBe(devtoolsCloseBefore + 1);
+    expect(debugMocks.pushDebug).toHaveBeenCalledWith('DevTools opened');
+    expect(debugMocks.pushDebug).toHaveBeenCalledWith('DevTools closed');
+  });
+});

--- a/test/helpers/fake-better-sqlite3.js
+++ b/test/helpers/fake-better-sqlite3.js
@@ -1,0 +1,150 @@
+function cloneRow(row) {
+  return row ? { ...row } : row;
+}
+
+function matchesLike(value, pattern) {
+  const normalizedValue = String(value || '').toLowerCase();
+  const normalizedPattern = String(pattern || '')
+    .toLowerCase()
+    .replace(/%/g, '');
+
+  return normalizedValue.includes(normalizedPattern);
+}
+
+class FakeBetterSqlite3Database {
+  constructor(filePath) {
+    this.filePath = filePath;
+    this.rows = [];
+    this.nextId = 1;
+    this.userVersion = 0;
+  }
+
+  pragma(statement, options = {}) {
+    if (statement === 'journal_mode = WAL') {
+      return 'wal';
+    }
+
+    if (statement === 'user_version' && options.simple) {
+      return this.userVersion;
+    }
+
+    if (statement === 'user_version = 1') {
+      this.userVersion = 1;
+      return this.userVersion;
+    }
+
+    return null;
+  }
+
+  exec() {}
+
+  prepare(sql) {
+    const normalizedSql = sql.replace(/\s+/g, ' ').trim();
+
+    if (normalizedSql.startsWith('INSERT INTO history')) {
+      return {
+        run: (url, title, timestamp, protocol) => {
+          const existing = this.rows.find((row) => row.url === url);
+          if (existing) {
+            existing.title = title;
+            existing.timestamp = timestamp;
+            existing.visit_count += 1;
+            existing.protocol = protocol;
+
+            return {
+              changes: 1,
+              lastInsertRowid: existing.id,
+            };
+          }
+
+          const row = {
+            id: this.nextId++,
+            url,
+            title,
+            timestamp,
+            visit_count: 1,
+            protocol,
+          };
+          this.rows.push(row);
+
+          return {
+            changes: 1,
+            lastInsertRowid: row.id,
+          };
+        },
+      };
+    }
+
+    if (normalizedSql === 'SELECT * FROM history ORDER BY timestamp DESC LIMIT ?') {
+      return {
+        all: (limit) => this.getSortedRows().slice(0, limit).map(cloneRow),
+      };
+    }
+
+    if (normalizedSql === 'SELECT * FROM history ORDER BY timestamp DESC') {
+      return {
+        all: () => this.getSortedRows().map(cloneRow),
+      };
+    }
+
+    if (
+      normalizedSql === 'SELECT * FROM history WHERE url LIKE ? OR title LIKE ? ORDER BY timestamp DESC LIMIT ?'
+    ) {
+      return {
+        all: (urlPattern, titlePattern, limit) =>
+          this.getSortedRows()
+            .filter(
+              (row) => matchesLike(row.url, urlPattern) || matchesLike(row.title, titlePattern)
+            )
+            .slice(0, limit)
+            .map(cloneRow),
+      };
+    }
+
+    if (normalizedSql === 'SELECT * FROM history WHERE id = ?') {
+      return {
+        get: (id) => cloneRow(this.rows.find((row) => row.id === id) || null),
+      };
+    }
+
+    if (normalizedSql === 'DELETE FROM history WHERE id = ?') {
+      return {
+        run: (id) => {
+          const initialLength = this.rows.length;
+          this.rows = this.rows.filter((row) => row.id !== id);
+
+          return {
+            changes: initialLength - this.rows.length,
+          };
+        },
+      };
+    }
+
+    if (normalizedSql === 'DELETE FROM history') {
+      return {
+        run: () => {
+          const changes = this.rows.length;
+          this.rows = [];
+
+          return { changes };
+        },
+      };
+    }
+
+    if (normalizedSql === 'SELECT COUNT(*) as count FROM history') {
+      return {
+        get: () => ({ count: this.rows.length }),
+      };
+    }
+
+    throw new Error(`Unsupported SQL in fake better-sqlite3: ${normalizedSql}`);
+  }
+
+  close() {}
+
+  getSortedRows() {
+    return [...this.rows].sort((first, second) => second.timestamp - first.timestamp);
+  }
+}
+
+module.exports = FakeBetterSqlite3Database;

--- a/test/helpers/fake-dom.js
+++ b/test/helpers/fake-dom.js
@@ -44,7 +44,7 @@ const getDataAttributeName = (selector) => {
   };
 };
 
-const matchesSelector = (element, selector) => {
+const matchesSingleSelector = (element, selector) => {
   if (selector.startsWith('.')) {
     return element.classList.contains(selector.slice(1));
   }
@@ -65,6 +65,14 @@ const matchesSelector = (element, selector) => {
   return false;
 };
 
+const matchesSelector = (element, selector) => {
+  return selector
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .some((part) => matchesSingleSelector(element, part));
+};
+
 class FakeElement {
   constructor(tagName = 'div', options = {}) {
     this.tagName = tagName.toUpperCase();
@@ -76,7 +84,7 @@ class FakeElement {
     this.attributes = {};
     this.disabled = options.disabled || false;
     this.draggable = false;
-    this.innerHTML = options.innerHTML || '';
+    this._innerHTML = options.innerHTML || '';
     this.textContent = options.textContent || '';
     this.value = options.value || '';
     this.src = options.src || '';
@@ -106,6 +114,26 @@ class FakeElement {
             .filter(Boolean)
         );
         this.classList = this._classes;
+      },
+    });
+
+    Object.defineProperty(this, 'innerHTML', {
+      get: () => this._innerHTML,
+      set: (value) => {
+        this._innerHTML = String(value);
+        if (value === '') {
+          this.children.forEach((child) => {
+            child.parentNode = null;
+          });
+          this.children = [];
+        }
+      },
+    });
+
+    Object.defineProperty(this, 'offsetWidth', {
+      get: () => this._rect.width,
+      set: (value) => {
+        this._rect.width = value;
       },
     });
   }
@@ -199,6 +227,19 @@ class FakeElement {
     return this.children.some((child) => child.contains(target));
   }
 
+  closest(selector) {
+    let current = this;
+
+    while (current) {
+      if (matchesSelector(current, selector)) {
+        return current;
+      }
+      current = current.parentNode;
+    }
+
+    return null;
+  }
+
   querySelector(selector) {
     for (const child of this.children) {
       if (matchesSelector(child, selector)) {
@@ -236,11 +277,19 @@ class FakeElement {
 
 const createElement = (tagName = 'div', options = {}) => new FakeElement(tagName, options);
 
-const createDocument = ({ elementsById = {}, createElementOverride } = {}) => {
+const createDocument = ({ elementsById = {}, createElementOverride, body } = {}) => {
   const documentHandlers = {};
+  const documentBody = body || createElement('body');
+
+  Object.values(elementsById).forEach((element) => {
+    if (element && !element.parentNode) {
+      documentBody.appendChild(element);
+    }
+  });
 
   return {
     handlers: documentHandlers,
+    body: documentBody,
     createElement: jest.fn((tagName) => {
       if (createElementOverride) {
         return createElementOverride(tagName);
@@ -248,6 +297,8 @@ const createDocument = ({ elementsById = {}, createElementOverride } = {}) => {
       return createElement(tagName);
     }),
     getElementById: jest.fn((id) => elementsById[id] || null),
+    querySelector: jest.fn((selector) => documentBody.querySelector(selector)),
+    querySelectorAll: jest.fn((selector) => documentBody.querySelectorAll(selector)),
     addEventListener: jest.fn((event, handler) => {
       documentHandlers[event] = handler;
     }),

--- a/test/helpers/fake-dom.js
+++ b/test/helpers/fake-dom.js
@@ -1,0 +1,262 @@
+/* global jest */
+
+const createClassList = (initialClasses = []) => {
+  const classes = new Set(initialClasses);
+
+  return {
+    add: jest.fn((...names) => {
+      names.forEach((name) => classes.add(name));
+    }),
+    remove: jest.fn((...names) => {
+      names.forEach((name) => classes.delete(name));
+    }),
+    toggle: jest.fn((name, force) => {
+      if (force === undefined) {
+        if (classes.has(name)) {
+          classes.delete(name);
+          return false;
+        }
+
+        classes.add(name);
+        return true;
+      }
+
+      if (force) {
+        classes.add(name);
+      } else {
+        classes.delete(name);
+      }
+
+      return force;
+    }),
+    contains: jest.fn((name) => classes.has(name)),
+    toArray: () => Array.from(classes),
+  };
+};
+
+const getDataAttributeName = (selector) => {
+  const match = selector.match(/^\[data-([a-z-]+)="([^"]+)"\]$/);
+  if (!match) return null;
+
+  return {
+    key: match[1].replace(/-([a-z])/g, (_, char) => char.toUpperCase()),
+    value: match[2],
+  };
+};
+
+const matchesSelector = (element, selector) => {
+  if (selector.startsWith('.')) {
+    return element.classList.contains(selector.slice(1));
+  }
+
+  if (selector === 'webview') {
+    return element.tagName === 'WEBVIEW';
+  }
+
+  if (selector === 'webview:not(.hidden)') {
+    return element.tagName === 'WEBVIEW' && !element.classList.contains('hidden');
+  }
+
+  const dataAttr = getDataAttributeName(selector);
+  if (dataAttr) {
+    return element.dataset[dataAttr.key] === dataAttr.value;
+  }
+
+  return false;
+};
+
+class FakeElement {
+  constructor(tagName = 'div', options = {}) {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.parentNode = null;
+    this.dataset = { ...(options.dataset || {}) };
+    this.style = { ...(options.style || {}) };
+    this.handlers = {};
+    this.attributes = {};
+    this.disabled = options.disabled || false;
+    this.draggable = false;
+    this.innerHTML = options.innerHTML || '';
+    this.textContent = options.textContent || '';
+    this.value = options.value || '';
+    this.src = options.src || '';
+    this.alt = options.alt || '';
+    this.onclick = null;
+    this.onerror = null;
+    this._classes = createClassList(options.classes || []);
+    this.classList = this._classes;
+    this._className = this.classList.toArray().join(' ');
+    this._rect = options.rect || {
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 40,
+      width: 100,
+      height: 40,
+    };
+
+    Object.defineProperty(this, 'className', {
+      get: () => this._className,
+      set: (value) => {
+        this._className = value;
+        this._classes = createClassList(
+          String(value)
+            .split(/\s+/)
+            .map((part) => part.trim())
+            .filter(Boolean)
+        );
+        this.classList = this._classes;
+      },
+    });
+  }
+
+  get firstChild() {
+    return this.children[0] || null;
+  }
+
+  get nextSibling() {
+    if (!this.parentNode) return null;
+    const index = this.parentNode.children.indexOf(this);
+    return this.parentNode.children[index + 1] || null;
+  }
+
+  setRect(rect) {
+    this._rect = { ...this._rect, ...rect };
+  }
+
+  getBoundingClientRect() {
+    return { ...this._rect };
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+    this[name] = value;
+  }
+
+  getAttribute(name) {
+    return this.attributes[name];
+  }
+
+  addEventListener(event, handler) {
+    if (!this.handlers[event]) {
+      this.handlers[event] = [];
+    }
+    this.handlers[event].push(handler);
+  }
+
+  removeEventListener(event, handler) {
+    const listeners = this.handlers[event];
+    if (!listeners) return;
+    this.handlers[event] = listeners.filter((listener) => listener !== handler);
+  }
+
+  dispatch(event, payload = {}) {
+    const listeners = this.handlers[event] || [];
+    listeners.forEach((listener) => listener(payload));
+  }
+
+  appendChild(child) {
+    if (child.parentNode) {
+      child.remove();
+    }
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+
+  prepend(child) {
+    if (child.parentNode) {
+      child.remove();
+    }
+    child.parentNode = this;
+    this.children.unshift(child);
+    return child;
+  }
+
+  after(sibling) {
+    if (!this.parentNode) return;
+    if (sibling.parentNode) {
+      sibling.remove();
+    }
+
+    const index = this.parentNode.children.indexOf(this);
+    sibling.parentNode = this.parentNode;
+    this.parentNode.children.splice(index + 1, 0, sibling);
+  }
+
+  remove() {
+    if (!this.parentNode) return;
+
+    const index = this.parentNode.children.indexOf(this);
+    if (index >= 0) {
+      this.parentNode.children.splice(index, 1);
+    }
+    this.parentNode = null;
+  }
+
+  contains(target) {
+    if (this === target) return true;
+    return this.children.some((child) => child.contains(target));
+  }
+
+  querySelector(selector) {
+    for (const child of this.children) {
+      if (matchesSelector(child, selector)) {
+        return child;
+      }
+
+      const nested = child.querySelector(selector);
+      if (nested) {
+        return nested;
+      }
+    }
+
+    return null;
+  }
+
+  querySelectorAll(selector) {
+    const results = [];
+
+    for (const child of this.children) {
+      if (matchesSelector(child, selector)) {
+        results.push(child);
+      }
+      results.push(...child.querySelectorAll(selector));
+    }
+
+    return results;
+  }
+
+  focus() {}
+
+  blur() {}
+
+  select() {}
+}
+
+const createElement = (tagName = 'div', options = {}) => new FakeElement(tagName, options);
+
+const createDocument = ({ elementsById = {}, createElementOverride } = {}) => {
+  const documentHandlers = {};
+
+  return {
+    handlers: documentHandlers,
+    createElement: jest.fn((tagName) => {
+      if (createElementOverride) {
+        return createElementOverride(tagName);
+      }
+      return createElement(tagName);
+    }),
+    getElementById: jest.fn((id) => elementsById[id] || null),
+    addEventListener: jest.fn((event, handler) => {
+      documentHandlers[event] = handler;
+    }),
+  };
+};
+
+module.exports = {
+  FakeElement,
+  createClassList,
+  createDocument,
+  createElement,
+};

--- a/test/helpers/fake-dom.js
+++ b/test/helpers/fake-dom.js
@@ -45,6 +45,13 @@ const getDataAttributeName = (selector) => {
 };
 
 const matchesSingleSelector = (element, selector) => {
+  const classAndDataMatch = selector.match(/^\.([A-Za-z0-9_-]+)(\[data-([a-z-]+)="([^"]+)"\])$/);
+  if (classAndDataMatch) {
+    const [, className, , dataName, dataValue] = classAndDataMatch;
+    const dataKey = dataName.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+    return element.classList.contains(className) && element.dataset[dataKey] === dataValue;
+  }
+
   if (selector.startsWith('.')) {
     return element.classList.contains(selector.slice(1));
   }

--- a/test/helpers/fake-dom.js
+++ b/test/helpers/fake-dom.js
@@ -161,6 +161,11 @@ class FakeElement {
     this[name] = value;
   }
 
+  removeAttribute(name) {
+    delete this.attributes[name];
+    delete this[name];
+  }
+
   getAttribute(name) {
     return this.attributes[name];
   }

--- a/test/helpers/main-process-test-utils.js
+++ b/test/helpers/main-process-test-utils.js
@@ -1,0 +1,86 @@
+/* global jest */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function createIpcMainMock() {
+  const handlers = new Map();
+
+  return {
+    handlers,
+    handle: jest.fn((channel, handler) => {
+      handlers.set(channel, handler);
+    }),
+    async invoke(channel, ...args) {
+      const handler = handlers.get(channel);
+      if (!handler) {
+        throw new Error(`No IPC handler registered for ${channel}`);
+      }
+
+      return handler({}, ...args);
+    },
+  };
+}
+
+function createTempUserDataDir(prefix = 'freedom-test-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function removeTempUserDataDir(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function loadMainModule(modulePath, options = {}) {
+  jest.resetModules();
+
+  const ipcMain = options.ipcMain || createIpcMainMock();
+  const app = {
+    isPackaged: options.isPackaged ?? false,
+    getPath: jest.fn((name) => {
+      if (name === 'userData') {
+        return options.userDataDir ?? os.tmpdir();
+      }
+
+      if (options.appPaths?.[name]) {
+        return options.appPaths[name];
+      }
+
+      return path.join(os.tmpdir(), name);
+    }),
+  };
+  const nativeTheme = options.nativeTheme || { themeSource: 'system' };
+  const BrowserWindow = options.BrowserWindow || {
+    getAllWindows: jest.fn(() => options.windows ?? []),
+  };
+
+  jest.doMock('electron', () => ({
+    app,
+    ipcMain,
+    nativeTheme,
+    BrowserWindow,
+  }));
+
+  if (options.extraMocks) {
+    for (const [request, mockFactory] of Object.entries(options.extraMocks)) {
+      jest.doMock(request, mockFactory);
+    }
+  }
+
+  const mod = require(modulePath);
+
+  return {
+    mod,
+    app,
+    ipcMain,
+    nativeTheme,
+    BrowserWindow,
+  };
+}
+
+module.exports = {
+  createIpcMainMock,
+  createTempUserDataDir,
+  removeTempUserDataDir,
+  loadMainModule,
+};

--- a/test/helpers/main-process-test-utils.js
+++ b/test/helpers/main-process-test-utils.js
@@ -23,6 +23,98 @@ function createIpcMainMock() {
   };
 }
 
+function createIpcRendererMock(options = {}) {
+  const listeners = new Map();
+
+  const ipcRenderer = {
+    listeners,
+    invoke: jest.fn((channel, ...args) => {
+      if (typeof options.invokeImplementation === 'function') {
+        return options.invokeImplementation(channel, ...args);
+      }
+
+      if (options.invokeResponses && channel in options.invokeResponses) {
+        return Promise.resolve(options.invokeResponses[channel]);
+      }
+
+      return Promise.resolve(undefined);
+    }),
+    send: jest.fn(),
+    sendSync: jest.fn((channel, ...args) => {
+      if (typeof options.sendSyncImplementation === 'function') {
+        return options.sendSyncImplementation(channel, ...args);
+      }
+
+      if (options.syncResponses && channel in options.syncResponses) {
+        return options.syncResponses[channel];
+      }
+
+      return undefined;
+    }),
+    on: jest.fn((channel, handler) => {
+      if (!listeners.has(channel)) {
+        listeners.set(channel, []);
+      }
+      listeners.get(channel).push(handler);
+      return ipcRenderer;
+    }),
+    removeListener: jest.fn((channel, handler) => {
+      const channelListeners = listeners.get(channel) || [];
+      listeners.set(
+        channel,
+        channelListeners.filter((listener) => listener !== handler)
+      );
+      return ipcRenderer;
+    }),
+    emit(channel, ...args) {
+      const channelListeners = listeners.get(channel) || [];
+      channelListeners.forEach((listener) => listener({}, ...args));
+    },
+  };
+
+  return ipcRenderer;
+}
+
+function createContextBridgeMock() {
+  const exposedValues = {};
+
+  return {
+    exposedValues,
+    exposeInMainWorld: jest.fn((key, value) => {
+      exposedValues[key] = value;
+    }),
+  };
+}
+
+function createAppMock(options = {}) {
+  const handlers = new Map();
+
+  return {
+    handlers,
+    isPackaged: options.isPackaged ?? false,
+    on: jest.fn((event, handler) => {
+      handlers.set(event, handler);
+    }),
+    emit(event, ...args) {
+      const handler = handlers.get(event);
+      if (!handler) return undefined;
+      return handler(...args);
+    },
+    getPath: jest.fn((name) => {
+      if (name === 'userData') {
+        return options.userDataDir ?? os.tmpdir();
+      }
+
+      if (options.appPaths?.[name]) {
+        return options.appPaths[name];
+      }
+
+      return path.join(os.tmpdir(), name);
+    }),
+    showAboutPanel: jest.fn(),
+  };
+}
+
 function createTempUserDataDir(prefix = 'freedom-test-') {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }
@@ -35,30 +127,35 @@ function loadMainModule(modulePath, options = {}) {
   jest.resetModules();
 
   const ipcMain = options.ipcMain || createIpcMainMock();
-  const app = {
-    isPackaged: options.isPackaged ?? false,
-    getPath: jest.fn((name) => {
-      if (name === 'userData') {
-        return options.userDataDir ?? os.tmpdir();
-      }
-
-      if (options.appPaths?.[name]) {
-        return options.appPaths[name];
-      }
-
-      return path.join(os.tmpdir(), name);
-    }),
-  };
+  const ipcRenderer = options.ipcRenderer || createIpcRendererMock();
+  const contextBridge = options.contextBridge || createContextBridgeMock();
+  const app = options.app || createAppMock(options);
   const nativeTheme = options.nativeTheme || { themeSource: 'system' };
   const BrowserWindow = options.BrowserWindow || {
     getAllWindows: jest.fn(() => options.windows ?? []),
+  };
+  const dialog = options.dialog || { showSaveDialog: jest.fn() };
+  const clipboard = options.clipboard || {
+    writeText: jest.fn(),
+    writeImage: jest.fn(),
+  };
+  const nativeImage = options.nativeImage || {
+    createFromBuffer: jest.fn(() => ({
+      isEmpty: () => false,
+    })),
   };
 
   jest.doMock('electron', () => ({
     app,
     ipcMain,
+    ipcRenderer,
     nativeTheme,
     BrowserWindow,
+    contextBridge,
+    dialog,
+    clipboard,
+    nativeImage,
+    ...(options.electronOverrides || {}),
   }));
 
   if (options.extraMocks) {
@@ -73,13 +170,21 @@ function loadMainModule(modulePath, options = {}) {
     mod,
     app,
     ipcMain,
+    ipcRenderer,
     nativeTheme,
     BrowserWindow,
+    contextBridge,
+    dialog,
+    clipboard,
+    nativeImage,
   };
 }
 
 module.exports = {
+  createAppMock,
+  createContextBridgeMock,
   createIpcMainMock,
+  createIpcRendererMock,
   createTempUserDataDir,
   removeTempUserDataDir,
   loadMainModule,

--- a/test/helpers/main-process-test-utils.js
+++ b/test/helpers/main-process-test-utils.js
@@ -6,11 +6,16 @@ const path = require('path');
 
 function createIpcMainMock() {
   const handlers = new Map();
+  const listeners = new Map();
 
   return {
     handlers,
+    listeners,
     handle: jest.fn((channel, handler) => {
       handlers.set(channel, handler);
+    }),
+    on: jest.fn((channel, listener) => {
+      listeners.set(channel, listener);
     }),
     async invoke(channel, ...args) {
       const handler = handlers.get(channel);
@@ -19,6 +24,14 @@ function createIpcMainMock() {
       }
 
       return handler({}, ...args);
+    },
+    emit(channel, ...args) {
+      const listener = listeners.get(channel);
+      if (!listener) {
+        throw new Error(`No IPC listener registered for ${channel}`);
+      }
+
+      return listener(...args);
     },
   };
 }


### PR DESCRIPTION
## Summary

This PR establishes a real testing baseline for the project and raises coverage substantially across both renderer and main-process code.

It does five things:

- hardens the local test entrypoints and removes broken test plumbing
- switches Jest coverage to whole-source reporting instead of only touched files
- adds shared test harnesses for DOM-heavy renderer code and Electron/main-process code
- adds broad new unit and integration coverage across the app
- adds a first GitHub Actions CI workflow to run lint + coverage on pushes and pull requests

## Coverage impact

Whole-source coverage moved from roughly:

- Statements: `13.35%` -> `66.78%`
- Branches: `10.11%` -> `53.88%`
- Functions: `7.22%` -> `71.53%`
- Lines: `14.00%` -> `68.03%`

The suite is now at `33` test suites and `352` passing tests locally.

## What changed

### Test foundation

- removed the broken `test:updater` script
- split test entrypoints more cleanly in `package.json`
- reduced noisy test-time logging from `electron-log` and renderer debug output
- configured Jest to collect coverage across the actual source tree
- added and repeatedly ratcheted honest global coverage thresholds

### Shared test infrastructure

- added reusable main-process / Electron test helpers
- added reusable fake DOM helpers for renderer tests
- added a fake `better-sqlite3` helper for storage-oriented tests

### Renderer coverage

Added coverage for renderer modules including:

- `autocomplete`
- `page-urls`
- `menus`
- `menu-backdrop`
- `tabs`
- `settings-ui`
- `navigation` and extracted pure helper logic
- `bookmarks-ui`
- `bee-ui`
- `ipfs-ui`
- `radicle-ui`
- `github-bridge-ui`
- `state`
- `page-context-menu`

### Main-process / Electron-boundary coverage

Added integration-style coverage for:

- `preload`
- `webview-preload`
- `ipc-handlers`
- `webcontents-setup`
- `github-bridge`
- `radicle-manager`
- `ipfs-manager`
- `bee-manager`
- `service-registry`
- `settings-store`
- `history`
- `bookmarks-store`

### CI

Added a first GitHub Actions workflow that:

- runs on `push`, `pull_request`, and manual dispatch
- installs dependencies with `npm ci --ignore-scripts`
- runs `npm run lint`
- runs `npm run test:coverage`
- uploads the `coverage/` artifact

## Production code changes

Most of this PR is test and test-harness work. The non-test runtime changes are intentionally narrow:

- small refactors to extract pure renderer helper logic from `navigation` / `autocomplete`
- logger/debug behavior adjusted so Jest runs stay quiet unless `DEBUG` is set
- fixes in `radicle-manager`, `ipfs-manager`, and `bee-manager` shutdown paths so timers/intervals are cleaned up correctly and stop behavior is more robust

## Verification

Locally verified with:

- `npm run lint`
- `npm test`
- `npm run test:coverage`

## Reviewer notes

This is easiest to review in layers:

1. test/coverage plumbing: `package.json`, `jest.config.js`, `.github/workflows/ci.yml`
2. shared test helpers under `test/helpers/`
3. renderer test additions
4. main-process / Electron-boundary test additions
5. small runtime fixes in the node manager shutdown paths
