### PR TITLE
Feature/wallet improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,18 @@ All notable changes to Freedom will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `ethereum:` URI scheme (EIP-681) routes to the wallet sidebar's Send screen with recipient, chain, and amount pre-filled. Lets any page offer a "Tip author" link like `<a href="ethereum:vitalik.eth@1?value=1e16">` — no wallet connection required. Native-asset sends only in this release; ERC-20 and other contract-call variants are rejected explicitly.
+
 ### Changed
 
 - Wallet send: recipient field now accepts ENS names (`.eth`, `.box`, subdomains). The name is resolved to its `addr` record on mainnet when you press Continue, and the review screen shows both the name and the resolved address so you can verify before confirming.
+- Wallet send screen now honors the chain selected on the main wallet view instead of defaulting to the first chain with a balance.
+
+### Fixed
+
+- dApp-connect wallet picker dropdown no longer shows through to the content below (had an undefined CSS variable in both themes).
 
 ## [0.6.2] - 2026-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Freedom will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Wallet send: recipient field now accepts ENS names (`.eth`, `.box`, subdomains). The name is resolved to its `addr` record on mainnet when you press Continue, and the review screen shows both the name and the resolved address so you can verify before confirming.
+
 ## [0.6.2] - 2026-03-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ All notable changes to Freedom will be documented in this file.
 ### Added
 
 - `ethereum:` URI scheme (EIP-681) routes to the wallet sidebar's Send screen with recipient, chain, and amount pre-filled. Lets any page offer a "Tip author" link like `<a href="ethereum:vitalik.eth@1?value=1e16">` — no wallet connection required. Native-asset sends only in this release; ERC-20 and other contract-call variants are rejected explicitly.
+- Wallet send review screen shows the recipient's primary ENS name alongside their address when a verified reverse record is set. The name only appears when the reverse record forward-verifies (its `addr` record points back to the same address), so a spoofed reverse can't mislead.
 
 ### Changed
 
 - Wallet send: recipient field now accepts ENS names (`.eth`, `.box`, subdomains). The name is resolved to its `addr` record on mainnet when you press Continue, and the review screen shows both the name and the resolved address so you can verify before confirming.
 - Wallet send screen now honors the chain selected on the main wallet view instead of defaulting to the first chain with a balance.
+- ENS resolution now uses the Universal Resolver in a single RPC call for both content-hash and addr lookups. Cold-cache address-bar navigation to `.eth` / `.box` names is 3–4× fewer RPC round-trips (3 → 1 for direct names, 4 → 1 for wildcard-resolved names like `.box` via 3DNS). Same behavior and cache, just faster.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "prettier": "^3.8.1"
   },
   "dependencies": {
+    "@adraffy/ens-normalize": "^1.10.1",
     "@ensdomains/content-hash": "^3.0.0",
     "@ethersphere/bee-js": "^11.1.1",
     "@metamask/browser-passworder": "^6.0.0",

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -18,7 +18,7 @@ const UR_ABI = [
 ];
 
 // bytes4(keccak256("contenthash(bytes32)"))
-const CONTENTHASH_SELECTOR = '0xbc1c4a73';
+const CONTENTHASH_SELECTOR = '0xbc1c58d1';
 // bytes4(keccak256("addr(bytes32)"))
 const ADDR_SELECTOR = '0x3b3b57de';
 
@@ -192,15 +192,18 @@ function isResolverNotFoundError(err) {
 //
 // CCIP-Read is opted into per-call here because ethers v6 doesn't enable it
 // by default — needed for .box domains resolved via 3DNS.
+// Call UR.resolve for an arbitrary resolver function. Returns the raw
+// ABI-encoded response — the caller must decode per their function's
+// return type (e.g. decode(['bytes'], ...) for contenthash, or
+// decode(['address'], ...) for addr). Returning pre-decoded bytes here
+// would silently work for dynamic returns and overflow for static ones.
 async function universalResolverCall(provider, name, callData) {
   const ur = new ethers.Contract(UNIVERSAL_RESOLVER_ADDRESS, UR_ABI, provider);
   const encodedName = ethers.dnsEncode(name, 255);
   const [resolvedData, resolverAddress] = await ur.resolve(encodedName, callData, {
     enableCcipRead: true,
   });
-  // UR returns the resolver's ABI-encoded response as `bytes`; unwrap it.
-  const [bytes] = ethers.AbiCoder.defaultAbiCoder().decode(['bytes'], resolvedData);
-  return { bytes, resolverAddress };
+  return { resolvedData, resolverAddress };
 }
 
 // Batch multiple resolver lookups on the same ENS name through the UR.
@@ -217,8 +220,9 @@ async function universalResolverMulticall(provider, name, callDatas) {
   const results = await ur.resolveMulticall(encodedName, callDatas, {
     enableCcipRead: true,
   });
-  const coder = ethers.AbiCoder.defaultAbiCoder();
-  return results.map((r) => coder.decode(['bytes'], r)[0]);
+  // Each entry is the raw ABI-encoded response of the Nth call — caller
+  // decodes per each call's return type.
+  return [...results];
 }
 
 async function resolveEnsContent(name) {
@@ -242,7 +246,6 @@ async function doResolveEnsContent(normalized) {
         name: normalized,
       });
     }
-    // CCIP-Read gateway failures, resolver reverts, etc.
     log.info(`[ens] UR resolve failed for ${normalized}: ${err.message}`);
     return cacheContentResult(normalized, {
       type: 'not_found',
@@ -252,7 +255,22 @@ async function doResolveEnsContent(normalized) {
     });
   }
 
-  if (!urResult.bytes || urResult.bytes === '0x') {
+  // contenthash() returns dynamic `bytes` — ABI-unwrap to get the raw
+  // multicodec-prefixed content-hash bytes.
+  let innerBytes;
+  try {
+    [innerBytes] = ethers.AbiCoder.defaultAbiCoder().decode(['bytes'], urResult.resolvedData);
+  } catch (err) {
+    log.warn(`[ens] Failed to decode contenthash bytes for ${normalized}: ${err.message}`);
+    return cacheContentResult(normalized, {
+      type: 'unsupported',
+      reason: 'UNSUPPORTED_CONTENTHASH_FORMAT',
+      name: normalized,
+      contentHash: urResult.resolvedData,
+    });
+  }
+
+  if (!innerBytes || innerBytes === '0x') {
     return cacheContentResult(normalized, {
       type: 'not_found',
       reason: 'EMPTY_CONTENTHASH',
@@ -260,14 +278,14 @@ async function doResolveEnsContent(normalized) {
     });
   }
 
-  const parsed = parseContentHashBytes(urResult.bytes);
+  const parsed = parseContentHashBytes(innerBytes);
   if (!parsed) {
-    log.warn(`[ens] UNSUPPORTED_CONTENTHASH_FORMAT for ${normalized}: ${urResult.bytes}`);
+    log.warn(`[ens] UNSUPPORTED_CONTENTHASH_FORMAT for ${normalized}: ${innerBytes}`);
     return cacheContentResult(normalized, {
       type: 'unsupported',
       reason: 'UNSUPPORTED_CONTENTHASH_FORMAT',
       name: normalized,
-      contentHash: urResult.bytes,
+      contentHash: innerBytes,
     });
   }
 
@@ -376,13 +394,15 @@ async function doResolveEnsAddress(normalized) {
     });
   }
 
-  if (!urResult.bytes || urResult.bytes === '0x') {
+  // addr() returns `address` — the UR's resolvedData is the raw 32-byte
+  // ABI-encoded address, NOT bytes-wrapped. Decode directly.
+  if (!urResult.resolvedData || urResult.resolvedData === '0x') {
     return cacheAddressResult(normalized, noAddressResult(normalized));
   }
 
   let address;
   try {
-    [address] = ethers.AbiCoder.defaultAbiCoder().decode(['address'], urResult.bytes);
+    [address] = ethers.AbiCoder.defaultAbiCoder().decode(['address'], urResult.resolvedData);
   } catch (err) {
     log.warn(`[ens] Failed to decode addr bytes for ${normalized}: ${err.message}`);
     return cacheAddressResult(normalized, {

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -17,6 +17,10 @@ const UR_ABI = [
 
 // bytes4(keccak256("contenthash(bytes32)"))
 const CONTENTHASH_SELECTOR = '0xbc1c4a73';
+// bytes4(keccak256("addr(bytes32)"))
+const ADDR_SELECTOR = '0x3b3b57de';
+// 32-byte zero-padded address(0) — ABI-encoded `address` result for "no addr record set".
+const ZERO_ADDR_BYTES = '0x' + '0'.repeat(64);
 
 // ENS contenthash byte patterns (EIP-1577). We preserve the CIDv0 base58
 // output ("QmFoo…") for IPFS/IPNS to stay byte-compatible with the
@@ -328,9 +332,8 @@ function cacheContentResult(normalized, result) {
 }
 
 // Resolve an ENS name's primary ETH address (the `addr` record).
-// Uses provider.resolveName() which handles resolver lookup, addr(bytes32),
-// and CCIP-Read — so .eth, subdomains, and .box names all work via the
-// same path as address-bar content resolution.
+// Single UR call (vs ethers' registry → addr 2-step flow); CCIP-Read
+// handled transparently via OffchainLookup.
 async function resolveEnsAddress(name) {
   const trimmed = (name || '').trim();
   if (!trimmed) {
@@ -341,32 +344,14 @@ async function resolveEnsAddress(name) {
 
   const cached = ensAddressCache.get(normalized);
   if (cached && Date.now() - cached.timestamp < ENS_CACHE_TTL_MS) {
-    log.info(`[ens] Address cache hit for ${normalized} -> ${cached.address}`);
-    return { success: true, name: normalized, address: cached.address };
+    log.info(`[ens] Address cache hit for ${normalized} → ${cached.result.address || cached.result.reason}`);
+    return cached.result;
   }
 
   let lastError;
   for (let attempt = 1; attempt <= MAX_RESOLUTION_RETRIES; attempt++) {
     try {
-      const provider = await getWorkingProvider();
-      log.info(
-        `[ens] Resolving address record for: ${normalized}${attempt > 1 ? ` (attempt ${attempt})` : ''}`
-      );
-
-      const address = await provider.resolveName(normalized);
-
-      if (!address) {
-        return {
-          success: false,
-          name: normalized,
-          reason: 'NO_ADDRESS',
-          error: `No address record set for ${normalized}`,
-        };
-      }
-
-      ensAddressCache.set(normalized, { address, timestamp: Date.now() });
-      log.info(`[ens] Resolved address: ${normalized} -> ${address}`);
-      return { success: true, name: normalized, address };
+      return await doResolveEnsAddress(normalized);
     } catch (err) {
       lastError = err;
       if (isProviderError(err) && attempt < MAX_RESOLUTION_RETRIES) {
@@ -381,6 +366,74 @@ async function resolveEnsAddress(name) {
   }
 
   throw lastError;
+}
+
+async function doResolveEnsAddress(normalized) {
+  const provider = await getWorkingProvider();
+  const node = ethers.namehash(normalized);
+  const callData = ADDR_SELECTOR + node.slice(2);
+
+  let urResult;
+  try {
+    urResult = await universalResolverCall(provider, normalized, callData);
+  } catch (err) {
+    if (isProviderError(err)) throw err;
+    if (isResolverNotFoundError(err)) {
+      return cacheAddressResult(normalized, {
+        success: false,
+        name: normalized,
+        reason: 'NO_ADDRESS',
+        error: `No address record set for ${normalized}`,
+      });
+    }
+    log.info(`[ens] UR addr resolve failed for ${normalized}: ${err.message}`);
+    return cacheAddressResult(normalized, {
+      success: false,
+      name: normalized,
+      reason: 'RESOLUTION_ERROR',
+      error: err.message,
+    });
+  }
+
+  // The resolver's addr(bytes32) returns address — 32 bytes of ABI-encoded
+  // address. Empty or zero → no addr record set.
+  if (!urResult.bytes || urResult.bytes === '0x' || urResult.bytes === ZERO_ADDR_BYTES) {
+    return cacheAddressResult(normalized, {
+      success: false,
+      name: normalized,
+      reason: 'NO_ADDRESS',
+      error: `No address record set for ${normalized}`,
+    });
+  }
+
+  let address;
+  try {
+    [address] = ethers.AbiCoder.defaultAbiCoder().decode(['address'], urResult.bytes);
+  } catch (err) {
+    log.warn(`[ens] Failed to decode addr bytes for ${normalized}: ${err.message}`);
+    return cacheAddressResult(normalized, {
+      success: false,
+      name: normalized,
+      reason: 'RESOLUTION_ERROR',
+      error: err.message,
+    });
+  }
+
+  return cacheAddressResult(normalized, {
+    success: true,
+    name: normalized,
+    address,
+  });
+}
+
+function cacheAddressResult(normalized, result) {
+  ensAddressCache.set(normalized, { result, timestamp: Date.now() });
+  if (result.success) {
+    log.info(`[ens] Resolved address: ${normalized} → ${result.address}`);
+  } else {
+    log.info(`[ens] ${result.reason} for ${normalized}`);
+  }
+  return result;
 }
 
 // Test an RPC URL by connecting and fetching the block number.

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -25,8 +25,9 @@ const CONTENTHASH_SELECTOR = '0xbc1c4a73';
 //   0xe3 01 70             — ipfs-ns, cidv1, dag-pb
 //   0xe5 01 72             — ipns-ns, cidv1, libp2p-key
 //   0xe4 01 01 fa 01 1b 20 — swarm-ns + manifest codec, 32-byte keccak
-const IPFS_CONTENTHASH_RE = /^0x(e3010170|e5010172)(([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]*))$/;
-const SWARM_CONTENTHASH_RE = /^0xe40101fa011b20([0-9a-f]{64})$/;
+const IPFS_CONTENTHASH_RE =
+  /^0x(?<codecPrefix>e3010170|e5010172)(?<multihash>(?<mhCode>[0-9a-f]{2})(?<mhLen>[0-9a-f]{2})(?<digest>[0-9a-f]*))$/;
+const SWARM_CONTENTHASH_RE = /^0xe40101fa011b20(?<swarmHash>[0-9a-f]{64})$/;
 
 // Public RPC providers as fallbacks
 const PUBLIC_RPC_PROVIDERS = [
@@ -58,12 +59,10 @@ function getRpcProviders() {
   return PUBLIC_RPC_PROVIDERS;
 }
 
-// Cache for working provider
 let cachedProvider = null;
 let cachedProviderUrl = null;
 
-// Cache for ENS resolution results (name -> { result, timestamp })
-const ENS_CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
+const ENS_CACHE_TTL_MS = 15 * 60 * 1000;
 const ensResultCache = new Map();
 
 // Independent from ensResultCache so content and addr lookups don't evict each other.
@@ -216,7 +215,7 @@ async function resolveEnsContent(name) {
   let lastError;
   for (let attempt = 1; attempt <= MAX_RESOLUTION_RETRIES; attempt++) {
     try {
-      return await doResolveEnsContent(normalized, attempt);
+      return await doResolveEnsContent(normalized);
     } catch (err) {
       lastError = err;
       if (isProviderError(err) && attempt < MAX_RESOLUTION_RETRIES) {
@@ -236,14 +235,10 @@ async function resolveEnsContent(name) {
   throw lastError;
 }
 
-async function doResolveEnsContent(normalized, attempt) {
+async function doResolveEnsContent(normalized) {
   const provider = await getWorkingProvider();
   const node = ethers.namehash(normalized);
   const callData = CONTENTHASH_SELECTOR + node.slice(2);
-
-  log.info(
-    `[ens] UR resolving content for: ${normalized}${attempt > 1 ? ` (attempt ${attempt})` : ''}`
-  );
 
   let urResult;
   try {
@@ -297,10 +292,10 @@ async function doResolveEnsContent(normalized, attempt) {
 function parseContentHashBytes(hex0x) {
   const ipfs = hex0x.match(IPFS_CONTENTHASH_RE);
   if (ipfs) {
-    const scheme = ipfs[1] === 'e3010170' ? 'ipfs' : 'ipns';
-    const length = parseInt(ipfs[4], 16);
-    if (ipfs[5].length === length * 2) {
-      const decoded = ethers.encodeBase58('0x' + ipfs[2]);
+    const { codecPrefix, multihash, mhLen, digest } = ipfs.groups;
+    if (digest.length === parseInt(mhLen, 16) * 2) {
+      const scheme = codecPrefix === 'e3010170' ? 'ipfs' : 'ipns';
+      const decoded = ethers.encodeBase58('0x' + multihash);
       return {
         codec: `${scheme}-ns`,
         protocol: scheme,
@@ -311,11 +306,12 @@ function parseContentHashBytes(hex0x) {
   }
   const swarm = hex0x.match(SWARM_CONTENTHASH_RE);
   if (swarm) {
+    const hash = swarm.groups.swarmHash;
     return {
       codec: 'swarm-ns',
       protocol: 'bzz',
-      uri: `bzz://${swarm[1]}`,
-      decoded: swarm[1],
+      uri: `bzz://${hash}`,
+      decoded: hash,
     };
   }
   return null;

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -5,6 +5,16 @@ const IPC = require('../shared/ipc-channels');
 const { success, failure } = require('./ipc-contract');
 const { loadSettings } = require('./settings-store');
 
+// ENS v3 Universal Resolver (ENS Labs, current generation).
+// One call here replaces the 3-step "registry lookup → supportsWildcard
+// → contenthash" flow ethers would otherwise make, and handles CCIP-Read
+// transparently for offchain resolvers (.box via 3DNS).
+// If ENS ships a v4 UR, old deployments keep working — bumping is optional.
+const UNIVERSAL_RESOLVER_ADDRESS = '0x5a9236e72a66d3e08b83dcf489b4d850792b6009';
+const UR_ABI = [
+  'function resolve(bytes name, bytes data) view returns (bytes resolvedData, address resolverAddress)',
+];
+
 // Public RPC providers as fallbacks
 const PUBLIC_RPC_PROVIDERS = [
   process.env.ETH_RPC,
@@ -140,6 +150,36 @@ function isProviderError(err) {
 
 // Maximum retries for provider errors during resolution
 const MAX_RESOLUTION_RETRIES = 3;
+
+// UR reverts with these custom errors when a name has no resolver or its
+// resolver isn't a contract. Callers want to treat both as "not found".
+function isResolverNotFoundError(err) {
+  const msg = err?.message || '';
+  const data = err?.info?.error?.data || err?.data || '';
+  return (
+    /ResolverNotFound|ResolverNotContract/i.test(msg) ||
+    // ResolverNotFound(bytes) selector
+    (typeof data === 'string' && data.startsWith('0x7199966d'))
+  );
+}
+
+// Call the Universal Resolver's resolve(name, data). `callData` is the raw
+// ABI-encoded call the resolver would have received directly (selector +
+// args). Returns { bytes, resolverAddress } where `bytes` is the decoded
+// inner return value of that call.
+//
+// CCIP-Read is opted into per-call here because ethers v6 doesn't enable it
+// by default — needed for .box domains resolved via 3DNS.
+async function universalResolverCall(provider, name, callData) {
+  const ur = new ethers.Contract(UNIVERSAL_RESOLVER_ADDRESS, UR_ABI, provider);
+  const encodedName = ethers.dnsEncode(name, 255);
+  const [resolvedData, resolverAddress] = await ur.resolve(encodedName, callData, {
+    enableCcipRead: true,
+  });
+  // UR returns the resolver's ABI-encoded response as `bytes`; unwrap it.
+  const [bytes] = ethers.AbiCoder.defaultAbiCoder().decode(['bytes'], resolvedData);
+  return { bytes, resolverAddress };
+}
 
 async function resolveEnsContent(name) {
   const trimmed = (name || '').trim();
@@ -444,4 +484,6 @@ module.exports = {
   resolveEnsAddress,
   testRpcUrl,
   invalidateCachedProvider,
+  universalResolverCall,
+  isResolverNotFoundError,
 };

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -15,6 +15,19 @@ const UR_ABI = [
   'function resolve(bytes name, bytes data) view returns (bytes resolvedData, address resolverAddress)',
 ];
 
+// bytes4(keccak256("contenthash(bytes32)"))
+const CONTENTHASH_SELECTOR = '0xbc1c4a73';
+
+// ENS contenthash byte patterns (EIP-1577). We preserve the CIDv0 base58
+// output ("QmFoo…") for IPFS/IPNS to stay byte-compatible with the
+// previous ethers-based implementation — users' bookmarks and history
+// entries keyed on the old URI form keep matching.
+//   0xe3 01 70             — ipfs-ns, cidv1, dag-pb
+//   0xe5 01 72             — ipns-ns, cidv1, libp2p-key
+//   0xe4 01 01 fa 01 1b 20 — swarm-ns + manifest codec, 32-byte keccak
+const IPFS_CONTENTHASH_RE = /^0x(e3010170|e5010172)(([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]*))$/;
+const SWARM_CONTENTHASH_RE = /^0xe40101fa011b20([0-9a-f]{64})$/;
+
 // Public RPC providers as fallbacks
 const PUBLIC_RPC_PROVIDERS = [
   process.env.ETH_RPC,
@@ -225,124 +238,96 @@ async function resolveEnsContent(name) {
 
 async function doResolveEnsContent(normalized, attempt) {
   const provider = await getWorkingProvider();
+  const node = ethers.namehash(normalized);
+  const callData = CONTENTHASH_SELECTOR + node.slice(2);
 
-  // Use ethers.js built-in resolver which handles CCIP-Read (EIP-3668) automatically.
-  // This is required for .box domains which use offchain resolution via 3dns.xyz.
   log.info(
-    `[ens] Getting resolver for: ${normalized}${attempt > 1 ? ` (attempt ${attempt})` : ''}`
+    `[ens] UR resolving content for: ${normalized}${attempt > 1 ? ` (attempt ${attempt})` : ''}`
   );
-  const resolver = await provider.getResolver(normalized);
 
-  if (!resolver) {
-    log.info(`[ens] No resolver found for: ${normalized}`);
-    const result = {
-      type: 'not_found',
-      reason: 'NO_RESOLVER',
-      name: normalized,
-    };
-    ensResultCache.set(normalized, { result, timestamp: Date.now() });
-    return result;
-  }
-
-  log.info(`[ens] Getting content hash for: ${normalized}`);
-  let contentHash;
+  let urResult;
   try {
-    // getContentHash() handles CCIP-Read and returns formatted URI like "ipfs://Qm..." or "bzz://..."
-    contentHash = await resolver.getContentHash();
+    urResult = await universalResolverCall(provider, normalized, callData);
   } catch (err) {
-    // Re-throw provider errors so they trigger retry logic
-    if (isProviderError(err)) {
-      throw err;
+    if (isProviderError(err)) throw err;
+    if (isResolverNotFoundError(err)) {
+      return cacheContentResult(normalized, {
+        type: 'not_found',
+        reason: 'NO_RESOLVER',
+        name: normalized,
+      });
     }
-    // CCIP-Read failures or missing contenthash
-    log.info(`[ens] Failed to get content hash for ${normalized}: ${err.message}`);
-    const result = {
+    // CCIP-Read gateway failures, resolver reverts, etc.
+    log.info(`[ens] UR resolve failed for ${normalized}: ${err.message}`);
+    return cacheContentResult(normalized, {
       type: 'not_found',
       reason: 'NO_CONTENTHASH',
       name: normalized,
       error: err.message,
-    };
-    ensResultCache.set(normalized, { result, timestamp: Date.now() });
-    return result;
+    });
   }
 
-  if (!contentHash) {
-    log.info(`[ens] Empty content hash for: ${normalized}`);
-    const result = {
+  if (!urResult.bytes || urResult.bytes === '0x') {
+    return cacheContentResult(normalized, {
       type: 'not_found',
       reason: 'EMPTY_CONTENTHASH',
       name: normalized,
-    };
-    ensResultCache.set(normalized, { result, timestamp: Date.now() });
-    return result;
+    });
   }
 
-  // ethers.js getContentHash() returns formatted URIs like:
-  // - "ipfs://QmHash" or "ipfs://bafyHash"
-  // - "ipns://name"
-  // - "bzz://hash"
-  // Parse the protocol and decoded value from the URI
-  log.info(`[ens] Raw content hash for ${normalized}: ${contentHash}`);
-  let result;
-  const match = contentHash.match(/^([a-z]+):\/\/(.+)$/i);
-
-  if (!match) {
-    log.warn(`[ens] Unsupported content hash format for ${normalized}: ${contentHash}`);
-    result = {
+  const parsed = parseContentHashBytes(urResult.bytes);
+  if (!parsed) {
+    log.warn(`[ens] UNSUPPORTED_CONTENTHASH_FORMAT for ${normalized}: ${urResult.bytes}`);
+    return cacheContentResult(normalized, {
       type: 'unsupported',
-      reason: `UNSUPPORTED_CONTENTHASH_FORMAT`,
+      reason: 'UNSUPPORTED_CONTENTHASH_FORMAT',
       name: normalized,
-      contentHash,
-    };
-    ensResultCache.set(normalized, { result, timestamp: Date.now() });
-    return result;
+      contentHash: urResult.bytes,
+    });
   }
 
-  const [, protocol, decoded] = match;
-  const protocolLower = protocol.toLowerCase();
+  return cacheContentResult(normalized, { type: 'ok', name: normalized, ...parsed });
+}
 
-  if (protocolLower === 'bzz' || protocolLower === 'swarm') {
-    result = {
-      type: 'ok',
-      name: normalized,
+// Decode raw ENS contenthash bytes into our result shape. Mirrors ethers'
+// internal decoder bit-for-bit to preserve CIDv0 base58 output for IPFS
+// — a content-hash library would normalize everything to CIDv1, breaking
+// history/bookmark matching on names users already visited.
+// Returns null for any format we don't support.
+function parseContentHashBytes(hex0x) {
+  const ipfs = hex0x.match(IPFS_CONTENTHASH_RE);
+  if (ipfs) {
+    const scheme = ipfs[1] === 'e3010170' ? 'ipfs' : 'ipns';
+    const length = parseInt(ipfs[4], 16);
+    if (ipfs[5].length === length * 2) {
+      const decoded = ethers.encodeBase58('0x' + ipfs[2]);
+      return {
+        codec: `${scheme}-ns`,
+        protocol: scheme,
+        uri: `${scheme}://${decoded}`,
+        decoded,
+      };
+    }
+  }
+  const swarm = hex0x.match(SWARM_CONTENTHASH_RE);
+  if (swarm) {
+    return {
       codec: 'swarm-ns',
       protocol: 'bzz',
-      uri: `bzz://${decoded}`,
-      decoded,
-    };
-  } else if (protocolLower === 'ipfs') {
-    result = {
-      type: 'ok',
-      name: normalized,
-      codec: 'ipfs-ns',
-      protocol: 'ipfs',
-      uri: `ipfs://${decoded}`,
-      decoded,
-    };
-  } else if (protocolLower === 'ipns') {
-    result = {
-      type: 'ok',
-      name: normalized,
-      codec: 'ipns-ns',
-      protocol: 'ipns',
-      uri: `ipns://${decoded}`,
-      decoded,
-    };
-  } else {
-    log.warn(`[ens] Unsupported protocol for ${normalized}: ${protocol}`);
-    result = {
-      type: 'unsupported',
-      reason: `UNSUPPORTED_PROTOCOL (${protocol})`,
-      name: normalized,
-      protocol,
-      decoded,
+      uri: `bzz://${swarm[1]}`,
+      decoded: swarm[1],
     };
   }
+  return null;
+}
 
+function cacheContentResult(normalized, result) {
+  ensResultCache.set(normalized, { result, timestamp: Date.now() });
   if (result.type === 'ok') {
     log.info(`[ens] Resolved: ${normalized} → ${result.uri}`);
+  } else {
+    log.info(`[ens] ${result.reason} for ${normalized}`);
   }
-  ensResultCache.set(normalized, { result, timestamp: Date.now() });
   return result;
 }
 

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -444,31 +444,10 @@ async function resolveEnsReverse(address) {
       error: `Invalid address: ${address}`,
     };
   }
-  const normalized = address.toLowerCase();
-
-  const cached = ensReverseCache.get(normalized);
-  if (cached && Date.now() - cached.timestamp < ENS_CACHE_TTL_MS) {
-    log.info(`[ens] reverse cache hit for ${normalized}`);
-    return cached.result;
-  }
-
-  let lastError;
-  for (let attempt = 1; attempt <= MAX_RESOLUTION_RETRIES; attempt++) {
-    try {
-      return await doResolveEnsReverse(normalized);
-    } catch (err) {
-      lastError = err;
-      if (isProviderError(err) && attempt < MAX_RESOLUTION_RETRIES) {
-        log.warn(
-          `[ens] reverse provider error on attempt ${attempt}/${MAX_RESOLUTION_RETRIES}: ${err.message}`
-        );
-        invalidateCachedProvider();
-        continue;
-      }
-      throw err;
-    }
-  }
-  throw lastError;
+  // Address is already validated — delegate cache/retry plumbing to the
+  // shared helper. trim() + lowercase inside are no-ops on a canonical
+  // lowercased 40-hex address.
+  return resolveWithCache(address, ensReverseCache, doResolveEnsReverse, 'reverse');
 }
 
 async function doResolveEnsReverse(normalizedAddress) {
@@ -498,14 +477,16 @@ async function doResolveEnsReverse(normalizedAddress) {
     return cacheReverseResult(normalizedAddress, noReverseResult(normalizedAddress));
   }
 
-  // Forward-verify: resolve the claimed name's addr record and ensure it
-  // matches the input address. Otherwise the reverse is spoofed or stale.
+  // Otherwise the reverse is spoofed or stale — reject.
   const forward = await resolveEnsAddress(claimedName);
-  if (!forward.success || forward.address.toLowerCase() !== normalizedAddress) {
+  if (!forward.success || forward.address.toLowerCase() !== normalizedAddress.toLowerCase()) {
     return cacheReverseResult(normalizedAddress, {
       success: false,
       address: normalizedAddress,
-      claimed: claimedName,
+      // Deliberately verbose key so a naive UI can't mistake it for the
+      // verified name — callers reading `.claimedUnverifiedName` know it
+      // failed forward-verify and must not render it as the recipient.
+      claimedUnverifiedName: claimedName,
       reason: 'UNVERIFIED',
       error: `Reverse record ${claimedName} does not forward-verify to ${normalizedAddress}`,
     });

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -5,16 +5,16 @@ const IPC = require('../shared/ipc-channels');
 const { success, failure } = require('./ipc-contract');
 const { loadSettings } = require('./settings-store');
 
-// ENS v3 Universal Resolver (ENS Labs, current generation).
-// One call here replaces the 3-step "registry lookup → supportsWildcard
-// → contenthash" flow ethers would otherwise make, and handles CCIP-Read
+// Canonical ENS Universal Resolver — a DAO-owned proxy that delegates to
+// the current implementation, so future UR upgrades don't require a code
+// change here. Docs: https://docs.ens.domains/resolvers/universal/
+// One call replaces the 3-step "registry lookup → supportsWildcard →
+// contenthash" flow ethers would otherwise make, and handles CCIP-Read
 // transparently for offchain resolvers (.box via 3DNS).
-// If ENS ships a v4 UR, old deployments keep working — bumping is optional.
-const UNIVERSAL_RESOLVER_ADDRESS = '0x5a9236e72a66d3e08b83dcf489b4d850792b6009';
+const UNIVERSAL_RESOLVER_ADDRESS = '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe';
 const UR_ABI = [
-  'function resolve(bytes name, bytes data) view returns (bytes resolvedData, address resolverAddress)',
-  'function resolveMulticall(bytes name, bytes[] calls) view returns (bytes[] results)',
-  'function reverse(bytes lookupAddress, uint256 coinType) view returns (string primaryName, address resolver, address reverseResolver)',
+  'function resolve(bytes name, bytes data) view returns (bytes result, address resolver)',
+  'function reverse(bytes lookupAddress, uint256 coinType) view returns (string primary, address resolver, address reverseResolver)',
 ];
 
 // bytes4(keccak256("contenthash(bytes32)"))
@@ -173,27 +173,38 @@ function isProviderError(err) {
 // Maximum retries for provider errors during resolution
 const MAX_RESOLUTION_RETRIES = 3;
 
-// UR reverts with these custom errors when a name has no resolver, its
-// resolver isn't a contract, or the name can't be reached. Callers want
-// to treat all of them as "not found".
+// Canonical UR custom errors we classify. ethers v6 surfaces the 4-byte
+// selector via err.data on CALL_EXCEPTION; some wrappers (JSON-RPC
+// proxies) expose it under err.info.error.data instead — check both.
+// Selectors are bytes4(keccak256(signature)).
 //
-// ethers v6 surfaces the 4-byte selector via err.data on CALL_EXCEPTION;
-// some wrappers (JSON-RPC proxies) expose it under err.info.error.data
-// instead. Check both.
+// https://docs.ens.domains/resolvers/universal/
 const UR_NOT_FOUND_SELECTORS = new Set([
   '0x77209fe8', // ResolverNotFound(bytes)
   '0x1e9535f2', // ResolverNotContract(bytes,address)
-  '0x5fe9a5df', // UnreachableName(bytes)
 ]);
+const REVERSE_MISMATCH_SELECTOR = '0xef9c03ce'; // ReverseAddressMismatch(string,bytes)
+
+function urErrorSelector(err) {
+  const data = err?.data || err?.info?.error?.data || '';
+  if (typeof data !== 'string' || data.length < 10) return null;
+  return data.slice(0, 10).toLowerCase();
+}
 
 function isResolverNotFoundError(err) {
   const msg = err?.message || '';
-  const data = err?.data || err?.info?.error?.data || '';
-  if (/ResolverNotFound|ResolverNotContract|UnreachableName/i.test(msg)) return true;
-  if (typeof data === 'string' && data.length >= 10) {
-    return UR_NOT_FOUND_SELECTORS.has(data.slice(0, 10).toLowerCase());
-  }
-  return false;
+  if (/ResolverNotFound|ResolverNotContract/i.test(msg)) return true;
+  const sel = urErrorSelector(err);
+  return sel !== null && UR_NOT_FOUND_SELECTORS.has(sel);
+}
+
+// UR.reverse reverts with this when the claimed primary name doesn't
+// forward-resolve back to the input address. Semantically: spoofed or
+// stale reverse record.
+function isReverseAddressMismatchError(err) {
+  const msg = err?.message || '';
+  if (/ReverseAddressMismatch/i.test(msg)) return true;
+  return urErrorSelector(err) === REVERSE_MISMATCH_SELECTOR;
 }
 
 // Call the Universal Resolver's resolve(name, data). `callData` is the raw
@@ -215,25 +226,6 @@ async function universalResolverCall(provider, name, callData) {
     enableCcipRead: true,
   });
   return { resolvedData, resolverAddress };
-}
-
-// Batch multiple resolver lookups on the same ENS name through the UR.
-// Each `callData` entry is a resolver function selector + args (e.g. addr
-// + text + contenthash for a profile view). Returns an array of the
-// per-call inner bytes, in order — each is the resolver's raw response
-// that the caller can then ABI-decode for its specific return type.
-//
-// Unlike the single-call helper, this does not return the resolver
-// address — the UR's resolveMulticall signature doesn't expose it.
-async function universalResolverMulticall(provider, name, callDatas) {
-  const ur = new ethers.Contract(UNIVERSAL_RESOLVER_ADDRESS, UR_ABI, provider);
-  const encodedName = ethers.dnsEncode(name, 255);
-  const results = await ur.resolveMulticall(encodedName, callDatas, {
-    enableCcipRead: true,
-  });
-  // Each entry is the raw ABI-encoded response of the Nth call — caller
-  // decodes per each call's return type.
-  return [...results];
 }
 
 async function resolveEnsContent(name) {
@@ -461,11 +453,10 @@ function cacheAndLog(cache, normalized, result, okValue) {
   return result;
 }
 
-// Resolve an address to its ENS primary name, forward-verifying the
-// result. Conservative: returns { success: true, name } ONLY when the
-// claimed reverse name resolves its own addr record back to the same
-// address. Reverse records are user-set and spoofable; anyone can claim
-// any name, so the forward-verify is the only way to trust the output.
+// Resolve an address to its ENS primary name. The UR verifies the reverse
+// record forward-resolves back to the input address internally and reverts
+// with ReverseAddressMismatch if not — so a successful return is already
+// a trusted name. Spoofed/stale reverses surface as UNVERIFIED.
 async function resolveEnsReverse(address) {
   if (typeof address !== 'string' || !/^0x[a-fA-F0-9]{40}$/.test(address)) {
     return {
@@ -475,9 +466,6 @@ async function resolveEnsReverse(address) {
       error: `Invalid address: ${address}`,
     };
   }
-  // Address is already validated — delegate cache/retry plumbing to the
-  // shared helper. trim() + lowercase inside are no-ops on a canonical
-  // lowercased 40-hex address.
   return resolveWithCache(address, ensReverseCache, doResolveEnsReverse, 'reverse');
 }
 
@@ -495,6 +483,14 @@ async function doResolveEnsReverse(normalizedAddress) {
     if (isResolverNotFoundError(err)) {
       return cacheReverseResult(normalizedAddress, noReverseResult(normalizedAddress));
     }
+    if (isReverseAddressMismatchError(err)) {
+      return cacheReverseResult(normalizedAddress, {
+        success: false,
+        address: normalizedAddress,
+        reason: 'UNVERIFIED',
+        error: `Reverse record for ${normalizedAddress} does not forward-verify`,
+      });
+    }
     log.info(`[ens] UR reverse failed for ${normalizedAddress}: ${err.message}`);
     return cacheReverseResult(normalizedAddress, {
       success: false,
@@ -506,21 +502,6 @@ async function doResolveEnsReverse(normalizedAddress) {
 
   if (!claimedName) {
     return cacheReverseResult(normalizedAddress, noReverseResult(normalizedAddress));
-  }
-
-  // Otherwise the reverse is spoofed or stale — reject.
-  const forward = await resolveEnsAddress(claimedName);
-  if (!forward.success || forward.address.toLowerCase() !== normalizedAddress.toLowerCase()) {
-    return cacheReverseResult(normalizedAddress, {
-      success: false,
-      address: normalizedAddress,
-      // Deliberately verbose key so a naive UI can't mistake it for the
-      // verified name — callers reading `.claimedUnverifiedName` know it
-      // failed forward-verify and must not render it as the recipient.
-      claimedUnverifiedName: claimedName,
-      reason: 'UNVERIFIED',
-      error: `Reverse record ${claimedName} does not forward-verify to ${normalizedAddress}`,
-    });
   }
 
   return cacheReverseResult(normalizedAddress, {
@@ -642,6 +623,5 @@ module.exports = {
   testRpcUrl,
   invalidateCachedProvider,
   universalResolverCall,
-  universalResolverMulticall,
   isResolverNotFoundError,
 };

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -13,6 +13,7 @@ const { loadSettings } = require('./settings-store');
 const UNIVERSAL_RESOLVER_ADDRESS = '0x5a9236e72a66d3e08b83dcf489b4d850792b6009';
 const UR_ABI = [
   'function resolve(bytes name, bytes data) view returns (bytes resolvedData, address resolverAddress)',
+  'function resolveMulticall(bytes name, bytes[] calls) view returns (bytes[] results)',
 ];
 
 // bytes4(keccak256("contenthash(bytes32)"))
@@ -195,6 +196,21 @@ async function universalResolverCall(provider, name, callData) {
   // UR returns the resolver's ABI-encoded response as `bytes`; unwrap it.
   const [bytes] = ethers.AbiCoder.defaultAbiCoder().decode(['bytes'], resolvedData);
   return { bytes, resolverAddress };
+}
+
+// Batch multiple resolver lookups on the same ENS name through the UR.
+// Each `callData` entry is a resolver function selector + args (e.g. addr
+// + text + contenthash for a profile view). Returns an array of the
+// per-call inner bytes, in order — each is the resolver's raw response
+// that the caller can then ABI-decode for its specific return type.
+async function universalResolverMulticall(provider, name, callDatas) {
+  const ur = new ethers.Contract(UNIVERSAL_RESOLVER_ADDRESS, UR_ABI, provider);
+  const encodedName = ethers.dnsEncode(name, 255);
+  const results = await ur.resolveMulticall(encodedName, callDatas, {
+    enableCcipRead: true,
+  });
+  const coder = ethers.AbiCoder.defaultAbiCoder();
+  return results.map((r) => coder.decode(['bytes'], r)[0]);
 }
 
 async function resolveEnsContent(name) {
@@ -519,5 +535,6 @@ module.exports = {
   testRpcUrl,
   invalidateCachedProvider,
   universalResolverCall,
+  universalResolverMulticall,
   isResolverNotFoundError,
 };

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -43,6 +43,9 @@ let cachedProviderUrl = null;
 const ENS_CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
 const ensResultCache = new Map();
 
+// Independent from ensResultCache so content and addr lookups don't evict each other.
+const ensAddressCache = new Map();
+
 // Get a working provider, trying each in sequence with fallback
 async function getWorkingProvider() {
   // If the cached provider's URL no longer matches the current settings, invalidate it
@@ -303,6 +306,62 @@ async function doResolveEnsContent(normalized, attempt) {
   return result;
 }
 
+// Resolve an ENS name's primary ETH address (the `addr` record).
+// Uses provider.resolveName() which handles resolver lookup, addr(bytes32),
+// and CCIP-Read — so .eth, subdomains, and .box names all work via the
+// same path as address-bar content resolution.
+async function resolveEnsAddress(name) {
+  const trimmed = (name || '').trim();
+  if (!trimmed) {
+    throw new Error('ENS name is empty');
+  }
+
+  const normalized = trimmed.toLowerCase();
+
+  const cached = ensAddressCache.get(normalized);
+  if (cached && Date.now() - cached.timestamp < ENS_CACHE_TTL_MS) {
+    log.info(`[ens] Address cache hit for ${normalized} -> ${cached.address}`);
+    return { success: true, name: normalized, address: cached.address };
+  }
+
+  let lastError;
+  for (let attempt = 1; attempt <= MAX_RESOLUTION_RETRIES; attempt++) {
+    try {
+      const provider = await getWorkingProvider();
+      log.info(
+        `[ens] Resolving address record for: ${normalized}${attempt > 1 ? ` (attempt ${attempt})` : ''}`
+      );
+
+      const address = await provider.resolveName(normalized);
+
+      if (!address) {
+        return {
+          success: false,
+          name: normalized,
+          reason: 'NO_ADDRESS',
+          error: `No address record set for ${normalized}`,
+        };
+      }
+
+      ensAddressCache.set(normalized, { address, timestamp: Date.now() });
+      log.info(`[ens] Resolved address: ${normalized} -> ${address}`);
+      return { success: true, name: normalized, address };
+    } catch (err) {
+      lastError = err;
+      if (isProviderError(err) && attempt < MAX_RESOLUTION_RETRIES) {
+        log.warn(
+          `[ens] Address resolution provider error on attempt ${attempt}/${MAX_RESOLUTION_RETRIES}: ${err.message}`
+        );
+        invalidateCachedProvider();
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  throw lastError;
+}
+
 // Test an RPC URL by connecting and fetching the block number.
 // Note: this intentionally accepts any reachable http(s) URL — testing a
 // local node (anvil/geth on 127.0.0.1, an internal RPC, etc.) is the
@@ -362,11 +421,27 @@ function registerEnsIpc() {
   ipcMain.handle(IPC.ENS_TEST_RPC, async (_event, payload = {}) => {
     return testRpcUrl(payload.url);
   });
+
+  ipcMain.handle(IPC.ENS_RESOLVE_ADDRESS, async (_event, payload = {}) => {
+    const { name } = payload;
+    try {
+      return await resolveEnsAddress(name);
+    } catch (err) {
+      log.error('[ens] address resolution error', err);
+      return {
+        success: false,
+        name: (name || '').trim().toLowerCase(),
+        reason: 'RESOLUTION_ERROR',
+        error: err.message,
+      };
+    }
+  });
 }
 
 module.exports = {
   registerEnsIpc,
   resolveEnsContent,
+  resolveEnsAddress,
   testRpcUrl,
   invalidateCachedProvider,
 };

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -20,8 +20,6 @@ const UR_ABI = [
 const CONTENTHASH_SELECTOR = '0xbc1c4a73';
 // bytes4(keccak256("addr(bytes32)"))
 const ADDR_SELECTOR = '0x3b3b57de';
-// 32-byte zero-padded address(0) — ABI-encoded `address` result for "no addr record set".
-const ZERO_ADDR_BYTES = '0x' + '0'.repeat(64);
 
 // ENS contenthash byte patterns (EIP-1577). We preserve the CIDv0 base58
 // output ("QmFoo…") for IPFS/IPNS to stay byte-compatible with the
@@ -203,6 +201,9 @@ async function universalResolverCall(provider, name, callData) {
 // + text + contenthash for a profile view). Returns an array of the
 // per-call inner bytes, in order — each is the resolver's raw response
 // that the caller can then ABI-decode for its specific return type.
+//
+// Unlike the single-call helper, this does not return the resolver
+// address — the UR's resolveMulticall signature doesn't expose it.
 async function universalResolverMulticall(provider, name, callDatas) {
   const ur = new ethers.Contract(UNIVERSAL_RESOLVER_ADDRESS, UR_ABI, provider);
   const encodedName = ethers.dnsEncode(name, 255);
@@ -214,45 +215,7 @@ async function universalResolverMulticall(provider, name, callDatas) {
 }
 
 async function resolveEnsContent(name) {
-  const trimmed = (name || '').trim();
-  if (!trimmed) {
-    throw new Error('ENS name is empty');
-  }
-
-  // Basic normalization; full ENS nameprep is more complex but this is fine
-  // for normal .eth and .box names.
-  const normalized = trimmed.toLowerCase();
-  log.info(`[ens] Resolving: ${normalized}`);
-
-  // Check cache first
-  const cached = ensResultCache.get(normalized);
-  if (cached && Date.now() - cached.timestamp < ENS_CACHE_TTL_MS) {
-    log.info(`[ens] Cache hit for ${normalized} → ${cached.result.uri || cached.result.reason}`);
-    return cached.result;
-  }
-
-  // Retry loop for provider errors
-  let lastError;
-  for (let attempt = 1; attempt <= MAX_RESOLUTION_RETRIES; attempt++) {
-    try {
-      return await doResolveEnsContent(normalized);
-    } catch (err) {
-      lastError = err;
-      if (isProviderError(err) && attempt < MAX_RESOLUTION_RETRIES) {
-        log.warn(
-          `[ens] Provider error on attempt ${attempt}/${MAX_RESOLUTION_RETRIES}: ${err.message}`
-        );
-        invalidateCachedProvider();
-        // Continue to next attempt
-      } else {
-        // Not a provider error or out of retries - rethrow
-        throw err;
-      }
-    }
-  }
-
-  // Should not reach here, but just in case
-  throw lastError;
+  return resolveWithCache(name, ensResultCache, doResolveEnsContent, 'content');
 }
 
 async function doResolveEnsContent(normalized) {
@@ -338,41 +301,42 @@ function parseContentHashBytes(hex0x) {
 }
 
 function cacheContentResult(normalized, result) {
-  ensResultCache.set(normalized, { result, timestamp: Date.now() });
-  if (result.type === 'ok') {
-    log.info(`[ens] Resolved: ${normalized} → ${result.uri}`);
-  } else {
-    log.info(`[ens] ${result.reason} for ${normalized}`);
-  }
-  return result;
+  return cacheAndLog(ensResultCache, normalized, result, result.uri);
 }
 
 // Resolve an ENS name's primary ETH address (the `addr` record).
 // Single UR call (vs ethers' registry → addr 2-step flow); CCIP-Read
 // handled transparently via OffchainLookup.
 async function resolveEnsAddress(name) {
+  return resolveWithCache(name, ensAddressCache, doResolveEnsAddress, 'addr');
+}
+
+// Shared validation + cache + retry wrapper for the content-hash and
+// addr lookup paths. Both do the same thing: trim, lowercase, check the
+// same-shape TTL cache, retry up to MAX_RESOLUTION_RETRIES on provider
+// errors, invalidate the cached provider between attempts.
+async function resolveWithCache(name, cache, doResolve, label) {
   const trimmed = (name || '').trim();
   if (!trimmed) {
     throw new Error('ENS name is empty');
   }
-
   const normalized = trimmed.toLowerCase();
 
-  const cached = ensAddressCache.get(normalized);
+  const cached = cache.get(normalized);
   if (cached && Date.now() - cached.timestamp < ENS_CACHE_TTL_MS) {
-    log.info(`[ens] Address cache hit for ${normalized} → ${cached.result.address || cached.result.reason}`);
+    log.info(`[ens] ${label} cache hit for ${normalized}`);
     return cached.result;
   }
 
   let lastError;
   for (let attempt = 1; attempt <= MAX_RESOLUTION_RETRIES; attempt++) {
     try {
-      return await doResolveEnsAddress(normalized);
+      return await doResolve(normalized);
     } catch (err) {
       lastError = err;
       if (isProviderError(err) && attempt < MAX_RESOLUTION_RETRIES) {
         log.warn(
-          `[ens] Address resolution provider error on attempt ${attempt}/${MAX_RESOLUTION_RETRIES}: ${err.message}`
+          `[ens] ${label} provider error on attempt ${attempt}/${MAX_RESOLUTION_RETRIES}: ${err.message}`
         );
         invalidateCachedProvider();
         continue;
@@ -380,7 +344,6 @@ async function resolveEnsAddress(name) {
       throw err;
     }
   }
-
   throw lastError;
 }
 
@@ -395,12 +358,7 @@ async function doResolveEnsAddress(normalized) {
   } catch (err) {
     if (isProviderError(err)) throw err;
     if (isResolverNotFoundError(err)) {
-      return cacheAddressResult(normalized, {
-        success: false,
-        name: normalized,
-        reason: 'NO_ADDRESS',
-        error: `No address record set for ${normalized}`,
-      });
+      return cacheAddressResult(normalized, noAddressResult(normalized));
     }
     log.info(`[ens] UR addr resolve failed for ${normalized}: ${err.message}`);
     return cacheAddressResult(normalized, {
@@ -411,15 +369,8 @@ async function doResolveEnsAddress(normalized) {
     });
   }
 
-  // The resolver's addr(bytes32) returns address — 32 bytes of ABI-encoded
-  // address. Empty or zero → no addr record set.
-  if (!urResult.bytes || urResult.bytes === '0x' || urResult.bytes === ZERO_ADDR_BYTES) {
-    return cacheAddressResult(normalized, {
-      success: false,
-      name: normalized,
-      reason: 'NO_ADDRESS',
-      error: `No address record set for ${normalized}`,
-    });
+  if (!urResult.bytes || urResult.bytes === '0x') {
+    return cacheAddressResult(normalized, noAddressResult(normalized));
   }
 
   let address;
@@ -435,6 +386,10 @@ async function doResolveEnsAddress(normalized) {
     });
   }
 
+  if (address === ethers.ZeroAddress) {
+    return cacheAddressResult(normalized, noAddressResult(normalized));
+  }
+
   return cacheAddressResult(normalized, {
     success: true,
     name: normalized,
@@ -442,10 +397,26 @@ async function doResolveEnsAddress(normalized) {
   });
 }
 
+function noAddressResult(normalized) {
+  return {
+    success: false,
+    name: normalized,
+    reason: 'NO_ADDRESS',
+    error: `No address record set for ${normalized}`,
+  };
+}
+
 function cacheAddressResult(normalized, result) {
-  ensAddressCache.set(normalized, { result, timestamp: Date.now() });
-  if (result.success) {
-    log.info(`[ens] Resolved address: ${normalized} → ${result.address}`);
+  return cacheAndLog(ensAddressCache, normalized, result, result.address);
+}
+
+// Shared cache-set + log-and-return for both lookup paths. `okValue` is
+// the success-case display (uri for content, address for addr); passing
+// a truthy value logs "Resolved → <value>", otherwise logs the reason.
+function cacheAndLog(cache, normalized, result, okValue) {
+  cache.set(normalized, { result, timestamp: Date.now() });
+  if (okValue) {
+    log.info(`[ens] Resolved: ${normalized} → ${okValue}`);
   } else {
     log.info(`[ens] ${result.reason} for ${normalized}`);
   }

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -1,6 +1,7 @@
 const log = require('./logger');
 const { ipcMain } = require('electron');
 const { ethers } = require('ethers');
+const { ens_normalize } = require('@adraffy/ens-normalize');
 const IPC = require('../shared/ipc-channels');
 const { success, failure } = require('./ipc-contract');
 const { loadSettings } = require('./settings-store');
@@ -340,15 +341,21 @@ async function resolveEnsAddress(name) {
 }
 
 // Shared validation + cache + retry wrapper for the content-hash and
-// addr lookup paths. Both do the same thing: trim, lowercase, check the
-// same-shape TTL cache, retry up to MAX_RESOLUTION_RETRIES on provider
-// errors, invalidate the cached provider between attempts.
+// addr lookup paths.
+//
+// Normalization goes through @adraffy/ens-normalize (UTS-46 / ENSIP-15),
+// not a bare .toLowerCase(). That's correct for unicode ENS names
+// (emoji labels, non-ASCII domains) whose namehash depends on canonical
+// NFC form. `ens_normalize` is a no-op beyond lowercasing for pure-ASCII
+// names like "Vitalik.ETH", so callers that pass 0x addresses (reverse
+// lookup) are unaffected. Invalid labels throw — which propagates to
+// the IPC handler and surfaces as a RESOLUTION_ERROR to the renderer.
 async function resolveWithCache(name, cache, doResolve, label) {
   const trimmed = (name || '').trim();
   if (!trimmed) {
     throw new Error('ENS name is empty');
   }
-  const normalized = trimmed.toLowerCase();
+  const normalized = ens_normalize(trimmed);
 
   const cached = cache.get(normalized);
   if (cached && Date.now() - cached.timestamp < ENS_CACHE_TTL_MS) {

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -14,12 +14,16 @@ const UNIVERSAL_RESOLVER_ADDRESS = '0x5a9236e72a66d3e08b83dcf489b4d850792b6009';
 const UR_ABI = [
   'function resolve(bytes name, bytes data) view returns (bytes resolvedData, address resolverAddress)',
   'function resolveMulticall(bytes name, bytes[] calls) view returns (bytes[] results)',
+  'function reverse(bytes lookupAddress, uint256 coinType) view returns (string primaryName, address resolver, address reverseResolver)',
 ];
 
 // bytes4(keccak256("contenthash(bytes32)"))
 const CONTENTHASH_SELECTOR = '0xbc1c4a73';
 // bytes4(keccak256("addr(bytes32)"))
 const ADDR_SELECTOR = '0x3b3b57de';
+
+// SLIP-0044 coin type for Ethereum mainnet, used by UR.reverse.
+const ETH_COIN_TYPE = 60n;
 
 // ENS contenthash byte patterns (EIP-1577). We preserve the CIDv0 base58
 // output ("QmFoo…") for IPFS/IPNS to stay byte-compatible with the
@@ -70,6 +74,9 @@ const ensResultCache = new Map();
 
 // Independent from ensResultCache so content and addr lookups don't evict each other.
 const ensAddressCache = new Map();
+
+// Address (lowercased 0x) → { result, timestamp } for reverse lookups.
+const ensReverseCache = new Map();
 
 // Get a working provider, trying each in sequence with fallback
 async function getWorkingProvider() {
@@ -423,6 +430,107 @@ function cacheAndLog(cache, normalized, result, okValue) {
   return result;
 }
 
+// Resolve an address to its ENS primary name, forward-verifying the
+// result. Conservative: returns { success: true, name } ONLY when the
+// claimed reverse name resolves its own addr record back to the same
+// address. Reverse records are user-set and spoofable; anyone can claim
+// any name, so the forward-verify is the only way to trust the output.
+async function resolveEnsReverse(address) {
+  if (typeof address !== 'string' || !/^0x[a-fA-F0-9]{40}$/.test(address)) {
+    return {
+      success: false,
+      address,
+      reason: 'INVALID_ADDRESS',
+      error: `Invalid address: ${address}`,
+    };
+  }
+  const normalized = address.toLowerCase();
+
+  const cached = ensReverseCache.get(normalized);
+  if (cached && Date.now() - cached.timestamp < ENS_CACHE_TTL_MS) {
+    log.info(`[ens] reverse cache hit for ${normalized}`);
+    return cached.result;
+  }
+
+  let lastError;
+  for (let attempt = 1; attempt <= MAX_RESOLUTION_RETRIES; attempt++) {
+    try {
+      return await doResolveEnsReverse(normalized);
+    } catch (err) {
+      lastError = err;
+      if (isProviderError(err) && attempt < MAX_RESOLUTION_RETRIES) {
+        log.warn(
+          `[ens] reverse provider error on attempt ${attempt}/${MAX_RESOLUTION_RETRIES}: ${err.message}`
+        );
+        invalidateCachedProvider();
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastError;
+}
+
+async function doResolveEnsReverse(normalizedAddress) {
+  const provider = await getWorkingProvider();
+  const ur = new ethers.Contract(UNIVERSAL_RESOLVER_ADDRESS, UR_ABI, provider);
+  const addrBytes = ethers.getBytes(normalizedAddress);
+
+  let claimedName;
+  try {
+    const [name] = await ur.reverse(addrBytes, ETH_COIN_TYPE, { enableCcipRead: true });
+    claimedName = name;
+  } catch (err) {
+    if (isProviderError(err)) throw err;
+    if (isResolverNotFoundError(err)) {
+      return cacheReverseResult(normalizedAddress, noReverseResult(normalizedAddress));
+    }
+    log.info(`[ens] UR reverse failed for ${normalizedAddress}: ${err.message}`);
+    return cacheReverseResult(normalizedAddress, {
+      success: false,
+      address: normalizedAddress,
+      reason: 'RESOLUTION_ERROR',
+      error: err.message,
+    });
+  }
+
+  if (!claimedName) {
+    return cacheReverseResult(normalizedAddress, noReverseResult(normalizedAddress));
+  }
+
+  // Forward-verify: resolve the claimed name's addr record and ensure it
+  // matches the input address. Otherwise the reverse is spoofed or stale.
+  const forward = await resolveEnsAddress(claimedName);
+  if (!forward.success || forward.address.toLowerCase() !== normalizedAddress) {
+    return cacheReverseResult(normalizedAddress, {
+      success: false,
+      address: normalizedAddress,
+      claimed: claimedName,
+      reason: 'UNVERIFIED',
+      error: `Reverse record ${claimedName} does not forward-verify to ${normalizedAddress}`,
+    });
+  }
+
+  return cacheReverseResult(normalizedAddress, {
+    success: true,
+    address: normalizedAddress,
+    name: claimedName,
+  });
+}
+
+function noReverseResult(normalizedAddress) {
+  return {
+    success: false,
+    address: normalizedAddress,
+    reason: 'NO_REVERSE',
+    error: `No primary ENS name set for ${normalizedAddress}`,
+  };
+}
+
+function cacheReverseResult(normalizedAddress, result) {
+  return cacheAndLog(ensReverseCache, normalizedAddress, result, result.name);
+}
+
 // Test an RPC URL by connecting and fetching the block number.
 // Note: this intentionally accepts any reachable http(s) URL — testing a
 // local node (anvil/geth on 127.0.0.1, an internal RPC, etc.) is the
@@ -497,12 +605,28 @@ function registerEnsIpc() {
       };
     }
   });
+
+  ipcMain.handle(IPC.ENS_RESOLVE_REVERSE, async (_event, payload = {}) => {
+    const { address } = payload;
+    try {
+      return await resolveEnsReverse(address);
+    } catch (err) {
+      log.error('[ens] reverse resolution error', err);
+      return {
+        success: false,
+        address: typeof address === 'string' ? address.toLowerCase() : null,
+        reason: 'RESOLUTION_ERROR',
+        error: err.message,
+      };
+    }
+  });
 }
 
 module.exports = {
   registerEnsIpc,
   resolveEnsContent,
   resolveEnsAddress,
+  resolveEnsReverse,
   testRpcUrl,
   invalidateCachedProvider,
   universalResolverCall,

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -173,16 +173,27 @@ function isProviderError(err) {
 // Maximum retries for provider errors during resolution
 const MAX_RESOLUTION_RETRIES = 3;
 
-// UR reverts with these custom errors when a name has no resolver or its
-// resolver isn't a contract. Callers want to treat both as "not found".
+// UR reverts with these custom errors when a name has no resolver, its
+// resolver isn't a contract, or the name can't be reached. Callers want
+// to treat all of them as "not found".
+//
+// ethers v6 surfaces the 4-byte selector via err.data on CALL_EXCEPTION;
+// some wrappers (JSON-RPC proxies) expose it under err.info.error.data
+// instead. Check both.
+const UR_NOT_FOUND_SELECTORS = new Set([
+  '0x77209fe8', // ResolverNotFound(bytes)
+  '0x1e9535f2', // ResolverNotContract(bytes,address)
+  '0x5fe9a5df', // UnreachableName(bytes)
+]);
+
 function isResolverNotFoundError(err) {
   const msg = err?.message || '';
-  const data = err?.info?.error?.data || err?.data || '';
-  return (
-    /ResolverNotFound|ResolverNotContract/i.test(msg) ||
-    // ResolverNotFound(bytes) selector
-    (typeof data === 'string' && data.startsWith('0x7199966d'))
-  );
+  const data = err?.data || err?.info?.error?.data || '';
+  if (/ResolverNotFound|ResolverNotContract|UnreachableName/i.test(msg)) return true;
+  if (typeof data === 'string' && data.length >= 10) {
+    return UR_NOT_FOUND_SELECTORS.has(data.slice(0, 10).toLowerCase());
+  }
+  return false;
 }
 
 // Call the Universal Resolver's resolve(name, data). `callData` is the raw

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -71,11 +71,16 @@ beforeEach(() => {
   mockLoadSettings.mockReturnValue({ enableEnsCustomRpc: false, ensRpcUrl: '' });
 });
 
-// Helpers for building mocked UR responses.
+// Helpers for building mocked UR responses. The UR returns
+// [resolvedData, resolverAddress] where resolvedData is the RAW
+// ABI-encoded response of the resolver function — its shape depends
+// on that function's return type. For `contenthash() returns (bytes)`
+// it's ABI-encoded `(bytes)`; for `addr() returns (address)` it's the
+// 32-byte address directly. Each helper mirrors one of those shapes.
 const actualEthers = jest.requireActual('ethers').ethers;
 const FAKE_RESOLVER = '0x0000000000000000000000000000000000001234';
 
-// Wrap raw contenthash hex bytes as the UR's ABI-encoded (bytes) return.
+// For contenthash-like (dynamic `bytes` return): wrap inner hex as ABI (bytes).
 function urReturnsBytes(innerHex) {
   const wrapped = actualEthers.AbiCoder.defaultAbiCoder().encode(['bytes'], [innerHex]);
   return [wrapped, FAKE_RESOLVER];
@@ -99,11 +104,11 @@ function swarmContenthashFor(hash64Hex) {
   return '0xe40101fa011b20' + hash64Hex;
 }
 
-// Wrap an address as the UR's return where `bytes` is the ABI-encoded
-// `address` output of the resolver's addr(bytes32).
+// For addr-like (static `address` return): the UR's resolvedData is just
+// the 32-byte ABI-encoded address. No bytes-wrapper.
 function urReturnsAddress(address) {
-  const inner = actualEthers.AbiCoder.defaultAbiCoder().encode(['address'], [address]);
-  return urReturnsBytes(inner);
+  const encoded = actualEthers.AbiCoder.defaultAbiCoder().encode(['address'], [address]);
+  return [encoded, FAKE_RESOLVER];
 }
 
 describe('ens-resolver', () => {
@@ -344,15 +349,6 @@ describe('ens-resolver', () => {
         reason: 'NO_ADDRESS',
         error: 'No address record set for no-addr.eth',
       });
-    });
-
-    test('returns NO_ADDRESS for empty bytes return', async () => {
-      mockUrResolve.mockResolvedValue(urReturnsBytes('0x'));
-
-      const result = await resolveEnsAddress('empty-bytes.eth');
-
-      expect(result.success).toBe(false);
-      expect(result.reason).toBe('NO_ADDRESS');
     });
 
     test('maps UR ResolverNotFound revert to NO_ADDRESS', async () => {
@@ -615,27 +611,21 @@ describe('ens-resolver', () => {
   });
 
   describe('universalResolverCall', () => {
-    const actualEthers = jest.requireActual('ethers').ethers;
-    const FAKE_RESOLVER = '0x0000000000000000000000000000000000001234';
-
-    // Helper: wrap raw hex bytes as the UR's ABI-encoded `(bytes)` return value.
-    const wrapAsUrBytes = (innerHex) => {
-      const coder = actualEthers.AbiCoder.defaultAbiCoder();
-      return coder.encode(['bytes'], [innerHex]);
-    };
-
-    test('encodes name, opts into CCIP-Read, and unwraps inner bytes', async () => {
-      const inner = '0xdeadbeef';
-      mockUrResolve.mockResolvedValue([wrapAsUrBytes(inner), FAKE_RESOLVER]);
+    test('encodes name, opts into CCIP-Read, returns raw resolvedData', async () => {
+      const rawResponse = actualEthers.AbiCoder.defaultAbiCoder().encode(
+        ['bytes'],
+        ['0xdeadbeef']
+      );
+      mockUrResolve.mockResolvedValue([rawResponse, FAKE_RESOLVER]);
 
       const provider = new ethers.JsonRpcProvider('http://localhost:8545');
-      const callData = '0xbc1c4a73' + actualEthers.namehash('vitalik.eth').slice(2);
+      const callData = '0xbc1c58d1' + actualEthers.namehash('vitalik.eth').slice(2);
       const result = await universalResolverCall(provider, 'vitalik.eth', callData);
 
-      expect(result.bytes.toLowerCase()).toBe(inner);
+      // Returns raw ABI-encoded response — caller decodes per return type.
+      expect(result.resolvedData).toBe(rawResponse);
       expect(result.resolverAddress).toBe(FAKE_RESOLVER);
 
-      // Verify the call shape the UR actually received
       expect(mockUrResolve).toHaveBeenCalledTimes(1);
       const [encodedName, passedCallData, overrides] = mockUrResolve.mock.calls[0];
       expect(encodedName).toBe(actualEthers.dnsEncode('vitalik.eth', 255));
@@ -644,9 +634,9 @@ describe('ens-resolver', () => {
     });
 
     test('constructs Contract with UR address and minimal ABI', async () => {
-      mockUrResolve.mockResolvedValue([wrapAsUrBytes('0x'), FAKE_RESOLVER]);
+      mockUrResolve.mockResolvedValue(['0x', FAKE_RESOLVER]);
       const provider = new ethers.JsonRpcProvider('http://localhost:8545');
-      await universalResolverCall(provider, 'vitalik.eth', '0xbc1c4a73');
+      await universalResolverCall(provider, 'vitalik.eth', '0xbc1c58d1');
 
       expect(ethers.Contract).toHaveBeenCalledWith(
         '0x5a9236e72a66d3e08b83dcf489b4d850792b6009',
@@ -660,29 +650,30 @@ describe('ens-resolver', () => {
       mockUrResolve.mockRejectedValue(err);
       const provider = new ethers.JsonRpcProvider('http://localhost:8545');
       await expect(
-        universalResolverCall(provider, 'unregistered.eth', '0xbc1c4a73')
+        universalResolverCall(provider, 'unregistered.eth', '0xbc1c58d1')
       ).rejects.toThrow('ResolverNotFound');
     });
   });
 
   describe('universalResolverMulticall', () => {
-    test('encodes name, opts into CCIP-Read, and unwraps per-call inner bytes', async () => {
-      const coder = actualEthers.AbiCoder.defaultAbiCoder();
-      // Simulate three resolver responses (e.g. addr + text + contenthash).
-      const inner1 = '0xdeadbeef';
-      const inner2 = '0xfeedface';
-      const inner3 = '0x';
-      mockUrResolveMulticall.mockResolvedValue([
-        coder.encode(['bytes'], [inner1]),
-        coder.encode(['bytes'], [inner2]),
-        coder.encode(['bytes'], [inner3]),
-      ]);
+    test('encodes name, opts into CCIP-Read, returns raw per-call responses', async () => {
+      // Simulate three responses with different return-type shapes, as the
+      // real UR would: (address), (bytes), (string) — each raw-ABI-encoded.
+      const r1 = actualEthers.AbiCoder.defaultAbiCoder().encode(
+        ['address'],
+        ['0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045']
+      );
+      const r2 = actualEthers.AbiCoder.defaultAbiCoder().encode(['bytes'], ['0xdeadbeef']);
+      const r3 = actualEthers.AbiCoder.defaultAbiCoder().encode(['string'], ['hello']);
+      mockUrResolveMulticall.mockResolvedValue([r1, r2, r3]);
 
       const provider = new ethers.JsonRpcProvider('http://localhost:8545');
-      const calls = ['0x3b3b57de', '0xbc1c4a73', '0x59d1d43c'];
+      const calls = ['0x3b3b57de', '0xbc1c58d1', '0x59d1d43c'];
       const results = await universalResolverMulticall(provider, 'vitalik.eth', calls);
 
-      expect(results.map((r) => r.toLowerCase())).toEqual([inner1, inner2, inner3]);
+      // Results are the raw per-call ABI-encoded responses. Caller decodes
+      // each per its specific return type.
+      expect(results).toEqual([r1, r2, r3]);
 
       expect(mockUrResolveMulticall).toHaveBeenCalledTimes(1);
       const [encodedName, passedCalls, overrides] = mockUrResolveMulticall.mock.calls[0];

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -293,8 +293,17 @@ describe('ens-resolver', () => {
   });
 
   describe('resolveEnsAddress', () => {
+    // Wrap an address as the UR's (bytes, address) return value where `bytes`
+    // is the ABI-encoded `address` output of the resolver's addr(bytes32).
+    function urReturnsAddress(address) {
+      const inner = actualEthers.AbiCoder.defaultAbiCoder().encode(['address'], [address]);
+      return urReturnsBytes(inner);
+    }
+
     test('resolves ENS name to its addr record', async () => {
-      mockResolveName.mockResolvedValue('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045');
+      mockUrResolve.mockResolvedValue(
+        urReturnsAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
+      );
 
       const result = await resolveEnsAddress('vitalik.eth');
 
@@ -303,21 +312,21 @@ describe('ens-resolver', () => {
         name: 'vitalik.eth',
         address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
       });
-      expect(mockResolveName).toHaveBeenCalledWith('vitalik.eth');
     });
 
-    test('normalizes mixed-case input to lowercase before resolving', async () => {
-      mockResolveName.mockResolvedValue('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045');
+    test('normalizes mixed-case input to lowercase', async () => {
+      mockUrResolve.mockResolvedValue(
+        urReturnsAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
+      );
 
       const result = await resolveEnsAddress('Mixed.ETH');
 
       expect(result.success).toBe(true);
       expect(result.name).toBe('mixed.eth');
-      expect(mockResolveName).toHaveBeenCalledWith('mixed.eth');
     });
 
-    test('returns NO_ADDRESS when the name has no addr record', async () => {
-      mockResolveName.mockResolvedValue(null);
+    test('returns NO_ADDRESS for zero-address return (resolver says no addr set)', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsAddress('0x0000000000000000000000000000000000000000'));
 
       const result = await resolveEnsAddress('no-addr.eth');
 
@@ -329,6 +338,36 @@ describe('ens-resolver', () => {
       });
     });
 
+    test('returns NO_ADDRESS for empty bytes return', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsBytes('0x'));
+
+      const result = await resolveEnsAddress('empty-bytes.eth');
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('NO_ADDRESS');
+    });
+
+    test('maps UR ResolverNotFound revert to NO_ADDRESS', async () => {
+      mockUrResolve.mockRejectedValue(
+        new Error('execution reverted: ResolverNotFound("unreg.eth")')
+      );
+
+      const result = await resolveEnsAddress('unreg.eth');
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('NO_ADDRESS');
+    });
+
+    test('maps generic UR revert to RESOLUTION_ERROR', async () => {
+      mockUrResolve.mockRejectedValue(new Error('some other revert reason'));
+
+      const result = await resolveEnsAddress('broken.eth');
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('RESOLUTION_ERROR');
+      expect(result.error).toContain('some other revert');
+    });
+
     test('throws on empty name', async () => {
       await expect(resolveEnsAddress('')).rejects.toThrow('ENS name is empty');
       await expect(resolveEnsAddress('   ')).rejects.toThrow('ENS name is empty');
@@ -338,27 +377,50 @@ describe('ens-resolver', () => {
       const providerError = new Error('server error');
       providerError.code = 'SERVER_ERROR';
 
-      mockResolveName
+      mockUrResolve
         .mockRejectedValueOnce(providerError)
-        .mockResolvedValueOnce('0x0000000000000000000000000000000000000001');
+        .mockResolvedValueOnce(urReturnsAddress('0x0000000000000000000000000000000000000001'));
 
       const result = await resolveEnsAddress('retry.eth');
 
       expect(result.success).toBe(true);
       expect(result.address).toBe('0x0000000000000000000000000000000000000001');
-      expect(mockResolveName).toHaveBeenCalledTimes(2);
+      expect(mockUrResolve).toHaveBeenCalledTimes(2);
     });
 
     test('caches successful resolutions', async () => {
-      mockResolveName.mockResolvedValue('0x1111111111111111111111111111111111111111');
+      mockUrResolve.mockResolvedValue(
+        urReturnsAddress('0x1111111111111111111111111111111111111111')
+      );
 
-      const first = await resolveEnsAddress('cached.eth');
-      const second = await resolveEnsAddress('cached.eth');
+      const first = await resolveEnsAddress('cached-addr.eth');
+      const second = await resolveEnsAddress('cached-addr.eth');
 
       expect(first.address).toBe('0x1111111111111111111111111111111111111111');
       expect(second.address).toBe('0x1111111111111111111111111111111111111111');
-      // Second call hits the cache, so resolveName is only invoked once.
-      expect(mockResolveName).toHaveBeenCalledTimes(1);
+      expect(mockUrResolve).toHaveBeenCalledTimes(1);
+    });
+
+    test('caches negative results too (NO_ADDRESS misses)', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsAddress('0x0000000000000000000000000000000000000000'));
+
+      const first = await resolveEnsAddress('no-addr-cached.eth');
+      const second = await resolveEnsAddress('no-addr-cached.eth');
+
+      expect(first.reason).toBe('NO_ADDRESS');
+      expect(second.reason).toBe('NO_ADDRESS');
+      // Second call hit the cache, no second RPC round-trip.
+      expect(mockUrResolve).toHaveBeenCalledTimes(1);
+    });
+
+    test('makes exactly one UR call per cold resolution (perf regression guard)', async () => {
+      mockUrResolve.mockResolvedValue(
+        urReturnsAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
+      );
+
+      await resolveEnsAddress('oneshot-addr.eth');
+
+      expect(mockUrResolve).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -16,6 +16,7 @@ const mockGetResolver = jest.fn();
 const mockResolveName = jest.fn();
 const mockUrResolve = jest.fn();
 const mockUrResolveMulticall = jest.fn();
+const mockUrReverse = jest.fn();
 
 jest.mock('ethers', () => {
   const actual = jest.requireActual('ethers').ethers;
@@ -30,6 +31,7 @@ jest.mock('ethers', () => {
       Contract: jest.fn().mockImplementation(() => ({
         resolve: mockUrResolve,
         resolveMulticall: mockUrResolveMulticall,
+        reverse: mockUrReverse,
       })),
       // Pure helpers — use the real implementations so the UR helper's
       // encoding and the inline contenthash decoder are actually exercised.
@@ -38,6 +40,7 @@ jest.mock('ethers', () => {
       AbiCoder: actual.AbiCoder,
       encodeBase58: actual.encodeBase58,
       decodeBase58: actual.decodeBase58,
+      getBytes: actual.getBytes,
       ZeroAddress: actual.ZeroAddress,
     },
   };
@@ -47,6 +50,7 @@ const { ethers } = require('ethers');
 const {
   resolveEnsContent,
   resolveEnsAddress,
+  resolveEnsReverse,
   testRpcUrl,
   invalidateCachedProvider,
   universalResolverCall,
@@ -425,6 +429,142 @@ describe('ens-resolver', () => {
       await resolveEnsAddress('oneshot-addr.eth');
 
       expect(mockUrResolve).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('resolveEnsReverse', () => {
+    const RESOLVER = '0x0000000000000000000000000000000000001234';
+    // Address pool — each test uses a unique one to avoid ensReverseCache
+    // pollution across tests (same pattern as the name-keyed tests above).
+    const addr = (n) => '0x' + String(n).padStart(40, '0');
+
+    test('returns verified name when forward-verify passes', async () => {
+      const input = addr('1001');
+      mockUrReverse.mockResolvedValue(['verified1.eth', RESOLVER, RESOLVER]);
+      mockUrResolve.mockResolvedValue(urReturnsAddress(input));
+
+      const result = await resolveEnsReverse(input);
+
+      expect(result).toEqual({
+        success: true,
+        address: input.toLowerCase(),
+        name: 'verified1.eth',
+      });
+    });
+
+    test('UNVERIFIED when reverse name resolves to a different address', async () => {
+      const input = addr('1002');
+      mockUrReverse.mockResolvedValue(['spoof.eth', RESOLVER, RESOLVER]);
+      mockUrResolve.mockResolvedValue(urReturnsAddress(addr('9999')));
+
+      const result = await resolveEnsReverse(input);
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('UNVERIFIED');
+      expect(result.claimedUnverifiedName).toBe('spoof.eth');
+    });
+
+    test('UNVERIFIED when the reverse-claimed name has no forward addr record', async () => {
+      const input = addr('1003');
+      mockUrReverse.mockResolvedValue(['orphan.eth', RESOLVER, RESOLVER]);
+      mockUrResolve.mockResolvedValue(
+        urReturnsAddress('0x0000000000000000000000000000000000000000')
+      );
+
+      const result = await resolveEnsReverse(input);
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('UNVERIFIED');
+    });
+
+    test('NO_REVERSE when UR returns empty name', async () => {
+      const input = addr('1004');
+      mockUrReverse.mockResolvedValue(['', RESOLVER, RESOLVER]);
+
+      const result = await resolveEnsReverse(input);
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('NO_REVERSE');
+    });
+
+    test('NO_REVERSE when UR reverts with ResolverNotFound', async () => {
+      const input = addr('1005');
+      mockUrReverse.mockRejectedValue(
+        new Error('execution reverted: ResolverNotFound')
+      );
+
+      const result = await resolveEnsReverse(input);
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('NO_REVERSE');
+    });
+
+    test('RESOLUTION_ERROR on generic UR revert', async () => {
+      const input = addr('1006');
+      mockUrReverse.mockRejectedValue(new Error('some other revert'));
+
+      const result = await resolveEnsReverse(input);
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('RESOLUTION_ERROR');
+    });
+
+    test('INVALID_ADDRESS for malformed input', async () => {
+      expect((await resolveEnsReverse('not-an-address')).reason).toBe('INVALID_ADDRESS');
+      expect((await resolveEnsReverse('')).reason).toBe('INVALID_ADDRESS');
+      expect((await resolveEnsReverse(null)).reason).toBe('INVALID_ADDRESS');
+      expect((await resolveEnsReverse('0x1234')).reason).toBe('INVALID_ADDRESS');
+      expect(mockUrReverse).not.toHaveBeenCalled();
+    });
+
+    test('retries on provider error then succeeds', async () => {
+      const input = addr('1007');
+      const providerError = new Error('server error');
+      providerError.code = 'SERVER_ERROR';
+
+      mockUrReverse
+        .mockRejectedValueOnce(providerError)
+        .mockResolvedValueOnce(['retry-reverse.eth', RESOLVER, RESOLVER]);
+      mockUrResolve.mockResolvedValue(urReturnsAddress(input));
+
+      const result = await resolveEnsReverse(input);
+
+      expect(result.success).toBe(true);
+      expect(result.name).toBe('retry-reverse.eth');
+      expect(mockUrReverse).toHaveBeenCalledTimes(2);
+    });
+
+    test('caches successful verified results', async () => {
+      const input = addr('1008');
+      mockUrReverse.mockResolvedValue(['cached.eth', RESOLVER, RESOLVER]);
+      mockUrResolve.mockResolvedValue(urReturnsAddress(input));
+
+      await resolveEnsReverse(input);
+      await resolveEnsReverse(input);
+
+      expect(mockUrReverse).toHaveBeenCalledTimes(1);
+    });
+
+    test('caches NO_REVERSE negative results too', async () => {
+      const input = addr('1009');
+      mockUrReverse.mockResolvedValue(['', RESOLVER, RESOLVER]);
+
+      await resolveEnsReverse(input);
+      await resolveEnsReverse(input);
+
+      expect(mockUrReverse).toHaveBeenCalledTimes(1);
+    });
+
+    test('normalizes input address to lowercase for caching', async () => {
+      const input = '0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa10101010';
+      mockUrReverse.mockResolvedValue(['mixed.eth', RESOLVER, RESOLVER]);
+      mockUrResolve.mockResolvedValue(urReturnsAddress(input.toLowerCase()));
+
+      await resolveEnsReverse(input);
+      await resolveEnsReverse(input.toLowerCase());
+
+      // Second call hits the cache keyed on lowercase form.
+      expect(mockUrReverse).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -29,10 +29,13 @@ jest.mock('ethers', () => {
       Contract: jest.fn().mockImplementation(() => ({
         resolve: mockUrResolve,
       })),
-      // dnsEncode / AbiCoder are pure — use the real implementations so the
-      // UR helper's encoding/decoding is actually exercised in tests.
+      // Pure helpers — use the real implementations so the UR helper's
+      // encoding and the inline contenthash decoder are actually exercised.
       dnsEncode: actual.dnsEncode,
+      namehash: actual.namehash,
       AbiCoder: actual.AbiCoder,
+      encodeBase58: actual.encodeBase58,
+      decodeBase58: actual.decodeBase58,
     },
   };
 });
@@ -60,35 +63,61 @@ beforeEach(() => {
   mockLoadSettings.mockReturnValue({ enableEnsCustomRpc: false, ensRpcUrl: '' });
 });
 
-describe('ens-resolver', () => {
-  describe('.box domain resolution', () => {
-    test('resolves .box domain with IPFS content hash', async () => {
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest
-          .fn()
-          .mockResolvedValue('ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'),
-        address: '0xF97aAc6C8dbaEBCB54ff166d79706E3AF7a813c8',
-      });
+// Helpers for building mocked UR responses.
+const actualEthers = jest.requireActual('ethers').ethers;
+const FAKE_RESOLVER = '0x0000000000000000000000000000000000001234';
 
-      const result = await resolveEnsContent('fleek.box');
+// Wrap raw contenthash hex bytes as the UR's ABI-encoded (bytes) return.
+function urReturnsBytes(innerHex) {
+  const wrapped = actualEthers.AbiCoder.defaultAbiCoder().encode(['bytes'], [innerHex]);
+  return [wrapped, FAKE_RESOLVER];
+}
+
+// Build real ENS contenthash bytes for each codec we support. These are the
+// exact byte patterns a resolver's contenthash(bytes32) would return on
+// mainnet — we feed them through the UR mock so the real regex decoder runs.
+// decodeBase58 returns a BigInt; for CIDv0 "Qm…" it always has a leading
+// 0x12, so .toString(16) yields the full 68-char multihash (no leading-zero
+// loss). padStart is a defensive lower bound.
+function ipfsContenthashFor(base58Hash) {
+  const multihashHex = actualEthers.decodeBase58(base58Hash).toString(16).padStart(68, '0');
+  return '0xe3010170' + multihashHex;
+}
+function ipnsContenthashFor(base58Hash) {
+  const multihashHex = actualEthers.decodeBase58(base58Hash).toString(16).padStart(68, '0');
+  return '0xe5010172' + multihashHex;
+}
+function swarmContenthashFor(hash64Hex) {
+  return '0xe40101fa011b20' + hash64Hex;
+}
+
+describe('ens-resolver', () => {
+  describe('resolveEnsContent', () => {
+    // Real IPFS v0 hash (34 bytes: 0x12 0x20 + 32-byte digest). Using a known
+    // valid CID here so encodeBase58 round-trips cleanly.
+    const IPFS_V0 = 'QmW81r84Aihiqqi2Jw6nM1LnpeMfRCenRxtjwHNkXVkZYa';
+
+    test('decodes ipfs contenthash and returns CIDv0 base58 URI', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
+
+      const result = await resolveEnsContent('vitalik.eth');
+
       expect(result).toEqual({
         type: 'ok',
-        name: 'fleek.box',
+        name: 'vitalik.eth',
         codec: 'ipfs-ns',
         protocol: 'ipfs',
-        uri: 'ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG',
-        decoded: 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG',
+        uri: `ipfs://${IPFS_V0}`,
+        decoded: IPFS_V0,
       });
     });
 
-    test('resolves .box domain with Swarm content hash', async () => {
+    test('decodes swarm contenthash', async () => {
       const swarmHash = 'a'.repeat(64);
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest.fn().mockResolvedValue(`bzz://${swarmHash}`),
-        address: '0xF97aAc6C8dbaEBCB54ff166d79706E3AF7a813c8',
-      });
+      mockUrResolve.mockResolvedValue(urReturnsBytes(swarmContenthashFor(swarmHash)));
 
       const result = await resolveEnsContent('mysite.box');
+
       expect(result).toEqual({
         type: 'ok',
         name: 'mysite.box',
@@ -99,243 +128,167 @@ describe('ens-resolver', () => {
       });
     });
 
-    test('resolves .box domain with IPNS content hash', async () => {
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest
-          .fn()
-          .mockResolvedValue(
-            'ipns://k51qzi5uqu5dlvj2baxnqndepeb86cbk3lg7ekjjnof1ock2yxz7p8q1qf2v9o'
-          ),
-        address: '0xF97aAc6C8dbaEBCB54ff166d79706E3AF7a813c8',
-      });
+    test('decodes ipns contenthash', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipnsContenthashFor(IPFS_V0)));
 
       const result = await resolveEnsContent('dynamic.box');
+
+      expect(result.type).toBe('ok');
+      expect(result.protocol).toBe('ipns');
+      expect(result.uri).toBe(`ipns://${IPFS_V0}`);
+      expect(result.codec).toBe('ipns-ns');
+    });
+
+    test('maps UR ResolverNotFound revert to NO_RESOLVER', async () => {
+      mockUrResolve.mockRejectedValue(new Error('execution reverted: ResolverNotFound("unreg.box")'));
+
+      const result = await resolveEnsContent('unreg.box');
+
       expect(result).toEqual({
-        type: 'ok',
-        name: 'dynamic.box',
-        codec: 'ipns-ns',
-        protocol: 'ipns',
-        uri: 'ipns://k51qzi5uqu5dlvj2baxnqndepeb86cbk3lg7ekjjnof1ock2yxz7p8q1qf2v9o',
-        decoded: 'k51qzi5uqu5dlvj2baxnqndepeb86cbk3lg7ekjjnof1ock2yxz7p8q1qf2v9o',
+        type: 'not_found',
+        reason: 'NO_RESOLVER',
+        name: 'unreg.box',
       });
     });
 
-    test('returns not_found when .box domain has no resolver', async () => {
-      mockGetResolver.mockResolvedValue(null);
-
-      const result = await resolveEnsContent('unregistered.box');
-      expect(result.type).toBe('not_found');
-      expect(result.reason).toBe('NO_RESOLVER');
-      expect(result.name).toBe('unregistered.box');
-    });
-
-    test('returns not_found when .box domain has no content hash (CCIP 404)', async () => {
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest
-          .fn()
-          .mockRejectedValue(
-            new Error(
-              'response not found during CCIP fetch: 3dnsService:: InvalidParameters: CCIP_001'
-            )
-          ),
-        address: '0xF97aAc6C8dbaEBCB54ff166d79706E3AF7a813c8',
-      });
+    test('maps generic UR revert to NO_CONTENTHASH', async () => {
+      mockUrResolve.mockRejectedValue(
+        new Error('response not found during CCIP fetch: 3dnsService:: CCIP_001')
+      );
 
       const result = await resolveEnsContent('nocontent.box');
+
       expect(result.type).toBe('not_found');
       expect(result.reason).toBe('NO_CONTENTHASH');
-      expect(result.name).toBe('nocontent.box');
       expect(result.error).toContain('CCIP');
     });
 
-    test('returns not_found when .box domain has empty content hash', async () => {
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest.fn().mockResolvedValue(null),
-        address: '0xF97aAc6C8dbaEBCB54ff166d79706E3AF7a813c8',
-      });
+    test('returns EMPTY_CONTENTHASH for empty 0x return', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsBytes('0x'));
 
       const result = await resolveEnsContent('empty.box');
-      expect(result.type).toBe('not_found');
-      expect(result.reason).toBe('EMPTY_CONTENTHASH');
-      expect(result.name).toBe('empty.box');
+
+      expect(result).toEqual({
+        type: 'not_found',
+        reason: 'EMPTY_CONTENTHASH',
+        name: 'empty.box',
+      });
     });
 
-    test('normalizes .box domain to lowercase', async () => {
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest.fn().mockResolvedValue('ipfs://QmTest123'),
-        address: '0xF97aAc6C8dbaEBCB54ff166d79706E3AF7a813c8',
-      });
+    test('returns UNSUPPORTED_CONTENTHASH_FORMAT for unknown bytes', async () => {
+      // Arweave codec (0xb29910 varint) — valid contenthash but not supported.
+      mockUrResolve.mockResolvedValue(urReturnsBytes('0xb29910' + 'cd'.repeat(30)));
 
-      const result = await resolveEnsContent('MyDomain.BOX');
-      expect(result.name).toBe('mydomain.box');
+      const result = await resolveEnsContent('arweave.box');
+
+      expect(result.type).toBe('unsupported');
+      expect(result.reason).toBe('UNSUPPORTED_CONTENTHASH_FORMAT');
+      expect(result.name).toBe('arweave.box');
+    });
+
+    test('normalizes mixed-case input to lowercase', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
+
+      const result = await resolveEnsContent('Vitalik.ETH');
+
+      expect(result.name).toBe('vitalik.eth');
       expect(result.type).toBe('ok');
     });
-  });
 
-  describe('.eth domain resolution', () => {
-    test('resolves .eth domain with IPFS content hash', async () => {
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest
-          .fn()
-          .mockResolvedValue('ipfs://QmW81r84Aihiqqi2Jw6nM1LnpeMfRCenRxtjwHNkXVkZYa'),
-        address: '0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41',
-      });
-
-      const result = await resolveEnsContent('vitalik.eth');
-      expect(result).toEqual({
-        type: 'ok',
-        name: 'vitalik.eth',
-        codec: 'ipfs-ns',
-        protocol: 'ipfs',
-        uri: 'ipfs://QmW81r84Aihiqqi2Jw6nM1LnpeMfRCenRxtjwHNkXVkZYa',
-        decoded: 'QmW81r84Aihiqqi2Jw6nM1LnpeMfRCenRxtjwHNkXVkZYa',
-      });
-    });
-  });
-
-  describe('error handling', () => {
     test('throws on empty name', async () => {
       await expect(resolveEnsContent('')).rejects.toThrow('ENS name is empty');
-    });
-
-    test('throws on whitespace-only name', async () => {
       await expect(resolveEnsContent('   ')).rejects.toThrow('ENS name is empty');
     });
 
-    test('retries on provider error', async () => {
+    test('retries on provider error then succeeds', async () => {
       const providerError = new Error('server error');
       providerError.code = 'SERVER_ERROR';
 
-      // First attempt fails with provider error, second succeeds
-      const mockContentHash = jest
-        .fn()
+      mockUrResolve
         .mockRejectedValueOnce(providerError)
-        .mockResolvedValueOnce('ipfs://QmRetried');
-
-      mockGetResolver.mockResolvedValue({
-        getContentHash: mockContentHash,
-        address: '0xTest',
-      });
+        .mockResolvedValueOnce(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
 
       const result = await resolveEnsContent('retry.box');
+
       expect(result.type).toBe('ok');
-      expect(result.uri).toBe('ipfs://QmRetried');
+      expect(result.uri).toBe(`ipfs://${IPFS_V0}`);
+      expect(mockUrResolve).toHaveBeenCalledTimes(2);
     });
 
-    test('returns unsupported for unknown protocol', async () => {
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest.fn().mockResolvedValue('arweave://abc123'),
-        address: '0xTest',
-      });
+    test('caches successful resolutions', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
 
-      const result = await resolveEnsContent('arweave.box');
-      expect(result.type).toBe('unsupported');
-      expect(result.reason).toContain('UNSUPPORTED_PROTOCOL');
+      const first = await resolveEnsContent('cached.box');
+      const second = await resolveEnsContent('cached.box');
+
+      expect(first.type).toBe('ok');
+      expect(second.uri).toBe(`ipfs://${IPFS_V0}`);
+      expect(mockUrResolve).toHaveBeenCalledTimes(1);
     });
 
-    test('returns unsupported for malformed content hash', async () => {
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest.fn().mockResolvedValue('not-a-valid-uri'),
-        address: '0xTest',
-      });
+    test('makes exactly one UR call per cold resolution (perf regression guard)', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
 
-      const result = await resolveEnsContent('malformed.box');
-      expect(result.type).toBe('unsupported');
-      expect(result.reason).toBe('UNSUPPORTED_CONTENTHASH_FORMAT');
-    });
-  });
+      await resolveEnsContent('oneshot.eth');
 
-  describe('caching', () => {
-    test('returns cached result on second call', async () => {
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest.fn().mockResolvedValue('ipfs://QmCached'),
-        address: '0xTest',
-      });
-
-      const result1 = await resolveEnsContent('cached.box');
-      expect(result1.type).toBe('ok');
-
-      // Second call should use cache (resolver should only be called once)
-      const result2 = await resolveEnsContent('cached.box');
-      expect(result2.type).toBe('ok');
-      expect(result2.uri).toBe('ipfs://QmCached');
-
-      // getResolver called only once (second call used cache)
-      expect(mockGetResolver).toHaveBeenCalledTimes(1);
+      expect(mockUrResolve).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('custom RPC URL', () => {
     test('uses custom RPC URL from settings when set', async () => {
-      mockLoadSettings.mockReturnValue({ enableEnsCustomRpc: true, ensRpcUrl: 'http://localhost:8545' });
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest.fn().mockResolvedValue('ipfs://QmCustomRpc'),
-        address: '0xTest',
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: true,
+        ensRpcUrl: 'http://localhost:8545',
       });
+      mockUrResolve.mockResolvedValue(urReturnsBytes('0xe30101701220' + 'ab'.repeat(32)));
 
-      const result = await resolveEnsContent('custom.eth');
-      expect(result.type).toBe('ok');
+      await resolveEnsContent('custom.eth');
 
-      // JsonRpcProvider should have been called with custom URL first
       const calls = ethers.JsonRpcProvider.mock.calls;
       expect(calls[0][0]).toBe('http://localhost:8545');
     });
 
     test('falls back to public RPCs when custom RPC fails', async () => {
-      mockLoadSettings.mockReturnValue({ enableEnsCustomRpc: true, ensRpcUrl: 'http://localhost:8545' });
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: true,
+        ensRpcUrl: 'http://localhost:8545',
+      });
 
-      // First call (custom RPC) fails, second call (public) succeeds
       let callCount = 0;
       mockGetBlockNumber.mockImplementation(() => {
         callCount++;
-        if (callCount === 1) {
-          return Promise.reject(new Error('ECONNREFUSED'));
-        }
+        if (callCount === 1) return Promise.reject(new Error('ECONNREFUSED'));
         return Promise.resolve(12345678);
       });
 
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest.fn().mockResolvedValue('ipfs://QmFallback'),
-        address: '0xTest',
-      });
+      mockUrResolve.mockResolvedValue(urReturnsBytes('0xe30101701220' + 'ab'.repeat(32)));
 
-      const result = await resolveEnsContent('fallback.eth');
-      expect(result.type).toBe('ok');
-      expect(result.uri).toBe('ipfs://QmFallback');
+      await resolveEnsContent('fallback.eth');
 
-      // Should have tried custom URL first, then a public one
       expect(ethers.JsonRpcProvider).toHaveBeenCalledTimes(2);
       expect(ethers.JsonRpcProvider.mock.calls[0][0]).toBe('http://localhost:8545');
     });
 
     test('clearing custom RPC reverts to default behavior', async () => {
-      // Start with custom RPC
-      mockLoadSettings.mockReturnValue({ enableEnsCustomRpc: true, ensRpcUrl: 'http://localhost:8545' });
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest.fn().mockResolvedValue('ipfs://QmFirst'),
-        address: '0xTest',
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: true,
+        ensRpcUrl: 'http://localhost:8545',
       });
+      mockUrResolve.mockResolvedValue(urReturnsBytes('0xe30101701220' + 'ab'.repeat(32)));
 
       await resolveEnsContent('first.eth');
-      const firstUrl = ethers.JsonRpcProvider.mock.calls[0][0];
-      expect(firstUrl).toBe('http://localhost:8545');
+      expect(ethers.JsonRpcProvider.mock.calls[0][0]).toBe('http://localhost:8545');
 
-      // Disable custom RPC — cached provider URL won't match the new first provider,
-      // so getWorkingProvider will invalidate and re-connect
       jest.clearAllMocks();
       mockGetBlockNumber.mockResolvedValue(12345678);
       mockLoadSettings.mockReturnValue({ enableEnsCustomRpc: false, ensRpcUrl: '' });
       invalidateCachedProvider();
-      mockGetResolver.mockResolvedValue({
-        getContentHash: jest.fn().mockResolvedValue('ipfs://QmSecond'),
-        address: '0xTest',
-      });
+      mockUrResolve.mockResolvedValue(urReturnsBytes('0xe301017012' + 'cd'.repeat(34)));
 
       await resolveEnsContent('second.eth');
 
-      // Should use the first public provider, not localhost
-      const secondUrl = ethers.JsonRpcProvider.mock.calls[0][0];
-      expect(secondUrl).not.toBe('http://localhost:8545');
+      expect(ethers.JsonRpcProvider.mock.calls[0][0]).not.toBe('http://localhost:8545');
     });
   });
 

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -14,17 +14,28 @@ const mockGetBlockNumber = jest.fn();
 const mockDestroy = jest.fn();
 const mockGetResolver = jest.fn();
 const mockResolveName = jest.fn();
+const mockUrResolve = jest.fn();
 
-jest.mock('ethers', () => ({
-  ethers: {
-    JsonRpcProvider: jest.fn().mockImplementation(() => ({
-      getBlockNumber: mockGetBlockNumber,
-      getResolver: mockGetResolver,
-      resolveName: mockResolveName,
-      destroy: mockDestroy,
-    })),
-  },
-}));
+jest.mock('ethers', () => {
+  const actual = jest.requireActual('ethers').ethers;
+  return {
+    ethers: {
+      JsonRpcProvider: jest.fn().mockImplementation(() => ({
+        getBlockNumber: mockGetBlockNumber,
+        getResolver: mockGetResolver,
+        resolveName: mockResolveName,
+        destroy: mockDestroy,
+      })),
+      Contract: jest.fn().mockImplementation(() => ({
+        resolve: mockUrResolve,
+      })),
+      // dnsEncode / AbiCoder are pure — use the real implementations so the
+      // UR helper's encoding/decoding is actually exercised in tests.
+      dnsEncode: actual.dnsEncode,
+      AbiCoder: actual.AbiCoder,
+    },
+  };
+});
 
 const { ethers } = require('ethers');
 const {
@@ -32,6 +43,8 @@ const {
   resolveEnsAddress,
   testRpcUrl,
   invalidateCachedProvider,
+  universalResolverCall,
+  isResolverNotFoundError,
 } = require('./ens-resolver');
 
 beforeEach(() => {
@@ -439,6 +452,85 @@ describe('ens-resolver', () => {
       mockGetBlockNumber.mockRejectedValue(new Error('fail'));
       await testRpcUrl('http://localhost:8545');
       expect(mockDestroy).toHaveBeenCalled();
+    });
+  });
+
+  describe('universalResolverCall', () => {
+    const actualEthers = jest.requireActual('ethers').ethers;
+    const FAKE_RESOLVER = '0x0000000000000000000000000000000000001234';
+
+    // Helper: wrap raw hex bytes as the UR's ABI-encoded `(bytes)` return value.
+    const wrapAsUrBytes = (innerHex) => {
+      const coder = actualEthers.AbiCoder.defaultAbiCoder();
+      return coder.encode(['bytes'], [innerHex]);
+    };
+
+    test('encodes name, opts into CCIP-Read, and unwraps inner bytes', async () => {
+      const inner = '0xdeadbeef';
+      mockUrResolve.mockResolvedValue([wrapAsUrBytes(inner), FAKE_RESOLVER]);
+
+      const provider = new ethers.JsonRpcProvider('http://localhost:8545');
+      const callData = '0xbc1c4a73' + actualEthers.namehash('vitalik.eth').slice(2);
+      const result = await universalResolverCall(provider, 'vitalik.eth', callData);
+
+      expect(result.bytes.toLowerCase()).toBe(inner);
+      expect(result.resolverAddress).toBe(FAKE_RESOLVER);
+
+      // Verify the call shape the UR actually received
+      expect(mockUrResolve).toHaveBeenCalledTimes(1);
+      const [encodedName, passedCallData, overrides] = mockUrResolve.mock.calls[0];
+      expect(encodedName).toBe(actualEthers.dnsEncode('vitalik.eth', 255));
+      expect(passedCallData).toBe(callData);
+      expect(overrides).toEqual({ enableCcipRead: true });
+    });
+
+    test('constructs Contract with UR address and minimal ABI', async () => {
+      mockUrResolve.mockResolvedValue([wrapAsUrBytes('0x'), FAKE_RESOLVER]);
+      const provider = new ethers.JsonRpcProvider('http://localhost:8545');
+      await universalResolverCall(provider, 'vitalik.eth', '0xbc1c4a73');
+
+      expect(ethers.Contract).toHaveBeenCalledWith(
+        '0x5a9236e72a66d3e08b83dcf489b4d850792b6009',
+        expect.arrayContaining([expect.stringContaining('function resolve')]),
+        provider
+      );
+    });
+
+    test('propagates UR reverts to the caller', async () => {
+      const err = new Error('execution reverted: ResolverNotFound');
+      mockUrResolve.mockRejectedValue(err);
+      const provider = new ethers.JsonRpcProvider('http://localhost:8545');
+      await expect(
+        universalResolverCall(provider, 'unregistered.eth', '0xbc1c4a73')
+      ).rejects.toThrow('ResolverNotFound');
+    });
+  });
+
+  describe('isResolverNotFoundError', () => {
+    test('matches ResolverNotFound error message', () => {
+      expect(
+        isResolverNotFoundError(new Error('execution reverted: ResolverNotFound("foo.eth")'))
+      ).toBe(true);
+    });
+
+    test('matches ResolverNotContract error message', () => {
+      expect(
+        isResolverNotFoundError(new Error('execution reverted: ResolverNotContract'))
+      ).toBe(true);
+    });
+
+    test('matches ResolverNotFound selector in error data', () => {
+      const err = new Error('call exception');
+      err.info = { error: { data: '0x7199966d00000000000000000000000000000000' } };
+      expect(isResolverNotFoundError(err)).toBe(true);
+    });
+
+    test('rejects unrelated errors', () => {
+      expect(isResolverNotFoundError(new Error('network timeout'))).toBe(false);
+      expect(isResolverNotFoundError(new Error('ECONNREFUSED'))).toBe(false);
+      expect(isResolverNotFoundError(null)).toBe(false);
+      expect(isResolverNotFoundError(undefined)).toBe(false);
+      expect(isResolverNotFoundError({})).toBe(false);
     });
   });
 });

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -15,6 +15,7 @@ const mockDestroy = jest.fn();
 const mockGetResolver = jest.fn();
 const mockResolveName = jest.fn();
 const mockUrResolve = jest.fn();
+const mockUrResolveMulticall = jest.fn();
 
 jest.mock('ethers', () => {
   const actual = jest.requireActual('ethers').ethers;
@@ -28,6 +29,7 @@ jest.mock('ethers', () => {
       })),
       Contract: jest.fn().mockImplementation(() => ({
         resolve: mockUrResolve,
+        resolveMulticall: mockUrResolveMulticall,
       })),
       // Pure helpers — use the real implementations so the UR helper's
       // encoding and the inline contenthash decoder are actually exercised.
@@ -47,6 +49,7 @@ const {
   testRpcUrl,
   invalidateCachedProvider,
   universalResolverCall,
+  universalResolverMulticall,
   isResolverNotFoundError,
 } = require('./ens-resolver');
 
@@ -517,6 +520,51 @@ describe('ens-resolver', () => {
       const provider = new ethers.JsonRpcProvider('http://localhost:8545');
       await expect(
         universalResolverCall(provider, 'unregistered.eth', '0xbc1c4a73')
+      ).rejects.toThrow('ResolverNotFound');
+    });
+  });
+
+  describe('universalResolverMulticall', () => {
+    test('encodes name, opts into CCIP-Read, and unwraps per-call inner bytes', async () => {
+      const coder = actualEthers.AbiCoder.defaultAbiCoder();
+      // Simulate three resolver responses (e.g. addr + text + contenthash).
+      const inner1 = '0xdeadbeef';
+      const inner2 = '0xfeedface';
+      const inner3 = '0x';
+      mockUrResolveMulticall.mockResolvedValue([
+        coder.encode(['bytes'], [inner1]),
+        coder.encode(['bytes'], [inner2]),
+        coder.encode(['bytes'], [inner3]),
+      ]);
+
+      const provider = new ethers.JsonRpcProvider('http://localhost:8545');
+      const calls = ['0x3b3b57de', '0xbc1c4a73', '0x59d1d43c'];
+      const results = await universalResolverMulticall(provider, 'vitalik.eth', calls);
+
+      expect(results.map((r) => r.toLowerCase())).toEqual([inner1, inner2, inner3]);
+
+      expect(mockUrResolveMulticall).toHaveBeenCalledTimes(1);
+      const [encodedName, passedCalls, overrides] = mockUrResolveMulticall.mock.calls[0];
+      expect(encodedName).toBe(actualEthers.dnsEncode('vitalik.eth', 255));
+      expect(passedCalls).toEqual(calls);
+      expect(overrides).toEqual({ enableCcipRead: true });
+    });
+
+    test('handles empty calls array', async () => {
+      mockUrResolveMulticall.mockResolvedValue([]);
+
+      const provider = new ethers.JsonRpcProvider('http://localhost:8545');
+      const results = await universalResolverMulticall(provider, 'vitalik.eth', []);
+
+      expect(results).toEqual([]);
+    });
+
+    test('propagates reverts to the caller', async () => {
+      mockUrResolveMulticall.mockRejectedValue(new Error('execution reverted: ResolverNotFound'));
+
+      const provider = new ethers.JsonRpcProvider('http://localhost:8545');
+      await expect(
+        universalResolverMulticall(provider, 'unreg.eth', ['0x3b3b57de'])
       ).rejects.toThrow('ResolverNotFound');
     });
   });

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -13,19 +13,26 @@ jest.mock('./settings-store', () => ({
 const mockGetBlockNumber = jest.fn();
 const mockDestroy = jest.fn();
 const mockGetResolver = jest.fn();
+const mockResolveName = jest.fn();
 
 jest.mock('ethers', () => ({
   ethers: {
     JsonRpcProvider: jest.fn().mockImplementation(() => ({
       getBlockNumber: mockGetBlockNumber,
       getResolver: mockGetResolver,
+      resolveName: mockResolveName,
       destroy: mockDestroy,
     })),
   },
 }));
 
 const { ethers } = require('ethers');
-const { resolveEnsContent, testRpcUrl, invalidateCachedProvider } = require('./ens-resolver');
+const {
+  resolveEnsContent,
+  resolveEnsAddress,
+  testRpcUrl,
+  invalidateCachedProvider,
+} = require('./ens-resolver');
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -34,6 +41,8 @@ beforeEach(() => {
   mockGetBlockNumber.mockResolvedValue(12345678);
   // Default: resolver returns null (no resolver found)
   mockGetResolver.mockResolvedValue(null);
+  // Default: resolveName returns null (no addr record)
+  mockResolveName.mockResolvedValue(null);
   // Default: no custom RPC
   mockLoadSettings.mockReturnValue({ enableEnsCustomRpc: false, ensRpcUrl: '' });
 });
@@ -314,6 +323,76 @@ describe('ens-resolver', () => {
       // Should use the first public provider, not localhost
       const secondUrl = ethers.JsonRpcProvider.mock.calls[0][0];
       expect(secondUrl).not.toBe('http://localhost:8545');
+    });
+  });
+
+  describe('resolveEnsAddress', () => {
+    test('resolves ENS name to its addr record', async () => {
+      mockResolveName.mockResolvedValue('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045');
+
+      const result = await resolveEnsAddress('vitalik.eth');
+
+      expect(result).toEqual({
+        success: true,
+        name: 'vitalik.eth',
+        address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+      });
+      expect(mockResolveName).toHaveBeenCalledWith('vitalik.eth');
+    });
+
+    test('normalizes mixed-case input to lowercase before resolving', async () => {
+      mockResolveName.mockResolvedValue('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045');
+
+      const result = await resolveEnsAddress('Mixed.ETH');
+
+      expect(result.success).toBe(true);
+      expect(result.name).toBe('mixed.eth');
+      expect(mockResolveName).toHaveBeenCalledWith('mixed.eth');
+    });
+
+    test('returns NO_ADDRESS when the name has no addr record', async () => {
+      mockResolveName.mockResolvedValue(null);
+
+      const result = await resolveEnsAddress('no-addr.eth');
+
+      expect(result).toEqual({
+        success: false,
+        name: 'no-addr.eth',
+        reason: 'NO_ADDRESS',
+        error: 'No address record set for no-addr.eth',
+      });
+    });
+
+    test('throws on empty name', async () => {
+      await expect(resolveEnsAddress('')).rejects.toThrow('ENS name is empty');
+      await expect(resolveEnsAddress('   ')).rejects.toThrow('ENS name is empty');
+    });
+
+    test('retries on provider error then succeeds', async () => {
+      const providerError = new Error('server error');
+      providerError.code = 'SERVER_ERROR';
+
+      mockResolveName
+        .mockRejectedValueOnce(providerError)
+        .mockResolvedValueOnce('0x0000000000000000000000000000000000000001');
+
+      const result = await resolveEnsAddress('retry.eth');
+
+      expect(result.success).toBe(true);
+      expect(result.address).toBe('0x0000000000000000000000000000000000000001');
+      expect(mockResolveName).toHaveBeenCalledTimes(2);
+    });
+
+    test('caches successful resolutions', async () => {
+      mockResolveName.mockResolvedValue('0x1111111111111111111111111111111111111111');
+
+      const first = await resolveEnsAddress('cached.eth');
+      const second = await resolveEnsAddress('cached.eth');
+
+      expect(first.address).toBe('0x1111111111111111111111111111111111111111');
+      expect(second.address).toBe('0x1111111111111111111111111111111111111111');
+      // Second call hits the cache, so resolveName is only invoked once.
+      expect(mockResolveName).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -38,6 +38,7 @@ jest.mock('ethers', () => {
       AbiCoder: actual.AbiCoder,
       encodeBase58: actual.encodeBase58,
       decodeBase58: actual.decodeBase58,
+      ZeroAddress: actual.ZeroAddress,
     },
   };
 });
@@ -92,6 +93,13 @@ function ipnsContenthashFor(base58Hash) {
 }
 function swarmContenthashFor(hash64Hex) {
   return '0xe40101fa011b20' + hash64Hex;
+}
+
+// Wrap an address as the UR's return where `bytes` is the ABI-encoded
+// `address` output of the resolver's addr(bytes32).
+function urReturnsAddress(address) {
+  const inner = actualEthers.AbiCoder.defaultAbiCoder().encode(['address'], [address]);
+  return urReturnsBytes(inner);
 }
 
 describe('ens-resolver', () => {
@@ -296,13 +304,6 @@ describe('ens-resolver', () => {
   });
 
   describe('resolveEnsAddress', () => {
-    // Wrap an address as the UR's (bytes, address) return value where `bytes`
-    // is the ABI-encoded `address` output of the resolver's addr(bytes32).
-    function urReturnsAddress(address) {
-      const inner = actualEthers.AbiCoder.defaultAbiCoder().encode(['address'], [address]);
-      return urReturnsBytes(inner);
-    }
-
     test('resolves ENS name to its addr record', async () => {
       mockUrResolve.mockResolvedValue(
         urReturnsAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -15,7 +15,6 @@ const mockDestroy = jest.fn();
 const mockGetResolver = jest.fn();
 const mockResolveName = jest.fn();
 const mockUrResolve = jest.fn();
-const mockUrResolveMulticall = jest.fn();
 const mockUrReverse = jest.fn();
 
 jest.mock('ethers', () => {
@@ -30,7 +29,6 @@ jest.mock('ethers', () => {
       })),
       Contract: jest.fn().mockImplementation(() => ({
         resolve: mockUrResolve,
-        resolveMulticall: mockUrResolveMulticall,
         reverse: mockUrReverse,
       })),
       // Pure helpers — use the real implementations so the UR helper's
@@ -54,7 +52,6 @@ const {
   testRpcUrl,
   invalidateCachedProvider,
   universalResolverCall,
-  universalResolverMulticall,
   isResolverNotFoundError,
 } = require('./ens-resolver');
 
@@ -430,14 +427,14 @@ describe('ens-resolver', () => {
 
   describe('resolveEnsReverse', () => {
     const RESOLVER = '0x0000000000000000000000000000000000001234';
-    // Address pool — each test uses a unique one to avoid ensReverseCache
-    // pollution across tests (same pattern as the name-keyed tests above).
+    // Unique per-test addresses avoid ensReverseCache pollution across tests.
     const addr = (n) => '0x' + String(n).padStart(40, '0');
 
-    test('returns verified name when forward-verify passes', async () => {
+    test('returns verified name when UR resolves successfully', async () => {
+      // UR verifies forward-resolution internally before returning a name —
+      // a successful return is already a trusted match, no external check.
       const input = addr('1001');
       mockUrReverse.mockResolvedValue(['verified1.eth', RESOLVER, RESOLVER]);
-      mockUrResolve.mockResolvedValue(urReturnsAddress(input));
 
       const result = await resolveEnsReverse(input);
 
@@ -448,29 +445,19 @@ describe('ens-resolver', () => {
       });
     });
 
-    test('UNVERIFIED when reverse name resolves to a different address', async () => {
+    test('UNVERIFIED when UR reverts with ReverseAddressMismatch', async () => {
       const input = addr('1002');
-      mockUrReverse.mockResolvedValue(['spoof.eth', RESOLVER, RESOLVER]);
-      mockUrResolve.mockResolvedValue(urReturnsAddress(addr('9999')));
+      const err = new Error('execution reverted: ReverseAddressMismatch');
+      err.data = '0xef9c03ce00000000000000000000000000000000';
+      mockUrReverse.mockRejectedValue(err);
 
       const result = await resolveEnsReverse(input);
 
       expect(result.success).toBe(false);
       expect(result.reason).toBe('UNVERIFIED');
-      expect(result.claimedUnverifiedName).toBe('spoof.eth');
-    });
-
-    test('UNVERIFIED when the reverse-claimed name has no forward addr record', async () => {
-      const input = addr('1003');
-      mockUrReverse.mockResolvedValue(['orphan.eth', RESOLVER, RESOLVER]);
-      mockUrResolve.mockResolvedValue(
-        urReturnsAddress('0x0000000000000000000000000000000000000000')
-      );
-
-      const result = await resolveEnsReverse(input);
-
-      expect(result.success).toBe(false);
-      expect(result.reason).toBe('UNVERIFIED');
+      // No claimed-name field — keeps spoofed names out of the return shape
+      // entirely so no caller can accidentally surface them.
+      expect(result.claimedUnverifiedName).toBeUndefined();
     });
 
     test('NO_REVERSE when UR returns empty name', async () => {
@@ -485,9 +472,9 @@ describe('ens-resolver', () => {
 
     test('NO_REVERSE when UR reverts with ResolverNotFound', async () => {
       const input = addr('1005');
-      mockUrReverse.mockRejectedValue(
-        new Error('execution reverted: ResolverNotFound')
-      );
+      const err = new Error('execution reverted: ResolverNotFound');
+      err.data = '0x77209fe800000000';
+      mockUrReverse.mockRejectedValue(err);
 
       const result = await resolveEnsReverse(input);
 
@@ -521,7 +508,6 @@ describe('ens-resolver', () => {
       mockUrReverse
         .mockRejectedValueOnce(providerError)
         .mockResolvedValueOnce(['retry-reverse.eth', RESOLVER, RESOLVER]);
-      mockUrResolve.mockResolvedValue(urReturnsAddress(input));
 
       const result = await resolveEnsReverse(input);
 
@@ -533,7 +519,6 @@ describe('ens-resolver', () => {
     test('caches successful verified results', async () => {
       const input = addr('1008');
       mockUrReverse.mockResolvedValue(['cached.eth', RESOLVER, RESOLVER]);
-      mockUrResolve.mockResolvedValue(urReturnsAddress(input));
 
       await resolveEnsReverse(input);
       await resolveEnsReverse(input);
@@ -554,7 +539,6 @@ describe('ens-resolver', () => {
     test('normalizes input address to lowercase for caching', async () => {
       const input = '0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa10101010';
       mockUrReverse.mockResolvedValue(['mixed.eth', RESOLVER, RESOLVER]);
-      mockUrResolve.mockResolvedValue(urReturnsAddress(input.toLowerCase()));
 
       await resolveEnsReverse(input);
       await resolveEnsReverse(input.toLowerCase());
@@ -639,7 +623,7 @@ describe('ens-resolver', () => {
       await universalResolverCall(provider, 'vitalik.eth', '0xbc1c58d1');
 
       expect(ethers.Contract).toHaveBeenCalledWith(
-        '0x5a9236e72a66d3e08b83dcf489b4d850792b6009',
+        '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe',
         expect.arrayContaining([expect.stringContaining('function resolve')]),
         provider
       );
@@ -651,52 +635,6 @@ describe('ens-resolver', () => {
       const provider = new ethers.JsonRpcProvider('http://localhost:8545');
       await expect(
         universalResolverCall(provider, 'unregistered.eth', '0xbc1c58d1')
-      ).rejects.toThrow('ResolverNotFound');
-    });
-  });
-
-  describe('universalResolverMulticall', () => {
-    test('encodes name, opts into CCIP-Read, returns raw per-call responses', async () => {
-      // Simulate three responses with different return-type shapes, as the
-      // real UR would: (address), (bytes), (string) — each raw-ABI-encoded.
-      const r1 = actualEthers.AbiCoder.defaultAbiCoder().encode(
-        ['address'],
-        ['0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045']
-      );
-      const r2 = actualEthers.AbiCoder.defaultAbiCoder().encode(['bytes'], ['0xdeadbeef']);
-      const r3 = actualEthers.AbiCoder.defaultAbiCoder().encode(['string'], ['hello']);
-      mockUrResolveMulticall.mockResolvedValue([r1, r2, r3]);
-
-      const provider = new ethers.JsonRpcProvider('http://localhost:8545');
-      const calls = ['0x3b3b57de', '0xbc1c58d1', '0x59d1d43c'];
-      const results = await universalResolverMulticall(provider, 'vitalik.eth', calls);
-
-      // Results are the raw per-call ABI-encoded responses. Caller decodes
-      // each per its specific return type.
-      expect(results).toEqual([r1, r2, r3]);
-
-      expect(mockUrResolveMulticall).toHaveBeenCalledTimes(1);
-      const [encodedName, passedCalls, overrides] = mockUrResolveMulticall.mock.calls[0];
-      expect(encodedName).toBe(actualEthers.dnsEncode('vitalik.eth', 255));
-      expect(passedCalls).toEqual(calls);
-      expect(overrides).toEqual({ enableCcipRead: true });
-    });
-
-    test('handles empty calls array', async () => {
-      mockUrResolveMulticall.mockResolvedValue([]);
-
-      const provider = new ethers.JsonRpcProvider('http://localhost:8545');
-      const results = await universalResolverMulticall(provider, 'vitalik.eth', []);
-
-      expect(results).toEqual([]);
-    });
-
-    test('propagates reverts to the caller', async () => {
-      mockUrResolveMulticall.mockRejectedValue(new Error('execution reverted: ResolverNotFound'));
-
-      const provider = new ethers.JsonRpcProvider('http://localhost:8545');
-      await expect(
-        universalResolverMulticall(provider, 'unreg.eth', ['0x3b3b57de'])
       ).rejects.toThrow('ResolverNotFound');
     });
   });
@@ -714,12 +652,6 @@ describe('ens-resolver', () => {
       ).toBe(true);
     });
 
-    test('matches UnreachableName in error message', () => {
-      expect(
-        isResolverNotFoundError(new Error('execution reverted: UnreachableName'))
-      ).toBe(true);
-    });
-
     // ethers v6 surfaces revert selectors on err.data directly — this is
     // the shape we see on real CALL_EXCEPTION errors from a live RPC.
     test('matches ResolverNotFound selector on err.data (ethers v6)', () => {
@@ -731,12 +663,6 @@ describe('ens-resolver', () => {
     test('matches ResolverNotContract selector on err.data', () => {
       const err = new Error('execution reverted');
       err.data = '0x1e9535f2000000000000000000';
-      expect(isResolverNotFoundError(err)).toBe(true);
-    });
-
-    test('matches UnreachableName selector on err.data', () => {
-      const err = new Error('execution reverted');
-      err.data = '0x5fe9a5df000000000000000000';
       expect(isResolverNotFoundError(err)).toBe(true);
     });
 
@@ -762,6 +688,12 @@ describe('ens-resolver', () => {
       expect(isResolverNotFoundError(null)).toBe(false);
       expect(isResolverNotFoundError(undefined)).toBe(false);
       expect(isResolverNotFoundError({})).toBe(false);
+    });
+
+    test('does NOT match ReverseAddressMismatch (separate concept)', () => {
+      const err = new Error('execution reverted: ReverseAddressMismatch');
+      err.data = '0xef9c03ce00000000';
+      expect(isResolverNotFoundError(err)).toBe(false);
     });
   });
 });

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -702,27 +702,63 @@ describe('ens-resolver', () => {
   });
 
   describe('isResolverNotFoundError', () => {
-    test('matches ResolverNotFound error message', () => {
+    test('matches ResolverNotFound in error message', () => {
       expect(
         isResolverNotFoundError(new Error('execution reverted: ResolverNotFound("foo.eth")'))
       ).toBe(true);
     });
 
-    test('matches ResolverNotContract error message', () => {
+    test('matches ResolverNotContract in error message', () => {
       expect(
         isResolverNotFoundError(new Error('execution reverted: ResolverNotContract'))
       ).toBe(true);
     });
 
-    test('matches ResolverNotFound selector in error data', () => {
+    test('matches UnreachableName in error message', () => {
+      expect(
+        isResolverNotFoundError(new Error('execution reverted: UnreachableName'))
+      ).toBe(true);
+    });
+
+    // ethers v6 surfaces revert selectors on err.data directly — this is
+    // the shape we see on real CALL_EXCEPTION errors from a live RPC.
+    test('matches ResolverNotFound selector on err.data (ethers v6)', () => {
+      const err = new Error('execution reverted (unknown custom error)');
+      err.data = '0x77209fe800000000000000000000000000000000000000000000000000000000';
+      expect(isResolverNotFoundError(err)).toBe(true);
+    });
+
+    test('matches ResolverNotContract selector on err.data', () => {
+      const err = new Error('execution reverted');
+      err.data = '0x1e9535f2000000000000000000';
+      expect(isResolverNotFoundError(err)).toBe(true);
+    });
+
+    test('matches UnreachableName selector on err.data', () => {
+      const err = new Error('execution reverted');
+      err.data = '0x5fe9a5df000000000000000000';
+      expect(isResolverNotFoundError(err)).toBe(true);
+    });
+
+    // Some JSON-RPC wrappers nest the revert data one level deeper.
+    test('matches selector nested under err.info.error.data', () => {
       const err = new Error('call exception');
-      err.info = { error: { data: '0x7199966d00000000000000000000000000000000' } };
+      err.info = { error: { data: '0x77209fe80000' } };
+      expect(isResolverNotFoundError(err)).toBe(true);
+    });
+
+    test('selector match is case-insensitive', () => {
+      const err = new Error('x');
+      err.data = '0x77209FE80000';
       expect(isResolverNotFoundError(err)).toBe(true);
     });
 
     test('rejects unrelated errors', () => {
       expect(isResolverNotFoundError(new Error('network timeout'))).toBe(false);
       expect(isResolverNotFoundError(new Error('ECONNREFUSED'))).toBe(false);
+      const unrelated = new Error('x');
+      unrelated.data = '0xdeadbeef00000000';
+      expect(isResolverNotFoundError(unrelated)).toBe(false);
       expect(isResolverNotFoundError(null)).toBe(false);
       expect(isResolverNotFoundError(undefined)).toBe(false);
       expect(isResolverNotFoundError({})).toBe(false);

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -212,6 +212,22 @@ describe('ens-resolver', () => {
       expect(result.type).toBe('ok');
     });
 
+    // Unicode names need full UTS-46 / ENSIP-15 normalization, not bare
+    // lowercase — otherwise namehash is computed against an unnormalized
+    // form and the resolver lookup silently misses.
+    test('normalizes unicode names via ENSIP-15', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
+
+      const result = await resolveEnsContent('nic🦊.eth');
+
+      expect(result.type).toBe('ok');
+      expect(result.name).toBe('nic🦊.eth');
+    });
+
+    test('throws on invalid ENS label (e.g. mid-label underscore)', async () => {
+      await expect(resolveEnsContent('invalid_label.eth')).rejects.toThrow(/underscore/i);
+    });
+
     test('throws on empty name', async () => {
       await expect(resolveEnsContent('')).rejects.toThrow('ENS name is empty');
       await expect(resolveEnsContent('   ')).rejects.toThrow('ENS name is empty');

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -46,6 +46,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('bookmarks:update', { originalTarget, bookmark }),
   removeBookmark: (target) => ipcRenderer.invoke('bookmarks:remove', target),
   resolveEns: (name) => ipcRenderer.invoke('ens:resolve', { name }),
+  resolveEnsAddress: (name) => ipcRenderer.invoke('ens:resolve-address', { name }),
   testEnsRpc: (url) => ipcRenderer.invoke('ens:test-rpc', { url }),
   // History
   getHistory: (options) => ipcRenderer.invoke('history:get', options),

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -47,6 +47,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   removeBookmark: (target) => ipcRenderer.invoke('bookmarks:remove', target),
   resolveEns: (name) => ipcRenderer.invoke('ens:resolve', { name }),
   resolveEnsAddress: (name) => ipcRenderer.invoke('ens:resolve-address', { name }),
+  resolveEnsReverse: (address) => ipcRenderer.invoke('ens:resolve-reverse', { address }),
   testEnsRpc: (url) => ipcRenderer.invoke('ens:test-rpc', { url }),
   // History
   getHistory: (options) => ipcRenderer.invoke('history:get', options),

--- a/src/main/preload.test.js
+++ b/src/main/preload.test.js
@@ -128,6 +128,7 @@ describe('preload', () => {
       [exposures.electronAPI, 'updateBookmark', ['https://old.example', { label: 'New', target: 'https://new.example' }], IPC.BOOKMARKS_UPDATE, [{ originalTarget: 'https://old.example', bookmark: { label: 'New', target: 'https://new.example' } }]],
       [exposures.electronAPI, 'removeBookmark', ['https://example.com'], IPC.BOOKMARKS_REMOVE, ['https://example.com']],
       [exposures.electronAPI, 'resolveEns', ['myname.box'], IPC.ENS_RESOLVE, [{ name: 'myname.box' }]],
+      [exposures.electronAPI, 'resolveEnsAddress', ['vitalik.eth'], IPC.ENS_RESOLVE_ADDRESS, [{ name: 'vitalik.eth' }]],
       [exposures.electronAPI, 'getHistory', [{ limit: 10 }], IPC.HISTORY_GET, [{ limit: 10 }]],
       [exposures.electronAPI, 'addHistory', [{ url: 'https://example.com' }], IPC.HISTORY_ADD, [{ url: 'https://example.com' }]],
       [exposures.electronAPI, 'removeHistory', [7], IPC.HISTORY_REMOVE, [7]],

--- a/src/main/preload.test.js
+++ b/src/main/preload.test.js
@@ -129,6 +129,7 @@ describe('preload', () => {
       [exposures.electronAPI, 'removeBookmark', ['https://example.com'], IPC.BOOKMARKS_REMOVE, ['https://example.com']],
       [exposures.electronAPI, 'resolveEns', ['myname.box'], IPC.ENS_RESOLVE, [{ name: 'myname.box' }]],
       [exposures.electronAPI, 'resolveEnsAddress', ['vitalik.eth'], IPC.ENS_RESOLVE_ADDRESS, [{ name: 'vitalik.eth' }]],
+      [exposures.electronAPI, 'resolveEnsReverse', ['0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'], IPC.ENS_RESOLVE_REVERSE, [{ address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' }]],
       [exposures.electronAPI, 'getHistory', [{ limit: 10 }], IPC.HISTORY_GET, [{ limit: 10 }]],
       [exposures.electronAPI, 'addHistory', [{ url: 'https://example.com' }], IPC.HISTORY_ADD, [{ url: 'https://example.com' }]],
       [exposures.electronAPI, 'removeHistory', [7], IPC.HISTORY_REMOVE, [7]],

--- a/src/main/webcontents-setup.js
+++ b/src/main/webcontents-setup.js
@@ -86,7 +86,8 @@ function registerWebContentsHandlers() {
           url.startsWith('bzz://') ||
           url.startsWith('ipfs://') ||
           url.startsWith('ipns://') ||
-          url.startsWith('rad:')
+          url.startsWith('rad:') ||
+          url.startsWith('ethereum:')
         ) {
           log.info(`${tag} intercepted custom protocol navigation: ${sanitizeUrlForLog(url)}`);
           event.preventDefault();

--- a/src/main/webcontents-setup.test.js
+++ b/src/main/webcontents-setup.test.js
@@ -189,6 +189,16 @@ describe('webcontents-setup', () => {
       expect.stringContaining('intercepted custom protocol navigation')
     );
 
+    const ethEvent = {
+      preventDefault: jest.fn(),
+    };
+    contents.emit('will-navigate', ethEvent, 'ethereum:vitalik.eth@1?value=1e16');
+    expect(ethEvent.preventDefault).toHaveBeenCalled();
+    expect(parentWindow.webContents.send).toHaveBeenCalledWith(
+      'navigate-to-url',
+      'ethereum:vitalik.eth@1?value=1e16'
+    );
+
     const httpEvent = {
       preventDefault: jest.fn(),
     };

--- a/src/renderer/lib/ethereum-uri.js
+++ b/src/renderer/lib/ethereum-uri.js
@@ -1,0 +1,88 @@
+// EIP-681 "ethereum:" URI parser — native-asset subset.
+// https://eips.ethereum.org/EIPS/eip-681
+//
+// Accepts:
+//   ethereum:<0xAddress | .eth / .box name>[@<chainId>][?value=<wei>][&label=<str>]
+//
+// Rejects function-call variants ("ethereum:<token>@<chain>/transfer?...")
+// explicitly so a tip link can never be confused with an ERC-20 transfer.
+
+const SCHEME = 'ethereum:';
+
+// Accepts integer or scientific notation ("1e18", "1.5e17"). No signs, no
+// fractional wei.
+const VALUE_RE = /^[0-9]+(\.[0-9]+)?([eE][0-9]+)?$/;
+
+// Convert an EIP-681 numeric value string to an exact wei BigInt (as a
+// decimal string). Returns null on malformed input or non-integer wei
+// (e.g. "0.1" without exponent, "1.5e0").
+export function parseWeiValue(s) {
+  if (typeof s !== 'string' || !VALUE_RE.test(s)) return null;
+  const [mantissa, expStr] = s.toLowerCase().split('e');
+  const exp = expStr ? parseInt(expStr, 10) : 0;
+  const [intPart, fracPart = ''] = mantissa.split('.');
+  const shift = exp - fracPart.length;
+  if (shift < 0) return null;
+  const wei = BigInt(intPart + fracPart) * 10n ** BigInt(shift);
+  return wei.toString();
+}
+
+// Performs no ENS resolution, no address checksumming, no chain-registry
+// lookup — the caller owns semantics.
+export function parseEthereumUri(raw) {
+  if (typeof raw !== 'string') return { ok: false, reason: 'MALFORMED' };
+  const trimmed = raw.trim();
+  if (!trimmed.toLowerCase().startsWith(SCHEME)) {
+    return { ok: false, reason: 'NOT_ETHEREUM_URI' };
+  }
+
+  let body = trimmed.slice(SCHEME.length);
+
+  let queryStr = '';
+  const qIdx = body.indexOf('?');
+  if (qIdx >= 0) {
+    queryStr = body.slice(qIdx + 1);
+    body = body.slice(0, qIdx);
+  }
+
+  if (body.includes('/')) {
+    return { ok: false, reason: 'UNSUPPORTED_FUNCTION' };
+  }
+
+  let target = body;
+  let chainId = 1;
+  const atIdx = body.indexOf('@');
+  if (atIdx >= 0) {
+    target = body.slice(0, atIdx);
+    const chainIdStr = body.slice(atIdx + 1);
+    if (!/^[0-9]+$/.test(chainIdStr)) return { ok: false, reason: 'MALFORMED' };
+    chainId = parseInt(chainIdStr, 10);
+    if (!Number.isFinite(chainId) || chainId <= 0) {
+      return { ok: false, reason: 'MALFORMED' };
+    }
+  }
+
+  if (!target) return { ok: false, reason: 'MALFORMED' };
+
+  const isAddress = /^0x[a-fA-F0-9]{40}$/.test(target);
+  const isEnsLike = /^[a-z0-9-]+(\.[a-z0-9-]+)*\.(eth|box)$/i.test(target);
+  if (!isAddress && !isEnsLike) return { ok: false, reason: 'MALFORMED' };
+
+  const params = new URLSearchParams(queryStr);
+  let value = null;
+  const valueRaw = params.get('value');
+  if (valueRaw !== null) {
+    value = parseWeiValue(valueRaw);
+    if (value === null) return { ok: false, reason: 'MALFORMED' };
+  }
+
+  const label = params.get('label');
+
+  return {
+    ok: true,
+    target,
+    chainId,
+    value,
+    label: label || null,
+  };
+}

--- a/src/renderer/lib/ethereum-uri.test.js
+++ b/src/renderer/lib/ethereum-uri.test.js
@@ -1,0 +1,165 @@
+import { parseEthereumUri, parseWeiValue } from './ethereum-uri.js';
+
+describe('parseWeiValue', () => {
+  test('integer string', () => {
+    expect(parseWeiValue('1000000000000000000')).toBe('1000000000000000000');
+  });
+
+  test('scientific notation with integer mantissa', () => {
+    expect(parseWeiValue('1e18')).toBe('1000000000000000000');
+    expect(parseWeiValue('1E18')).toBe('1000000000000000000');
+  });
+
+  test('scientific notation with decimal mantissa', () => {
+    expect(parseWeiValue('1.5e18')).toBe('1500000000000000000');
+    expect(parseWeiValue('1.5e17')).toBe('150000000000000000');
+  });
+
+  test('zero', () => {
+    expect(parseWeiValue('0')).toBe('0');
+  });
+
+  test('rejects fractional wei (no exponent)', () => {
+    expect(parseWeiValue('0.1')).toBeNull();
+  });
+
+  test('rejects fractional wei after exponent shift', () => {
+    expect(parseWeiValue('1.5e0')).toBeNull();
+  });
+
+  test('rejects signs and garbage', () => {
+    expect(parseWeiValue('-1')).toBeNull();
+    expect(parseWeiValue('+1')).toBeNull();
+    expect(parseWeiValue('1e')).toBeNull();
+    expect(parseWeiValue('abc')).toBeNull();
+    expect(parseWeiValue('')).toBeNull();
+  });
+
+  test('rejects non-string input', () => {
+    expect(parseWeiValue(null)).toBeNull();
+    expect(parseWeiValue(undefined)).toBeNull();
+    expect(parseWeiValue(1)).toBeNull();
+  });
+});
+
+describe('parseEthereumUri', () => {
+  test('bare 0x address defaults to mainnet', () => {
+    const result = parseEthereumUri('ethereum:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045');
+    expect(result).toEqual({
+      ok: true,
+      target: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+      chainId: 1,
+      value: null,
+      label: null,
+    });
+  });
+
+  test('.eth name defaults to mainnet', () => {
+    const result = parseEthereumUri('ethereum:vitalik.eth');
+    expect(result).toEqual({
+      ok: true,
+      target: 'vitalik.eth',
+      chainId: 1,
+      value: null,
+      label: null,
+    });
+  });
+
+  test('.box name supported', () => {
+    const result = parseEthereumUri('ethereum:author.box');
+    expect(result.ok).toBe(true);
+    expect(result.target).toBe('author.box');
+  });
+
+  test('subdomain ENS name supported', () => {
+    const result = parseEthereumUri('ethereum:tips.author.eth@100?value=1e18');
+    expect(result.ok).toBe(true);
+    expect(result.target).toBe('tips.author.eth');
+    expect(result.chainId).toBe(100);
+    expect(result.value).toBe('1000000000000000000');
+  });
+
+  test('explicit chainId', () => {
+    const result = parseEthereumUri('ethereum:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@100');
+    expect(result.ok).toBe(true);
+    expect(result.chainId).toBe(100);
+  });
+
+  test('value in wei (integer)', () => {
+    const result = parseEthereumUri(
+      'ethereum:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045?value=1000000000000000000'
+    );
+    expect(result.value).toBe('1000000000000000000');
+  });
+
+  test('value in scientific notation', () => {
+    const result = parseEthereumUri('ethereum:vitalik.eth?value=1e16');
+    expect(result.value).toBe('10000000000000000');
+  });
+
+  test('label param captured', () => {
+    const result = parseEthereumUri('ethereum:vitalik.eth?value=1e18&label=Tip%20Jar');
+    expect(result.label).toBe('Tip Jar');
+  });
+
+  test('rejects ERC-20 transfer function-call variant', () => {
+    const result = parseEthereumUri(
+      'ethereum:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48@1/transfer?address=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045&uint256=1000000'
+    );
+    expect(result).toEqual({ ok: false, reason: 'UNSUPPORTED_FUNCTION' });
+  });
+
+  test('rejects any function-call path', () => {
+    const result = parseEthereumUri('ethereum:0xAbC0000000000000000000000000000000000000@1/pay-foo');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('UNSUPPORTED_FUNCTION');
+  });
+
+  test('rejects non-ethereum scheme', () => {
+    expect(parseEthereumUri('bzz://abc123')).toEqual({
+      ok: false,
+      reason: 'NOT_ETHEREUM_URI',
+    });
+    expect(parseEthereumUri('https://example.com')).toEqual({
+      ok: false,
+      reason: 'NOT_ETHEREUM_URI',
+    });
+  });
+
+  test('rejects empty target', () => {
+    expect(parseEthereumUri('ethereum:').ok).toBe(false);
+    expect(parseEthereumUri('ethereum:@1').ok).toBe(false);
+  });
+
+  test('rejects non-decimal chainId', () => {
+    expect(parseEthereumUri('ethereum:vitalik.eth@0x1').ok).toBe(false);
+    expect(parseEthereumUri('ethereum:vitalik.eth@abc').ok).toBe(false);
+    expect(parseEthereumUri('ethereum:vitalik.eth@0').ok).toBe(false);
+  });
+
+  test('rejects non-address non-ENS target', () => {
+    expect(parseEthereumUri('ethereum:example.com').ok).toBe(false);
+    expect(parseEthereumUri('ethereum:not_a_name').ok).toBe(false);
+    expect(parseEthereumUri('ethereum:0x1234').ok).toBe(false); // too short
+  });
+
+  test('rejects malformed value param', () => {
+    expect(parseEthereumUri('ethereum:vitalik.eth?value=abc').ok).toBe(false);
+    expect(parseEthereumUri('ethereum:vitalik.eth?value=0.1').ok).toBe(false);
+  });
+
+  test('rejects non-string input', () => {
+    expect(parseEthereumUri(null).ok).toBe(false);
+    expect(parseEthereumUri(undefined).ok).toBe(false);
+    expect(parseEthereumUri(42).ok).toBe(false);
+  });
+
+  test('scheme match is case-insensitive', () => {
+    expect(parseEthereumUri('Ethereum:vitalik.eth').ok).toBe(true);
+    expect(parseEthereumUri('ETHEREUM:vitalik.eth').ok).toBe(true);
+  });
+
+  test('trims whitespace', () => {
+    expect(parseEthereumUri('  ethereum:vitalik.eth  ').ok).toBe(true);
+  });
+});

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -44,6 +44,10 @@ import {
   getInternalPageName,
   parseEnsInput,
 } from './page-urls.js';
+import { parseEthereumUri } from './ethereum-uri.js';
+import { openSendFlow } from './wallet-ui.js';
+import { walletState } from './wallet/wallet-state.js';
+import { formatWeiToDecimal } from './wallet/send.js';
 
 // Helper to get active tab's navigation state (with fallback to empty object)
 const getNavState = () => getActiveTabState() || {};
@@ -241,6 +245,41 @@ const syncRadBase = (nextBase) => {
     });
 };
 
+// EIP-681 carries value in the chain's base unit (wei for ETH et al.); we
+// assume 18 decimals for the native token, correct for every chain freedom
+// currently ships with.
+const handleEthereumUri = (value) => {
+  const parsed = parseEthereumUri(value);
+  if (!parsed.ok) {
+    if (parsed.reason === 'UNSUPPORTED_FUNCTION') {
+      alert('ERC-20 and other contract-call ethereum: URIs are not yet supported.');
+    } else {
+      alert(`Malformed ethereum: URI: ${value}`);
+    }
+    return;
+  }
+
+  const chains = walletState.registeredChains;
+  if (!chains || Object.keys(chains).length === 0) {
+    alert('Wallet is still initializing — please try again in a moment.');
+    return;
+  }
+  if (!chains[parsed.chainId]) {
+    alert(`Chain ${parsed.chainId} is not supported by this wallet.`);
+    return;
+  }
+
+  const amount = parsed.value ? formatWeiToDecimal(BigInt(parsed.value)) : undefined;
+  const opened = openSendFlow({
+    recipient: parsed.target,
+    chainId: parsed.chainId,
+    amount,
+  });
+  if (!opened) {
+    alert('Enable Identity & Wallet (Settings → Experimental) to accept tips.');
+  }
+};
+
 export const loadTarget = (value, displayOverride = null, targetWebview = null) => {
   // Use provided webview or fall back to active webview
   const webview = targetWebview || getActiveWebview();
@@ -315,6 +354,12 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null) 
 
   // Not viewing source for regular navigation
   isViewingSource = false;
+
+  // ethereum: URIs route to the wallet sidebar — no page load.
+  if (value.trim().toLowerCase().startsWith('ethereum:')) {
+    handleEthereumUri(value);
+    return;
+  }
 
   // Handle freedom:// protocol for internal pages
   const fbMatch = value.match(/^freedom:\/\/([a-zA-Z0-9-]+)$/i);

--- a/src/renderer/lib/wallet-ui.js
+++ b/src/renderer/lib/wallet-ui.js
@@ -17,7 +17,7 @@ import { initRpcSettings, closeRpcApiKeyScreen } from './wallet/rpc-settings.js'
 import { initDappConnect, showDappConnect, updateConnectionBanner } from './wallet/dapp-connect.js';
 import { initDappTx, showDappTxApproval } from './wallet/dapp-tx.js';
 import { initDappSign, showDappSignApproval } from './wallet/dapp-sign.js';
-import { initSend, closeSend } from './wallet/send.js';
+import { initSend, openSend, closeSend } from './wallet/send.js';
 import { initExportMnemonic, closeExportMnemonic } from './wallet/export-mnemonic.js';
 import { initWalletSelector, loadDerivedWallets } from './wallet/wallet-selector.js';
 import { initChainSwitcher, updateChainSwitcherDisplay, getSelectedChainId, setSelectedChainId } from './wallet/chain-switcher.js';
@@ -302,6 +302,20 @@ export function openPublishSetupFlow() {
   openSidebarPanel();
   switchTab('nodes');
   openPublishSetup();
+}
+
+// Open the wallet sidebar's Send screen with pre-filled recipient / chain /
+// amount. Used by the ethereum: URI scheme handler (EIP-681) so static web
+// pages can offer "Tip" links that route straight into the send flow.
+//
+// Same bail conditions as openPublishSetupFlow.
+export function openSendFlow({ recipient, chainId, amount } = {}) {
+  if (!isSidebarFeatureEnabled()) return false;
+  if (walletState.viewMode === 'setup') return false;
+  openSidebarPanel();
+  switchTab('wallet');
+  openSend({ recipient, chainId, amount });
+  return true;
 }
 
 /**

--- a/src/renderer/lib/wallet/send.js
+++ b/src/renderer/lib/wallet/send.js
@@ -407,6 +407,11 @@ function applySendOpenOptions(options = {}) {
     sendRecipientInput.value = options.recipient;
     sendTxState.recipient = options.recipient;
   }
+
+  if (options.amount && sendAmountInput) {
+    sendAmountInput.value = options.amount;
+    sendTxState.amount = options.amount;
+  }
 }
 
 function resolvePreferredSendToken(options = {}) {
@@ -664,7 +669,7 @@ async function handleSendMax() {
   }
 }
 
-function formatWeiToDecimal(wei, decimals = 18) {
+export function formatWeiToDecimal(wei, decimals = 18) {
   if (wei === 0n) return '0';
 
   const weiStr = wei.toString().padStart(decimals + 1, '0');

--- a/src/renderer/lib/wallet/send.js
+++ b/src/renderer/lib/wallet/send.js
@@ -133,7 +133,8 @@ export function initSend() {
 function setupSendScreen() {
   const sendBtn = document.getElementById('wallet-send-btn');
   if (sendBtn) {
-    sendBtn.addEventListener('click', openSend);
+    // Arrow wrapper so the click Event isn't passed as `options`.
+    sendBtn.addEventListener('click', () => openSend());
   }
 
   if (sendBackBtn) {
@@ -369,14 +370,23 @@ function closeSendChainDropdown() {
 }
 
 function populateSendChainSelector() {
-  const chainsWithBalance = getChainsWithBalance();
+  // Carry over the chain the user has active on the main wallet view, even
+  // if it has no balance yet — their intent beats "pick the top chain with
+  // funds". selectedChainId is null only in the "All chains" view.
+  const selected = walletState.selectedChainId;
+  if (selected !== null && walletState.registeredChains[selected]) {
+    selectSendChain(selected);
+    return;
+  }
 
+  const chainsWithBalance = getChainsWithBalance();
   if (chainsWithBalance.length > 0) {
     selectSendChain(chainsWithBalance[0].chainId);
-  } else {
-    if (sendChainName) sendChainName.textContent = 'No funds';
-    if (sendAssetName) sendAssetName.textContent = 'No assets';
+    return;
   }
+
+  if (sendChainName) sendChainName.textContent = 'No funds';
+  if (sendAssetName) sendAssetName.textContent = 'No assets';
 }
 
 function applySendOpenOptions(options = {}) {

--- a/src/renderer/lib/wallet/send.js
+++ b/src/renderer/lib/wallet/send.js
@@ -64,6 +64,8 @@ let sendRetryBtn;
 let sendTxState = {
   selectedToken: null,
   recipient: '',
+  // Set only when `recipient` was resolved from ENS; review view shows both.
+  recipientName: null,
   amount: '',
   gasLimit: null,
   maxFeePerGas: null,
@@ -156,7 +158,12 @@ function setupSendScreen() {
   });
 
   if (sendRecipientInput) {
-    sendRecipientInput.addEventListener('input', () => clearSendError('recipient'));
+    sendRecipientInput.addEventListener('input', () => {
+      clearSendError('recipient');
+      // Edits invalidate any previously-resolved ENS address.
+      hideResolvedAddress();
+      sendTxState.recipientName = null;
+    });
   }
 
   if (sendAmountInput) {
@@ -250,6 +257,7 @@ function resetSendState() {
   sendTxState = {
     selectedToken: null,
     recipient: '',
+    recipientName: null,
     amount: '',
     gasLimit: null,
     maxFeePerGas: null,
@@ -262,6 +270,8 @@ function resetSendState() {
   if (sendRecipientInput) sendRecipientInput.value = '';
   if (sendAmountInput) sendAmountInput.value = '';
   if (sendPasswordInput) sendPasswordInput.value = '';
+
+  if (sendResolvedAddress) sendResolvedAddress.textContent = '';
 
   closeSendChainDropdown();
   closeSendAssetDropdown();
@@ -660,29 +670,34 @@ function formatWeiToDecimal(wei, decimals = 18) {
   return `${integerPart}.${trimmed}`;
 }
 
-function validateRecipient() {
+// ENS-like only matches .eth/.box — mainnet resolution decides whether the
+// name actually has an addr record.
+function classifyRecipient() {
   const recipient = sendRecipientInput?.value?.trim() || '';
 
   if (!recipient) {
     showSendError('recipient', 'Recipient address is required');
-    return false;
+    return { ok: false };
   }
 
-  if (!isValidEthereumAddress(recipient)) {
-    if (recipient.endsWith('.eth')) {
-      showSendError('recipient', 'ENS names not supported yet. Please enter an address.');
-      return false;
-    }
-    showSendError('recipient', 'Invalid Ethereum address');
-    return false;
+  if (isValidEthereumAddress(recipient)) {
+    return { ok: true, type: 'address', value: recipient };
   }
 
-  sendTxState.recipient = recipient;
-  return true;
+  if (isEnsLikeName(recipient)) {
+    return { ok: true, type: 'ens', value: recipient.toLowerCase() };
+  }
+
+  showSendError('recipient', 'Invalid Ethereum address or ENS name');
+  return { ok: false };
 }
 
 function isValidEthereumAddress(address) {
   return /^0x[a-fA-F0-9]{40}$/.test(address);
+}
+
+function isEnsLikeName(value) {
+  return /^[a-z0-9-]+(\.[a-z0-9-]+)*\.(eth|box)$/i.test(value);
 }
 
 function validateAmount() {
@@ -754,7 +769,8 @@ function clearSendError(field) {
 }
 
 async function handleSendContinue() {
-  if (!validateRecipient() || !validateAmount()) {
+  const recipientClass = classifyRecipient();
+  if (!recipientClass.ok || !validateAmount()) {
     return;
   }
 
@@ -764,6 +780,20 @@ async function handleSendContinue() {
   }
 
   try {
+    if (recipientClass.type === 'ens') {
+      if (sendContinueBtn) sendContinueBtn.textContent = 'Resolving ENS…';
+      const resolved = await resolveRecipientEns(recipientClass.value);
+      if (!resolved) return; // error already surfaced on the recipient field
+      sendTxState.recipient = resolved.address;
+      sendTxState.recipientName = resolved.name;
+      showResolvedAddress(resolved.address);
+    } else {
+      sendTxState.recipient = recipientClass.value;
+      sendTxState.recipientName = null;
+      hideResolvedAddress();
+    }
+
+    if (sendContinueBtn) sendContinueBtn.textContent = 'Loading...';
     await estimateTransactionGas();
     populateSendReview();
     await configureSendUnlockUI();
@@ -777,6 +807,45 @@ async function handleSendContinue() {
       sendContinueBtn.textContent = 'Continue';
     }
   }
+}
+
+async function resolveRecipientEns(name) {
+  const api = window.electronAPI;
+  if (!api?.resolveEnsAddress) {
+    showSendError('recipient', 'ENS resolution unavailable');
+    return null;
+  }
+
+  let result;
+  try {
+    result = await api.resolveEnsAddress(name);
+  } catch (err) {
+    showSendError('recipient', err.message || 'ENS resolution failed');
+    return null;
+  }
+
+  if (!result?.success || !result.address) {
+    const message =
+      result?.reason === 'NO_ADDRESS'
+        ? `No address set for ${name}`
+        : result?.error || 'ENS resolution failed';
+    showSendError('recipient', message);
+    return null;
+  }
+
+  return { name: result.name || name, address: result.address };
+}
+
+function showResolvedAddress(address) {
+  if (!sendResolvedAddress) return;
+  sendResolvedAddress.textContent = address;
+  sendResolvedAddress.classList.remove('hidden');
+}
+
+function hideResolvedAddress() {
+  if (!sendResolvedAddress) return;
+  sendResolvedAddress.textContent = '';
+  sendResolvedAddress.classList.add('hidden');
 }
 
 async function estimateTransactionGas() {
@@ -840,7 +909,11 @@ function populateSendReview() {
   const chain = walletState.registeredChains[sendTxState.chainId];
 
   if (sendReviewTo) {
-    sendReviewTo.textContent = sendTxState.recipient;
+    if (sendTxState.recipientName) {
+      sendReviewTo.textContent = `${sendTxState.recipientName} (${sendTxState.recipient})`;
+    } else {
+      sendReviewTo.textContent = sendTxState.recipient;
+    }
   }
 
   if (sendReviewAmount) {

--- a/src/renderer/lib/wallet/send.js
+++ b/src/renderer/lib/wallet/send.js
@@ -804,8 +804,11 @@ async function handleSendContinue() {
       showResolvedAddress(resolved.address);
     } else {
       sendTxState.recipient = recipientClass.value;
-      sendTxState.recipientName = null;
       hideResolvedAddress();
+      // Best-effort reverse lookup so the review screen can show the
+      // recipient's primary ENS name alongside the address when one is
+      // verifiably set. A failure here doesn't block the send.
+      sendTxState.recipientName = await lookupPrimaryNameForAddress(recipientClass.value);
     }
 
     if (sendContinueBtn) sendContinueBtn.textContent = 'Loading...';
@@ -821,6 +824,20 @@ async function handleSendContinue() {
       sendContinueBtn.disabled = false;
       sendContinueBtn.textContent = 'Continue';
     }
+  }
+}
+
+// Ask main for the primary ENS name set for an address and return it
+// only if it forward-verifies. Never throws — returns null on any
+// failure or unavailability so the send flow isn't blocked.
+async function lookupPrimaryNameForAddress(address) {
+  const api = window.electronAPI;
+  if (!api?.resolveEnsReverse) return null;
+  try {
+    const result = await api.resolveEnsReverse(address);
+    return result?.success && result.name ? result.name : null;
+  } catch {
+    return null;
   }
 }
 

--- a/src/renderer/lib/wallet/send.js
+++ b/src/renderer/lib/wallet/send.js
@@ -795,6 +795,7 @@ async function handleSendContinue() {
   }
 
   try {
+    let reverseLookup = Promise.resolve(null);
     if (recipientClass.type === 'ens') {
       if (sendContinueBtn) sendContinueBtn.textContent = 'Resolving ENS…';
       const resolved = await resolveRecipientEns(recipientClass.value);
@@ -807,12 +808,17 @@ async function handleSendContinue() {
       hideResolvedAddress();
       // Best-effort reverse lookup so the review screen can show the
       // recipient's primary ENS name alongside the address when one is
-      // verifiably set. A failure here doesn't block the send.
-      sendTxState.recipientName = await lookupPrimaryNameForAddress(recipientClass.value);
+      // verifiably set. Fire in parallel with gas estimation so it
+      // doesn't add latency to the Continue → Review transition; a
+      // failure here doesn't block the send.
+      reverseLookup = lookupPrimaryNameForAddress(recipientClass.value);
     }
 
     if (sendContinueBtn) sendContinueBtn.textContent = 'Loading...';
-    await estimateTransactionGas();
+    const [, reverseName] = await Promise.all([estimateTransactionGas(), reverseLookup]);
+    if (reverseName && !sendTxState.recipientName) {
+      sendTxState.recipientName = reverseName;
+    }
     populateSendReview();
     await configureSendUnlockUI();
     showSendReviewView();

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -4889,7 +4889,7 @@
   top: calc(100% + 4px);
   left: 0;
   right: 0;
-  background: var(--background);
+  background: var(--toolbar);
   border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);

--- a/src/shared/ipc-channels.js
+++ b/src/shared/ipc-channels.js
@@ -35,6 +35,7 @@ module.exports = {
 
   // ENS resolution
   ENS_RESOLVE: 'ens:resolve',
+  ENS_RESOLVE_ADDRESS: 'ens:resolve-address',
   ENS_TEST_RPC: 'ens:test-rpc',
 
   // Settings

--- a/src/shared/ipc-channels.js
+++ b/src/shared/ipc-channels.js
@@ -36,6 +36,7 @@ module.exports = {
   // ENS resolution
   ENS_RESOLVE: 'ens:resolve',
   ENS_RESOLVE_ADDRESS: 'ens:resolve-address',
+  ENS_RESOLVE_REVERSE: 'ens:resolve-reverse',
   ENS_TEST_RPC: 'ens:test-rpc',
 
   // Settings


### PR DESCRIPTION
# Wallet Improvements — ENS Send, Chain Carryover, Picker Background

## Summary

Three small, user-visible fixes to the wallet UI, landing together on `feature/wallet-improvements`:

1. **ENS names in the send recipient field.** The field placeholder already said "Address or ENS name", but typing `vitalik.eth` hit a hard-coded "ENS names not supported yet" error. Now resolves to the `addr` record on mainnet and shows both the name and the resolved address on the review screen.
2. **Carry over the selected chain into the send screen.** If the user had Gnosis active on the main wallet view and pressed Send, the send screen defaulted to whichever chain had a balance first (usually Ethereum), ignoring their selection. Now honors `walletState.selectedChainId`.
3. **Fix transparent dropdown on the dApp-connect wallet picker.** The "Select wallet to connect" dropdown referenced an undefined CSS variable (`--background`), making it see-through. Now uses `--toolbar`, matching the other sidebar dropdowns.

## Why

- The three issues are all small enough individually that a single bundled PR is less churn than three separate ones, and all touch the wallet UX surface.
- The ENS-send rejection was particularly jarring: the field advertises ENS support, and the browser already does ENS content-hash resolution for the address bar — the `addr`-record companion was just never wired.
- Losing the user's chain selection on Send is a subtle trap: they see "Gnosis" in the main view, click Send, and only notice the switch to Ethereum if they look at the network row before confirming. On an L2 that cost mismatch is a real loss.
- The dropdown bug was cosmetic but blocking — the user literally cannot read the list.

## Change 1 — ENS send resolution (`feat(wallet): 414f44a`)

### Main process

New `resolveEnsAddress(name)` in `src/main/ens-resolver.js`. Wraps ethers' `provider.resolveName()`, which handles resolver lookup + `addr(bytes32)` + CCIP-Read in one call — so `.eth`, subdomains, and `.box` names (3DNS via CCIP-Read) all work via the same path as address-bar content resolution.

Reuses the existing provider fallback + retry infra (`getWorkingProvider`, `isProviderError`, `invalidateCachedProvider`, `MAX_RESOLUTION_RETRIES`). Has its own 15-min `ensAddressCache` — kept independent from `ensResultCache` so content and addr lookups don't evict each other.

Exposed on a new IPC channel `ENS_RESOLVE_ADDRESS: 'ens:resolve-address'` and on the preload bridge as `electronAPI.resolveEnsAddress(name)`. Return shape: `{success: true, name, address}` on hit, `{success: false, name, reason: 'NO_ADDRESS'|'RESOLUTION_ERROR', error}` otherwise.

### Renderer

`src/renderer/lib/wallet/send.js`:

- Replaced the hard-coded `.eth` rejection with `classifyRecipient()` returning `{ok, type: 'address'|'ens', value}`.
- `isEnsLikeName` accepts `.eth`/`.box` only, matching the codebase's `parseEnsInput` convention in `page-urls.js`. Prevents sending `example.com`-style inputs to the RPC.
- `handleSendContinue` resolves ENS on Continue press (one RPC per attempt, button text shows "Resolving ENS…"), populates the existing-but-unused `#send-resolved-address` element with the full 0x, and stores the resolved address in `sendTxState.recipient` + original name in `sendTxState.recipientName`.
- `populateSendReview` renders `"vitalik.eth (0x…)"` when resolved — full address, not truncated, because the review screen is the user's trust checkpoint.
- Editing the recipient input hides the stale resolved-address display and clears `recipientName`.

### Security notes

- Review screen shows **both** the ENS name and the full resolved 0x. Do not truncate there.
- 15-min cache is short enough that a changed addr record is picked up within a session.
- Mainnet-only lookup regardless of the send chain. User can still send on an L2 to an address resolved from mainnet ENS — standard.
- Main-side `resolveEnsAddress` re-normalizes the input (trim + lowercase) even though the renderer already does it, so it doesn't trust IPC input.

## Change 2 — Send-screen chain carryover (`fix(wallet): 87719e6`)

`populateSendChainSelector()` in `send.js` ignored `walletState.selectedChainId` and picked `getChainsWithBalance()[0].chainId` — the first chain with *any* balance. Now:

1. If `selectedChainId !== null` and the chain is registered → use it (even if it has no balance on that chain yet; user intent beats "pick the chain with funds").
2. Otherwise — which happens only in the "All chains" main-view state — fall back to the previous "first chain with balance" pick.
3. If no chain has a balance at all → "No funds" label, unchanged.

Also wrapped the Send-button click handler: `sendBtn.addEventListener('click', () => openSend())`. Previously passed the raw `PointerEvent` as the `options` argument. Harmless today (Event properties don't collide with `chainId`/`tokenKey`/`recipient`) but a latent footgun — any future option that shares a name with an Event property would break silently.

## Change 3 — dApp-connect wallet dropdown background (`fix(renderer): 04628a2`)

One-line CSS change. `.dapp-connect-selector-dropdown` referenced `var(--background)`, which doesn't exist in `variables.css` (the codebase uses `--bg` / `--menu-bg` / `--toolbar`). CSS silently resolved it to `transparent`. Switched to `var(--toolbar)`, matching the two other sidebar dropdowns (`.wallet-selector-dropdown` at `sidebar.css:3183` and `.chain-switcher-dropdown` at `sidebar.css:3569`). Works in both dark and light themes without a `[data-theme='light']` override.

Out of scope for this PR but worth flagging: `sidebar.css` references three other undefined variables (`--foreground` in many places, `--toolbar-hover`, `--border-hover`) that are silently no-ops. Happy to do a CSS-variables cleanup pass as a follow-up.

## Files

| Area | File | Change |
|------|------|--------|
| Shared | `src/shared/ipc-channels.js` | add `ENS_RESOLVE_ADDRESS` |
| Main | `src/main/ens-resolver.js` | new `resolveEnsAddress()` + IPC handler |
| Main | `src/main/ens-resolver.test.js` | 6 new tests: happy path, lowercase, `NO_ADDRESS`, empty input, retry, cache |
| Preload | `src/main/preload.js` | expose `resolveEnsAddress` on `electronAPI` |
| Preload | `src/main/preload.test.js` | bridge row for `resolveEnsAddress` |
| Renderer | `src/renderer/lib/wallet/send.js` | ENS flow + chain carryover + click-handler wrap |
| Styles | `src/renderer/styles/sidebar.css` | `--background` → `--toolbar` on `.dapp-connect-selector-dropdown` |
| Docs | `CHANGELOG.md` | `[Unreleased] ### Changed` entry for ENS send |

## Test plan

Automated:

- [x] `npm run lint` clean.
- [x] `npm test` — 897/897 Jest tests pass. New coverage: `resolveEnsAddress` happy path, lowercase normalization, `NO_ADDRESS` fallback, empty-input throw, provider-error retry, cache hit; bridge row for the new preload method.