### PR TITLE
fix(main): register bzz/ipfs/ipns schemes as privileged to enable fetch() API

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,6 +1,16 @@
 // Set app name early, before electron-log initializes (it uses app name for log path)
-const { app } = require('electron');
+const { app, protocol } = require('electron');
 const appName = process.platform === 'linux' ? 'freedom' : 'Freedom';
+
+// Register custom schemes as privileged BEFORE app is ready so that Fetch API
+// and other browser features treat bzz://, ipfs://, and ipns:// as valid fetch
+// schemes. Without this, only XMLHttpRequest works (it bypasses scheme validation);
+// fetch() rejects unknown schemes before webRequest.onBeforeRequest can intercept them.
+protocol.registerSchemesAsPrivileged([
+  { scheme: 'bzz',  privileges: { standard: true, supportFetchAPI: true } },
+  { scheme: 'ipfs', privileges: { standard: true, supportFetchAPI: true } },
+  { scheme: 'ipns', privileges: { standard: true, supportFetchAPI: true } },
+]);
 
 // Suppress Electron security warnings in development (CSP handles security in production)
 if (!app.isPackaged) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -6,10 +6,18 @@ const appName = process.platform === 'linux' ? 'freedom' : 'Freedom';
 // and other browser features treat bzz://, ipfs://, and ipns:// as valid fetch
 // schemes. Without this, only XMLHttpRequest works (it bypasses scheme validation);
 // fetch() rejects unknown schemes before webRequest.onBeforeRequest can intercept them.
+const privileges = {
+  standard: true,
+  secure: true,
+  supportFetchAPI: true,
+  corsEnabled: true,
+  allowServiceWorkers: true,
+};
 protocol.registerSchemesAsPrivileged([
-  { scheme: 'bzz',  privileges: { standard: true, supportFetchAPI: true } },
-  { scheme: 'ipfs', privileges: { standard: true, supportFetchAPI: true } },
-  { scheme: 'ipns', privileges: { standard: true, supportFetchAPI: true } },
+  { scheme: 'bzz',  privileges: privileges },
+  { scheme: 'ipfs', privileges: privileges },
+  { scheme: 'ipns', privileges: privileges },
+  { scheme: 'rad',  privileges: privileges },
 ]);
 
 // Suppress Electron security warnings in development (CSP handles security in production)


### PR DESCRIPTION
## What

Registers `bzz://`, `ipfs://`, and `ipns://` as privileged schemes via
`protocol.registerSchemesAsPrivileged()` before `app.whenReady()`.

## Why

Chromium rejects `fetch()` calls to unknown schemes before `webRequest.onBeforeRequest`
can intercept them. `XMLHttpRequest` bypasses this check, so XHR worked but
`fetch()` did not.

## Changes

- `src/main/index.js` — add `protocol.registerSchemesAsPrivileged` call

Issue: https://github.com/solardev-xyz/freedom-browser/issues/22
