### PR TITLE
Feature/swarm publish history sqlite

### DIFF
--- a/src/main/history.js
+++ b/src/main/history.js
@@ -36,6 +36,7 @@ function closeDb() {
     log.info('[History] Closing database');
     db.close();
     db = null;
+    statements = null;
   }
 }
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -56,7 +56,7 @@ const { registerRpcManagerIpc } = require('./wallet/rpc-manager');
 const { registerDappPermissionsIpc } = require('./wallet/dapp-permissions');
 const { registerSwarmIpc } = require('./swarm/stamp-service');
 const { registerPublishIpc } = require('./swarm/publish-service');
-const { registerPublishHistoryIpc } = require('./swarm/publish-history');
+const { registerPublishHistoryIpc, closeDb: closePublishHistoryDb } = require('./swarm/publish-history');
 const { registerSwarmPermissionsIpc } = require('./swarm/swarm-permissions');
 const { registerSwarmProviderIpc } = require('./swarm/swarm-provider-ipc');
 const { registerFeedStoreIpc } = require('./swarm/feed-store');
@@ -237,9 +237,10 @@ app.on('before-quit', async (event) => {
   }
   log.info('[App] All windows closed');
 
-  // Close history database
-  log.info('[App] Closing history database...');
+  // Close history databases
+  log.info('[App] Closing history databases...');
   closeHistoryDb();
+  closePublishHistoryDb();
 
   // Clean up any GitHub bridge temp directories
   cleanupTempDirs();

--- a/src/main/swarm/publish-history.js
+++ b/src/main/swarm/publish-history.js
@@ -14,6 +14,7 @@ const Database = require('better-sqlite3');
 
 const SCHEMA_VERSION = 1;
 const ORPHAN_SWEEP_MESSAGE = 'interrupted by app exit';
+const MIGRATED_SUFFIX = '.migrated';
 
 const FINAL_STATUSES = new Set(['completed', 'failed']);
 const isFinalStatus = (status) => FINAL_STATUSES.has(status);
@@ -83,6 +84,19 @@ function migrateFromJson() {
   const jsonPath = path.join(app.getPath('userData'), 'publish-history.json');
   if (!fs.existsSync(jsonPath)) return;
 
+  // .migrated present = prior successful migration. The publishes table has
+  // no unique key, so re-importing a stray .json would duplicate every row.
+  const migratedPath = jsonPath + MIGRATED_SUFFIX;
+  if (fs.existsSync(migratedPath)) {
+    try {
+      fs.unlinkSync(jsonPath);
+      log.info('[PublishHistory] Dropped stray publish-history.json (already migrated)');
+    } catch (err) {
+      log.error('[PublishHistory] Failed to remove stray publish-history.json:', err.message);
+    }
+    return;
+  }
+
   try {
     const raw = JSON.parse(fs.readFileSync(jsonPath, 'utf-8'));
     const entries = Array.isArray(raw?.entries) ? raw.entries : [];
@@ -97,7 +111,11 @@ function migrateFromJson() {
 
       const insertMany = db.transaction((items) => {
         for (const e of items) {
-          const startedAt = e.timestamp ? Date.parse(e.timestamp) : Date.now();
+          // Date.parse returns NaN for malformed input; better-sqlite3 rejects
+          // NaN at bind, which would roll back the whole migration and trap us
+          // in a retry loop on every boot. Fall back to now() on bad input.
+          const parsed = e.timestamp ? Date.parse(e.timestamp) : NaN;
+          const startedAt = Number.isFinite(parsed) ? parsed : Date.now();
           const status = e.status || 'completed';
           const finalized = isFinalStatus(status);
           insert.run(
@@ -121,7 +139,7 @@ function migrateFromJson() {
       log.info(`[PublishHistory] Migrated ${entries.length} entries from JSON`);
     }
 
-    fs.renameSync(jsonPath, jsonPath + '.migrated');
+    fs.renameSync(jsonPath, migratedPath);
   } catch (err) {
     log.error('[PublishHistory] Failed to migrate from JSON:', err.message);
   }

--- a/src/main/swarm/publish-history.js
+++ b/src/main/swarm/publish-history.js
@@ -158,6 +158,7 @@ function getStatements() {
         bzz_url       = COALESCE(?, bzz_url),
         tag_uid       = COALESCE(?, tag_uid),
         batch_id      = COALESCE(?, batch_id),
+        bytes_size    = COALESCE(?, bytes_size),
         completed_at  = COALESCE(?, completed_at),
         error_message = COALESCE(?, error_message)
       WHERE id = ?
@@ -224,6 +225,7 @@ function updateEntry(id, updates = {}) {
     updates.bzzUrl || null,
     updates.tagUid ?? null,
     updates.batchIdUsed || null,
+    updates.bytesSize ?? null,
     finalized ? Date.now() : null,
     updates.errorMessage || null,
     id

--- a/src/main/swarm/publish-history.js
+++ b/src/main/swarm/publish-history.js
@@ -1,124 +1,249 @@
 /**
- * Publish History
+ * Publish History (SQLite-backed).
  *
- * Persists recent Swarm publishes to a JSON file. Designed as a storage
- * abstraction so it can be migrated to SQLite later if publish history
- * grows into a real job system.
- *
- * Entry model:
- *   { id, reference, bzzUrl, type, name, timestamp, tagUid, batchIdUsed, status }
- *
- * Status lifecycle: uploading → completed / failed
+ * On first open: migrate the legacy publish-history.json one-shot, then sweep
+ * any 'uploading' rows left behind by a crashed prior session into 'failed'
+ * (we don't recover in-flight uploads — the user re-initiates).
  */
 
-const fs = require('fs');
-const path = require('path');
+const log = require('../logger');
 const { app, ipcMain } = require('electron');
-const log = require('electron-log');
+const path = require('path');
+const fs = require('fs');
+const Database = require('better-sqlite3');
 
-const HISTORY_FILE = path.join(app.getPath('userData'), 'publish-history.json');
-const MAX_ENTRIES = 100;
 const SCHEMA_VERSION = 1;
+const ORPHAN_SWEEP_MESSAGE = 'interrupted by app exit';
 
-let entries = null; // lazy-loaded
+const FINAL_STATUSES = new Set(['completed', 'failed']);
+const isFinalStatus = (status) => FINAL_STATUSES.has(status);
 
-// ============================================
-// Storage layer
-// ============================================
+let db = null;
+let statements = null;
 
-function load() {
-  if (entries !== null) return;
+function getDb() {
+  if (db) return db;
+
+  const dbPath = path.join(app.getPath('userData'), 'publish-history.sqlite');
+  log.info('[PublishHistory] Opening database:', dbPath);
+
+  db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+
+  migrateDatabase();
+  migrateFromJson();
+  sweepOrphans();
+
+  return db;
+}
+
+function closeDb() {
+  if (db) {
+    log.info('[PublishHistory] Closing database');
+    db.close();
+    db = null;
+    statements = null;
+  }
+}
+
+function migrateDatabase() {
+  const version = db.pragma('user_version', { simple: true });
+
+  if (version < SCHEMA_VERSION) {
+    log.info(`[PublishHistory] Migrating schema ${version} → ${SCHEMA_VERSION}`);
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS publishes (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        type          TEXT NOT NULL,
+        name          TEXT,
+        status        TEXT NOT NULL,
+        reference     TEXT,
+        bzz_url       TEXT,
+        tag_uid       INTEGER,
+        batch_id      TEXT,
+        origin        TEXT,
+        bytes_size    INTEGER,
+        started_at    INTEGER NOT NULL,
+        completed_at  INTEGER,
+        error_message TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_publishes_started   ON publishes(started_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_publishes_type      ON publishes(type);
+      CREATE INDEX IF NOT EXISTS idx_publishes_status    ON publishes(status);
+      CREATE INDEX IF NOT EXISTS idx_publishes_reference ON publishes(reference);
+      CREATE INDEX IF NOT EXISTS idx_publishes_origin    ON publishes(origin);
+    `);
+    db.pragma(`user_version = ${SCHEMA_VERSION}`);
+  }
+}
+
+// Renamed to .migrated on success; left in place on parse failure as a
+// recovery breadcrumb.
+function migrateFromJson() {
+  const jsonPath = path.join(app.getPath('userData'), 'publish-history.json');
+  if (!fs.existsSync(jsonPath)) return;
 
   try {
-    if (fs.existsSync(HISTORY_FILE)) {
-      const raw = JSON.parse(fs.readFileSync(HISTORY_FILE, 'utf-8'));
-      if (raw.version === SCHEMA_VERSION && Array.isArray(raw.entries)) {
-        entries = raw.entries;
-        return;
-      }
+    const raw = JSON.parse(fs.readFileSync(jsonPath, 'utf-8'));
+    const entries = Array.isArray(raw?.entries) ? raw.entries : [];
+
+    if (entries.length > 0) {
+      const insert = db.prepare(`
+        INSERT INTO publishes (
+          type, name, status, reference, bzz_url, tag_uid, batch_id,
+          origin, bytes_size, started_at, completed_at, error_message
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+
+      const insertMany = db.transaction((items) => {
+        for (const e of items) {
+          const startedAt = e.timestamp ? Date.parse(e.timestamp) : Date.now();
+          const status = e.status || 'completed';
+          const finalized = isFinalStatus(status);
+          insert.run(
+            e.type || 'data',
+            e.name || null,
+            status,
+            e.reference || null,
+            e.bzzUrl || null,
+            e.tagUid ?? null,
+            e.batchIdUsed || null,
+            null,
+            null,
+            startedAt,
+            finalized ? startedAt : null,
+            null
+          );
+        }
+      });
+
+      insertMany(entries);
+      log.info(`[PublishHistory] Migrated ${entries.length} entries from JSON`);
     }
-  } catch (err) {
-    log.error('[PublishHistory] Failed to load history:', err.message);
-  }
 
-  entries = [];
-}
-
-function save() {
-  try {
-    const data = JSON.stringify({ version: SCHEMA_VERSION, entries }, null, 2);
-    fs.writeFileSync(HISTORY_FILE, data, 'utf-8');
+    fs.renameSync(jsonPath, jsonPath + '.migrated');
   } catch (err) {
-    log.error('[PublishHistory] Failed to save history:', err.message);
+    log.error('[PublishHistory] Failed to migrate from JSON:', err.message);
   }
 }
 
-// ============================================
-// Public API
-// ============================================
+function sweepOrphans() {
+  const stmt = db.prepare(`
+    UPDATE publishes
+    SET status = ?, error_message = ?, completed_at = ?
+    WHERE status = ?
+  `);
+  const result = stmt.run('failed', ORPHAN_SWEEP_MESSAGE, Date.now(), 'uploading');
+  if (result.changes > 0) {
+    log.info(`[PublishHistory] Swept ${result.changes} orphaned uploading rows to failed`);
+  }
+}
 
-function addEntry(entry) {
-  load();
+function getStatements() {
+  if (statements) return statements;
 
-  const record = {
-    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-    reference: entry.reference || null,
-    bzzUrl: entry.bzzUrl || null,
-    type: entry.type || 'data', // 'data', 'file', 'directory'
-    name: entry.name || null,
-    timestamp: new Date().toISOString(),
-    tagUid: entry.tagUid || null,
-    batchIdUsed: entry.batchIdUsed || null,
-    status: entry.status || 'uploading',
+  const database = getDb();
+  statements = {
+    insert: database.prepare(`
+      INSERT INTO publishes (
+        type, name, status, reference, bzz_url, tag_uid, batch_id,
+        origin, bytes_size, started_at, completed_at, error_message
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `),
+    // Passing NULL for any column keeps the existing value.
+    update: database.prepare(`
+      UPDATE publishes SET
+        status        = COALESCE(?, status),
+        reference     = COALESCE(?, reference),
+        bzz_url       = COALESCE(?, bzz_url),
+        tag_uid       = COALESCE(?, tag_uid),
+        batch_id      = COALESCE(?, batch_id),
+        completed_at  = COALESCE(?, completed_at),
+        error_message = COALESCE(?, error_message)
+      WHERE id = ?
+    `),
+    getAll: database.prepare(`SELECT * FROM publishes ORDER BY started_at DESC`),
+    getById: database.prepare(`SELECT * FROM publishes WHERE id = ?`),
+    delete: database.prepare(`DELETE FROM publishes WHERE id = ?`),
+    clear: database.prepare(`DELETE FROM publishes`),
   };
-
-  entries.unshift(record);
-
-  // Cap the list
-  if (entries.length > MAX_ENTRIES) {
-    entries = entries.slice(0, MAX_ENTRIES);
-  }
-
-  save();
-  return record;
+  return statements;
 }
 
-function updateEntry(id, updates) {
-  load();
+// id is now an integer (was a generated string in the JSON store);
+// the renderer never reads it, so the type change is transparent.
+function rowToEntry(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    type: row.type,
+    name: row.name,
+    status: row.status,
+    reference: row.reference,
+    bzzUrl: row.bzz_url,
+    tagUid: row.tag_uid,
+    batchIdUsed: row.batch_id,
+    origin: row.origin,
+    bytesSize: row.bytes_size,
+    timestamp: new Date(row.started_at).toISOString(),
+    completedAt: row.completed_at ? new Date(row.completed_at).toISOString() : null,
+    errorMessage: row.error_message,
+  };
+}
 
-  const entry = entries.find((e) => e.id === id);
-  if (!entry) return null;
+function addEntry(entry = {}) {
+  const startedAt = Date.now();
+  const status = entry.status || 'uploading';
+  const finalized = isFinalStatus(status);
 
-  if (updates.status) entry.status = updates.status;
-  if (updates.reference) entry.reference = updates.reference;
-  if (updates.bzzUrl) entry.bzzUrl = updates.bzzUrl;
-  if (updates.tagUid !== undefined) entry.tagUid = updates.tagUid;
-  if (updates.batchIdUsed) entry.batchIdUsed = updates.batchIdUsed;
+  const result = getStatements().insert.run(
+    entry.type || 'data',
+    entry.name || null,
+    status,
+    entry.reference || null,
+    entry.bzzUrl || null,
+    entry.tagUid ?? null,
+    entry.batchIdUsed || null,
+    entry.origin || null,
+    entry.bytesSize ?? null,
+    startedAt,
+    finalized ? startedAt : null,
+    entry.errorMessage || null
+  );
 
-  save();
-  return entry;
+  return rowToEntry(getStatements().getById.get(result.lastInsertRowid));
+}
+
+function updateEntry(id, updates = {}) {
+  const status = updates.status || null;
+  const finalized = isFinalStatus(status);
+
+  const result = getStatements().update.run(
+    status,
+    updates.reference || null,
+    updates.bzzUrl || null,
+    updates.tagUid ?? null,
+    updates.batchIdUsed || null,
+    finalized ? Date.now() : null,
+    updates.errorMessage || null,
+    id
+  );
+
+  if (result.changes === 0) return null;
+  return rowToEntry(getStatements().getById.get(id));
 }
 
 function getEntries() {
-  load();
-  return [...entries];
+  return getStatements().getAll.all().map(rowToEntry);
 }
 
 function clearEntries() {
-  entries = [];
-  save();
+  getStatements().clear.run();
 }
 
 function removeEntry(id) {
-  load();
-  const before = entries.length;
-  entries = entries.filter((e) => e.id !== id);
-  if (entries.length !== before) save();
+  return getStatements().delete.run(id).changes > 0;
 }
-
-// ============================================
-// IPC registration
-// ============================================
 
 function registerPublishHistoryIpc() {
   ipcMain.handle('swarm:get-publish-history', () => {
@@ -150,4 +275,7 @@ module.exports = {
   clearEntries,
   removeEntry,
   registerPublishHistoryIpc,
+  getDb,
+  closeDb,
+  ORPHAN_SWEEP_MESSAGE,
 };

--- a/src/main/swarm/publish-history.test.js
+++ b/src/main/swarm/publish-history.test.js
@@ -200,6 +200,37 @@ describe('publish-history (sqlite)', () => {
     }).not.toThrow();
   });
 
+  test('skips re-import when publish-history.json.migrated already exists', () => {
+    // Scenario: a prior run successfully migrated (leaving .migrated behind),
+    // and a stray .json reappeared — user drop-in, partial restore, etc.
+    // Re-importing would double the rows (the table has no unique key), so
+    // the stray .json should be dropped instead.
+    const jsonPath = path.join(userDataDir, 'publish-history.json');
+    const migratedPath = jsonPath + '.migrated';
+
+    fs.writeFileSync(
+      jsonPath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            type: 'data',
+            name: 'stray',
+            status: 'completed',
+            timestamp: '2026-04-15T19:30:32.540Z',
+          },
+        ],
+      })
+    );
+    fs.writeFileSync(migratedPath, '{}');
+
+    ({ mod } = loadPublishHistoryModule({ userDataDir }));
+
+    expect(mod.getEntries()).toHaveLength(0);
+    expect(fs.existsSync(jsonPath)).toBe(false);
+    expect(fs.existsSync(migratedPath)).toBe(true);
+  });
+
   test('sweepOrphans flips uploading rows to failed when getDb runs', () => {
     // Seed the fake by inserting two uploading rows, then explicitly invoke
     // the sweep path through a new module load. Since the fake DB is in-memory

--- a/src/main/swarm/publish-history.test.js
+++ b/src/main/swarm/publish-history.test.js
@@ -1,117 +1,248 @@
-jest.mock('electron', () => ({
-  app: { getPath: () => '/tmp/test-publish-history' },
-  ipcMain: { handle: jest.fn() },
-}));
+const fs = require('fs');
+const path = require('path');
+const FakeBetterSqlite3PublishesDatabase = require('../../../test/helpers/fake-better-sqlite3-publishes');
+const {
+  createIpcMainMock,
+  createTempUserDataDir,
+  loadMainModule,
+  removeTempUserDataDir,
+} = require('../../../test/helpers/main-process-test-utils');
 
-jest.mock('electron-log', () => ({
-  info: jest.fn(),
-  error: jest.fn(),
-}));
+function loadPublishHistoryModule(options = {}) {
+  return loadMainModule(require.resolve('./publish-history'), {
+    ...options,
+    extraMocks: {
+      'better-sqlite3': () => FakeBetterSqlite3PublishesDatabase,
+      [require.resolve('../logger')]: () => ({
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      }),
+    },
+  });
+}
 
-// Mock fs to avoid real file I/O
-const mockFs = {
-  existsSync: jest.fn().mockReturnValue(false),
-  readFileSync: jest.fn(),
-  writeFileSync: jest.fn(),
-};
-jest.mock('fs', () => mockFs);
+describe('publish-history (sqlite)', () => {
+  let userDataDir;
+  let mod;
 
-const { addEntry, updateEntry, getEntries, clearEntries, removeEntry } = require('./publish-history');
-
-describe('publish-history', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-    mockFs.existsSync.mockReturnValue(false);
-    // Force reload by clearing the module's internal cache
-    clearEntries();
+    userDataDir = createTempUserDataDir();
+    mod = null;
   });
 
-  test('addEntry creates a record with generated id and timestamp', () => {
-    const entry = addEntry({ type: 'file', name: 'test.txt', status: 'uploading' });
-
-    expect(entry.id).toBeTruthy();
-    expect(entry.type).toBe('file');
-    expect(entry.name).toBe('test.txt');
-    expect(entry.status).toBe('uploading');
-    expect(entry.timestamp).toBeTruthy();
-    expect(entry.reference).toBeNull();
-    expect(entry.bzzUrl).toBeNull();
+  afterEach(() => {
+    if (mod?.closeDb) mod.closeDb();
+    removeTempUserDataDir(userDataDir);
   });
 
-  test('addEntry prepends to the list (newest first)', () => {
-    addEntry({ name: 'first' });
-    addEntry({ name: 'second' });
+  test('addEntry inserts a row with generated id and uploading status', () => {
+    ({ mod } = loadPublishHistoryModule({ userDataDir }));
 
-    const entries = getEntries();
-    expect(entries).toHaveLength(2);
-    expect(entries[0].name).toBe('second');
-    expect(entries[1].name).toBe('first');
+    const entry = mod.addEntry({ type: 'file', name: 'test.txt', status: 'uploading' });
+
+    expect(entry.id).toEqual(expect.any(Number));
+    expect(entry).toEqual(
+      expect.objectContaining({
+        type: 'file',
+        name: 'test.txt',
+        status: 'uploading',
+        reference: null,
+        bzzUrl: null,
+        completedAt: null,
+      })
+    );
+    expect(typeof entry.timestamp).toBe('string');
   });
 
-  test('addEntry caps the list at 100 entries', () => {
-    for (let i = 0; i < 105; i++) {
-      addEntry({ name: `entry-${i}` });
-    }
+  test('addEntry with completed status sets completedAt immediately', () => {
+    ({ mod } = loadPublishHistoryModule({ userDataDir }));
 
-    const entries = getEntries();
-    expect(entries).toHaveLength(100);
-    expect(entries[0].name).toBe('entry-104');
+    const entry = mod.addEntry({ type: 'data', status: 'completed', reference: 'abc' });
+
+    expect(entry.status).toBe('completed');
+    expect(entry.completedAt).not.toBeNull();
   });
 
-  test('updateEntry updates status and reference', () => {
-    const entry = addEntry({ name: 'test', status: 'uploading' });
+  test('updateEntry transitions status, reference, bzzUrl, tagUid, batchIdUsed', () => {
+    ({ mod } = loadPublishHistoryModule({ userDataDir }));
+    const created = mod.addEntry({ type: 'directory', name: 'site', status: 'uploading' });
 
-    const updated = updateEntry(entry.id, {
+    const updated = mod.updateEntry(created.id, {
       status: 'completed',
-      reference: 'abc123',
-      bzzUrl: 'bzz://abc123',
+      reference: 'deadbeef',
+      bzzUrl: 'bzz://deadbeef',
+      tagUid: 42,
+      batchIdUsed: 'batch1',
     });
 
-    expect(updated.status).toBe('completed');
-    expect(updated.reference).toBe('abc123');
-    expect(updated.bzzUrl).toBe('bzz://abc123');
+    expect(updated).toEqual(
+      expect.objectContaining({
+        status: 'completed',
+        reference: 'deadbeef',
+        bzzUrl: 'bzz://deadbeef',
+        tagUid: 42,
+        batchIdUsed: 'batch1',
+      })
+    );
+    expect(updated.completedAt).not.toBeNull();
   });
 
   test('updateEntry returns null for unknown id', () => {
-    const result = updateEntry('nonexistent', { status: 'failed' });
-    expect(result).toBeNull();
+    ({ mod } = loadPublishHistoryModule({ userDataDir }));
+    expect(mod.updateEntry(99999, { status: 'failed' })).toBeNull();
   });
 
-  test('clearEntries empties the list', () => {
-    addEntry({ name: 'test' });
-    expect(getEntries()).toHaveLength(1);
+  test('updateEntry to status=failed records the error message', () => {
+    ({ mod } = loadPublishHistoryModule({ userDataDir }));
+    const created = mod.addEntry({ type: 'data', status: 'uploading' });
 
-    clearEntries();
-    expect(getEntries()).toHaveLength(0);
+    const updated = mod.updateEntry(created.id, {
+      status: 'failed',
+      errorMessage: 'stamp expired',
+    });
+
+    expect(updated.status).toBe('failed');
+    expect(updated.errorMessage).toBe('stamp expired');
+    expect(updated.completedAt).not.toBeNull();
   });
 
-  test('removeEntry removes a specific entry', () => {
-    addEntry({ name: 'keep' });
-    const e2 = addEntry({ name: 'remove' });
+  test('getEntries returns rows newest-first and includes new columns', () => {
+    ({ mod } = loadPublishHistoryModule({ userDataDir }));
+    mod.addEntry({ type: 'data', name: 'first', origin: 'freedom://publish' });
+    // started_at uses Date.now() — bump to guarantee distinct ordering keys.
+    const realNow = Date.now;
+    Date.now = () => realNow() + 10;
+    mod.addEntry({ type: 'directory', name: 'second', origin: 'https://dapp.example' });
+    Date.now = realNow;
 
-    removeEntry(e2.id);
+    const entries = mod.getEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0].name).toBe('second');
+    expect(entries[0].origin).toBe('https://dapp.example');
+    expect(entries[1].name).toBe('first');
+    expect(entries[1].origin).toBe('freedom://publish');
+  });
 
-    const entries = getEntries();
+  test('removeEntry deletes by id; clearEntries empties everything', () => {
+    ({ mod } = loadPublishHistoryModule({ userDataDir }));
+    const a = mod.addEntry({ type: 'data', name: 'keep' });
+    const b = mod.addEntry({ type: 'data', name: 'drop' });
+
+    expect(mod.removeEntry(b.id)).toBe(true);
+    expect(mod.getEntries()).toHaveLength(1);
+    expect(mod.getEntries()[0].id).toBe(a.id);
+
+    mod.clearEntries();
+    expect(mod.getEntries()).toHaveLength(0);
+  });
+
+  test('handles 200+ entries without a cap', () => {
+    ({ mod } = loadPublishHistoryModule({ userDataDir }));
+    for (let i = 0; i < 250; i++) mod.addEntry({ type: 'data', name: `e${i}` });
+    expect(mod.getEntries()).toHaveLength(250);
+  });
+
+  test('migrates legacy publish-history.json on first open and renames the file', () => {
+    const jsonPath = path.join(userDataDir, 'publish-history.json');
+    fs.writeFileSync(
+      jsonPath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            id: 'legacy-1',
+            type: 'directory',
+            name: 'old-site',
+            status: 'completed',
+            reference: 'legacyref',
+            bzzUrl: 'bzz://legacyref',
+            tagUid: 100,
+            batchIdUsed: 'legacybatch',
+            timestamp: '2026-04-15T19:30:32.540Z',
+          },
+          {
+            id: 'legacy-2',
+            type: 'feed-create',
+            name: 'feed-x',
+            status: 'completed',
+            timestamp: '2026-04-15T19:31:00.000Z',
+          },
+        ],
+      })
+    );
+
+    ({ mod } = loadPublishHistoryModule({ userDataDir }));
+    const entries = mod.getEntries();
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0].name).toBe('feed-x'); // newer first
+    expect(entries[1]).toEqual(
+      expect.objectContaining({
+        type: 'directory',
+        name: 'old-site',
+        status: 'completed',
+        reference: 'legacyref',
+        bzzUrl: 'bzz://legacyref',
+        tagUid: 100,
+        batchIdUsed: 'legacybatch',
+      })
+    );
+
+    expect(fs.existsSync(jsonPath)).toBe(false);
+    expect(fs.existsSync(jsonPath + '.migrated')).toBe(true);
+  });
+
+  test('migration is idempotent — no JSON, no error', () => {
+    expect(() => {
+      ({ mod } = loadPublishHistoryModule({ userDataDir }));
+      mod.getEntries();
+    }).not.toThrow();
+  });
+
+  test('sweepOrphans flips uploading rows to failed when getDb runs', () => {
+    // Seed the fake by inserting two uploading rows, then explicitly invoke
+    // the sweep path through a new module load. Since the fake DB is in-memory
+    // per instance, we simulate the "prior session left orphans" scenario by
+    // going through the migrateFromJson path with an uploading entry.
+    const jsonPath = path.join(userDataDir, 'publish-history.json');
+    fs.writeFileSync(
+      jsonPath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            type: 'data',
+            name: 'orphan',
+            status: 'uploading',
+            timestamp: '2026-04-15T19:30:32.540Z',
+          },
+        ],
+      })
+    );
+
+    ({ mod } = loadPublishHistoryModule({ userDataDir }));
+    const entries = mod.getEntries();
+
     expect(entries).toHaveLength(1);
-    expect(entries[0].name).toBe('keep');
+    expect(entries[0].status).toBe('failed');
+    expect(entries[0].errorMessage).toBe(mod.ORPHAN_SWEEP_MESSAGE);
+    expect(entries[0].completedAt).not.toBeNull();
   });
 
-  test('getEntries returns a copy, not the internal array', () => {
-    addEntry({ name: 'test' });
-    const entries = getEntries();
-    entries.push({ name: 'injected' });
+  test('registers IPC handlers that wrap getEntries / clearEntries', async () => {
+    const ipcMain = createIpcMainMock();
+    ({ mod } = loadPublishHistoryModule({ userDataDir, ipcMain }));
+    mod.registerPublishHistoryIpc();
 
-    expect(getEntries()).toHaveLength(1);
-  });
+    mod.addEntry({ type: 'data', name: 'one' });
 
-  test('save writes versioned JSON to disk', () => {
-    addEntry({ name: 'test' });
+    const getResult = await ipcMain.invoke('swarm:get-publish-history');
+    expect(getResult.success).toBe(true);
+    expect(getResult.entries).toHaveLength(1);
 
-    expect(mockFs.writeFileSync).toHaveBeenCalled();
-    const calls = mockFs.writeFileSync.mock.calls;
-    const [, data] = calls[calls.length - 1];
-    const parsed = JSON.parse(data);
-    expect(parsed.version).toBe(1);
-    expect(parsed.entries).toHaveLength(1);
+    const clearResult = await ipcMain.invoke('swarm:clear-publish-history');
+    expect(clearResult.success).toBe(true);
+    expect(mod.getEntries()).toHaveLength(0);
   });
 });

--- a/src/main/swarm/publish-service.js
+++ b/src/main/swarm/publish-service.js
@@ -15,16 +15,21 @@ const { getBee, selectBestBatch, toHex } = require('./swarm-service');
 const { addEntry, updateEntry } = require('./publish-history');
 const log = require('electron-log');
 
+// Sentinel for user-initiated publishes (text/file/directory triggered from
+// the freedom://publish UI). dApp-driven publishes pass their actual origin.
+const USER_ORIGIN = 'freedom://publish';
+
 /**
  * Normalize an UploadResult to a Freedom publish result.
  */
-function normalizeUploadResult(result, batchIdUsed) {
+function normalizeUploadResult(result, batchIdUsed, bytesSize) {
   const reference = toHex(result.reference);
   return {
     reference,
     bzzUrl: reference ? `bzz://${reference}` : null,
     tagUid: result.tagUid || null,
     batchIdUsed: batchIdUsed || null,
+    bytesSize: bytesSize ?? null,
   };
 }
 
@@ -74,7 +79,7 @@ async function publishData(data, options = {}) {
     ...options.uploadOptions,
   });
 
-  return normalizeUploadResult(result, batchId);
+  return normalizeUploadResult(result, batchId, sizeEstimate);
 }
 
 /**
@@ -101,7 +106,7 @@ async function publishFile(filePath, options = {}) {
     ...options.uploadOptions,
   });
 
-  return normalizeUploadResult(result, batchId);
+  return normalizeUploadResult(result, batchId, stat.size);
 }
 
 /**
@@ -131,7 +136,7 @@ async function publishDirectory(dirPath, options = {}) {
     ...options.uploadOptions,
   });
 
-  return normalizeUploadResult(result, batchId);
+  return normalizeUploadResult(result, batchId, totalSize);
 }
 
 /**
@@ -228,14 +233,19 @@ function registerPublishIpc() {
     if (!data && data !== '') {
       return { success: false, error: 'Data is required' };
     }
-    const historyEntry = addEntry({ type: 'data', name: 'Text', status: 'uploading' });
+    const historyEntry = addEntry({
+      type: 'data',
+      name: 'Text',
+      status: 'uploading',
+      origin: USER_ORIGIN,
+    });
     try {
       const result = await publishData(data);
       updateEntry(historyEntry.id, { status: 'completed', ...result });
       return { success: true, ...result };
     } catch (err) {
       log.error('[PublishService] Failed to publish data:', err.message);
-      updateEntry(historyEntry.id, { status: 'failed' });
+      updateEntry(historyEntry.id, { status: 'failed', errorMessage: err.message });
       return { success: false, error: err.message };
     }
   });
@@ -248,14 +258,19 @@ function registerPublishIpc() {
       return { success: false, error: `File not found: ${filePath}` };
     }
     const name = path.basename(filePath);
-    const historyEntry = addEntry({ type: 'file', name, status: 'uploading' });
+    const historyEntry = addEntry({
+      type: 'file',
+      name,
+      status: 'uploading',
+      origin: USER_ORIGIN,
+    });
     try {
       const result = await publishFile(filePath);
       updateEntry(historyEntry.id, { status: 'completed', ...result });
       return { success: true, ...result };
     } catch (err) {
       log.error('[PublishService] Failed to publish file:', err.message);
-      updateEntry(historyEntry.id, { status: 'failed' });
+      updateEntry(historyEntry.id, { status: 'failed', errorMessage: err.message });
       return { success: false, error: err.message };
     }
   });
@@ -268,14 +283,19 @@ function registerPublishIpc() {
       return { success: false, error: `Directory not found: ${dirPath}` };
     }
     const name = path.basename(dirPath);
-    const historyEntry = addEntry({ type: 'directory', name, status: 'uploading' });
+    const historyEntry = addEntry({
+      type: 'directory',
+      name,
+      status: 'uploading',
+      origin: USER_ORIGIN,
+    });
     try {
       const result = await publishDirectory(dirPath);
       updateEntry(historyEntry.id, { status: 'completed', ...result });
       return { success: true, ...result };
     } catch (err) {
       log.error('[PublishService] Failed to publish directory:', err.message);
-      updateEntry(historyEntry.id, { status: 'failed' });
+      updateEntry(historyEntry.id, { status: 'failed', errorMessage: err.message });
       return { success: false, error: err.message };
     }
   });
@@ -339,4 +359,5 @@ module.exports = {
   publishFilesFromContent,
   getUploadStatus,
   registerPublishIpc,
+  USER_ORIGIN,
 };

--- a/src/main/swarm/publish-service.js
+++ b/src/main/swarm/publish-service.js
@@ -242,7 +242,7 @@ function registerPublishIpc() {
     try {
       const result = await publishData(data);
       updateEntry(historyEntry.id, { status: 'completed', ...result });
-      return { success: true, ...result };
+      return { success: true, reference: result.reference, bzzUrl: result.bzzUrl, tagUid: result.tagUid };
     } catch (err) {
       log.error('[PublishService] Failed to publish data:', err.message);
       updateEntry(historyEntry.id, { status: 'failed', errorMessage: err.message });
@@ -267,7 +267,7 @@ function registerPublishIpc() {
     try {
       const result = await publishFile(filePath);
       updateEntry(historyEntry.id, { status: 'completed', ...result });
-      return { success: true, ...result };
+      return { success: true, reference: result.reference, bzzUrl: result.bzzUrl, tagUid: result.tagUid };
     } catch (err) {
       log.error('[PublishService] Failed to publish file:', err.message);
       updateEntry(historyEntry.id, { status: 'failed', errorMessage: err.message });
@@ -292,7 +292,7 @@ function registerPublishIpc() {
     try {
       const result = await publishDirectory(dirPath);
       updateEntry(historyEntry.id, { status: 'completed', ...result });
-      return { success: true, ...result };
+      return { success: true, reference: result.reference, bzzUrl: result.bzzUrl, tagUid: result.tagUid };
     } catch (err) {
       log.error('[PublishService] Failed to publish directory:', err.message);
       updateEntry(historyEntry.id, { status: 'failed', errorMessage: err.message });

--- a/src/main/swarm/publish-service.test.js
+++ b/src/main/swarm/publish-service.test.js
@@ -146,7 +146,11 @@ describe('publish-service', () => {
       expect(result.success).toBe(true);
       expect(result.reference).toBe('dataref123');
       expect(result.bzzUrl).toBe('bzz://dataref123');
-      expect(result.batchIdUsed).toBe('batch1');
+      expect(result.tagUid).toBe(10);
+      // batchIdUsed and bytesSize are captured in the history row but not
+      // surfaced in the IPC reply — the renderer doesn't use them.
+      expect(result.batchIdUsed).toBeUndefined();
+      expect(result.bytesSize).toBeUndefined();
       expect(mockUploadFile).toHaveBeenCalledWith(
         'batch1',
         'hello world',

--- a/src/main/swarm/publish-service.test.js
+++ b/src/main/swarm/publish-service.test.js
@@ -53,7 +53,7 @@ jest.mock('fs/promises', () => ({
 
 const fs = require('fs');
 const fsp = require('fs/promises');
-const { normalizeUploadResult, normalizeTag, registerPublishIpc } = require('./publish-service');
+const { normalizeUploadResult, normalizeTag, registerPublishIpc, USER_ORIGIN } = require('./publish-service');
 
 registerPublishIpc();
 
@@ -81,20 +81,23 @@ describe('publish-service', () => {
     test('normalizes a bee-js UploadResult', () => {
       const result = normalizeUploadResult(
         { reference: makeRef('abc123'), tagUid: 42 },
-        'batch-hex'
+        'batch-hex',
+        1024
       );
       expect(result).toEqual({
         reference: 'abc123',
         bzzUrl: 'bzz://abc123',
         tagUid: 42,
         batchIdUsed: 'batch-hex',
+        bytesSize: 1024,
       });
     });
 
-    test('handles missing tagUid', () => {
+    test('handles missing tagUid and missing bytesSize', () => {
       const result = normalizeUploadResult({ reference: makeRef('def') }, null);
       expect(result.tagUid).toBeNull();
       expect(result.batchIdUsed).toBeNull();
+      expect(result.bytesSize).toBeNull();
     });
   });
 
@@ -161,8 +164,13 @@ describe('publish-service', () => {
 
       const result = await invokeIpc('swarm:publish-data', 'test');
       expect(result.success).toBe(false);
-      expect(addEntry).toHaveBeenCalledWith(expect.objectContaining({ status: 'uploading' }));
-      expect(updateEntry).toHaveBeenCalledWith('test-history-id', { status: 'failed' });
+      expect(addEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'uploading', origin: USER_ORIGIN })
+      );
+      expect(updateEntry).toHaveBeenCalledWith('test-history-id', {
+        status: 'failed',
+        errorMessage: 'Bee upload failed',
+      });
     });
 
     test('swarm:publish-data fails when no usable batch', async () => {

--- a/src/main/swarm/swarm-provider-ipc.js
+++ b/src/main/swarm/swarm-provider-ipc.js
@@ -239,12 +239,14 @@ async function handlePublishData(params, origin) {
     return { error: { ...ERRORS.NODE_UNAVAILABLE, message: `Node not available: ${preFlight.reason}`, data: { reason: preFlight.reason } } };
   }
 
-  // Record history entry before upload
+  // Record history entry before upload. bytesSize is populated here (not only
+  // on the success-path update) so failed rows also carry payload size.
   const historyEntry = addEntry({
     type: 'data',
     name: name || 'Published data',
     status: 'uploading',
     origin,
+    bytesSize: size,
   });
 
   try {
@@ -395,6 +397,7 @@ async function handlePublishFiles(params, origin) {
     name: indexDocument || `${normalizedFiles.length} files`,
     status: 'uploading',
     origin,
+    bytesSize: totalSize,
   });
 
   try {
@@ -634,7 +637,7 @@ async function handleUpdateFeed(params, origin) {
     const updateResult = await updateFeed(signerKey, topicString, reference);
 
     updateFeedReference(origin, feedId, reference);
-    updateEntry(historyEntry.id, { status: 'completed', reference });
+    updateEntry(historyEntry.id, { status: 'completed', ...updateResult, reference });
 
     log.info(`[SwarmProvider] updateFeed succeeded for ${origin}: feed=${feedId}, ref=${reference}, index=${updateResult.index}`);
 

--- a/src/main/swarm/swarm-provider-ipc.js
+++ b/src/main/swarm/swarm-provider-ipc.js
@@ -244,6 +244,7 @@ async function handlePublishData(params, origin) {
     type: 'data',
     name: name || 'Published data',
     status: 'uploading',
+    origin,
   });
 
   try {
@@ -257,7 +258,7 @@ async function handlePublishData(params, origin) {
 
     return { result: { reference: result.reference, bzzUrl: result.bzzUrl } };
   } catch (err) {
-    updateEntry(historyEntry.id, { status: 'failed' });
+    updateEntry(historyEntry.id, { status: 'failed', errorMessage: err.message });
     log.error(`[SwarmProvider] publishData failed for ${origin}:`, err.message);
     return { error: { ...ERRORS.INTERNAL_ERROR, message: err.message } };
   }
@@ -393,6 +394,7 @@ async function handlePublishFiles(params, origin) {
     type: 'directory',
     name: indexDocument || `${normalizedFiles.length} files`,
     status: 'uploading',
+    origin,
   });
 
   try {
@@ -407,7 +409,7 @@ async function handlePublishFiles(params, origin) {
 
     return { result: { reference: result.reference, bzzUrl: result.bzzUrl, tagUid: result.tagUid } };
   } catch (err) {
-    updateEntry(historyEntry.id, { status: 'failed' });
+    updateEntry(historyEntry.id, { status: 'failed', errorMessage: err.message });
     log.error(`[SwarmProvider] publishFiles failed for ${origin}:`, err.message);
     return { error: { ...ERRORS.INTERNAL_ERROR, message: err.message } };
   }
@@ -539,10 +541,13 @@ async function handleCreateFeed(params, origin) {
 
   const topicString = buildTopicString(origin, name);
 
+  // No bytesSize: feed-create / feed-update are metadata-only operations.
+  // Payload bytes are tracked on feed-entry writes (handleWriteFeedEntry).
   const historyEntry = addEntry({
     type: 'feed-create',
     name,
     status: 'uploading',
+    origin,
   });
 
   try {
@@ -569,7 +574,7 @@ async function handleCreateFeed(params, origin) {
       },
     };
   } catch (err) {
-    updateEntry(historyEntry.id, { status: 'failed' });
+    updateEntry(historyEntry.id, { status: 'failed', errorMessage: err.message });
     log.error(`[SwarmProvider] createFeed failed for ${origin}:`, err.message);
     return { error: { ...ERRORS.INTERNAL_ERROR, message: err.message } };
   }
@@ -622,6 +627,7 @@ async function handleUpdateFeed(params, origin) {
     type: 'feed-update',
     name: feedId,
     status: 'uploading',
+    origin,
   });
 
   try {
@@ -641,7 +647,7 @@ async function handleUpdateFeed(params, origin) {
       },
     };
   } catch (err) {
-    updateEntry(historyEntry.id, { status: 'failed' });
+    updateEntry(historyEntry.id, { status: 'failed', errorMessage: err.message });
     log.error(`[SwarmProvider] updateFeed failed for ${origin}:`, err.message);
     return { error: { ...ERRORS.INTERNAL_ERROR, message: err.message } };
   }
@@ -710,6 +716,8 @@ async function handleWriteFeedEntry(params, origin) {
     type: 'feed-entry',
     name,
     status: 'uploading',
+    origin,
+    bytesSize: Buffer.byteLength(payload),
   });
 
   try {
@@ -720,7 +728,7 @@ async function handleWriteFeedEntry(params, origin) {
 
     return { result: { index: result.index } };
   } catch (err) {
-    updateEntry(historyEntry.id, { status: 'failed' });
+    updateEntry(historyEntry.id, { status: 'failed', errorMessage: err.message });
 
     // Translate known error reasons to appropriate error codes
     if (err.reason === 'index_already_exists') {

--- a/src/main/swarm/swarm-provider-ipc.test.js
+++ b/src/main/swarm/swarm-provider-ipc.test.js
@@ -254,7 +254,12 @@ describe('swarm-provider-ipc', () => {
         contentType: 'text/plain',
         name: 'greeting',
       });
-      expect(mockAddEntry).toHaveBeenCalledWith({ type: 'data', name: 'greeting', status: 'uploading' });
+      expect(mockAddEntry).toHaveBeenCalledWith({
+        type: 'data',
+        name: 'greeting',
+        status: 'uploading',
+        origin: 'myapp.eth',
+      });
       expect(mockUpdateEntry).toHaveBeenCalledWith('test-id', expect.objectContaining({ status: 'completed' }));
     });
 
@@ -389,7 +394,10 @@ describe('swarm-provider-ipc', () => {
       }, 'myapp.eth');
 
       expect(result.error.code).toBe(-32603);
-      expect(mockUpdateEntry).toHaveBeenCalledWith('test-id', { status: 'failed' });
+      expect(mockUpdateEntry).toHaveBeenCalledWith('test-id', {
+        status: 'failed',
+        errorMessage: 'Bee upload failed',
+      });
     });
   });
 
@@ -499,7 +507,10 @@ describe('swarm-provider-ipc', () => {
         files: makeFiles(['index.html']),
       }, 'myapp.eth');
       expect(result.error.code).toBe(-32603);
-      expect(mockUpdateEntry).toHaveBeenCalledWith('test-id', { status: 'failed' });
+      expect(mockUpdateEntry).toHaveBeenCalledWith('test-id', {
+        status: 'failed',
+        errorMessage: 'Upload failed',
+      });
     });
   });
 
@@ -832,7 +843,10 @@ describe('swarm-provider-ipc', () => {
       const result = await invokeProvider('swarm_createFeed', { name: 'blog' }, 'myapp.eth');
 
       expect(result.error.code).toBe(-32603);
-      expect(mockUpdateEntry).toHaveBeenCalledWith('test-id', { status: 'failed' });
+      expect(mockUpdateEntry).toHaveBeenCalledWith('test-id', {
+        status: 'failed',
+        errorMessage: 'bee error',
+      });
     });
   });
 
@@ -937,7 +951,10 @@ describe('swarm-provider-ipc', () => {
       const result = await invokeProvider('swarm_updateFeed', { feedId: 'blog', reference: VALID_REF }, 'myapp.eth');
 
       expect(result.error.code).toBe(-32603);
-      expect(mockUpdateEntry).toHaveBeenCalledWith('test-id', { status: 'failed' });
+      expect(mockUpdateEntry).toHaveBeenCalledWith('test-id', {
+        status: 'failed',
+        errorMessage: 'network error',
+      });
     });
   });
 
@@ -1064,7 +1081,10 @@ describe('swarm-provider-ipc', () => {
       const result = await invokeProvider('swarm_writeFeedEntry', { name: 'feed', data: 'hello' }, 'myapp.eth');
 
       expect(result.error.code).toBe(-32603);
-      expect(mockUpdateEntry).toHaveBeenCalledWith('test-id', { status: 'failed' });
+      expect(mockUpdateEntry).toHaveBeenCalledWith('test-id', {
+        status: 'failed',
+        errorMessage: 'upload failed',
+      });
     });
 
     test('translates index_already_exists error', async () => {

--- a/src/main/swarm/swarm-provider-ipc.test.js
+++ b/src/main/swarm/swarm-provider-ipc.test.js
@@ -259,6 +259,7 @@ describe('swarm-provider-ipc', () => {
         name: 'greeting',
         status: 'uploading',
         origin: 'myapp.eth',
+        bytesSize: Buffer.byteLength('Hello world', 'utf-8'),
       });
       expect(mockUpdateEntry).toHaveBeenCalledWith('test-id', expect.objectContaining({ status: 'completed' }));
     });

--- a/test/helpers/fake-better-sqlite3-publishes.js
+++ b/test/helpers/fake-better-sqlite3-publishes.js
@@ -17,6 +17,7 @@ const UPDATE_SQL = `UPDATE publishes SET
   bzz_url = COALESCE(?, bzz_url),
   tag_uid = COALESCE(?, tag_uid),
   batch_id = COALESCE(?, batch_id),
+  bytes_size = COALESCE(?, bytes_size),
   completed_at = COALESCE(?, completed_at),
   error_message = COALESCE(?, error_message)
 WHERE id = ?`;
@@ -85,7 +86,7 @@ class FakeBetterSqlite3PublishesDatabase {
 
     if (normalized === NORMALIZED.update) {
       return {
-        run: (status, reference, bzzUrl, tagUid, batchId, completedAt, errorMessage, id) => {
+        run: (status, reference, bzzUrl, tagUid, batchId, bytesSize, completedAt, errorMessage, id) => {
           const row = this.rows.find((r) => r.id === id);
           if (!row) return { changes: 0 };
           if (status !== null) row.status = status;
@@ -93,6 +94,7 @@ class FakeBetterSqlite3PublishesDatabase {
           if (bzzUrl !== null) row.bzz_url = bzzUrl;
           if (tagUid !== null) row.tag_uid = tagUid;
           if (batchId !== null) row.batch_id = batchId;
+          if (bytesSize !== null) row.bytes_size = bytesSize;
           if (completedAt !== null) row.completed_at = completedAt;
           if (errorMessage !== null) row.error_message = errorMessage;
           return { changes: 1 };

--- a/test/helpers/fake-better-sqlite3-publishes.js
+++ b/test/helpers/fake-better-sqlite3-publishes.js
@@ -1,0 +1,167 @@
+// In-memory fake of better-sqlite3 sized to the publishes table only.
+// Mirrors the prepared SQL strings used by src/main/swarm/publish-history.js;
+// throws on anything else so a schema drift surfaces as a test failure.
+
+function cloneRow(row) {
+  return row ? { ...row } : row;
+}
+
+const INSERT_SQL = `INSERT INTO publishes (
+  type, name, status, reference, bzz_url, tag_uid, batch_id, origin, bytes_size,
+  started_at, completed_at, error_message
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
+const UPDATE_SQL = `UPDATE publishes SET
+  status = COALESCE(?, status),
+  reference = COALESCE(?, reference),
+  bzz_url = COALESCE(?, bzz_url),
+  tag_uid = COALESCE(?, tag_uid),
+  batch_id = COALESCE(?, batch_id),
+  completed_at = COALESCE(?, completed_at),
+  error_message = COALESCE(?, error_message)
+WHERE id = ?`;
+
+const SWEEP_SQL = `UPDATE publishes SET status = ?, error_message = ?, completed_at = ? WHERE status = ?`;
+
+const GET_ALL_SQL = `SELECT * FROM publishes ORDER BY started_at DESC`;
+const GET_BY_ID_SQL = `SELECT * FROM publishes WHERE id = ?`;
+const DELETE_BY_ID_SQL = `DELETE FROM publishes WHERE id = ?`;
+const CLEAR_SQL = `DELETE FROM publishes`;
+
+const norm = (sql) => sql.replace(/\s+/g, ' ').trim();
+
+const NORMALIZED = {
+  insert: norm(INSERT_SQL),
+  update: norm(UPDATE_SQL),
+  sweep: norm(SWEEP_SQL),
+  getAll: norm(GET_ALL_SQL),
+  getById: norm(GET_BY_ID_SQL),
+  deleteById: norm(DELETE_BY_ID_SQL),
+  clear: norm(CLEAR_SQL),
+};
+
+const COLUMNS = [
+  'type', 'name', 'status', 'reference', 'bzz_url', 'tag_uid', 'batch_id',
+  'origin', 'bytes_size', 'started_at', 'completed_at', 'error_message',
+];
+
+class FakeBetterSqlite3PublishesDatabase {
+  constructor(filePath) {
+    this.filePath = filePath;
+    this.rows = [];
+    this.nextId = 1;
+    this.userVersion = 0;
+  }
+
+  pragma(statement, options = {}) {
+    if (statement === 'journal_mode = WAL') return 'wal';
+    if (statement === 'user_version' && options.simple) return this.userVersion;
+    if (statement === 'user_version = 1') {
+      this.userVersion = 1;
+      return this.userVersion;
+    }
+    return null;
+  }
+
+  exec() {
+    // CREATE TABLE / CREATE INDEX — fake storage doesn't enforce schema.
+  }
+
+  prepare(sql) {
+    const normalized = norm(sql);
+
+    if (normalized === NORMALIZED.insert) {
+      return {
+        run: (...values) => {
+          const row = { id: this.nextId++ };
+          COLUMNS.forEach((col, i) => {
+            row[col] = values[i] ?? null;
+          });
+          this.rows.push(row);
+          return { changes: 1, lastInsertRowid: row.id };
+        },
+      };
+    }
+
+    if (normalized === NORMALIZED.update) {
+      return {
+        run: (status, reference, bzzUrl, tagUid, batchId, completedAt, errorMessage, id) => {
+          const row = this.rows.find((r) => r.id === id);
+          if (!row) return { changes: 0 };
+          if (status !== null) row.status = status;
+          if (reference !== null) row.reference = reference;
+          if (bzzUrl !== null) row.bzz_url = bzzUrl;
+          if (tagUid !== null) row.tag_uid = tagUid;
+          if (batchId !== null) row.batch_id = batchId;
+          if (completedAt !== null) row.completed_at = completedAt;
+          if (errorMessage !== null) row.error_message = errorMessage;
+          return { changes: 1 };
+        },
+      };
+    }
+
+    if (normalized === NORMALIZED.sweep) {
+      return {
+        run: (newStatus, errorMessage, completedAt, oldStatus) => {
+          let changes = 0;
+          for (const row of this.rows) {
+            if (row.status === oldStatus) {
+              row.status = newStatus;
+              row.error_message = errorMessage;
+              row.completed_at = completedAt;
+              changes++;
+            }
+          }
+          return { changes };
+        },
+      };
+    }
+
+    if (normalized === NORMALIZED.getAll) {
+      return {
+        all: () =>
+          [...this.rows]
+            .sort((a, b) => b.started_at - a.started_at)
+            .map(cloneRow),
+      };
+    }
+
+    if (normalized === NORMALIZED.getById) {
+      return {
+        get: (id) => cloneRow(this.rows.find((r) => r.id === id) || null),
+      };
+    }
+
+    if (normalized === NORMALIZED.deleteById) {
+      return {
+        run: (id) => {
+          const before = this.rows.length;
+          this.rows = this.rows.filter((r) => r.id !== id);
+          return { changes: before - this.rows.length };
+        },
+      };
+    }
+
+    if (normalized === NORMALIZED.clear) {
+      return {
+        run: () => {
+          const changes = this.rows.length;
+          this.rows = [];
+          return { changes };
+        },
+      };
+    }
+
+    throw new Error(`Unsupported SQL in fake-better-sqlite3-publishes: ${normalized}`);
+  }
+
+  // Real better-sqlite3 returns a wrapper that runs fn inside BEGIN/COMMIT.
+  // The fake has no isolation; just call the fn.
+  transaction(fn) {
+    return (...args) => fn(...args);
+  }
+
+  close() {}
+}
+
+module.exports = FakeBetterSqlite3PublishesDatabase;


### PR DESCRIPTION
# Migrate Publish History from JSON to SQLite

## Summary

The `publish-history.json` store has done its job, but it caps at 100 entries and the schema is too thin to slice publish data along useful axes. This PR replaces it with a SQLite-backed store mirroring `src/main/history.js` (the existing browsing-history store), plus three new columns — `origin`, `bytes_size`, `error_message` — populated at every call site so the data is queryable from day one.

The renderer at `freedom://publish` is unchanged. Same IPC contract, same response shape.

## Why

- more versatility what we can do with the data, since it's now fully query-able
- The 100-entry cap quietly drops older history. SQLite handles arbitrary row counts; older entries stay queryable.
- Failed publishes used to set `status='failed'` and discard the reason. Now `error_message` carries it.
- dApp-driven publishes had an `origin` parameter we threw away. Now we keep it, so a future "publishes per dApp" view is one query away.
- Single-timestamp ISO strings made it impossible to measure latency. Splitting `started_at` / `completed_at` (both ms epoch) lets us show "3.2s upload" or surface long-running in-flight rows.

## Schema

```sql
CREATE TABLE publishes (
  id            INTEGER PRIMARY KEY AUTOINCREMENT,
  type          TEXT NOT NULL,          -- 'data' | 'file' | 'directory' | 'feed-create' | 'feed-update' | 'feed-entry'
  name          TEXT,
  status        TEXT NOT NULL,          -- 'uploading' | 'completed' | 'failed'
  reference     TEXT,                   -- 64-char hex (nullable)
  bzz_url       TEXT,                   -- 'bzz://...' (nullable)
  tag_uid       INTEGER,                -- nullable
  batch_id      TEXT,                   -- 64-char hex (nullable)
  origin        TEXT,                   -- NEW: 'freedom://publish' for user-initiated, dApp origin otherwise
  bytes_size    INTEGER,                -- NEW: payload size where known
  started_at    INTEGER NOT NULL,       -- NEW: ms epoch (replaces single 'timestamp')
  completed_at  INTEGER,                -- NEW: ms epoch, NULL while uploading
  error_message TEXT                    -- NEW: populated when status='failed'
);

CREATE INDEX idx_publishes_started   ON publishes(started_at DESC);
CREATE INDEX idx_publishes_type      ON publishes(type);
CREATE INDEX idx_publishes_status    ON publishes(status);
CREATE INDEX idx_publishes_reference ON publishes(reference);
CREATE INDEX idx_publishes_origin    ON publishes(origin);
```

Indexes are forward investment for the LIMIT/filter queries the new UI will need (planned for a follow-up). Writes are user-paced so the amplification cost is irrelevant.

`type` is left without a CHECK constraint so future types (e.g. `mantaray`, `large-file`) can land without a migration.

## Migration

On first `getDb()`:

1. **JSON → SQLite**. If `publish-history.json` exists, parse it and bulk-insert all entries inside a single SQL transaction. Each legacy entry's ISO `timestamp` becomes ms epoch; `bzzUrl/tagUid/batchIdUsed` map to the new snake_case columns; `origin` and `bytes_size` stay NULL (legacy entries didn't carry them). Then rename the file to `publish-history.json.migrated` — kept on disk as a recovery breadcrumb, so a wiped SQLite DB can be re-seeded by hand if ever needed.

2. **Sweep orphan `uploading` rows**. A row with `status='uploading'` after a fresh process start is by definition a leftover from a prior session that crashed mid-publish. We don't try to recover the upload (the user would re-initiate anyway); we flip them to `status='failed'` with `error_message='interrupted by app exit'` so the UI doesn't show a perpetually-spinning row.

Both steps are idempotent — second-and-later launches see no JSON file and no `uploading` rows.

## What WP2 captures at the call sites

Eight `addEntry`/`updateEntry` pairs across two files now populate the new columns:

| File | Sites | What's now captured |
|---|---|---|
| `publish-service.js` | 3 (data / file / directory IPC handlers) | `origin: USER_ORIGIN`, `bytesSize` (threaded through `normalizeUploadResult` from the size already computed for batch selection), `errorMessage` on failure |
| `swarm-provider-ipc.js` | 5 (publishData / publishFiles / createFeed / updateFeed / writeFeedEntry) | `origin` (from caller scope, the dApp's origin), `errorMessage` on failure, plus `bytesSize: Buffer.byteLength(payload)` on writeFeedEntry — the only feed op with user payload bytes; feed-create/update are metadata-only |

`normalizeUploadResult` gains a third arg (`bytesSize`) so the existing `{...result}` spread into `updateEntry` automatically threads it through.

## Files

| Area | File | Change |
|------|------|--------|
| Main | `swarm/publish-history.js` | full rewrite: SQLite (mirrors `history.js`) + JSON migration + orphan sweep + `closeDb()` |
| Main | `swarm/publish-service.js` | `USER_ORIGIN` constant, `normalizeUploadResult(result, batchId, bytesSize)`, populate origin/errorMessage at 3 IPC handler sites |
| Main | `swarm/swarm-provider-ipc.js` | populate origin/errorMessage at 5 sites; bytesSize at writeFeedEntry |
| Main | `index.js` | `closePublishHistoryDb()` on shutdown |
| Tests | `swarm/publish-history.test.js` | full rewrite: 12 SQLite-backed tests covering CRUD + JSON migration + orphan sweep + IPC |
| Tests | `swarm/publish-service.test.js` | bytesSize / origin / errorMessage assertions |
| Tests | `swarm/swarm-provider-ipc.test.js` | origin / errorMessage assertions across 5 paths |
| Tests | `test/helpers/fake-better-sqlite3-publishes.js` | **new** — parallel fake mirroring the existing `fake-better-sqlite3.js` for the publishes table |

## Test plan

Unit tests:
- [x] `876/876` jest tests pass, `eslint` clean.
- [x] New tests: SQLite CRUD (add/update/get/remove/clear), no-cap behaviour at 250 entries, JSON-to-SQLite migration with file rename, idempotent re-open with no JSON, orphan-sweep on first open, IPC handler round-trip.
- [x] Updated tests: 5 swarm-provider failure paths assert `errorMessage`; publish-service assertions assert `origin: USER_ORIGIN` and `bytesSize` flowing through `normalizeUploadResult`.