### PR TITLE
feat(ton): add TON Sites support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ bee-bin/
 bee-data/
 ipfs-bin/
 ipfs-data/
+ton-bin/
 dev-scripts/
 helios-bin/
 radicle-bin/

--- a/package.json
+++ b/package.json
@@ -32,8 +32,13 @@
     "dist:mac:notary-status": "dotenv -- node scripts/macos-notary.js status",
     "dist:mac:notary-log": "dotenv -- node scripts/macos-notary.js log",
     "dist:mac:staple-notary": "dotenv -- node scripts/macos-notary.js staple",
-    "dist:linux:arm64:docker": "docker run --rm -v \"$PWD\":/app -v /app/node_modules -v \"${ELECTRON_CACHE:-$HOME/Library/Caches/electron}\":/root/.cache/electron -w /app -e USE_SYSTEM_FPM=true --platform linux/arm64 node:20 bash -c \"apt-get update && apt-get install -y ruby ruby-dev build-essential xz-utils && gem install fpm --no-document && npm ci && npm run radicle:download && npm run dist -- --linux --arm64\"",
-    "dist:linux:x64:docker": "docker run --rm -v \"$PWD\":/app -v /app/node_modules -v \"${ELECTRON_CACHE:-$HOME/Library/Caches/electron}\":/root/.cache/electron -w /app --platform linux/amd64 electronuserland/builder:20 bash -c \"npm ci && npm run radicle:download && npm run dist -- --linux --x64\"",
+    "dist:linux:arm64:docker": "docker run --rm -v \"$PWD\":/app -v /app/node_modules -v \"${ELECTRON_CACHE:-$HOME/Library/Caches/electron}\":/root/.cache/electron -w /app -e USE_SYSTEM_FPM=true --platform linux/arm64 node:20 bash -c \"apt-get update && apt-get install -y ruby ruby-dev build-essential xz-utils && gem install fpm --no-document && npm ci && npm run radicle:download && npm run ton:download && npm run dist -- --linux --arm64\"",
+    "dist:linux:x64:docker": "docker run --rm -v \"$PWD\":/app -v /app/node_modules -v \"${ELECTRON_CACHE:-$HOME/Library/Caches/electron}\":/root/.cache/electron -w /app --platform linux/amd64 electronuserland/builder:20 bash -c \"npm ci && npm run radicle:download && npm run ton:download && npm run dist -- --linux --x64\"",
+    "ton:download": "node scripts/fetch-tonutils-freedom.js",
+    "ton:start": "node -e \"const p=require('./scripts/fetch-tonutils-freedom');const b=p.checkBinary();if(!b.available){console.error('Binary missing. Run: npm run ton:download');process.exit(1);}require('child_process').spawnSync(b.path,['-addr','127.0.0.1:18085','-verbosity','1'],{stdio:'inherit'})\"",
+    "ton:stop": "pkill -SIGTERM tonutils-freedom-cli || echo 'TON proxy not running or failed to stop'",
+    "ton:status": "curl -s --max-time 5 -x http://127.0.0.1:18085 http://health.ton/ || echo 'TON proxy not responding'",
+    "ton:reset": "rm -rf ton-bin && echo 'TON binaries removed.'",
     "bee:download": "node scripts/fetch-bee.js",
     "bee:init": "node scripts/init-bee.js",
     "bee:start": "test -f bee-data/config.yaml || npm run bee:init; ./bee-bin/mac-arm64/bee start --config=./bee-data/config.yaml",
@@ -138,6 +143,13 @@
       {
         "from": "ipfs-bin/${os}-${arch}/",
         "to": "ipfs-bin",
+        "filter": [
+          "**/*"
+        ]
+      },
+      {
+        "from": "ton-bin/${os}-${arch}/",
+        "to": "ton-bin",
         "filter": [
           "**/*"
         ]

--- a/scripts/fetch-tonutils-freedom.js
+++ b/scripts/fetch-tonutils-freedom.js
@@ -1,0 +1,207 @@
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const crypto = require('crypto');
+
+// Pin to a specific release. Update src/shared/ton-version.js to upgrade.
+const { RELEASE_TAG } = require('../src/shared/ton-version');
+
+const OUTPUT_DIR = path.join(__dirname, '..', 'ton-bin');
+
+const BINARY_NAME = 'tonutils-freedom-cli';
+
+const TARGETS = [
+  { os: 'mac', arch: 'arm64', platform: 'darwin', goArch: 'arm64' },
+  { os: 'mac', arch: 'x64', platform: 'darwin', goArch: 'amd64' },
+  { os: 'linux', arch: 'x64', platform: 'linux', goArch: 'amd64' },
+  { os: 'linux', arch: 'arm64', platform: 'linux', goArch: 'arm64' },
+  { os: 'win', arch: 'x64', platform: 'windows', goArch: 'amd64', exe: true },
+];
+
+function buildDownloadUrl(tag, platform, goArch, isExe) {
+  const suffix = isExe ? '.exe' : '';
+  return (
+    `https://github.com/TONresistor/Tonutils-Proxy/releases/download/${tag}/` +
+    `${BINARY_NAME}-${platform}-${goArch}${suffix}`
+  );
+}
+
+function downloadFile(url, dest) {
+  console.log(`Downloading ${url} to ${dest}...`);
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
+    https
+      .get(url, { headers: { 'User-Agent': 'Freedom-Updater' } }, (response) => {
+        if (response.statusCode === 302 || response.statusCode === 301) {
+          file.close();
+          fs.unlink(dest, () => {});
+          downloadFile(response.headers.location, dest).then(resolve).catch(reject);
+          return;
+        }
+        if (response.statusCode !== 200) {
+          file.close();
+          fs.unlink(dest, () => {});
+          reject(new Error(`HTTP ${response.statusCode} downloading ${url}`));
+          return;
+        }
+        response.pipe(file);
+        file.on('finish', () => {
+          file.close(resolve);
+        });
+        file.on('error', (err) => {
+          fs.unlink(dest, () => {});
+          reject(err);
+        });
+      })
+      .on('error', (err) => {
+        fs.unlink(dest, () => {});
+        reject(err);
+      });
+  });
+}
+
+function sha256File(filePath) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha256');
+    const stream = fs.createReadStream(filePath);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('hex')));
+    stream.on('error', reject);
+  });
+}
+
+function downloadText(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, { headers: { 'User-Agent': 'Freedom-Updater' } }, (response) => {
+        if (response.statusCode === 302 || response.statusCode === 301) {
+          downloadText(response.headers.location).then(resolve).catch(reject);
+          return;
+        }
+        if (response.statusCode !== 200) {
+          reject(new Error(`HTTP ${response.statusCode} fetching ${url}`));
+          return;
+        }
+        let body = '';
+        response.setEncoding('utf8');
+        response.on('data', (chunk) => {
+          body += chunk;
+        });
+        response.on('end', () => resolve(body));
+        response.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}
+
+async function fetchChecksums(tag) {
+  const url =
+    `https://github.com/TONresistor/Tonutils-Proxy/releases/download/${tag}/checksums.txt`;
+  const text = await downloadText(url);
+  const map = new Map();
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parts = trimmed.split(/\s+/);
+    if (parts.length < 2) continue;
+    const [hash, name] = parts;
+    map.set(name, hash.toLowerCase());
+  }
+  return map;
+}
+
+function checkBinary() {
+  const platformMap = { darwin: 'mac', linux: 'linux', win32: 'win' };
+  const os = platformMap[process.platform] || process.platform;
+  const arch = process.arch;
+
+  const basePath = path.join(__dirname, '..', 'ton-bin');
+  const binName = process.platform === 'win32' ? `${BINARY_NAME}.exe` : BINARY_NAME;
+  const binPath = path.join(basePath, `${os}-${arch}`, binName);
+  const available = fs.existsSync(binPath);
+  return {
+    available,
+    path: available ? binPath : null,
+    version: null,
+  };
+}
+
+async function main() {
+  try {
+    console.log(`Fetching tonutils-freedom-cli ${RELEASE_TAG}...`);
+
+    let checksums;
+    try {
+      checksums = await fetchChecksums(RELEASE_TAG);
+      console.log(`Loaded ${checksums.size} pinned checksums from release.`);
+    } catch (err) {
+      console.error(`Cannot fetch checksums.txt: ${err.message}. Aborting.`);
+      process.exit(1);
+    }
+
+    for (const target of TARGETS) {
+      const url = buildDownloadUrl(RELEASE_TAG, target.platform, target.goArch, target.exe);
+      const targetDir = path.join(OUTPUT_DIR, `${target.os}-${target.arch}`);
+
+      if (!fs.existsSync(targetDir)) {
+        fs.mkdirSync(targetDir, { recursive: true });
+      }
+
+      const binName = target.exe ? `${BINARY_NAME}.exe` : BINARY_NAME;
+      const destFile = path.join(targetDir, binName);
+
+      try {
+        await downloadFile(url, destFile);
+
+        if (!target.exe) {
+          fs.chmodSync(destFile, '755');
+        }
+
+        const checksum = await sha256File(destFile);
+        const assetName = `${BINARY_NAME}-${target.platform}-${target.goArch}${target.exe ? '.exe' : ''}`;
+        const expected = checksums.get(assetName);
+        if (!expected) {
+          fs.unlinkSync(destFile);
+          throw new Error(`No pinned checksum for ${assetName}`);
+        }
+        if (expected !== checksum) {
+          fs.unlinkSync(destFile);
+          throw new Error(
+            `Checksum mismatch for ${assetName}: expected ${expected}, got ${checksum}`
+          );
+        }
+        console.log(
+          `Installed tonutils-freedom-cli for ${target.os}-${target.arch} (sha256: ${checksum})`
+        );
+      } catch (err) {
+        console.warn(`Could not fetch ${target.os}-${target.arch}: ${err.message}`);
+        console.warn('Binary may not yet exist for this target, skipping.');
+      }
+    }
+
+    // Copy win-x64 to win-arm64 as emulation fallback
+    const winX64Bin = path.join(OUTPUT_DIR, 'win-x64', `${BINARY_NAME}.exe`);
+    const winArm64Dir = path.join(OUTPUT_DIR, 'win-arm64');
+    const winArm64Bin = path.join(winArm64Dir, `${BINARY_NAME}.exe`);
+
+    if (fs.existsSync(winX64Bin)) {
+      if (!fs.existsSync(winArm64Dir)) {
+        fs.mkdirSync(winArm64Dir, { recursive: true });
+      }
+      fs.copyFileSync(winX64Bin, winArm64Bin);
+      console.log('Copied win-x64 binary to win-arm64 (emulation fallback)');
+    }
+
+    console.log('All downloads complete.');
+    process.exit(0);
+  } catch (err) {
+    console.error('Error:', err);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { checkBinary, RELEASE_TAG, BINARY_NAME };

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -48,6 +48,7 @@ const { registerEnsIpc } = require('./ens-resolver');
 const { registerBeeIpc, stopBee, startBee, setUseInjectedIdentity: setBeeInjectedIdentity } = require('./bee-manager');
 const { registerIpfsIpc, stopIpfs, startIpfs, setUseInjectedIdentity: setIpfsInjectedIdentity } = require('./ipfs-manager');
 const { registerRadicleIpc, stopRadicle, startRadicle, setUseInjectedIdentity: setRadicleInjectedIdentity } = require('./radicle-manager');
+const { registerTonIpc, stopTon, startTon } = require('./ton-manager');
 const { registerIdentityIpc, hasVault, isBeeIdentityInjected, isIpfsIdentityInjected, isRadicleIdentityInjected } = require('./identity-manager');
 const { registerQuickUnlockIpc } = require('./quick-unlock');
 const { registerWalletIpc } = require('./wallet/wallet-ipc');
@@ -106,6 +107,7 @@ async function bootstrap() {
   registerBeeIpc();
   registerIpfsIpc();
   registerRadicleIpc();
+  registerTonIpc();
   registerGithubBridgeIpc();
   registerServiceRegistryIpc();
   registerIdentityIpc();
@@ -172,6 +174,9 @@ async function bootstrap() {
   }
   if (settings.enableRadicleIntegration && settings.startRadicleAtLaunch) {
     startRadicle();
+  }
+  if (settings.startTonAtLaunch) {
+    startTon();
   }
 
   const mainWindow = createMainWindow();
@@ -244,8 +249,8 @@ app.on('before-quit', async (event) => {
   // Clean up any GitHub bridge temp directories
   cleanupTempDirs();
 
-  log.info('[App] Waiting for Bee, IPFS, and Radicle to stop...');
-  await Promise.all([stopBee(), stopIpfs(), stopRadicle()]);
+  log.info('[App] Waiting for Bee, IPFS, Radicle and TON to stop...');
+  await Promise.all([stopBee(), stopIpfs(), stopRadicle(), stopTon()]);
   log.info('[App] All processes stopped, quitting...');
 
 

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -7,7 +7,6 @@ const { loadSettings } = require('./settings-store');
 const { fetchBuffer, fetchToFile } = require('./http-fetch');
 const { success, failure, validateWebContentsId } = require('./ipc-contract');
 const IPC = require('../shared/ipc-channels');
-
 // Path to webview preload script (for internal pages)
 const webviewPreloadPath = path.join(__dirname, 'webview-preload.js');
 

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -227,6 +227,19 @@ contextBridge.exposeInMainWorld('radicle', {
   },
 });
 
+contextBridge.exposeInMainWorld('ton', {
+  start: () => ipcRenderer.invoke('ton:start'),
+  stop: () => ipcRenderer.invoke('ton:stop'),
+  getStatus: () => ipcRenderer.invoke('ton:getStatus'),
+  checkBinary: () => ipcRenderer.invoke('ton:checkBinary'),
+  onStatusUpdate: (callback) => {
+    const handler = (_event, value) => callback(value);
+    ipcRenderer.on('ton:statusUpdate', handler);
+    ipcRenderer.invoke('ton:getStatus').then(callback);
+    return () => ipcRenderer.removeListener('ton:statusUpdate', handler);
+  },
+});
+
 contextBridge.exposeInMainWorld('githubBridge', {
   import: (url) => ipcRenderer.invoke('github-bridge:import', url),
   checkGit: () => ipcRenderer.invoke('github-bridge:check-git'),

--- a/src/main/preload.test.js
+++ b/src/main/preload.test.js
@@ -28,6 +28,7 @@ function loadPreloadModule(options = {}) {
         [IPC.BEE_GET_STATUS]: { status: 'running', error: null },
         [IPC.IPFS_GET_STATUS]: { status: 'stopped', error: null },
         [IPC.RADICLE_GET_STATUS]: { status: 'error', error: 'offline' },
+        [IPC.TON_GET_STATUS]: { status: 'stopped', error: null },
         ...(options.invokeResponses || {}),
       },
     });
@@ -85,7 +86,7 @@ describe('preload', () => {
       ipfsGatewayEnv: 'http://127.0.0.1:9090',
     });
 
-    expect(contextBridge.exposeInMainWorld).toHaveBeenCalledTimes(18);
+    expect(contextBridge.exposeInMainWorld).toHaveBeenCalledTimes(19);
     expect(Object.keys(exposures)).toEqual([
       'nodeConfig',
       'internalPages',
@@ -93,6 +94,7 @@ describe('preload', () => {
       'bee',
       'ipfs',
       'radicle',
+      'ton',
       'githubBridge',
       'serviceRegistry',
       'identity',
@@ -153,6 +155,10 @@ describe('preload', () => {
       [exposures.radicle, 'getStatus', [], IPC.RADICLE_GET_STATUS, []],
       [exposures.radicle, 'checkBinary', [], IPC.RADICLE_CHECK_BINARY, []],
       [exposures.radicle, 'getConnections', [], IPC.RADICLE_GET_CONNECTIONS, []],
+      [exposures.ton, 'start', [], IPC.TON_START, []],
+      [exposures.ton, 'stop', [], IPC.TON_STOP, []],
+      [exposures.ton, 'getStatus', [], IPC.TON_GET_STATUS, []],
+      [exposures.ton, 'checkBinary', [], IPC.TON_CHECK_BINARY, []],
       [exposures.githubBridge, 'import', ['https://github.com/openai/project'], IPC.GITHUB_BRIDGE_IMPORT, ['https://github.com/openai/project']],
       [exposures.githubBridge, 'checkGit', [], IPC.GITHUB_BRIDGE_CHECK_GIT, []],
       [exposures.githubBridge, 'checkPrerequisites', [], IPC.GITHUB_BRIDGE_CHECK_PREREQUISITES, []],
@@ -242,10 +248,12 @@ describe('preload', () => {
       },
     });
 
+    const tonStatus = { status: 'stopped', error: null };
     const statusCases = [
       [exposures.bee, IPC.BEE_STATUS_UPDATE, IPC.BEE_GET_STATUS, beeStatus, { status: 'starting', error: null }],
       [exposures.ipfs, IPC.IPFS_STATUS_UPDATE, IPC.IPFS_GET_STATUS, ipfsStatus, { status: 'running', error: null }],
       [exposures.radicle, IPC.RADICLE_STATUS_UPDATE, IPC.RADICLE_GET_STATUS, radicleStatus, { status: 'running', error: null }],
+      [exposures.ton, IPC.TON_STATUS_UPDATE, IPC.TON_GET_STATUS, tonStatus, { status: 'running', error: null }],
     ];
 
     for (const [target, updateChannel, getStatusChannel, initialStatus, pushedStatus] of statusCases) {

--- a/src/main/service-registry.js
+++ b/src/main/service-registry.js
@@ -35,8 +35,15 @@ const registry = {
     tempMessageTimeout: null,
   },
   radicle: {
-    api: null,        // e.g., 'http://127.0.0.1:8780'
-    gateway: null,    // Same as api for radicle-httpd
+    api: null, // e.g., 'http://127.0.0.1:8780'
+    gateway: null, // Same as api for radicle-httpd
+    mode: MODE.NONE,
+    statusMessage: null,
+    tempMessage: null,
+    tempMessageTimeout: null,
+  },
+  ton: {
+    proxy: null,
     mode: MODE.NONE,
     statusMessage: null,
     tempMessage: null,
@@ -59,8 +66,12 @@ const DEFAULTS = {
     fallbackRange: 10,
   },
   radicle: {
-    httpPort: 8780,   // radicle-httpd port (avoids 8080 conflicts)
-    p2pPort: 8776,    // radicle-node P2P port
+    httpPort: 8780, // radicle-httpd port (avoids 8080 conflicts)
+    p2pPort: 8776, // radicle-node P2P port
+    fallbackRange: 10,
+  },
+  ton: {
+    proxyPort: 18085,
     fallbackRange: 10,
   },
 };
@@ -80,6 +91,7 @@ function getRegistry() {
     ipfs: { ...registry.ipfs },
     bee: { ...registry.bee },
     radicle: { ...registry.radicle },
+    ton: { ...registry.ton },
   };
 }
 
@@ -164,6 +176,14 @@ function clearErrorState(service) {
   broadcastRegistryUpdate();
 }
 
+// Initial shapes used to reset each service cleanly on clearService()
+const INITIAL_SHAPES = {
+  ipfs: { api: null, gateway: null, mode: MODE.NONE, statusMessage: null, tempMessage: null, tempMessageTimeout: null },
+  bee: { api: null, gateway: null, mode: MODE.NONE, statusMessage: null, tempMessage: null, tempMessageTimeout: null },
+  radicle: { api: null, gateway: null, mode: MODE.NONE, statusMessage: null, tempMessage: null, tempMessageTimeout: null },
+  ton: { proxy: null, mode: MODE.NONE, statusMessage: null, tempMessage: null, tempMessageTimeout: null },
+};
+
 /**
  * Clear service state (when stopped)
  */
@@ -174,14 +194,7 @@ function clearService(service) {
     clearTimeout(registry[service].tempMessageTimeout);
   }
 
-  registry[service] = {
-    api: null,
-    gateway: null,
-    mode: MODE.NONE,
-    statusMessage: null,
-    tempMessage: null,
-    tempMessageTimeout: null,
-  };
+  registry[service] = { ...INITIAL_SHAPES[service] };
 
   broadcastRegistryUpdate();
 }

--- a/src/main/settings-store.js
+++ b/src/main/settings-store.js
@@ -24,6 +24,7 @@ const DEFAULT_SETTINGS = {
   startBeeAtLaunch: true,
   startIpfsAtLaunch: true,
   startRadicleAtLaunch: false,
+  startTonAtLaunch: false,
   autoUpdate: true,
   showBookmarkBar: false,
   enableEnsCustomRpc: false,

--- a/src/main/settings-store.test.js
+++ b/src/main/settings-store.test.js
@@ -43,6 +43,7 @@ describe('settings-store', () => {
         startBeeAtLaunch: true,
         startIpfsAtLaunch: true,
         startRadicleAtLaunch: false,
+        startTonAtLaunch: false,
         autoUpdate: true,
         showBookmarkBar: false,
         sidebarOpen: false,

--- a/src/main/ton-manager.js
+++ b/src/main/ton-manager.js
@@ -1,0 +1,415 @@
+const log = require('./logger');
+const { ipcMain, app, BrowserWindow } = require('electron');
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const http = require('http');
+const net = require('net');
+const EventEmitter = require('events');
+const IPC = require('../shared/ipc-channels');
+const {
+  MODE,
+  DEFAULTS,
+  updateService,
+  setStatusMessage,
+  setErrorState,
+  clearErrorState,
+  clearService,
+} = require('./service-registry');
+const { RELEASE_TAG } = require('../shared/ton-version');
+
+const STATUS = {
+  STOPPED: 'stopped',
+  STARTING: 'starting',
+  RUNNING: 'running',
+  STOPPING: 'stopping',
+  ERROR: 'error',
+};
+
+const events = new EventEmitter();
+// Lifecycle signals only; unhandled 'error' would crash the process.
+events.on('error', () => {});
+
+let currentState = STATUS.STOPPED;
+let lastError = null;
+let tonProcess = null;
+let healthCheckInterval = null;
+let pendingStart = false;
+let forceKillTimeout = null;
+
+let currentProxyPort = DEFAULTS.ton.proxyPort;
+let currentMode = MODE.NONE;
+// Cached at module load for the hot status-payload path; refreshed on explicit checkBinary() IPC call.
+let _binaryExists = null;
+
+function getTonBinaryPath() {
+  if (app.isPackaged) {
+    const binName =
+      process.platform === 'win32' ? 'tonutils-freedom-cli.exe' : 'tonutils-freedom-cli';
+    return path.join(process.resourcesPath, 'ton-bin', binName);
+  }
+
+  const platformMap = {
+    darwin: 'mac',
+    linux: 'linux',
+    win32: 'win',
+  };
+  const platform = platformMap[process.platform] || process.platform;
+  const arch = process.arch;
+  const binName =
+    process.platform === 'win32' ? 'tonutils-freedom-cli.exe' : 'tonutils-freedom-cli';
+  return path.join(__dirname, '..', '..', 'ton-bin', `${platform}-${arch}`, binName);
+}
+
+function isPortOpen(port, host = '127.0.0.1') {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    socket.setTimeout(1000);
+
+    socket.on('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+
+    socket.on('timeout', () => {
+      socket.destroy();
+      resolve(false);
+    });
+
+    socket.on('error', () => {
+      socket.destroy();
+      resolve(false);
+    });
+
+    socket.connect(port, host);
+  });
+}
+
+async function findAvailablePort(defaultPort, maxAttempts = DEFAULTS.ton.fallbackRange) {
+  for (let i = 0; i < maxAttempts; i++) {
+    const port = defaultPort + i;
+    const open = await isPortOpen(port);
+    if (!open) {
+      return port;
+    }
+    log.info(`[TON] Port ${port} is busy, trying next...`);
+  }
+  return null;
+}
+
+function probeTonProxy(port) {
+  return new Promise((resolve) => {
+    const options = {
+      hostname: '127.0.0.1',
+      port,
+      path: '/',
+      method: 'HEAD',
+      headers: { Host: 'health.ton' },
+      timeout: 5000,
+    };
+
+    const req = http.request(options, (res) => {
+      // Any response (even 502) means the proxy is alive
+      res.resume();
+      resolve(true);
+    });
+
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve(false);
+    });
+
+    req.end();
+  });
+}
+
+function updateState(newState, error = null) {
+  currentState = newState;
+  lastError = error;
+
+  const windows = BrowserWindow.getAllWindows();
+  for (const win of windows) {
+    win.webContents.send(IPC.TON_STATUS_UPDATE, buildStatusPayload());
+  }
+}
+
+function buildStatusPayload() {
+  const running = currentState === STATUS.RUNNING;
+  return {
+    status: currentState,
+    mode: currentMode === MODE.NONE ? 'none' : currentMode,
+    proxyUrl: running ? `http://127.0.0.1:${currentProxyPort}` : null,
+    proxyPort: running ? currentProxyPort : null,
+    version: running ? RELEASE_TAG : null,
+    statusMessage: null,
+    error: lastError,
+    binaryAvailable: checkBinaryInternal(),
+  };
+}
+
+function checkBinaryInternal() {
+  if (_binaryExists === null) {
+    _binaryExists = fs.existsSync(getTonBinaryPath());
+  }
+  return _binaryExists;
+}
+
+function startHealthCheck() {
+  if (healthCheckInterval) {
+    clearInterval(healthCheckInterval);
+    healthCheckInterval = null;
+  }
+
+  healthCheckInterval = setInterval(async () => {
+    const alive = await probeTonProxy(currentProxyPort);
+
+    if (!alive && currentState === STATUS.RUNNING) {
+      updateState(STATUS.ERROR, 'Health check failed');
+      setErrorState('ton', 'Proxy unreachable. Retrying…');
+    } else if (alive && currentState === STATUS.ERROR) {
+      clearErrorState('ton');
+      updateState(STATUS.RUNNING);
+    }
+  }, 3000);
+}
+
+async function startTon() {
+  if (currentState === STATUS.RUNNING || currentState === STATUS.STARTING) {
+    log.info(`[TON] Ignoring start request, current state: ${currentState}`);
+    return;
+  }
+
+  if (currentState === STATUS.STOPPING) {
+    log.info('[TON] Currently stopping, queuing start for after stop completes');
+    pendingStart = true;
+    return;
+  }
+
+  pendingStart = false;
+  updateState(STATUS.STARTING);
+
+  const defaultPort = DEFAULTS.ton.proxyPort;
+  const portOpen = await isPortOpen(defaultPort);
+  let proxyPort = defaultPort;
+
+  if (portOpen) {
+    log.info(`[TON] Port ${defaultPort} is busy, trying next...`);
+    const fallback = await findAvailablePort(defaultPort + 1);
+    if (!fallback) {
+      updateState(STATUS.ERROR, 'No available ports for TON proxy');
+      setStatusMessage('ton', 'Proxy failed to start');
+      return;
+    }
+    proxyPort = fallback;
+  }
+
+  currentProxyPort = proxyPort;
+  currentMode = MODE.BUNDLED;
+
+  const binPath = getTonBinaryPath();
+  if (!fs.existsSync(binPath)) {
+    updateState(STATUS.ERROR, `Binary not found at ${binPath}`);
+    setStatusMessage('ton', 'Proxy failed to start');
+    return;
+  }
+
+  const args = ['-addr', `127.0.0.1:${proxyPort}`, '-verbosity', '1'];
+
+  const configPath = app.isPackaged
+    ? path.join(process.resourcesPath, 'ton-bin', 'mainnet.json')
+    : path.join(__dirname, '..', '..', 'ton-bin', 'mainnet.json');
+
+  if (fs.existsSync(configPath)) {
+    args.push('-global-config', configPath);
+  }
+
+  log.info(`[TON] Starting: ${binPath} ${args.join(' ')}`);
+
+  try {
+    tonProcess = spawn(binPath, args);
+
+    tonProcess.stdout.on('data', (data) => {
+      log.info(`[TON stdout]: ${data}`);
+    });
+
+    tonProcess.stderr.on('data', (data) => {
+      log.error(`[TON stderr]: ${data}`);
+    });
+
+    tonProcess.on('close', (code) => {
+      log.info(`[TON] Process exited with code ${code}`);
+      tonProcess = null;
+
+      if (forceKillTimeout) {
+        clearTimeout(forceKillTimeout);
+        forceKillTimeout = null;
+      }
+      if (healthCheckInterval) {
+        clearInterval(healthCheckInterval);
+        healthCheckInterval = null;
+      }
+
+      const wasRunning = currentState === STATUS.RUNNING || currentState === STATUS.STOPPING;
+
+      if (currentState !== STATUS.STOPPING) {
+        updateState(STATUS.STOPPED, code !== 0 ? `Exited with code ${code}` : null);
+      } else {
+        updateState(STATUS.STOPPED);
+      }
+
+      clearService('ton');
+      currentMode = MODE.NONE;
+
+      if (wasRunning) {
+        events.emit('stopped');
+      }
+
+      if (pendingStart) {
+        log.info('[TON] Processing queued start request');
+        pendingStart = false;
+        setTimeout(() => startTon(), 100);
+      }
+    });
+
+    tonProcess.on('error', (err) => {
+      log.error('[TON] Failed to start process:', err);
+      updateState(STATUS.ERROR, err.message);
+      setStatusMessage('ton', 'Proxy failed to start');
+      events.emit('error', err);
+    });
+
+    let attempts = 0;
+    const maxAttempts = 60;
+    const usingFallback = proxyPort !== defaultPort;
+
+    const pollInterval = setInterval(async () => {
+      if (
+        currentState === STATUS.STOPPED ||
+        currentState === STATUS.STOPPING ||
+        currentState === STATUS.ERROR
+      ) {
+        clearInterval(pollInterval);
+        return;
+      }
+
+      const alive = await probeTonProxy(currentProxyPort);
+      if (alive) {
+        clearInterval(pollInterval);
+
+        updateService('ton', {
+          proxy: `http://127.0.0.1:${currentProxyPort}`,
+          mode: MODE.BUNDLED,
+        });
+
+        if (usingFallback) {
+          setStatusMessage('ton', `Fallback Port: ${currentProxyPort}`);
+        } else {
+          setStatusMessage('ton', null);
+        }
+
+        updateState(STATUS.RUNNING);
+        startHealthCheck();
+        events.emit('started', { proxyPort: currentProxyPort });
+      } else {
+        attempts++;
+        if (attempts >= maxAttempts) {
+          clearInterval(pollInterval);
+          stopTon();
+          updateState(STATUS.ERROR, 'Startup timed out');
+          setStatusMessage('ton', 'Proxy failed to start');
+          events.emit('error', new Error('Startup timed out'));
+        }
+      }
+    }, 3000);
+  } catch (err) {
+    updateState(STATUS.ERROR, err.message);
+    setStatusMessage('ton', 'Proxy failed to start');
+    events.emit('error', err);
+  }
+}
+
+function stopTon() {
+  return new Promise((resolve) => {
+    pendingStart = false;
+
+    if (!tonProcess) {
+      if (healthCheckInterval) {
+        clearInterval(healthCheckInterval);
+        healthCheckInterval = null;
+      }
+      updateState(STATUS.STOPPED);
+      clearService('ton');
+      currentMode = MODE.NONE;
+      resolve();
+      return;
+    }
+
+    const onExit = () => {
+      if (forceKillTimeout) {
+        clearTimeout(forceKillTimeout);
+        forceKillTimeout = null;
+      }
+      resolve();
+    };
+
+    tonProcess.once('close', onExit);
+
+    updateState(STATUS.STOPPING);
+
+    if (healthCheckInterval) {
+      clearInterval(healthCheckInterval);
+      healthCheckInterval = null;
+    }
+
+    tonProcess.kill('SIGTERM');
+
+    if (forceKillTimeout) clearTimeout(forceKillTimeout);
+    forceKillTimeout = setTimeout(() => {
+      if (tonProcess) {
+        log.warn('[TON] Force killing process...');
+        tonProcess.kill('SIGKILL');
+      }
+      forceKillTimeout = null;
+    }, 5000);
+  });
+}
+
+function checkBinary() {
+  const binPath = getTonBinaryPath();
+  _binaryExists = fs.existsSync(binPath);
+  return {
+    available: _binaryExists,
+    path: _binaryExists ? binPath : null,
+    version: null,
+  };
+}
+
+function registerTonIpc() {
+  ipcMain.handle(IPC.TON_START, async () => {
+    await startTon();
+    return buildStatusPayload();
+  });
+
+  ipcMain.handle(IPC.TON_STOP, async () => {
+    await stopTon();
+    return buildStatusPayload();
+  });
+
+  ipcMain.handle(IPC.TON_GET_STATUS, () => {
+    return buildStatusPayload();
+  });
+
+  ipcMain.handle(IPC.TON_CHECK_BINARY, () => {
+    return checkBinary();
+  });
+}
+
+module.exports = {
+  registerTonIpc,
+  startTon,
+  stopTon,
+  checkBinary,
+  STATUS,
+  events,
+};

--- a/src/main/ton-manager.test.js
+++ b/src/main/ton-manager.test.js
@@ -1,0 +1,601 @@
+const path = require('path');
+const IPC = require('../shared/ipc-channels');
+const {
+  createAppMock,
+  createIpcMainMock,
+  loadMainModule,
+} = require('../../test/helpers/main-process-test-utils');
+
+const PROJECT_ROOT = path.join(__dirname, '..', '..');
+
+function flushMicrotasks() {
+  return Promise.resolve().then(() => Promise.resolve());
+}
+
+function createProcessMock(binary, options = {}) {
+  const listeners = new Map();
+  const onceListeners = new Map();
+  const stdoutListeners = new Map();
+  const stderrListeners = new Map();
+
+  const emitAll = (store, event, args) => {
+    for (const handler of store.get(event) || []) {
+      handler(...args);
+    }
+  };
+
+  const proc = {
+    binary,
+    kills: [],
+    stdout: {
+      on: jest.fn((event, handler) => {
+        if (!stdoutListeners.has(event)) stdoutListeners.set(event, []);
+        stdoutListeners.get(event).push(handler);
+      }),
+    },
+    stderr: {
+      on: jest.fn((event, handler) => {
+        if (!stderrListeners.has(event)) stderrListeners.set(event, []);
+        stderrListeners.get(event).push(handler);
+      }),
+    },
+    on: jest.fn((event, handler) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      listeners.get(event).push(handler);
+    }),
+    once: jest.fn((event, handler) => {
+      if (!onceListeners.has(event)) onceListeners.set(event, []);
+      onceListeners.get(event).push(handler);
+    }),
+    emit(event, ...args) {
+      emitAll(listeners, event, args);
+      const oneTimeHandlers = onceListeners.get(event) || [];
+      onceListeners.delete(event);
+      oneTimeHandlers.forEach((h) => h(...args));
+    },
+    kill: jest.fn((signal) => {
+      proc.kills.push(signal);
+      if (options.autoCloseOnKill !== false) {
+        setTimeout(() => proc.emit('close', options.closeCode ?? 0), 0);
+      }
+      return true;
+    }),
+  };
+
+  return proc;
+}
+
+function createSocketClass(portResolver) {
+  const queue = Array.isArray(portResolver) ? [...portResolver] : null;
+
+  return class MockSocket {
+    constructor() {
+      this.handlers = {};
+    }
+
+    setTimeout() {}
+
+    on(event, handler) {
+      this.handlers[event] = handler;
+    }
+
+    destroy() {}
+
+    connect(port) {
+      const result =
+        typeof portResolver === 'function'
+          ? portResolver(port)
+          : queue && queue.length > 0
+            ? queue.shift()
+            : false;
+
+      if (result === true) {
+        this.handlers.connect?.();
+        return;
+      }
+
+      if (result === 'timeout') {
+        this.handlers.timeout?.();
+        return;
+      }
+
+      this.handlers.error?.(new Error('closed'));
+    }
+  };
+}
+
+function createHttpRequestMock(responseResolver) {
+  const resolveResponse = responseResolver || (() => ({ statusCode: 200 }));
+
+  return jest.fn((options, callback) => {
+    const requestHandlers = new Map();
+    const request = {
+      on: jest.fn((event, fn) => {
+        requestHandlers.set(event, fn);
+        return request;
+      }),
+      destroy: jest.fn(),
+      end: jest.fn(),
+    };
+
+    const responseConfig = resolveResponse(options);
+
+    if (responseConfig?.error) {
+      // Defer so end() is called first
+      setTimeout(() => requestHandlers.get('error')?.(responseConfig.error), 0);
+      return request;
+    }
+
+    if (responseConfig?.timeout) {
+      setTimeout(() => requestHandlers.get('timeout')?.(), 0);
+      return request;
+    }
+
+    const response = {
+      statusCode: responseConfig?.statusCode ?? 200,
+      resume: jest.fn(),
+    };
+
+    if (typeof callback === 'function') {
+      callback(response);
+    }
+
+    return request;
+  });
+}
+
+function createWindowMock() {
+  return {
+    webContents: {
+      send: jest.fn(),
+    },
+  };
+}
+
+function loadTonManagerModule(options = {}) {
+  const ipcMain = options.ipcMain || createIpcMainMock();
+  const app = options.app || createAppMock({
+    isPackaged: options.isPackaged ?? false,
+    userDataDir: options.userDataDir || '/tmp/freedom-user-data',
+  });
+  const windows = options.windows || [];
+  const BrowserWindow = {
+    getAllWindows: jest.fn(() => windows),
+  };
+  const log = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  const updateService = jest.fn();
+  const setStatusMessage = jest.fn();
+  const setErrorState = jest.fn();
+  const clearErrorState = jest.fn();
+  const clearService = jest.fn();
+  const spawnedProcesses = [];
+  const spawn = jest.fn((binary, args = []) => {
+    const proc = (options.createProcess || createProcessMock)(binary, options.processOptions || {});
+    proc.args = args;
+    spawnedProcesses.push(proc);
+    return proc;
+  });
+
+  const platformMap = { darwin: 'mac', linux: 'linux', win32: 'win' };
+  const platform = platformMap[process.platform] || process.platform;
+  const binName =
+    process.platform === 'win32' ? 'tonutils-freedom-cli.exe' : 'tonutils-freedom-cli';
+  const tonBinPath = path.join(
+    PROJECT_ROOT,
+    'ton-bin',
+    `${platform}-${process.arch}`,
+    binName
+  );
+
+  const fsMock = {
+    existsSync: jest.fn((target) => {
+      if (typeof options.existsSync === 'function') return options.existsSync(target);
+      if (target === tonBinPath) return options.binExists !== false;
+      return false;
+    }),
+    mkdirSync: jest.fn(),
+    readFileSync: jest.fn(() => ''),
+    writeFileSync: jest.fn(),
+    createReadStream: jest.fn(),
+  };
+
+  const httpRequest = options.httpRequest || createHttpRequestMock(options.httpResponse);
+  const Socket = createSocketClass(options.portSequence || options.portResolver || false);
+
+  const { mod } = loadMainModule(require.resolve('./ton-manager'), {
+    app,
+    ipcMain,
+    BrowserWindow,
+    extraMocks: {
+      child_process: () => ({ spawn }),
+      fs: () => fsMock,
+      http: () => ({ request: httpRequest }),
+      net: () => ({ Socket }),
+      [require.resolve('./logger')]: () => log,
+      [require.resolve('../../scripts/fetch-tonutils-freedom')]: () => ({
+        checkBinary: jest.fn(() => ({ available: options.binExists !== false, path: null, version: null })),
+        RELEASE_TAG: 'v1.8.3',
+        BINARY_NAME: 'tonutils-freedom-cli',
+      }),
+      [require.resolve('./service-registry')]: () => ({
+        MODE: { BUNDLED: 'bundled', REUSED: 'reused', EXTERNAL: 'external', NONE: 'none' },
+        DEFAULTS: {
+          ton: { proxyPort: 18085, fallbackRange: 10 },
+        },
+        updateService,
+        setStatusMessage,
+        setErrorState,
+        clearErrorState,
+        clearService,
+      }),
+    },
+  });
+
+  return {
+    BrowserWindow,
+    clearErrorState,
+    clearService,
+    fsMock,
+    httpRequest,
+    ipcMain,
+    log,
+    mod,
+    setErrorState,
+    setStatusMessage,
+    spawn,
+    spawnedProcesses,
+    tonBinPath,
+    updateService,
+    windows,
+  };
+}
+
+describe('ton-manager', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('registers IPC handlers and reports binary availability plus initial status', async () => {
+    const ctx = loadTonManagerModule({ binExists: false });
+    ctx.mod.registerTonIpc();
+
+    expect([...ctx.ipcMain.handlers.keys()].sort()).toEqual(
+      [IPC.TON_START, IPC.TON_STOP, IPC.TON_GET_STATUS, IPC.TON_CHECK_BINARY].sort()
+    );
+
+    const status = await ctx.ipcMain.invoke(IPC.TON_GET_STATUS);
+    expect(status.status).toBe('stopped');
+    expect(status.error).toBeNull();
+
+    const binary = await ctx.ipcMain.invoke(IPC.TON_CHECK_BINARY);
+    expect(binary.available).toBe(false);
+  });
+
+  test('fails startup when binary is missing', async () => {
+    const ctx = loadTonManagerModule({
+      binExists: false,
+      portSequence: [false],
+    });
+
+    await ctx.mod.startTon();
+    await flushMicrotasks();
+
+    expect(ctx.spawn).not.toHaveBeenCalled();
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('ton', 'Proxy failed to start');
+  });
+
+  test('transitions STOPPED → STARTING → RUNNING on first successful health check', async () => {
+    jest.useFakeTimers();
+
+    const window = createWindowMock();
+    const ctx = loadTonManagerModule({
+      windows: [window],
+      portSequence: [false], // default port 18085 is free
+      httpResponse: () => ({ statusCode: 200 }),
+    });
+
+    const startPromise = ctx.mod.startTon();
+    await flushMicrotasks();
+
+    // Should be STARTING before health check resolves
+    expect(window.webContents.send).toHaveBeenCalledWith(
+      IPC.TON_STATUS_UPDATE,
+      expect.objectContaining({ status: 'starting' })
+    );
+
+    // Advance to first health poll (3 s)
+    await jest.advanceTimersByTimeAsync(3000);
+    await flushMicrotasks();
+    await startPromise;
+
+    expect(ctx.spawnedProcesses).toHaveLength(1);
+    expect(ctx.spawnedProcesses[0].binary).toBe(ctx.tonBinPath);
+    expect(ctx.spawnedProcesses[0].args).toContain('-addr');
+    expect(ctx.spawnedProcesses[0].args).toContain('127.0.0.1:18085');
+
+    expect(ctx.updateService).toHaveBeenCalledWith(
+      'ton',
+      expect.objectContaining({ proxy: 'http://127.0.0.1:18085', mode: 'bundled' })
+    );
+
+    expect(window.webContents.send).toHaveBeenLastCalledWith(
+      IPC.TON_STATUS_UPDATE,
+      expect.objectContaining({ status: 'running' })
+    );
+
+    // Clean up
+    const stopPromise = ctx.mod.stopTon();
+    await jest.advanceTimersByTimeAsync(0);
+    await flushMicrotasks();
+    await stopPromise;
+  });
+
+  test('walks to next port when default is busy', async () => {
+    jest.useFakeTimers();
+
+    const ctx = loadTonManagerModule({
+      portSequence: [true, false], // 18085 busy, 18086 free
+      httpResponse: () => ({ statusCode: 200 }),
+    });
+
+    await ctx.mod.startTon();
+    await flushMicrotasks();
+    await jest.advanceTimersByTimeAsync(3000);
+    await flushMicrotasks();
+
+    expect(ctx.log.info).toHaveBeenCalledWith(
+      expect.stringContaining('Port 18085 is busy, trying next...')
+    );
+    expect(ctx.spawnedProcesses[0].args).toContain('127.0.0.1:18086');
+
+    const stopPromise = ctx.mod.stopTon();
+    await jest.advanceTimersByTimeAsync(0);
+    await flushMicrotasks();
+    await stopPromise;
+  });
+
+  test('transitions RUNNING → STOPPING → STOPPED on graceful stop', async () => {
+    jest.useFakeTimers();
+
+    const window = createWindowMock();
+    const ctx = loadTonManagerModule({
+      windows: [window],
+      portSequence: [false],
+      httpResponse: () => ({ statusCode: 200 }),
+    });
+
+    await ctx.mod.startTon();
+    await flushMicrotasks();
+    await jest.advanceTimersByTimeAsync(3000);
+    await flushMicrotasks();
+
+    const stopPromise = ctx.mod.stopTon();
+    await jest.advanceTimersByTimeAsync(0);
+    await flushMicrotasks();
+    await stopPromise;
+
+    expect(ctx.spawnedProcesses[0].kills).toContain('SIGTERM');
+    expect(ctx.clearService).toHaveBeenCalledWith('ton');
+
+    const statusCalls = window.webContents.send.mock.calls.map((c) => c[1].status);
+    expect(statusCalls).toContain('stopping');
+    expect(statusCalls[statusCalls.length - 1]).toBe('stopped');
+  });
+
+  test('emits "started" event after first successful health probe', async () => {
+    jest.useFakeTimers();
+
+    const ctx = loadTonManagerModule({
+      portSequence: [false],
+      httpResponse: () => ({ statusCode: 200 }),
+    });
+
+    const startedHandler = jest.fn();
+    ctx.mod.events.on('started', startedHandler);
+
+    await ctx.mod.startTon();
+    await flushMicrotasks();
+    await jest.advanceTimersByTimeAsync(3000);
+    await flushMicrotasks();
+
+    expect(startedHandler).toHaveBeenCalledTimes(1);
+    expect(startedHandler).toHaveBeenCalledWith(expect.objectContaining({ proxyPort: 18085 }));
+
+    const stopPromise = ctx.mod.stopTon();
+    await jest.advanceTimersByTimeAsync(0);
+    await flushMicrotasks();
+    await stopPromise;
+  });
+
+  test('emits "stopped" event when process exits after running', async () => {
+    jest.useFakeTimers();
+
+    const ctx = loadTonManagerModule({
+      portSequence: [false],
+      httpResponse: () => ({ statusCode: 200 }),
+    });
+
+    const stoppedHandler = jest.fn();
+    ctx.mod.events.on('stopped', stoppedHandler);
+
+    await ctx.mod.startTon();
+    await flushMicrotasks();
+    await jest.advanceTimersByTimeAsync(3000);
+    await flushMicrotasks();
+
+    const stopPromise = ctx.mod.stopTon();
+    await jest.advanceTimersByTimeAsync(0);
+    await flushMicrotasks();
+    await stopPromise;
+
+    expect(stoppedHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test('transitions STARTING → ERROR when spawn emits error', async () => {
+    jest.useFakeTimers();
+
+    const ctx = loadTonManagerModule({
+      portSequence: [false],
+      httpResponse: () => ({ error: new Error('network down') }),
+      createProcess: (binary, opts) => {
+        const proc = createProcessMock(binary, opts);
+        // Trigger process error event asynchronously
+        proc.on = jest.fn((event, handler) => {
+          if (!proc._listeners) proc._listeners = new Map();
+          if (!proc._listeners.has(event)) proc._listeners.set(event, []);
+          proc._listeners.get(event).push(handler);
+          if (event === 'error') {
+            setTimeout(() => handler(new Error('spawn ENOENT')), 10);
+          }
+        });
+        proc.once = jest.fn((event, handler) => {
+          if (!proc._onceListeners) proc._onceListeners = new Map();
+          if (!proc._onceListeners.has(event)) proc._onceListeners.set(event, []);
+          proc._onceListeners.get(event).push(handler);
+        });
+        proc.kill = jest.fn();
+        return proc;
+      },
+    });
+
+    const errorHandler = jest.fn();
+    ctx.mod.events.on('error', errorHandler);
+
+    await ctx.mod.startTon();
+    await flushMicrotasks();
+    await jest.advanceTimersByTimeAsync(50);
+    await flushMicrotasks();
+
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('ton', 'Proxy failed to start');
+    expect(errorHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test('broadcasts TON_STATUS_UPDATE on every state transition', async () => {
+    jest.useFakeTimers();
+
+    const window = createWindowMock();
+    const ctx = loadTonManagerModule({
+      windows: [window],
+      portSequence: [false],
+      httpResponse: () => ({ statusCode: 200 }),
+    });
+
+    await ctx.mod.startTon();
+    await flushMicrotasks();
+    await jest.advanceTimersByTimeAsync(3000);
+    await flushMicrotasks();
+
+    const sentChannels = window.webContents.send.mock.calls.map((c) => c[0]);
+    const tonUpdates = sentChannels.filter((ch) => ch === IPC.TON_STATUS_UPDATE);
+    // At minimum: starting + running = 2 broadcasts
+    expect(tonUpdates.length).toBeGreaterThanOrEqual(2);
+
+    const stopPromise = ctx.mod.stopTon();
+    await jest.advanceTimersByTimeAsync(0);
+    await flushMicrotasks();
+    await stopPromise;
+  });
+
+  test('stopTon resolves immediately when already stopped', async () => {
+    const ctx = loadTonManagerModule();
+
+    await expect(ctx.mod.stopTon()).resolves.toBeUndefined();
+    expect(ctx.clearService).toHaveBeenCalledWith('ton');
+  });
+
+  test('transitions to ERROR when all fallback ports are busy', async () => {
+    // All 11 probes (default + 10 fallbacks) report the port as open
+    const ctx = loadTonManagerModule({
+      portSequence: Array(11).fill(true),
+    });
+    ctx.mod.registerTonIpc();
+
+    await ctx.mod.startTon();
+    await flushMicrotasks();
+
+    const s = await ctx.ipcMain.invoke(IPC.TON_GET_STATUS);
+    expect(s.status).toBe('error');
+    expect(s.error).toMatch(/No available ports/);
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('ton', 'Proxy failed to start');
+  });
+
+  test('transitions to ERROR when startup times out after 60 attempts', async () => {
+    jest.useFakeTimers();
+
+    const window = createWindowMock();
+    // Use a synchronous-error http mock: fires the error handler in .end() so
+    // that probeTonProxy resolves within the same fake-timer tick without
+    // relying on an inner setTimeout(0) that fake timers schedule-deferred.
+    const syncErrorHttpRequest = jest.fn((_options, _callback) => {
+      const requestHandlers = new Map();
+      const request = {
+        on: jest.fn((event, fn) => {
+          requestHandlers.set(event, fn);
+          return request;
+        }),
+        destroy: jest.fn(),
+        end: jest.fn(() => {
+          requestHandlers.get('error')?.(new Error('ECONNREFUSED'));
+        }),
+      };
+      return request;
+    });
+
+    const ctx = loadTonManagerModule({
+      windows: [window],
+      portSequence: [false],
+      httpRequest: syncErrorHttpRequest,
+    });
+    ctx.mod.registerTonIpc();
+
+    ctx.mod.startTon();
+    await flushMicrotasks();
+
+    // Advance through all 60 poll intervals; each probe fails synchronously
+    // so flushMicrotasks() is sufficient to settle each iteration.
+    for (let i = 0; i < 60; i++) {
+      await jest.advanceTimersByTimeAsync(3000);
+      await flushMicrotasks();
+    }
+
+    const s = await ctx.ipcMain.invoke(IPC.TON_GET_STATUS);
+    expect(s.status).toBe('error');
+    expect(s.error).toMatch(/Startup timed out/);
+    expect(ctx.setStatusMessage).toHaveBeenCalledWith('ton', 'Proxy failed to start');
+  });
+
+  test('escalates to SIGKILL when SIGTERM does not close process within 5 s', async () => {
+    jest.useFakeTimers();
+
+    // Process ignores SIGTERM: autoCloseOnKill=false prevents the mock from
+    // auto-emitting 'close', simulating a hung process.
+    const ctx = loadTonManagerModule({
+      portSequence: [false],
+      httpResponse: () => ({ statusCode: 200 }),
+      processOptions: { autoCloseOnKill: false },
+    });
+
+    await ctx.mod.startTon();
+    await flushMicrotasks();
+    await jest.advanceTimersByTimeAsync(3000);
+    await flushMicrotasks();
+
+    ctx.mod.stopTon();
+    await flushMicrotasks();
+
+    expect(ctx.spawnedProcesses[0].kills).toContain('SIGTERM');
+
+    // Advance 5 s to trigger the force-kill timeout
+    await jest.advanceTimersByTimeAsync(5000);
+    await flushMicrotasks();
+
+    expect(ctx.spawnedProcesses[0].kills).toContain('SIGKILL');
+  });
+});

--- a/src/main/ton-pac.js
+++ b/src/main/ton-pac.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const { TON_SUFFIXES } = require('../shared/ton-suffixes');
+
+function buildPacScript({ proxyHost, proxyPort }) {
+  if (!proxyHost || !proxyPort) {
+    throw new Error('buildPacScript: proxyHost and proxyPort are required');
+  }
+
+  const suffixChecks = TON_SUFFIXES.map((s) => `lower.endsWith("${s}")`).join(' || ');
+
+  const body = `function FindProxyForURL(url, host) {
+  var lower = host.toLowerCase();
+  if (lower === "ton" || ${suffixChecks}) {
+    return "PROXY ${proxyHost}:${proxyPort}";
+  }
+  return "DIRECT";
+}`;
+
+  return 'data:application/x-ns-proxy-autoconfig,' + encodeURIComponent(body);
+}
+
+module.exports = { buildPacScript };

--- a/src/main/ton-pac.test.js
+++ b/src/main/ton-pac.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const vm = require('vm');
+const { buildPacScript } = require('./ton-pac');
+const { isTonHost, TON_SUFFIXES } = require('../shared/ton-suffixes');
+
+function evalPac(pacDataUri, url, host) {
+  const encoded = pacDataUri.slice('data:application/x-ns-proxy-autoconfig,'.length);
+  const body = decodeURIComponent(encoded);
+  const sandbox = {};
+  vm.createContext(sandbox);
+  vm.runInContext(body, sandbox);
+  return sandbox.FindProxyForURL(url, host);
+}
+
+describe('isTonHost', () => {
+  test('.ton suffix', () => expect(isTonHost('foo.ton')).toBe(true));
+  test('.adnl suffix', () => expect(isTonHost('foo.adnl')).toBe(true));
+  test('.bag suffix', () => expect(isTonHost('foo.bag')).toBe(true));
+  test('single-label "ton"', () => expect(isTonHost('ton')).toBe(true));
+  test('clearnet host', () => expect(isTonHost('example.com')).toBe(false));
+  test('loopback', () => expect(isTonHost('127.0.0.1')).toBe(false));
+  test('case-insensitive', () => expect(isTonHost('FOO.TON')).toBe(true));
+  test('suffix-boundary: .tonic.example', () =>
+    expect(isTonHost('foo.tonic.example')).toBe(false));
+  test('falsy input', () => expect(isTonHost('')).toBe(false));
+  test('null input', () => expect(isTonHost(null)).toBe(false));
+  test('.t.me host matches', () => expect(isTonHost('foo.t.me')).toBe(true));
+  // Bare t.me is the Telegram root domain (clearnet); only subdomains are TON-proxied.
+  test('bare t.me is not a TON host', () => expect(isTonHost('t.me')).toBe(false));
+});
+
+test('TON_SUFFIXES contains the expected values', () => {
+  expect(TON_SUFFIXES).toEqual(expect.arrayContaining(['.ton', '.adnl', '.bag', '.t.me']));
+  expect(TON_SUFFIXES).toHaveLength(4);
+});
+
+describe('buildPacScript: validation', () => {
+  test('throws when proxyHost is missing', () => {
+    expect(() => buildPacScript({ proxyPort: 18085 })).toThrow();
+  });
+
+  test('throws when proxyPort is missing', () => {
+    expect(() => buildPacScript({ proxyHost: '127.0.0.1' })).toThrow();
+  });
+});
+
+describe('buildPacScript: data URI', () => {
+  const pac = buildPacScript({ proxyHost: '127.0.0.1', proxyPort: 18085 });
+
+  test('returns a data: URI', () => {
+    expect(pac).toMatch(/^data:application\/x-ns-proxy-autoconfig,/);
+  });
+
+  test('port is interpolated into the PAC body', () => {
+    const decoded = decodeURIComponent(
+      pac.slice('data:application/x-ns-proxy-autoconfig,'.length)
+    );
+    expect(decoded).toContain('127.0.0.1:18085');
+  });
+
+  test('different ports produce different PAC bodies', () => {
+    const pac2 = buildPacScript({ proxyHost: '127.0.0.1', proxyPort: 18086 });
+    expect(pac).not.toBe(pac2);
+    const decoded2 = decodeURIComponent(
+      pac2.slice('data:application/x-ns-proxy-autoconfig,'.length)
+    );
+    expect(decoded2).toContain('18086');
+  });
+});
+
+describe('buildPacScript: PAC routing', () => {
+  const pac = buildPacScript({ proxyHost: '127.0.0.1', proxyPort: 18085 });
+
+  const cases = [
+    // TON → PROXY
+    ['http://ton/', 'ton', 'PROXY 127.0.0.1:18085'],
+    ['http://foo.ton/', 'foo.ton', 'PROXY 127.0.0.1:18085'],
+    ['http://sub.foo.ton/', 'sub.foo.ton', 'PROXY 127.0.0.1:18085'],
+    ['http://foo.adnl/', 'foo.adnl', 'PROXY 127.0.0.1:18085'],
+    ['http://foo.bag/', 'foo.bag', 'PROXY 127.0.0.1:18085'],
+    ['http://FOO.TON/', 'FOO.TON', 'PROXY 127.0.0.1:18085'],
+    ['http://foo.t.me/', 'foo.t.me', 'PROXY 127.0.0.1:18085'],
+    // DIRECT
+    ['https://example.com/', 'example.com', 'DIRECT'],
+    // bzz loopback regression: request-rewriter redirects bzz:// → loopback URL,
+    // which must NOT be routed through the TON proxy
+    ['http://127.0.0.1:1633/bzz/abc', '127.0.0.1', 'DIRECT'],
+    // suffix-boundary enforcement: "tonic" is not ".ton"
+    ['http://foo.tonic.example/', 'foo.tonic.example', 'DIRECT'],
+    // ".ton" as substring of longer TLD
+    ['http://example.ton-is-nice.example/', 'example.ton-is-nice.example', 'DIRECT'],
+  ];
+
+  test.each(cases)('FindProxyForURL(%s, %s) → %s', (url, host, expected) => {
+    expect(evalPac(pac, url, host)).toBe(expected);
+  });
+});

--- a/src/main/webcontents-setup.js
+++ b/src/main/webcontents-setup.js
@@ -1,6 +1,29 @@
 const log = require('./logger');
-const { BrowserWindow, app } = require('electron');
+const { BrowserWindow, app, session } = require('electron');
 const { activeBzzBases, activeIpfsBases, activeRadBases } = require('./state');
+const tonManager = require('./ton-manager');
+const { buildPacScript } = require('./ton-pac');
+const { isTonHost } = require('../shared/ton-suffixes');
+
+function registerTonCertHandler() {
+  if (registerTonCertHandler._registered) return;
+  registerTonCertHandler._registered = true;
+  app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
+    try {
+      const { hostname } = new URL(url);
+      if (isTonHost(hostname)) {
+        event.preventDefault();
+        callback(true);
+        return;
+      }
+    } catch {
+      // fall through: non-parseable URL is not a TON host
+    }
+    // Do NOT call callback(false) here: Electron's default handler takes over
+    // when we don't preventDefault(), and calling callback(false) would
+    // incorrectly reject clearnet certs that Chromium would otherwise accept.
+  });
+}
 
 const sanitizeUrlForLog = (rawUrl) => {
   if (!rawUrl || typeof rawUrl !== 'string') return 'unknown';
@@ -32,6 +55,28 @@ const sanitizeUrlForLog = (rawUrl) => {
 };
 
 function registerWebContentsHandlers() {
+  if (!registerWebContentsHandlers._tonEventsBound) {
+    registerWebContentsHandlers._tonEventsBound = true;
+    tonManager.events.on('started', ({ proxyPort }) => {
+      session.defaultSession
+        .setProxy({
+          mode: 'pac_script',
+          pacScript: buildPacScript({ proxyHost: '127.0.0.1', proxyPort }),
+        })
+        .then(() => log.info('[TON] session proxy applied, port=' + proxyPort))
+        .catch((err) => log.error('[TON] setProxy failed', err));
+    });
+
+    tonManager.events.on('stopped', () => {
+      session.defaultSession
+        .setProxy({ mode: 'direct' })
+        .then(() => log.info('[TON] session proxy cleared'))
+        .catch((err) => log.error('[TON] setProxy(direct) failed', err));
+    });
+  }
+
+  registerTonCertHandler();
+
   app.on('web-contents-created', (_event, contents) => {
     contents.once('destroyed', () => {
       activeBzzBases.delete(contents.id);

--- a/src/main/webcontents-setup.test.js
+++ b/src/main/webcontents-setup.test.js
@@ -1,3 +1,4 @@
+const EventEmitter = require('events');
 const {
   loadMainModule,
 } = require('../../test/helpers/main-process-test-utils');
@@ -54,10 +55,24 @@ function loadWebContentsSetupModule(options = {}) {
   const BrowserWindow = options.BrowserWindow || {
     getAllWindows: jest.fn(() => options.windows || []),
   };
+
+  // Default session mock (can be overridden via options.session)
+  const session = options.session || {
+    defaultSession: {
+      setProxy: jest.fn(() => Promise.resolve()),
+    },
+  };
+
+  // Default ton-manager mock with a real EventEmitter
+  const tonEvents = options.tonEvents || new EventEmitter();
+  const tonManagerMock = { events: tonEvents };
+
   const { app, mod } = loadMainModule(require.resolve('./webcontents-setup'), {
     BrowserWindow,
+    electronOverrides: { session },
     extraMocks: {
       [require.resolve('./logger')]: () => log,
+      [require.resolve('./ton-manager')]: () => tonManagerMock,
     },
   });
   const state = require('./state');
@@ -71,6 +86,8 @@ function loadWebContentsSetupModule(options = {}) {
     BrowserWindow,
     log,
     mod,
+    session,
+    tonEvents,
     state,
   };
 }
@@ -225,6 +242,152 @@ describe('webcontents-setup', () => {
     expect(ctx.log.error).toHaveBeenCalledWith('[render-process-gone-global]', {
       id: 99,
       reason: 'oom',
+    });
+  });
+
+  describe('TON proxy toggling', () => {
+    test('applies pac_script proxy when tonManager emits started', async () => {
+      const ctx = loadWebContentsSetupModule();
+      ctx.mod.registerWebContentsHandlers();
+
+      ctx.tonEvents.emit('started', { proxyPort: 18086 });
+
+      // setProxy is async; wait for the microtask queue to flush
+      await Promise.resolve();
+
+      expect(ctx.session.defaultSession.setProxy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: 'pac_script',
+          pacScript: expect.stringContaining('18086'),
+        })
+      );
+    });
+
+    test('reverts to direct mode when tonManager emits stopped', async () => {
+      const ctx = loadWebContentsSetupModule();
+      ctx.mod.registerWebContentsHandlers();
+
+      ctx.tonEvents.emit('stopped');
+
+      await Promise.resolve();
+
+      expect(ctx.session.defaultSession.setProxy).toHaveBeenCalledWith({ mode: 'direct' });
+    });
+
+    test('PAC body in started event contains the correct port', async () => {
+      const ctx = loadWebContentsSetupModule();
+      ctx.mod.registerWebContentsHandlers();
+
+      ctx.tonEvents.emit('started', { proxyPort: 19999 });
+      await Promise.resolve();
+
+      const call = ctx.session.defaultSession.setProxy.mock.calls[0][0];
+      const decoded = decodeURIComponent(
+        call.pacScript.slice('data:application/x-ns-proxy-autoconfig,'.length)
+      );
+      expect(decoded).toContain('127.0.0.1:19999');
+    });
+  });
+
+  describe('certificate-error handler', () => {
+    test('accepts certificate errors for .ton hosts', () => {
+      const ctx = loadWebContentsSetupModule();
+      ctx.mod.registerWebContentsHandlers();
+
+      const event = { preventDefault: jest.fn() };
+      const callback = jest.fn();
+      ctx.app.emit(
+        'certificate-error',
+        event,
+        {},
+        'http://foo.ton/',
+        'ERR_CERT_AUTHORITY_INVALID',
+        {},
+        callback
+      );
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledWith(true);
+    });
+
+    test('accepts certificate errors for .adnl hosts', () => {
+      const ctx = loadWebContentsSetupModule();
+      ctx.mod.registerWebContentsHandlers();
+
+      const event = { preventDefault: jest.fn() };
+      const callback = jest.fn();
+      ctx.app.emit(
+        'certificate-error',
+        event,
+        {},
+        'http://site.adnl/',
+        'ERR_CERT_AUTHORITY_INVALID',
+        {},
+        callback
+      );
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledWith(true);
+    });
+
+    test('accepts self-signed cert for .bag host', () => {
+      const ctx = loadWebContentsSetupModule();
+      ctx.mod.registerWebContentsHandlers();
+
+      const event = { preventDefault: jest.fn() };
+      const callback = jest.fn();
+      ctx.app.emit(
+        'certificate-error',
+        event,
+        {},
+        'http://site.bag/',
+        'ERR_CERT_AUTHORITY_INVALID',
+        {},
+        callback
+      );
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledWith(true);
+    });
+
+    test('accepts self-signed cert for .t.me host', () => {
+      const ctx = loadWebContentsSetupModule();
+      ctx.mod.registerWebContentsHandlers();
+
+      const event = { preventDefault: jest.fn() };
+      const callback = jest.fn();
+      ctx.app.emit(
+        'certificate-error',
+        event,
+        {},
+        'http://foo.t.me/',
+        'ERR_CERT_AUTHORITY_INVALID',
+        {},
+        callback
+      );
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledWith(true);
+    });
+
+    test('does NOT call callback for clearnet hosts', () => {
+      const ctx = loadWebContentsSetupModule();
+      ctx.mod.registerWebContentsHandlers();
+
+      const event = { preventDefault: jest.fn() };
+      const callback = jest.fn();
+      ctx.app.emit(
+        'certificate-error',
+        event,
+        {},
+        'https://example.com/',
+        'ERR_CERT_AUTHORITY_INVALID',
+        {},
+        callback
+      );
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(callback).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -213,6 +213,16 @@
                 <path d="M12 8c0-4-3-6-7-6 0 4 2 7 7 6" />
                 <path d="M12 14c0-4 3-6 7-6 0 4-2 7-7 6" />
               </svg>
+              <svg
+                class="icon-ton"
+                viewBox="0 0 237 237"
+                fill="currentColor"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M118.204 0.000292436C183.486 0.000292436 236.408 52.9224 236.408 118.205C236.408 183.487 183.486 236.408 118.204 236.408C52.9216 236.408 0.000184007 183.487 0 118.205C0 52.9225 52.9215 0.000452012 118.204 0.000292436ZM74.1011 62.1965C57.6799 62.1965 47.268 79.912 55.5308 94.2347L109.964 188.582C113.619 194.922 122.781 194.922 126.436 188.582L180.88 94.2347C189.132 79.9343 178.72 62.1966 162.31 62.1965H74.1011ZM162.288 78.8412C166.031 78.8412 168.234 82.8121 166.45 85.9075L137.856 137.091L137.851 137.099L126.506 159.046V78.8412H162.288ZM109.872 78.8517V159.024L98.5376 137.088L98.5334 137.08L69.9294 85.9215L69.8468 85.7725C68.2134 82.6997 70.405 78.8517 74.0899 78.8517H109.872Z"
+                />
+              </svg>
             </span>
             <input
               id="address-input"
@@ -508,6 +518,31 @@
                 <span class="radicle-info-label">Node ID:</span>
                 <span id="radicle-node-id" class="node-id-truncated" title=""></span>
               </div>
+            </div>
+          </div>
+
+          <!-- TON Section -->
+          <div class="nodes-divider"></div>
+          <button id="ton-toggle-btn" class="menu-item ton-toggle" type="button">
+            <span class="ton-toggle-label">
+              TON
+              <span class="ton-toggle-switch" id="ton-toggle-switch">
+                <span class="ton-toggle-knob"></span>
+              </span>
+            </span>
+          </button>
+          <div class="ton-info">
+            <div class="ton-info-row node-status-row" id="ton-status-row">
+              <span class="ton-info-label" id="ton-status-label"></span>
+              <span id="ton-status-value"></span>
+            </div>
+            <div class="ton-info-row">
+              <span class="ton-info-label">Proxy Port:</span>
+              <span id="ton-proxy-port">--</span>
+            </div>
+            <div class="ton-info-row">
+              <span class="ton-info-label">Version:</span>
+              <span id="ton-version-text">--</span>
             </div>
           </div>
         </div>

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -7,6 +7,7 @@ import {
   updateRadicleStatusLine,
   updateRadicleToggleState,
 } from './lib/radicle-ui.js';
+import { initTonUi, updateTonStatusLine } from './lib/ton-ui.js';
 import {
   initMenus,
   setOnOpenHistory,
@@ -68,6 +69,7 @@ window.serviceRegistry?.onUpdate?.((registry) => {
   updateIpfsToggleState();
   updateRadicleStatusLine();
   updateRadicleToggleState();
+  updateTonStatusLine();
 });
 
 // Fetch initial registry state
@@ -199,6 +201,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   initBeeUi();
   initIpfsUi();
   initRadicleUi();
+  initTonUi();
   initGithubBridgeUi();
   document.getElementById('settings-btn')?.addEventListener('click', () => {
     closeMenus();

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -1,4 +1,4 @@
-import { applyEnsNamePreservation, deriveDisplayValue } from './url-utils.js';
+import { applyEnsNamePreservation, deriveDisplayValue, isTonHost } from './url-utils.js';
 import { getInternalPageName } from './page-urls.js';
 
 export const resolveProtocolIconType = ({
@@ -23,6 +23,15 @@ export const resolveProtocolIconType = ({
     protocol = 'ipns';
   } else if (normalizedValue.startsWith('rad://') && enableRadicleIntegration) {
     protocol = 'radicle';
+  } else if (normalizedValue.startsWith('ton://')) {
+    protocol = 'ton';
+  } else if (isTonHost(normalizedValue.split(/[/?#]/)[0])) {
+    protocol = 'ton';
+  } else if (normalizedValue.startsWith('http://')) {
+    try {
+      const { hostname } = new URL(normalizedValue);
+      if (isTonHost(hostname)) protocol = 'ton';
+    } catch { /* ignore */ }
   } else if (normalizedValue.startsWith('freedom://')) {
     protocol = null;
   } else if (normalizedValue.startsWith('https://') || currentPageSecure) {

--- a/src/renderer/lib/navigation-utils.test.js
+++ b/src/renderer/lib/navigation-utils.test.js
@@ -66,6 +66,21 @@ describe('navigation-utils', () => {
         })
       ).toBe('https');
     });
+
+    test('detects bare TON host input without scheme', async () => {
+      const { resolveProtocolIconType } = await loadNavigationUtils();
+
+      expect(resolveProtocolIconType({ value: 'example.ton' })).toBe('ton');
+      expect(resolveProtocolIconType({ value: 'foundation.ton/path' })).toBe('ton');
+      expect(resolveProtocolIconType({ value: 'example.ton?query=1' })).toBe('ton');
+    });
+
+    test('detects ton:// canonical scheme', async () => {
+      const { resolveProtocolIconType } = await loadNavigationUtils();
+
+      expect(resolveProtocolIconType({ value: 'ton://foundation.ton' })).toBe('ton');
+      expect(resolveProtocolIconType({ value: 'ton://example.adnl/path' })).toBe('ton');
+    });
   });
 
   describe('buildRadicleDisabledUrl', () => {

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -23,6 +23,7 @@ import {
   deriveBzzBaseFromUrl,
   deriveIpfsBaseFromUrl,
   deriveRadBaseFromUrl,
+  isTonHost,
 } from './url-utils.js';
 import {
   getActiveWebview,
@@ -423,7 +424,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null) 
       updateProtocolIcon();
       return;
     }
-    // Invalid Radicle ID — show error page
+    // Invalid Radicle ID, show error page
     const withoutScheme = value.trim().replace(/^rad:\/\//i, '').replace(/^rad:/i, '');
     pushDebug(`Invalid Radicle ID: ${withoutScheme}`);
     const errorUrl = new URL('pages/rad-browser.html', window.location.href);
@@ -437,6 +438,28 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null) 
     syncBzzBase(null);
     syncIpfsBase(null);
     return;
+  }
+
+  // Try TON (.ton / .adnl / .bag hostnames, route as plain HTTP, no TLS upgrade)
+  {
+    const stripped = value.trim().replace(/^(https?|tonsite|ton):\/\//i, '');
+    const rawHost = stripped.split('/')[0];
+    if (isTonHost(rawHost)) {
+      const path = stripped.slice(rawHost.length) || '/';
+      const tonUrl = `http://${rawHost}${path}`;
+      const displayPath = (stripped.slice(rawHost.length) || '').replace(/\/+$/, '');
+      addressInput.value = displayOverride || `ton://${rawHost}${displayPath}`;
+      pushDebug(`[AddressBar] Loading TON target: ${tonUrl}`);
+      navState.pendingTitleForUrl = tonUrl;
+      navState.pendingNavigationUrl = tonUrl;
+      navState.hasNavigatedDuringCurrentLoad = false;
+      webview.loadURL(tonUrl);
+      syncBzzBase(null);
+      syncIpfsBase(null);
+      syncRadBase(null);
+      updateProtocolIcon();
+      return;
+    }
   }
 
   // Try IPFS (ipfs://, ipns://, or raw CID)

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -171,6 +171,7 @@ const loadNavigationModule = async (options = {}) => {
     deriveBzzBaseFromUrl: jest.fn((url) => (url.includes('/bzz/') ? 'https://gateway.example/bzz/hash/' : null)),
     deriveIpfsBaseFromUrl: jest.fn(() => null),
     deriveRadBaseFromUrl: jest.fn(() => null),
+    isTonHost: jest.fn((host) => /\.(ton|adnl|bag)$/.test((host || '').toLowerCase())),
   };
   const pageUrlsMocks = {
     homeUrl,
@@ -550,5 +551,53 @@ describe('navigation', () => {
     });
 
     expect(ctx.elements.addressInput.focus).toHaveBeenCalled();
+  });
+
+  test('loadTarget dispatches .ton host to http:// proxy URL', async () => {
+    const ctx = await loadNavigationModule();
+    await ctx.mod.initNavigation();
+
+    ctx.urlUtilsMocks.isTonHost.mockImplementation(
+      (host) => /\.(ton|adnl|bag)$/.test((host || '').toLowerCase())
+    );
+
+    ctx.mod.loadTarget('foundation.ton');
+
+    expect(ctx.urlUtilsMocks.isTonHost).toHaveBeenCalledWith('foundation.ton');
+    expect(ctx.activeRef.tab.webview.loadURL).toHaveBeenCalledWith('http://foundation.ton/');
+    expect(ctx.elements.addressInput.value).toBe('ton://foundation.ton');
+  });
+
+  test('loadTarget strips tonsite:// prefix and shows ton:// in address bar', async () => {
+    const ctx = await loadNavigationModule();
+    await ctx.mod.initNavigation();
+
+    ctx.urlUtilsMocks.isTonHost.mockImplementation(
+      (host) => /\.(ton|adnl|bag)$/.test((host || '').toLowerCase())
+    );
+
+    ctx.mod.loadTarget('tonsite://foundation.ton/path');
+
+    expect(ctx.activeRef.tab.webview.loadURL).toHaveBeenCalledWith('http://foundation.ton/path');
+    expect(ctx.elements.addressInput.value).toBe('ton://foundation.ton/path');
+  });
+
+  test('navigation-commit on TON host overwrites address bar to derived canonical form', async () => {
+    const ctx = await loadNavigationModule();
+    await ctx.mod.initNavigation();
+
+    global.document.dispatchEvent = jest.fn();
+
+    ctx.urlUtilsMocks.isTonHost.mockImplementation(
+      (host) => /\.(ton|adnl|bag)$/.test((host || '').toLowerCase())
+    );
+
+    ctx.elements.addressInput.value = 'foundation.ton';
+
+    ctx.tabsMocks.webviewEventHandler('did-navigate', {
+      event: { url: 'http://foundation.ton/' },
+    });
+
+    expect(ctx.elements.addressInput.value).toBe('display:http://foundation.ton/');
   });
 });

--- a/src/renderer/lib/page-urls.js
+++ b/src/renderer/lib/page-urls.js
@@ -2,6 +2,7 @@
 //
 // Canonical source of truth: src/shared/internal-pages.json
 // Served to the renderer via sync IPC → preload → window.internalPages
+import { isTonHost } from './url-utils.js';
 
 const ROUTABLE_PAGES = window.internalPages?.routable || {};
 
@@ -27,7 +28,13 @@ export const detectProtocol = (url) => {
   if (url.startsWith('ipns://')) return 'ipns';
   if (url.startsWith('rad:')) return 'radicle';
   if (url.startsWith('https://')) return 'https';
-  if (url.startsWith('http://')) return 'http';
+  if (url.startsWith('http://')) {
+    try {
+      const { hostname } = new URL(url);
+      if (isTonHost(hostname)) return 'ton';
+    } catch { /* ignore */ }
+    return 'http';
+  }
   return 'unknown';
 };
 

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -25,6 +25,11 @@ export const state = {
       statusMessage: null,
       tempMessage: null,
     },
+    ton: {
+      mode: 'none',
+      statusMessage: null,
+      tempMessage: null,
+    },
   },
 
   // Bee/Swarm Gateway config (defaults from env or hardcoded, updated from registry)
@@ -93,6 +98,10 @@ export const state = {
 
   // Navigation state for Radicle
   currentRadBase: null,
+
+  // TON state
+  currentTonStatus: 'stopped',
+  suppressTonRunningStatus: false,
 
   // Feature flags
   enableRadicleIntegration: false,

--- a/src/renderer/lib/ton-ui.js
+++ b/src/renderer/lib/ton-ui.js
@@ -1,0 +1,167 @@
+import { state, getDisplayMessage } from './state.js';
+import { pushDebug } from './debug.js';
+
+let tonToggleBtn = null;
+let tonToggleSwitch = null;
+let tonStatusRow = null;
+let tonStatusLabel = null;
+let tonStatusValue = null;
+let tonProxyPort = null;
+let tonVersionText = null;
+
+let tonInfoPanel = null;
+let tonBinaryAvailable = true;
+let tonUiInitialized = false;
+
+const setToggleDisabled = (disabled) => {
+  if (!tonToggleBtn) return;
+
+  if (disabled) {
+    tonToggleBtn.classList.add('disabled');
+    tonToggleBtn.setAttribute('disabled', 'true');
+    tonToggleBtn.setAttribute('title', 'TON binary not found');
+  } else {
+    tonToggleBtn.classList.remove('disabled');
+    tonToggleBtn.removeAttribute('disabled');
+    tonToggleBtn.removeAttribute('title');
+  }
+};
+
+export const updateTonStatusLine = () => {
+  if (!tonStatusRow || !tonStatusLabel || !tonStatusValue) return;
+
+  const message = getDisplayMessage('ton');
+
+  if (message) {
+    const colonIndex = message.indexOf(':');
+    if (colonIndex > 0) {
+      tonStatusLabel.textContent = message.substring(0, colonIndex + 1);
+      tonStatusValue.textContent = message.substring(colonIndex + 1).trim();
+    } else {
+      tonStatusLabel.textContent = message;
+      tonStatusValue.textContent = '';
+    }
+    tonStatusRow.classList.add('visible');
+  } else {
+    tonStatusLabel.textContent = '';
+    tonStatusValue.textContent = '';
+    tonStatusRow.classList.remove('visible');
+  }
+};
+
+export const updateTonUi = (status, payload = {}) => {
+  if (state.suppressTonRunningStatus && status === 'running') {
+    return;
+  }
+  if (status === 'stopped' || status === 'error') {
+    state.suppressTonRunningStatus = false;
+  }
+
+  state.currentTonStatus = status;
+
+  updateTonStatusLine();
+
+  if (!tonToggleBtn || !tonToggleSwitch) return;
+
+  tonToggleSwitch.classList.remove('running');
+
+  switch (status) {
+    case 'running':
+    case 'starting':
+      tonToggleSwitch.classList.add('running');
+      tonInfoPanel?.classList.add('visible');
+      if (payload.proxyPort && tonProxyPort) {
+        tonProxyPort.textContent = String(payload.proxyPort);
+      }
+      if (payload.version && tonVersionText) {
+        tonVersionText.textContent = payload.version;
+      }
+      break;
+    case 'error':
+      if (payload.error) pushDebug(`TON Error: ${payload.error}`);
+      tonInfoPanel?.classList.remove('visible');
+      break;
+    case 'stopping':
+    case 'stopped':
+    default:
+      tonInfoPanel?.classList.remove('visible');
+      if (tonStatusRow) tonStatusRow.classList.remove('visible');
+      if (tonProxyPort) tonProxyPort.textContent = '--';
+      if (tonVersionText) tonVersionText.textContent = '--';
+      break;
+  }
+};
+
+export const initTonUi = () => {
+  tonToggleBtn = document.getElementById('ton-toggle-btn');
+  tonToggleSwitch = document.getElementById('ton-toggle-switch');
+  tonStatusRow = document.getElementById('ton-status-row');
+  tonStatusLabel = document.getElementById('ton-status-label');
+  tonStatusValue = document.getElementById('ton-status-value');
+  tonProxyPort = document.getElementById('ton-proxy-port');
+  tonVersionText = document.getElementById('ton-version-text');
+  tonInfoPanel = document.querySelector('.ton-info');
+
+  if (window.ton) {
+    window.ton.checkBinary().then(({ available }) => {
+      tonBinaryAvailable = available;
+      setToggleDisabled(!available);
+      if (!available) {
+        pushDebug('TON binary not found - toggle disabled');
+      }
+    });
+  }
+
+  if (!tonUiInitialized) {
+    tonUiInitialized = true;
+
+    tonToggleBtn?.addEventListener('click', () => {
+      if (!tonBinaryAvailable) return;
+
+      if (
+        state.currentTonStatus === 'running' ||
+        state.currentTonStatus === 'starting'
+      ) {
+        state.suppressTonRunningStatus = true;
+        tonToggleSwitch?.classList.remove('running');
+        pushDebug('User toggled TON Off');
+        window.ton
+          .stop()
+          .then((payload) => updateTonUi(payload.status, payload))
+          .catch((err) => {
+            console.error('Failed to toggle TON', err);
+            pushDebug(`Failed to toggle TON: ${err.message}`);
+          });
+      } else {
+        state.suppressTonRunningStatus = false;
+        tonToggleSwitch?.classList.add('running');
+        pushDebug('User toggled TON On');
+        window.ton
+          .start()
+          .then((payload) => updateTonUi(payload.status, payload))
+          .catch((err) => {
+            console.error('Failed to toggle TON', err);
+            pushDebug(`Failed to toggle TON: ${err.message}`);
+          });
+      }
+    });
+
+    if (window.ton) {
+      const handleStatus = (payload) => {
+        const status = payload?.status || 'stopped';
+        const error = payload?.error || null;
+        pushDebug(`TON Status Update: ${status}${error ? ` (${error})` : ''}`);
+        updateTonUi(status, payload || {});
+      };
+      window.ton.onStatusUpdate(handleStatus);
+
+      const refreshTonStatus = () => {
+        window.ton.getStatus().then((payload) => {
+          updateTonUi(payload.status, payload);
+        });
+      };
+      refreshTonStatus();
+      setInterval(refreshTonStatus, 5000);
+    }
+  }
+};

--- a/src/renderer/lib/ton-ui.test.js
+++ b/src/renderer/lib/ton-ui.test.js
@@ -1,0 +1,281 @@
+const { createDocument, createElement } = require('../../../test/helpers/fake-dom.js');
+
+const originalWindow = global.window;
+const originalDocument = global.document;
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const loadTonModule = async (options = {}) => {
+  jest.resetModules();
+
+  const state = {
+    currentTonStatus: options.currentTonStatus || 'stopped',
+    suppressTonRunningStatus: options.suppressTonRunningStatus ?? false,
+    registry: {
+      ton: {
+        mode: options.mode || 'none',
+        statusMessage: options.statusMessage ?? null,
+        tempMessage: options.tempMessage ?? null,
+      },
+    },
+  };
+
+  const getDisplayMessage = jest.fn(() => {
+    return state.registry.ton.tempMessage || state.registry.ton.statusMessage;
+  });
+
+  const debugMocks = {
+    pushDebug: jest.fn(),
+  };
+
+  const tonToggleBtn = createElement('button');
+  const tonToggleSwitch = createElement('div');
+  const tonStatusRow = createElement('div');
+  const tonStatusLabel = createElement('span');
+  const tonStatusValue = createElement('span');
+  const tonProxyPort = createElement('span');
+  const tonVersionText = createElement('span');
+  const tonInfoPanel = createElement('div', { classes: ['ton-info'] });
+
+  const body = createElement('body');
+  body.appendChild(tonInfoPanel);
+  const document = createDocument({
+    body,
+    elementsById: {
+      'ton-toggle-btn': tonToggleBtn,
+      'ton-toggle-switch': tonToggleSwitch,
+      'ton-status-row': tonStatusRow,
+      'ton-status-label': tonStatusLabel,
+      'ton-status-value': tonStatusValue,
+      'ton-proxy-port': tonProxyPort,
+      'ton-version-text': tonVersionText,
+    },
+  });
+
+  let statusHandler = null;
+  const tonApi =
+    options.windowTon === false
+      ? undefined
+      : {
+          checkBinary: jest
+            .fn()
+            .mockResolvedValue({ available: options.binaryAvailable ?? true }),
+          start: jest
+            .fn()
+            .mockResolvedValue(options.startResult || { status: 'running', proxyPort: 18085, version: '0.1.0', error: null }),
+          stop: jest
+            .fn()
+            .mockResolvedValue(options.stopResult || { status: 'stopped', error: null }),
+          getStatus: jest
+            .fn()
+            .mockResolvedValue(options.statusResult || { status: 'stopped', error: null }),
+          onStatusUpdate: jest.fn((handler) => {
+            statusHandler = handler;
+          }),
+        };
+
+  const setIntervalMock = jest.spyOn(global, 'setInterval').mockImplementation(() => 1);
+
+  global.window = {
+    ton: tonApi,
+  };
+  global.document = document;
+
+  jest.doMock('./state.js', () => ({
+    state,
+    getDisplayMessage,
+  }));
+  jest.doMock('./debug.js', () => debugMocks);
+
+  const mod = await import('./ton-ui.js');
+
+  return {
+    mod,
+    state,
+    getDisplayMessage,
+    debugMocks,
+    setIntervalMock,
+    tonApi,
+    getStatusHandler: () => statusHandler,
+    elements: {
+      tonToggleBtn,
+      tonToggleSwitch,
+      tonStatusRow,
+      tonStatusLabel,
+      tonStatusValue,
+      tonProxyPort,
+      tonVersionText,
+      tonInfoPanel,
+    },
+  };
+};
+
+describe('ton-ui', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    jest.restoreAllMocks();
+  });
+
+  test('toggle click fires TON start when stopped', async () => {
+    const ctx = await loadTonModule({
+      currentTonStatus: 'stopped',
+      binaryAvailable: true,
+    });
+
+    ctx.mod.initTonUi();
+    await flushMicrotasks();
+
+    ctx.elements.tonToggleBtn.dispatch('click');
+    await flushMicrotasks();
+
+    expect(ctx.tonApi.start).toHaveBeenCalled();
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('User toggled TON On');
+    expect(ctx.elements.tonToggleSwitch.classList.contains('running')).toBe(true);
+    expect(ctx.state.currentTonStatus).toBe('running');
+  });
+
+  test('toggle click fires TON stop when running', async () => {
+    const ctx = await loadTonModule({
+      currentTonStatus: 'running',
+      binaryAvailable: true,
+      statusResult: { status: 'running', error: null },
+    });
+
+    ctx.mod.initTonUi();
+    await flushMicrotasks();
+
+    ctx.elements.tonToggleBtn.dispatch('click');
+    await flushMicrotasks();
+
+    expect(ctx.tonApi.stop).toHaveBeenCalled();
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('User toggled TON Off');
+  });
+
+  test('TON_STATUS_UPDATE payload with status=running updates status label', async () => {
+    const ctx = await loadTonModule({
+      currentTonStatus: 'stopped',
+      statusMessage: 'TON: Connected',
+    });
+
+    ctx.mod.initTonUi();
+    await flushMicrotasks();
+
+    const handler = ctx.getStatusHandler();
+    handler({ status: 'running', proxyPort: 18085, version: '0.1.0', error: null });
+
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('TON Status Update: running');
+    expect(ctx.elements.tonToggleSwitch.classList.contains('running')).toBe(true);
+    expect(ctx.elements.tonProxyPort.textContent).toBe('18085');
+    expect(ctx.elements.tonVersionText.textContent).toBe('0.1.0');
+  });
+
+  test('binaryAvailable=false disables the toggle', async () => {
+    const ctx = await loadTonModule({
+      binaryAvailable: false,
+    });
+
+    ctx.mod.initTonUi();
+    await flushMicrotasks();
+
+    expect(ctx.tonApi.checkBinary).toHaveBeenCalled();
+    expect(ctx.elements.tonToggleBtn.classList.contains('disabled')).toBe(true);
+    expect(ctx.elements.tonToggleBtn.getAttribute('disabled')).toBe('true');
+    expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('TON binary not found - toggle disabled');
+
+    // Click should not fire start
+    ctx.elements.tonToggleBtn.dispatch('click');
+    expect(ctx.tonApi.start).not.toHaveBeenCalled();
+  });
+
+  test('initTonUi is idempotent: can be called twice without duplicate listeners', async () => {
+    const ctx = await loadTonModule({
+      currentTonStatus: 'stopped',
+      binaryAvailable: true,
+    });
+
+    ctx.mod.initTonUi();
+    ctx.mod.initTonUi(); // second call
+    await flushMicrotasks();
+
+    ctx.elements.tonToggleBtn.dispatch('click');
+    await flushMicrotasks();
+
+    // start should only be called once despite two initTonUi calls
+    expect(ctx.tonApi.start).toHaveBeenCalledTimes(1);
+  });
+
+  test('updateTonStatusLine parses label: value format', async () => {
+    const ctx = await loadTonModule({
+      statusMessage: 'Status: Running',
+    });
+
+    ctx.mod.initTonUi();
+    ctx.mod.updateTonStatusLine();
+
+    expect(ctx.getDisplayMessage).toHaveBeenCalledWith('ton');
+    expect(ctx.elements.tonStatusLabel.textContent).toBe('Status:');
+    expect(ctx.elements.tonStatusValue.textContent).toBe('Running');
+    expect(ctx.elements.tonStatusRow.classList.contains('visible')).toBe(true);
+  });
+
+  test('updateTonUi stopped clears port and version', async () => {
+    const ctx = await loadTonModule({
+      currentTonStatus: 'running',
+      windowTon: false,
+    });
+
+    ctx.mod.initTonUi();
+    ctx.mod.updateTonUi('stopped', {});
+
+    expect(ctx.elements.tonToggleSwitch.classList.contains('running')).toBe(false);
+    expect(ctx.elements.tonProxyPort.textContent).toBe('--');
+    expect(ctx.elements.tonVersionText.textContent).toBe('--');
+    expect(ctx.elements.tonStatusRow.classList.contains('visible')).toBe(false);
+  });
+
+  test('shows info panel when status is running', async () => {
+    const ctx = await loadTonModule({
+      currentTonStatus: 'stopped',
+    });
+
+    ctx.mod.initTonUi();
+    await flushMicrotasks();
+
+    const handler = ctx.getStatusHandler();
+    handler({ status: 'running', proxyPort: 18085, version: '0.1.0', error: null });
+
+    expect(ctx.elements.tonInfoPanel.classList.contains('visible')).toBe(true);
+  });
+
+  test('hides info panel when status is stopped', async () => {
+    const ctx = await loadTonModule({
+      currentTonStatus: 'running',
+    });
+
+    ctx.mod.initTonUi();
+    await flushMicrotasks();
+
+    const handler = ctx.getStatusHandler();
+    handler({ status: 'stopped', error: null });
+
+    expect(ctx.elements.tonInfoPanel.classList.contains('visible')).toBe(false);
+  });
+
+  test('initial status check is called and push subscription is registered', async () => {
+    const ctx = await loadTonModule({
+      currentTonStatus: 'stopped',
+    });
+
+    ctx.mod.initTonUi();
+    await flushMicrotasks();
+
+    expect(ctx.tonApi.getStatus).toHaveBeenCalled();
+    expect(ctx.tonApi.onStatusUpdate).toHaveBeenCalledWith(expect.any(Function));
+    expect(ctx.setIntervalMock).toHaveBeenCalledTimes(1);
+    expect(ctx.setIntervalMock).toHaveBeenCalledWith(expect.any(Function), 5000);
+  });
+});

--- a/src/renderer/lib/url-utils.js
+++ b/src/renderer/lib/url-utils.js
@@ -1,5 +1,18 @@
 export const ensureTrailingSlash = (value = '') => (value.endsWith('/') ? value : `${value}/`);
 
+// TON TLD suffixes recognised by the proxy
+export const TON_SUFFIXES = ['.ton', '.adnl', '.bag', '.t.me'];
+
+/**
+ * Return true when the given host (without port) belongs to a TON TLD.
+ * Matches exact dot-boundary suffixes only; no substring matches.
+ */
+export const isTonHost = (host) => {
+  if (!host || typeof host !== 'string') return false;
+  const lower = host.toLowerCase().split(':')[0]; // strip port if present
+  return TON_SUFFIXES.some((tld) => lower === tld.slice(1) || lower.endsWith(tld));
+};
+
 // Check if a string looks like a valid Swarm reference (64 or 128 hex characters)
 const isValidSwarmHash = (str) => /^[a-fA-F0-9]{64}([a-fA-F0-9]{64})?$/.test(str);
 
@@ -328,6 +341,13 @@ export const deriveDisplayValue = (
       const cleaned = remainder.replace(/\/+$/, '');
       return cleaned ? `rad://${cleaned}` : '';
     }
+  }
+
+  const tonMatch = url.match(/^https?:\/\/([^/]+)(\/.*)?$/i);
+  if (tonMatch && isTonHost(tonMatch[1])) {
+    const host = tonMatch[1];
+    const path = (tonMatch[2] || '').replace(/\/+$/, '');
+    return `ton://${host}${path}`;
   }
 
   return url;

--- a/src/renderer/lib/url-utils.test.js
+++ b/src/renderer/lib/url-utils.test.js
@@ -335,6 +335,24 @@ describe('url-utils', () => {
         deriveDisplayValue(url, BZZ_ROUTE_PREFIX, HOME_URL, IPFS_ROUTE_PREFIX, IPNS_ROUTE_PREFIX)
       ).toBe('ipns://docs.ipfs.tech/index.html');
     });
+
+    test('rewrites TON http URLs to ton:// canonical form', () => {
+      expect(deriveDisplayValue('http://foo.ton/', BZZ_ROUTE_PREFIX, HOME_URL)).toBe(
+        'ton://foo.ton'
+      );
+      expect(deriveDisplayValue('http://foundation.ton/path', BZZ_ROUTE_PREFIX, HOME_URL)).toBe(
+        'ton://foundation.ton/path'
+      );
+      expect(deriveDisplayValue('http://example.adnl/', BZZ_ROUTE_PREFIX, HOME_URL)).toBe(
+        'ton://example.adnl'
+      );
+      expect(deriveDisplayValue('http://file.bag/path/to', BZZ_ROUTE_PREFIX, HOME_URL)).toBe(
+        'ton://file.bag/path/to'
+      );
+      expect(deriveDisplayValue('http://telegram.t.me/', BZZ_ROUTE_PREFIX, HOME_URL)).toBe(
+        'ton://telegram.t.me'
+      );
+    });
   });
 
   // ============ IPFS Tests ============

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -547,6 +547,17 @@
                 </label>
               </div>
             </div>
+            <div class="row">
+              <div class="row-body">
+                <p class="row-label">Start TON node</p>
+              </div>
+              <div class="row-control">
+                <label class="toggle">
+                  <input type="checkbox" id="start-ton-at-launch" />
+                  <span class="slider"></span>
+                </label>
+              </div>
+            </div>
           </div>
         </section>
 
@@ -673,6 +684,7 @@
         enableRadicle: $('enable-radicle-integration'),
         startRadicleRow: $('start-radicle-row'),
         startRadicle: $('start-radicle-at-launch'),
+        startTon: $('start-ton-at-launch'),
         enableIdentity: $('enable-identity-wallet'),
         autoUpdate: $('auto-update'),
       };
@@ -741,6 +753,7 @@
         startIpfsAtLaunch: fields.startIpfs.checked,
         enableRadicleIntegration: isWindows ? false : fields.enableRadicle.checked,
         startRadicleAtLaunch: isWindows ? false : fields.startRadicle.checked,
+        startTonAtLaunch: fields.startTon.checked,
         enableIdentityWallet: fields.enableIdentity.checked,
         autoUpdate: fields.autoUpdate.checked,
         enableEnsCustomRpc: fields.enableEnsCustomRpc.checked,
@@ -754,6 +767,7 @@
         fields.startIpfs.checked = settings.startIpfsAtLaunch !== false;
         fields.enableRadicle.checked = settings.enableRadicleIntegration === true;
         fields.startRadicle.checked = settings.startRadicleAtLaunch === true;
+        fields.startTon.checked = settings.startTonAtLaunch === true;
         fields.enableIdentity.checked = settings.enableIdentityWallet === true;
         fields.autoUpdate.checked = settings.autoUpdate !== false;
         fields.enableEnsCustomRpc.checked = settings.enableEnsCustomRpc === true;
@@ -865,6 +879,7 @@
         save();
       });
       fields.startRadicle.addEventListener('change', save);
+      fields.startTon.addEventListener('change', save);
       fields.enableIdentity.addEventListener('change', save);
       fields.autoUpdate.addEventListener('change', save);
 

--- a/src/renderer/styles/services.css
+++ b/src/renderer/styles/services.css
@@ -229,21 +229,99 @@
 /* Disable hover highlight on toggle menu items */
 .bee-toggle:hover,
 .ipfs-toggle:hover,
-.radicle-toggle:hover {
+.radicle-toggle:hover,
+.ton-toggle:hover {
   background: transparent;
+}
+
+/* TON Toggle and Info */
+.ton-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+}
+
+.ton-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  width: 100%;
+  justify-content: space-between;
+}
+
+.ton-toggle-switch {
+  width: 36px;
+  height: 18px;
+  border-radius: 9px;
+  background: var(--border);
+  position: relative;
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+
+.ton-toggle-knob {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--text);
+  transition: transform 0.2s ease;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+}
+
+.ton-toggle-switch.running {
+  background: #4caf50;
+}
+
+.ton-toggle-switch.starting {
+  background: #ffcc00;
+}
+
+.ton-toggle-switch.running .ton-toggle-knob {
+  transform: translateX(18px);
+}
+
+.ton-info {
+  padding: 8px 14px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--muted);
+  opacity: 0.8;
+}
+
+.ton-info:not(.visible) {
+  display: none;
+}
+
+.ton-info-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.ton-info-label {
+  color: var(--muted);
 }
 
 /* Disabled toggle states for missing binaries */
 .bee-toggle.disabled,
 .ipfs-toggle.disabled,
-.radicle-toggle.disabled {
+.radicle-toggle.disabled,
+.ton-toggle.disabled {
   opacity: 0.4;
   pointer-events: none;
 }
 
 .bee-toggle.disabled .bee-toggle-switch,
 .ipfs-toggle.disabled .ipfs-toggle-switch,
-.radicle-toggle.disabled .radicle-toggle-switch {
+.radicle-toggle.disabled .radicle-toggle-switch,
+.ton-toggle.disabled .ton-toggle-switch {
   background: var(--border);
 }
 

--- a/src/renderer/styles/toolbar.css
+++ b/src/renderer/styles/toolbar.css
@@ -143,6 +143,11 @@
   stroke: #9b59b6;
 }
 
+.protocol-icon[data-protocol='ton'] .icon-ton {
+  display: block;
+  color: #4db8ff;
+}
+
 /* HTTP - muted */
 .protocol-icon[data-protocol='http'] .icon-http {
   display: block;

--- a/src/shared/ipc-channels.js
+++ b/src/shared/ipc-channels.js
@@ -33,6 +33,13 @@ module.exports = {
   RADICLE_GET_REPO_PAYLOAD: 'radicle:getRepoPayload',
   RADICLE_SYNC_REPO: 'radicle:syncRepo',
 
+  // TON node management
+  TON_START: 'ton:start',
+  TON_STOP: 'ton:stop',
+  TON_GET_STATUS: 'ton:getStatus',
+  TON_STATUS_UPDATE: 'ton:statusUpdate',
+  TON_CHECK_BINARY: 'ton:checkBinary',
+
   // ENS resolution
   ENS_RESOLVE: 'ens:resolve',
   ENS_TEST_RPC: 'ens:test-rpc',

--- a/src/shared/ton-suffixes.js
+++ b/src/shared/ton-suffixes.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const TON_SUFFIXES = ['.ton', '.adnl', '.bag', '.t.me'];
+
+function isTonHost(host) {
+  if (!host || typeof host !== 'string') return false;
+  const lower = host.toLowerCase().split(':')[0];
+  if (lower === 'ton') return true;
+  for (const suffix of TON_SUFFIXES) {
+    if (lower.endsWith(suffix)) return true;
+  }
+  return false;
+}
+
+module.exports = { TON_SUFFIXES, isTonHost };

--- a/src/shared/ton-version.js
+++ b/src/shared/ton-version.js
@@ -1,0 +1,3 @@
+const RELEASE_TAG = 'v0.1.0-freedom';
+
+module.exports = { RELEASE_TAG };


### PR DESCRIPTION
Adds navigation to `.ton`, `.adnl`, `.bag`, and `.t.me` hosts through a
bundled local TON proxy, with a PAC script handling the routing.
Follows the same pattern as the Bee, IPFS, and Radicle integrations.

The three commits split the feature into the daemon lifecycle (state
machine, binary fetch with SHA256 verification, IPC, `startTonAtLaunch`
setting), the PAC and cert-error wiring (scoped to TON TLDs, shared
`TON_SUFFIXES` in `src/shared/ton-suffixes.js`), and the UI (nodes
dropdown section, protocol icon, canonical `ton://host/path` address
bar rewrite).

The binary comes from
[`TONresistor/Tonutils-Proxy`](https://github.com/TONresistor/Tonutils-Proxy),
an MIT-only fork of `xssnick/tonutils-proxy` with the GPL
`adnl-tunnel` dependency removed. The address bar canonicalises TON
input forms to match the existing `bzz://` / `ipfs://` / `rad://`
behaviour. See #16 for the rationale.