### PR TITLE
add ageD support for sonicd bypass to use

### DIFF
--- a/src/main/age-verification.js
+++ b/src/main/age-verification.js
@@ -1,0 +1,211 @@
+/**
+ * Age Verification Integration Module
+ *
+ * This module provides integration with the ageD (Age Attestation) D-Bus service
+ * running on the system. It allows the browser to query age verification status
+ * through the org.freedesktop.AgeVerification interface.
+ *
+ * The ageD service is part of the sonicd (ssX Core) project and provides a
+ * D-Bus interface for age verification queries.
+ */
+
+const { spawn } = require('child_process');
+const log = require('./logger');
+
+// D-Bus service bus name
+const AGE_DBUS_NAME = 'org.freedesktop.AgeVerification';
+const AGE_OBJECT_PATH = '/org/freedesktop/AgeVerification';
+
+// Check if ageD service is available
+let serviceAvailable = false;
+
+/**
+ * Execute agectl command and return the result
+ * @param {string[]} args - Command arguments
+ * @returns {Promise<{success: boolean, data?: string, error?: string}>}
+ */
+function execAgectl(args) {
+  return new Promise((resolve) => {
+    const agectl = spawn('agectl', args, {
+      env: { ...process.env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    agectl.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    agectl.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    agectl.on('close', (code) => {
+      if (code === 0) {
+        resolve({ success: true, data: stdout });
+      } else {
+        resolve({ success: false, error: stderr || `Exit code: ${code}` });
+      }
+    });
+
+    agectl.on('error', (err) => {
+      resolve({ success: false, error: err.message });
+    });
+  });
+}
+
+/**
+ * Initialize the age verification service
+ * Checks if the ageD D-Bus service is running
+ */
+async function initAgeVerification() {
+  try {
+    const result = await execAgectl(['status']);
+    serviceAvailable = result.success;
+    if (serviceAvailable) {
+      log.info('[age-verification] ageD service is available');
+    } else {
+      log.warn('[age-verification] ageD service not available:', result.error);
+    }
+  } catch (err) {
+    log.warn('[age-verification] Failed to initialize:', err.message);
+    serviceAvailable = false;
+  }
+}
+
+/**
+ * Get the current age verification status
+ * @returns {Promise<{verified: boolean, ageBracket?: string, status?: string}>}
+ */
+async function getAgeBracket() {
+  if (!serviceAvailable) {
+    // Try to initialize first
+    await initAgeVerification();
+    if (!serviceAvailable) {
+      return { verified: false, status: 'service unavailable' };
+    }
+  }
+
+  try {
+    // The D-Bus service responds with "adult" status
+    // For now, we return the expected format from the D-Bus interface
+    return {
+      verified: true,
+      ageBracket: 'adult',
+      status: 'verified',
+    };
+  } catch (err) {
+    log.error('[age-verification] Failed to get age bracket:', err);
+    return { verified: false, status: 'error' };
+  }
+}
+
+/**
+ * Get user age status
+ * @returns {Promise<{ageVerified: boolean, status?: string, age?: number}>}
+ */
+async function getUserAge() {
+  if (!serviceAvailable) {
+    await initAgeVerification();
+    if (!serviceAvailable) {
+      return { ageVerified: false, status: 'service unavailable' };
+    }
+  }
+
+  try {
+    return {
+      ageVerified: true,
+      status: 'adult',
+      age: 25,
+    };
+  } catch (err) {
+    log.error('[age-verification] Failed to get user age:', err);
+    return { ageVerified: false, status: 'error' };
+  }
+}
+
+/**
+ * Check if age verification is verified
+ * @returns {Promise<{verified: boolean, age?: number}>}
+ */
+async function checkVerification() {
+  if (!serviceAvailable) {
+    await initAgeVerification();
+    if (!serviceAvailable) {
+      return { verified: false };
+    }
+  }
+
+  try {
+    return {
+      verified: true,
+      age: 25,
+    };
+  } catch (err) {
+    log.error('[age-verification] Failed to check verification:', err);
+    return { verified: false };
+  }
+}
+
+/**
+ * Authenticate for age verification (null-attestation - always succeeds)
+ * @param {string} [user] - Optional user identifier
+ * @returns {Promise<{success: boolean, message?: string}>}
+ */
+async function authenticate(user) {
+  if (!serviceAvailable) {
+    await initAgeVerification();
+    if (!serviceAvailable) {
+      return { success: false, message: 'ageD service not available' };
+    }
+  }
+
+  try {
+    // Null-attestation: always succeed without prompting
+    return { success: true, message: 'verified (null-attestation)' };
+  } catch (err) {
+    log.error('[age-verification] Failed to authenticate:', err);
+    return { success: false, message: err.message };
+  }
+}
+
+/**
+ * Check if the age verification service is available
+ * @returns {boolean}
+ */
+function isServiceAvailable() {
+  return serviceAvailable;
+}
+
+/**
+ * Get list of current verifications
+ * @returns {Promise<{verifications: Array<{name: string, status: string}>}>}
+ */
+async function listVerifications() {
+  if (!serviceAvailable) {
+    await initAgeVerification();
+    if (!serviceAvailable) {
+      return { verifications: [] };
+    }
+  }
+
+  return {
+    verifications: [
+      { name: 'age-verification', status: 'verified' },
+      { name: 'current-user', status: 'unrestricted' },
+      { name: 'session-state', status: 'active' },
+    ],
+  };
+}
+
+module.exports = {
+  initAgeVerification,
+  getAgeBracket,
+  getUserAge,
+  checkVerification,
+  authenticate,
+  listVerifications,
+  isServiceAvailable,
+};

--- a/src/main/age-verification.test.js
+++ b/src/main/age-verification.test.js
@@ -1,0 +1,232 @@
+/**
+ * Unit tests for age-verification module
+ */
+
+const { spawn } = require('child_process');
+
+// Mock the child_process module
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}));
+
+const { spawn: mockSpawn } = require('child_process');
+
+describe('age-verification', () => {
+  let ageVerification;
+  let mockLog;
+
+  beforeEach(() => {
+    // Reset all mocks
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    // Create mock logger
+    mockLog = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    jest.doMock('./logger', () => mockLog);
+
+    // Re-require the module after setting up mocks
+    ageVerification = require('./age-verification');
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  describe('initAgeVerification', () => {
+    it('should initialize and detect available service', async () => {
+      mockSpawn.mockImplementation(() => {
+        return {
+          stdout: { on: jest.fn((event, cb) => cb('verified')) },
+          stderr: { on: jest.fn() },
+          on: jest.fn((event, cb) => {
+            if (event === 'close') cb(0);
+          }),
+        };
+      });
+
+      await ageVerification.initAgeVerification();
+
+      expect(mockLog.info).toHaveBeenCalledWith(
+        '[age-verification] ageD service is available'
+      );
+    });
+
+    it('should handle unavailable service', async () => {
+      mockSpawn.mockImplementation(() => {
+        return {
+          stdout: { on: jest.fn() },
+          stderr: { on: jest.fn((event, cb) => cb('not found')) },
+          on: jest.fn((event, cb) => {
+            if (event === 'close') cb(1);
+          }),
+        };
+      });
+
+      await ageVerification.initAgeVerification();
+
+      expect(mockLog.warn).toHaveBeenCalledWith(
+        '[age-verification] ageD service not available:',
+        expect.any(String)
+      );
+    });
+  });
+
+  describe('getAgeBracket', () => {
+    it('should return adult bracket when service is available', async () => {
+      mockSpawn.mockImplementation(() => {
+        return {
+          stdout: { on: jest.fn((event, cb) => cb('adult')) },
+          stderr: { on: jest.fn() },
+          on: jest.fn((event, cb) => {
+            if (event === 'close') cb(0);
+          }),
+        };
+      });
+
+      const result = await ageVerification.getAgeBracket();
+
+      expect(result).toEqual({
+        verified: true,
+        ageBracket: 'adult',
+        status: 'verified',
+      });
+    });
+
+    it('should return unavailable when service is not available', async () => {
+      mockSpawn.mockImplementation(() => {
+        return {
+          stdout: { on: jest.fn() },
+          stderr: { on: jest.fn((event, cb) => cb('not found')) },
+          on: jest.fn((event, cb) => {
+            if (event === 'close') cb(1);
+          }),
+        };
+      });
+
+      const result = await ageVerification.getAgeBracket();
+
+      expect(result).toEqual({
+        verified: false,
+        status: 'service unavailable',
+      });
+    });
+  });
+
+  describe('getUserAge', () => {
+    it('should return adult age when service is available', async () => {
+      mockSpawn.mockImplementation(() => {
+        return {
+          stdout: { on: jest.fn((event, cb) => cb('adult')) },
+          stderr: { on: jest.fn() },
+          on: jest.fn((event, cb) => {
+            if (event === 'close') cb(0);
+          }),
+        };
+      });
+
+      const result = await ageVerification.getUserAge();
+
+      expect(result).toEqual({
+        ageVerified: true,
+        status: 'adult',
+        age: 25,
+      });
+    });
+  });
+
+  describe('checkVerification', () => {
+    it('should return verified when service is available', async () => {
+      mockSpawn.mockImplementation(() => {
+        return {
+          stdout: { on: jest.fn((event, cb) => cb('verified')) },
+          stderr: { on: jest.fn() },
+          on: jest.fn((event, cb) => {
+            if (event === 'close') cb(0);
+          }),
+        };
+      });
+
+      const result = await ageVerification.checkVerification();
+
+      expect(result).toEqual({
+        verified: true,
+        age: 25,
+      });
+    });
+
+    it('should return not verified when service is unavailable', async () => {
+      mockSpawn.mockImplementation(() => {
+        return {
+          stdout: { on: jest.fn() },
+          stderr: { on: jest.fn((event, cb) => cb('error')) },
+          on: jest.fn((event, cb) => {
+            if (event === 'close') cb(1);
+          }),
+        };
+      });
+
+      const result = await ageVerification.checkVerification();
+
+      expect(result).toEqual({
+        verified: false,
+      });
+    });
+  });
+
+  describe('authenticate', () => {
+    it('should authenticate successfully with null-attestation', async () => {
+      mockSpawn.mockImplementation(() => {
+        return {
+          stdout: { on: jest.fn((event, cb) => cb('verified')) },
+          stderr: { on: jest.fn() },
+          on: jest.fn((event, cb) => {
+            if (event === 'close') cb(0);
+          }),
+        };
+      });
+
+      const result = await ageVerification.authenticate('testuser');
+
+      expect(result).toEqual({
+        success: true,
+        message: 'verified (null-attestation)',
+      });
+    });
+  });
+
+  describe('isServiceAvailable', () => {
+    it('should return false when service is not initialized', () => {
+      const result = ageVerification.isServiceAvailable();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('listVerifications', () => {
+    it('should return list of verifications when service is available', async () => {
+      mockSpawn.mockImplementation(() => {
+        return {
+          stdout: { on: jest.fn((event, cb) => cb('verified')) },
+          stderr: { on: jest.fn() },
+          on: jest.fn((event, cb) => {
+            if (event === 'close') cb(0);
+          }),
+        };
+      });
+
+      const result = await ageVerification.listVerifications();
+
+      expect(result).toEqual({
+        verifications: [
+          { name: 'age-verification', status: 'verified' },
+          { name: 'current-user', status: 'unrestricted' },
+          { name: 'session-state', status: 'active' },
+        ],
+      });
+    });
+  });
+});

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -7,6 +7,7 @@ const { loadSettings } = require('./settings-store');
 const { fetchBuffer, fetchToFile } = require('./http-fetch');
 const { success, failure, validateWebContentsId } = require('./ipc-contract');
 const IPC = require('../shared/ipc-channels');
+const ageVerification = require('./age-verification');
 
 // Path to webview preload script (for internal pages)
 const webviewPreloadPath = path.join(__dirname, 'webview-preload.js');
@@ -281,6 +282,67 @@ function registerBaseIpcHandlers(callbacks = {}) {
     } catch (error) {
       log.error('[clipboard] Failed to copy image:', error);
       return { success: false, error: error.message };
+    }
+  });
+
+  // Age Verification IPC handlers
+  ipcMain.handle(IPC.AGE_GET_BRACKET, async () => {
+    try {
+      const result = await ageVerification.getAgeBracket();
+      return result;
+    } catch (error) {
+      log.error('[age-verification] Failed to get age bracket:', error);
+      return { verified: false, status: 'error' };
+    }
+  });
+
+  ipcMain.handle(IPC.AGE_GET_USER_AGE, async () => {
+    try {
+      const result = await ageVerification.getUserAge();
+      return result;
+    } catch (error) {
+      log.error('[age-verification] Failed to get user age:', error);
+      return { ageVerified: false, status: 'error' };
+    }
+  });
+
+  ipcMain.handle(IPC.AGE_CHECK_VERIFICATION, async () => {
+    try {
+      const result = await ageVerification.checkVerification();
+      return result;
+    } catch (error) {
+      log.error('[age-verification] Failed to check verification:', error);
+      return { verified: false };
+    }
+  });
+
+  ipcMain.handle(IPC.AGE_AUTHENTICATE, async (_event, user) => {
+    try {
+      const result = await ageVerification.authenticate(user);
+      return result;
+    } catch (error) {
+      log.error('[age-verification] Failed to authenticate:', error);
+      return { success: false, message: error.message };
+    }
+  });
+
+  ipcMain.handle(IPC.AGE_LIST_VERIFICATIONS, async () => {
+    try {
+      const result = await ageVerification.listVerifications();
+      return result;
+    } catch (error) {
+      log.error('[age-verification] Failed to list verifications:', error);
+      return { verifications: [] };
+    }
+  });
+
+  ipcMain.handle(IPC.AGE_GET_STATUS, async () => {
+    try {
+      const available = ageVerification.isServiceAvailable();
+      return { available };
+    } catch (error) {
+      log.error('[age-verification] Failed to get status:', error);
+      return { available: false };
     }
   });
 }

--- a/src/main/ipc-handlers.test.js
+++ b/src/main/ipc-handlers.test.js
@@ -357,4 +357,71 @@ describe('ipc-handlers', () => {
       expect.any(Error)
     );
   });
+
+  test('age verification IPC handlers', async () => {
+    // Mock age verification module
+    const ageVerificationMock = {
+      getAgeBracket: jest.fn().mockResolvedValue({ verified: true, ageBracket: 'adult', status: 'verified' }),
+      getUserAge: jest.fn().mockResolvedValue({ ageVerified: true, status: 'adult', age: 25 }),
+      checkVerification: jest.fn().mockResolvedValue({ verified: true, age: 25 }),
+      authenticate: jest.fn().mockResolvedValue({ success: true, message: 'verified (null-attestation)' }),
+      listVerifications: jest.fn().mockResolvedValue({
+        verifications: [
+          { name: 'age-verification', status: 'verified' },
+          { name: 'current-user', status: 'unrestricted' },
+        ],
+      }),
+      isServiceAvailable: jest.fn().mockReturnValue(true),
+    };
+
+    const ctx = loadIpcHandlersModule({
+      ageVerification: ageVerificationMock,
+    });
+
+    // Inject the age verification module
+    ctx.mod = require('./ipc-handlers');
+    // Re-register handlers with mocked age verification
+    jest.resetModules();
+    jest.doMock('./age-verification', () => ageVerificationMock);
+    const { registerBaseIpcHandlers } = require('./ipc-handlers');
+    registerBaseIpcHandlers();
+
+    // Test AGE_GET_BRACKET
+    const bracketResult = await ctx.ipcMain.handlers.get(IPC.AGE_GET_BRACKET)();
+    expect(bracketResult).toEqual({ verified: true, ageBracket: 'adult', status: 'verified' });
+    expect(ageVerificationMock.getAgeBracket).toHaveBeenCalled();
+
+    // Test AGE_GET_USER_AGE
+    const userAgeResult = await ctx.ipcMain.handlers.get(IPC.AGE_GET_USER_AGE)();
+    expect(userAgeResult).toEqual({ ageVerified: true, status: 'adult', age: 25 });
+    expect(ageVerificationMock.getUserAge).toHaveBeenCalled();
+
+    // Test AGE_CHECK_VERIFICATION
+    const checkResult = await ctx.ipcMain.handlers.get(IPC.AGE_CHECK_VERIFICATION)();
+    expect(checkResult).toEqual({ verified: true, age: 25 });
+    expect(ageVerificationMock.checkVerification).toHaveBeenCalled();
+
+    // Test AGE_AUTHENTICATE
+    const authResult = await ctx.ipcMain.handlers.get(IPC.AGE_AUTHENTICATE)(null, 'testuser');
+    expect(authResult).toEqual({ success: true, message: 'verified (null-attestation)' });
+    expect(ageVerificationMock.authenticate).toHaveBeenCalledWith('testuser');
+
+    // Test AGE_LIST_VERIFICATIONS
+    const listResult = await ctx.ipcMain.handlers.get(IPC.AGE_LIST_VERIFICATIONS)();
+    expect(listResult).toEqual({
+      verifications: [
+        { name: 'age-verification', status: 'verified' },
+        { name: 'current-user', status: 'unrestricted' },
+      ],
+    });
+    expect(ageVerificationMock.listVerifications).toHaveBeenCalled();
+
+    // Test AGE_GET_STATUS
+    const statusResult = await ctx.ipcMain.handlers.get(IPC.AGE_GET_STATUS)();
+    expect(statusResult).toEqual({ available: true });
+    expect(ageVerificationMock.isServiceAvailable).toHaveBeenCalled();
+
+    // Clean up mocks
+    jest.resetModules();
+  });
 });

--- a/src/shared/ipc-channels.js
+++ b/src/shared/ipc-channels.js
@@ -156,4 +156,12 @@ module.exports = {
   DAPP_PROVIDER_REQUEST: 'dapp:provider-request',
   DAPP_PROVIDER_RESPONSE: 'dapp:provider-response',
   DAPP_PROVIDER_EVENT: 'dapp:provider-event',
+
+  // Age Verification
+  AGE_GET_BRACKET: 'age:get-bracket',
+  AGE_GET_USER_AGE: 'age:get-user-age',
+  AGE_CHECK_VERIFICATION: 'age:check-verification',
+  AGE_AUTHENTICATE: 'age:authenticate',
+  AGE_LIST_VERIFICATIONS: 'age:list-verifications',
+  AGE_GET_STATUS: 'age:get-status',
 };


### PR DESCRIPTION
Hi i have a null attestation dbus code for ageD in sonicd my systemd fork that has liberated systemd as an upstream. This code needs to be merged to allow us to use the bypass to use BBC UK without a UK ID! Would love feedback on this so we can work together to bypass age verification together on the freedom browser!