### PR TITLE
fix(ipfs): route gateway through localhost so _redirects works

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Access built-in browser pages using the `freedom://` protocol:
 Freedom automatically manages node connections. By default:
 
 - **Swarm Bee**: `http://127.0.0.1:1633`
-- **IPFS Gateway**: `http://127.0.0.1:8080`
+- **IPFS Gateway**: `http://localhost:8080` (`localhost`, not `127.0.0.1`, so Kubo's built-in subdomain gateway kicks in — required for `_redirects` SPA support)
 - **IPFS API**: `http://127.0.0.1:5001`
 - **Radicle httpd**: `http://127.0.0.1:8780`
 

--- a/src/main/__tests__/integration/ipfs-subdomain-gateway.test.js
+++ b/src/main/__tests__/integration/ipfs-subdomain-gateway.test.js
@@ -79,7 +79,7 @@ function addFileViaApi(port, content, fileName = 'index.html') {
             // The /add endpoint returns one JSON object per line; we only add one file.
             const line = data.trim().split('\n')[0];
             resolve(JSON.parse(line));
-          } catch (e) {
+          } catch {
             reject(new Error(`Failed to parse /add response: ${data}`));
           }
         });

--- a/src/main/__tests__/integration/ipfs-subdomain-gateway.test.js
+++ b/src/main/__tests__/integration/ipfs-subdomain-gateway.test.js
@@ -1,0 +1,181 @@
+/**
+ * Integration test: Kubo's subdomain gateway behaviour on `localhost`.
+ *
+ * Freedom routes IPFS content through `http://localhost:<port>/ipfs/<CID>` and
+ * relies on Kubo redirecting to `http://<cidv1>.ipfs.localhost:<port>/` so that
+ * `_redirects` files (e.g. SPA fallbacks on ENS-hosted sites) work correctly.
+ *
+ * That redirect behaviour is load-bearing for the fix — it comes from Kubo's
+ * built-in `PublicGateways` default for the `localhost` hostname. This test
+ * guards against a Kubo upgrade silently breaking the assumption.
+ */
+
+const { spawn, execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const http = require('http');
+
+function getIpfsBinaryPath() {
+  const arch = process.arch;
+  const platformMap = { darwin: 'mac', linux: 'linux', win32: 'win' };
+  const platform = platformMap[process.platform] || process.platform;
+  const binName = process.platform === 'win32' ? 'ipfs.exe' : 'ipfs';
+  const projectRoot = path.resolve(__dirname, '../../../..');
+  const binPath = path.join(projectRoot, 'ipfs-bin', `${platform}-${arch}`, binName);
+  return fs.existsSync(binPath) ? binPath : null;
+}
+
+function waitForIpfsReady(port, timeout = 30000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      const req = http.request(
+        { host: '127.0.0.1', port, path: '/api/v0/id', method: 'POST', timeout: 2000 },
+        (res) => {
+          if (res.statusCode === 200) resolve(true);
+          else if (Date.now() - start < timeout) setTimeout(check, 500);
+          else reject(new Error(`IPFS not ready after ${timeout}ms`));
+        }
+      );
+      req.on('error', () => {
+        if (Date.now() - start < timeout) setTimeout(check, 500);
+        else reject(new Error(`IPFS not ready after ${timeout}ms`));
+      });
+      req.end();
+    };
+    check();
+  });
+}
+
+function addFileViaApi(port, content, fileName = 'index.html') {
+  const boundary = `----freedom-${Date.now()}`;
+  const body = Buffer.concat([
+    Buffer.from(
+      `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${fileName}"\r\n` +
+        `Content-Type: text/plain\r\n\r\n`
+    ),
+    Buffer.from(content),
+    Buffer.from(`\r\n--${boundary}--\r\n`),
+  ]);
+
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port,
+        path: '/api/v0/add?cid-version=0',
+        method: 'POST',
+        headers: {
+          'Content-Type': `multipart/form-data; boundary=${boundary}`,
+          'Content-Length': body.length,
+        },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (c) => (data += c));
+        res.on('end', () => {
+          try {
+            // The /add endpoint returns one JSON object per line; we only add one file.
+            const line = data.trim().split('\n')[0];
+            resolve(JSON.parse(line));
+          } catch (e) {
+            reject(new Error(`Failed to parse /add response: ${data}`));
+          }
+        });
+      }
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function headRequest(host, port, urlPath) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host, port, path: urlPath, method: 'HEAD', timeout: 5000 },
+      (res) => {
+        resolve({ statusCode: res.statusCode, headers: res.headers });
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('Kubo subdomain gateway redirect', () => {
+  const ipfsBinary = getIpfsBinaryPath();
+  let tempDir;
+  let ipfsProcess;
+  const TEST_API_PORT = 15011;
+  const TEST_GATEWAY_PORT = 18091;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ipfs-subdomain-test-'));
+  });
+
+  afterEach(async () => {
+    if (ipfsProcess && !ipfsProcess.killed) {
+      ipfsProcess.kill('SIGTERM');
+      await new Promise((resolve) => {
+        ipfsProcess.on('exit', resolve);
+        setTimeout(resolve, 3000);
+      });
+    }
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  const maybeTest = ipfsBinary ? test : test.skip;
+
+  maybeTest(
+    'redirects localhost path-gateway request to <cid>.ipfs.localhost subdomain form',
+    async () => {
+      execSync(`"${ipfsBinary}" init`, {
+        env: { ...process.env, IPFS_PATH: tempDir },
+        stdio: 'pipe',
+      });
+
+      const configPath = path.join(tempDir, 'config');
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      config.Addresses.API = `/ip4/127.0.0.1/tcp/${TEST_API_PORT}`;
+      config.Addresses.Gateway = `/ip4/127.0.0.1/tcp/${TEST_GATEWAY_PORT}`;
+      config.Addresses.Swarm = [];
+      config.Bootstrap = [];
+      config.Routing = { Type: 'none' };
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+      ipfsProcess = spawn(ipfsBinary, ['daemon', '--offline'], {
+        env: { ...process.env, IPFS_PATH: tempDir },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      ipfsProcess.stderr.on('data', () => {});
+
+      await waitForIpfsReady(TEST_API_PORT, 60000);
+
+      const added = await addFileViaApi(
+        TEST_API_PORT,
+        '<!doctype html><title>hi</title>',
+        'index.html'
+      );
+      const cid = added.Hash;
+      expect(cid).toMatch(/^Qm/); // CIDv0 (cid-version=0)
+
+      // Hitting the path gateway on hostname `localhost` must redirect to the
+      // subdomain gateway form. This is what makes `_redirects` work.
+      const res = await headRequest('localhost', TEST_GATEWAY_PORT, `/ipfs/${cid}/`);
+      expect(res.statusCode).toBe(301);
+      expect(res.headers.location).toMatch(
+        new RegExp(`^http://[a-z0-9]+\\.ipfs\\.localhost:${TEST_GATEWAY_PORT}/`)
+      );
+
+      // Sanity check: hitting 127.0.0.1 with the same path does NOT redirect to
+      // subdomain form (Kubo only applies subdomain rewriting for `localhost`).
+      const resLoopback = await headRequest('127.0.0.1', TEST_GATEWAY_PORT, `/ipfs/${cid}/`);
+      expect(resLoopback.statusCode).toBe(200);
+    },
+    120000
+  );
+});

--- a/src/main/ipfs-manager.js
+++ b/src/main/ipfs-manager.js
@@ -434,7 +434,7 @@ async function startIpfs() {
 
     updateService('ipfs', {
       api: `http://127.0.0.1:${currentApiPort}`,
-      gateway: `http://127.0.0.1:${currentGatewayPort}`,
+      gateway: `http://localhost:${currentGatewayPort}`,
       mode: MODE.REUSED,
     });
     setStatusMessage('ipfs', `Node: localhost:${currentApiPort}`);
@@ -572,7 +572,7 @@ async function startIpfs() {
         // Update registry
         updateService('ipfs', {
           api: `http://127.0.0.1:${currentApiPort}`,
-          gateway: `http://127.0.0.1:${currentGatewayPort}`,
+          gateway: `http://localhost:${currentGatewayPort}`,
           mode: MODE.BUNDLED,
         });
 

--- a/src/main/ipfs-manager.test.js
+++ b/src/main/ipfs-manager.test.js
@@ -386,7 +386,7 @@ describe('ipfs-manager', () => {
     expect(ctx.mod.getActiveGatewayPort()).toBe(8080);
     expect(ctx.updateService).toHaveBeenCalledWith('ipfs', {
       api: 'http://127.0.0.1:5001',
-      gateway: 'http://127.0.0.1:8080',
+      gateway: 'http://localhost:8080',
       mode: 'reused',
     });
     expect(ctx.setStatusMessage).toHaveBeenCalledWith('ipfs', 'Node: localhost:5001');
@@ -480,7 +480,7 @@ describe('ipfs-manager', () => {
     expect(ctx.mod.getActiveGatewayPort()).toBe(8081);
     expect(ctx.updateService).toHaveBeenCalledWith('ipfs', {
       api: 'http://127.0.0.1:5002',
-      gateway: 'http://127.0.0.1:8081',
+      gateway: 'http://localhost:8081',
       mode: 'bundled',
     });
     expect(ctx.setStatusMessage).toHaveBeenCalledWith('ipfs', 'Fallback Port: 5002');

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -10,7 +10,9 @@ const internalPages = ipcRenderer.sendSync('internal:get-pages');
 
 // Environment variable overrides for gateways (for advanced users)
 const defaultBeeApi = process.env.BEE_API || 'http://127.0.0.1:1633';
-const defaultIpfsGateway = process.env.IPFS_GATEWAY || 'http://127.0.0.1:8080';
+// Gateway uses `localhost` (not 127.0.0.1) so Kubo's default subdomain-gateway
+// PublicGateways entry kicks in — required for `_redirects` file support.
+const defaultIpfsGateway = process.env.IPFS_GATEWAY || 'http://localhost:8080';
 
 contextBridge.exposeInMainWorld('nodeConfig', {
   beeApi: defaultBeeApi,

--- a/src/main/preload.test.js
+++ b/src/main/preload.test.js
@@ -276,7 +276,7 @@ describe('preload', () => {
 
     expect(exposures.nodeConfig).toEqual({
       beeApi: 'http://127.0.0.1:1633',
-      ipfsGateway: 'http://127.0.0.1:8080',
+      ipfsGateway: 'http://localhost:8080',
     });
   });
 });

--- a/src/main/service-registry.js
+++ b/src/main/service-registry.js
@@ -222,7 +222,8 @@ function getIpfsApiUrl() {
  * Get URL for IPFS Gateway
  */
 function getIpfsGatewayUrl() {
-  return registry.ipfs.gateway || `http://127.0.0.1:${DEFAULTS.ipfs.gatewayPort}`;
+  // `localhost` triggers Kubo's default subdomain gateway (required for `_redirects`).
+  return registry.ipfs.gateway || `http://localhost:${DEFAULTS.ipfs.gatewayPort}`;
 }
 
 /**

--- a/src/main/service-registry.js
+++ b/src/main/service-registry.js
@@ -20,7 +20,7 @@ const MODE = {
 const registry = {
   ipfs: {
     api: null, // e.g., 'http://127.0.0.1:5001'
-    gateway: null, // e.g., 'http://127.0.0.1:8080'
+    gateway: null, // e.g., 'http://localhost:8080'
     mode: MODE.NONE,
     statusMessage: null,
     tempMessage: null,

--- a/src/main/service-registry.test.js
+++ b/src/main/service-registry.test.js
@@ -22,7 +22,7 @@ describe('service-registry', () => {
     const { mod } = loadServiceRegistry();
 
     expect(mod.getIpfsApiUrl()).toBe('http://127.0.0.1:5001');
-    expect(mod.getIpfsGatewayUrl()).toBe('http://127.0.0.1:8080');
+    expect(mod.getIpfsGatewayUrl()).toBe('http://localhost:8080');
     expect(mod.getBeeApiUrl()).toBe('http://127.0.0.1:1633');
     expect(mod.getBeeGatewayUrl()).toBe('http://127.0.0.1:1633');
     expect(mod.getRadicleApiUrl()).toBe('http://127.0.0.1:8780');

--- a/src/renderer/lib/cid-utils.js
+++ b/src/renderer/lib/cid-utils.js
@@ -1,0 +1,78 @@
+// Minimal CIDv0 → CIDv1 base32 converter.
+//
+// Needed because Kubo's subdomain gateway redirects requests from
+// `localhost:8080/ipfs/<CIDv0>` to `<CIDv1-base32>.ipfs.localhost:8080`
+// (DNS labels are case-insensitive, so base58btc CIDv0 is not subdomain-safe).
+//
+// Kept inline because the renderer has no bundler — bare module specifiers
+// like `multiformats/cid` don't resolve, and the sandboxed renderer can't
+// `require()` from node_modules.
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const BASE58_MAP = new Map();
+for (let i = 0; i < BASE58_ALPHABET.length; i++) BASE58_MAP.set(BASE58_ALPHABET[i], i);
+
+// RFC 4648 base32, lowercase, no padding (used by CIDv1 'b' multibase prefix).
+const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
+
+const base58Decode = (str) => {
+  if (!str) return null;
+  let num = 0n;
+  for (let i = 0; i < str.length; i++) {
+    const val = BASE58_MAP.get(str[i]);
+    if (val === undefined) return null;
+    num = num * 58n + BigInt(val);
+  }
+  let leadingOnes = 0;
+  while (leadingOnes < str.length && str[leadingOnes] === '1') leadingOnes++;
+
+  const bytes = [];
+  let n = num;
+  while (n > 0n) {
+    bytes.unshift(Number(n & 0xffn));
+    n >>= 8n;
+  }
+
+  const result = new Uint8Array(bytes.length + leadingOnes);
+  for (let i = 0; i < bytes.length; i++) {
+    result[leadingOnes + i] = bytes[i];
+  }
+  return result;
+};
+
+const base32Encode = (bytes) => {
+  let bits = 0;
+  let value = 0;
+  let output = '';
+  for (let i = 0; i < bytes.length; i++) {
+    value = ((value & 0xff) << 8) | bytes[i];
+    bits += 8;
+    while (bits >= 5) {
+      output += BASE32_ALPHABET[(value >>> (bits - 5)) & 0x1f];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    output += BASE32_ALPHABET[(value << (5 - bits)) & 0x1f];
+  }
+  return output;
+};
+
+/**
+ * Convert a CIDv0 ("Qm..." base58btc of a sha2-256 dag-pb multihash)
+ * to the CIDv1 base32 form ("bafybei...") used by Kubo's subdomain gateway.
+ * Returns null on any malformed input.
+ */
+export const cidV0ToV1Base32 = (cidV0) => {
+  if (typeof cidV0 !== 'string') return null;
+  if (!/^Qm[1-9A-HJ-NP-Za-km-z]{44}$/.test(cidV0)) return null;
+  const mh = base58Decode(cidV0);
+  if (!mh || mh.length !== 34) return null;
+  // Validate multihash header: 0x12 = sha2-256, 0x20 = 32-byte digest length.
+  if (mh[0] !== 0x12 || mh[1] !== 0x20) return null;
+  const v1 = new Uint8Array(mh.length + 2);
+  v1[0] = 0x01; // CIDv1 version (varint, <128 so one byte)
+  v1[1] = 0x70; // dag-pb codec (varint, <128 so one byte)
+  v1.set(mh, 2);
+  return 'b' + base32Encode(v1);
+};

--- a/src/renderer/lib/cid-utils.test.js
+++ b/src/renderer/lib/cid-utils.test.js
@@ -1,0 +1,25 @@
+import { cidV0ToV1Base32 } from './cid-utils.js';
+
+describe('cidV0ToV1Base32', () => {
+  // Expected values cross-checked against multiformats CID.parse(v0).toV1().toString().
+  test('converts canonical CIDv0 examples to CIDv1 base32', () => {
+    expect(cidV0ToV1Base32('QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG')).toBe(
+      'bafybeie5nqv6kd3qnfjupgvz34woh3oksc3iau6abmyajn7qvtf6d2ho34'
+    );
+    expect(cidV0ToV1Base32('Qmbnp5ufs7kauPzwnu5boMjbXM97TvmuiNd5F7F2ex8ThC')).toBe(
+      'bafybeigh3oq6pwrkspwgj4jcguizd7muxw4zdyq6cckqi5vl72yixnzpvm'
+    );
+    expect(cidV0ToV1Base32('QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o')).toBe(
+      'bafybeicg2rebjoofv4kbyovkw7af3rpiitvnl6i7ckcywaq6xjcxnc2mby'
+    );
+  });
+
+  test('returns null for non-CIDv0 input', () => {
+    expect(cidV0ToV1Base32(null)).toBeNull();
+    expect(cidV0ToV1Base32(undefined)).toBeNull();
+    expect(cidV0ToV1Base32('')).toBeNull();
+    expect(cidV0ToV1Base32('bafybeigh3oq6pwrkspwgj4jcguizd7muxw4zdyq6cckqi5vl72yixnzpvm')).toBeNull();
+    expect(cidV0ToV1Base32('Qmshort')).toBeNull();
+    expect(cidV0ToV1Base32('QmContainsInvalidChar!abcdefghijklmnopqrstuvwxyz0123')).toBeNull();
+  });
+});

--- a/src/renderer/lib/navigation-utils-helpers.test.js
+++ b/src/renderer/lib/navigation-utils-helpers.test.js
@@ -31,6 +31,21 @@ describe('navigation-utils extracted helpers', () => {
       knownEnsPairs: [['QmHash', 'name.eth']],
       resolvedProtocol: 'ipfs',
     });
+    // Real CIDv0 → also stores the CIDv1 base32 form (Kubo subdomain gateway
+    // redirects CIDv0 to CIDv1 base32; without this the address bar loses the
+    // ens:// display after the redirect).
+    expect(
+      mod.extractEnsResolutionMetadata(
+        'ipfs://Qmbnp5ufs7kauPzwnu5boMjbXM97TvmuiNd5F7F2ex8ThC/path',
+        'jthor.eth'
+      )
+    ).toEqual({
+      knownEnsPairs: [
+        ['Qmbnp5ufs7kauPzwnu5boMjbXM97TvmuiNd5F7F2ex8ThC', 'jthor.eth'],
+        ['bafybeigh3oq6pwrkspwgj4jcguizd7muxw4zdyq6cckqi5vl72yixnzpvm', 'jthor.eth'],
+      ],
+      resolvedProtocol: 'ipfs',
+    });
     expect(mod.extractEnsResolutionMetadata('ipns://docs.example/path', 'name.eth')).toEqual({
       knownEnsPairs: [['docs.example', 'name.eth']],
       resolvedProtocol: 'ipfs',

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -1,5 +1,6 @@
 import { applyEnsNamePreservation, deriveDisplayValue } from './url-utils.js';
 import { getInternalPageName } from './page-urls.js';
+import { cidV0ToV1Base32 } from './cid-utils.js';
 
 export const resolveProtocolIconType = ({
   value = '',
@@ -81,6 +82,13 @@ export const extractEnsResolutionMetadata = (targetUri, ensName) => {
   const ipfsMatch = targetUri.match(/^ipfs:\/\/([A-Za-z0-9]+)/);
   if (ipfsMatch) {
     knownEnsPairs.push([ipfsMatch[1], ensName]);
+    // Kubo's subdomain gateway redirects CIDv0 ("Qm...") to CIDv1 base32
+    // ("bafybei..."). Store both so the address bar still collapses back to
+    // `ens://name` after the redirect lands.
+    if (ipfsMatch[1].startsWith('Qm')) {
+      const cidV1 = cidV0ToV1Base32(ipfsMatch[1]);
+      if (cidV1) knownEnsPairs.push([cidV1, ensName]);
+    }
     resolvedProtocol = 'ipfs';
   }
 

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -34,7 +34,7 @@ export const state = {
   },
 
   // IPFS Gateway config (defaults from env or hardcoded, updated from registry)
-  ipfsBase: (window.nodeConfig?.ipfsGateway || 'http://127.0.0.1:8080').replace(/\/$/, ''),
+  ipfsBase: (window.nodeConfig?.ipfsGateway || 'http://localhost:8080').replace(/\/$/, ''),
   ipfsApiBase: 'http://127.0.0.1:5001',
   get ipfsRoutePrefix() {
     return `${this.ipfsBase}/ipfs/`;

--- a/src/renderer/lib/state.test.js
+++ b/src/renderer/lib/state.test.js
@@ -14,8 +14,8 @@ describe('renderer state', () => {
   test('builds route prefixes from defaults or window config', async () => {
     const defaults = await loadModule();
     expect(defaults.state.bzzRoutePrefix).toBe('http://127.0.0.1:1633/bzz/');
-    expect(defaults.state.ipfsRoutePrefix).toBe('http://127.0.0.1:8080/ipfs/');
-    expect(defaults.state.ipnsRoutePrefix).toBe('http://127.0.0.1:8080/ipns/');
+    expect(defaults.state.ipfsRoutePrefix).toBe('http://localhost:8080/ipfs/');
+    expect(defaults.state.ipnsRoutePrefix).toBe('http://localhost:8080/ipns/');
     expect(defaults.state.radicleApiPrefix).toBe('http://127.0.0.1:8780/api/v1/repos/');
 
     const custom = await loadModule({

--- a/src/renderer/lib/url-utils.js
+++ b/src/renderer/lib/url-utils.js
@@ -3,11 +3,10 @@ export const ensureTrailingSlash = (value = '') => (value.endsWith('/') ? value 
 // decodeURIComponent throws on malformed `%` sequences that show up in
 // user-typed URLs; fall back to the raw value in that case.
 const decodeAndTrim = (value) => {
-  const stripped = value.replace(/\/+$/, '');
   try {
     return decodeURIComponent(value).replace(/\/+$/, '');
   } catch {
-    return stripped;
+    return value.replace(/\/+$/, '');
   }
 };
 
@@ -400,17 +399,30 @@ export const parseIpfsInput = (rawInput, ipfsRoutePrefix) => {
 };
 
 /**
- * Recognise a Kubo subdomain-gateway URL and extract the CID + namespace.
- * Matches hostnames like "<cid>.ipfs.localhost" or "<cid>.ipns.localhost".
+ * Recognise a Kubo subdomain-gateway URL and extract the CID/name + namespace.
+ * Matches hostnames like:
+ *   - "<cid>.ipfs.localhost"              (CIDv1 base32 or libp2p base36)
+ *   - "<name>.ipns.localhost"             (IPNS key)
+ *   - "<dns.name>.ipns.localhost"         (DNSLink, dots preserved)
+ *   - "<dns-name>.ipns.localhost"         (DNSLink, dots inlined to dashes)
+ * Reverses Kubo's inline-DNSLink rule (. → -, - → --) for IPNS labels
+ * containing dashes so `docs-ipfs-tech.ipns.localhost` round-trips back to
+ * `ipns://docs.ipfs.tech`.
  * @param {URL} parsed
  * @returns {{cid: string, namespace: 'ipfs'|'ipns'}|null}
  */
 const matchIpfsSubdomain = (parsed) => {
   if (!parsed) return null;
   const hostname = parsed.hostname.toLowerCase();
-  const m = hostname.match(/^([a-z0-9]+)\.(ipfs|ipns)\.localhost$/);
+  const m = hostname.match(/^([a-z0-9][a-z0-9.-]*)\.(ipfs|ipns)\.localhost$/);
   if (!m) return null;
-  return { cid: m[1], namespace: m[2] };
+  let label = m[1];
+  if (m[2] === 'ipns' && label.includes('-')) {
+    // Greedy `--?` matches `--` in preference to `-`, so the callback cleanly
+    // reverses Kubo's rule (. → -, - → --) in a single pass.
+    label = label.replace(/--?/g, (match) => (match === '--' ? '-' : '.'));
+  }
+  return { cid: label, namespace: m[2] };
 };
 
 /**

--- a/src/renderer/lib/url-utils.js
+++ b/src/renderer/lib/url-utils.js
@@ -1,5 +1,16 @@
 export const ensureTrailingSlash = (value = '') => (value.endsWith('/') ? value : `${value}/`);
 
+// decodeURIComponent throws on malformed `%` sequences that show up in
+// user-typed URLs; fall back to the raw value in that case.
+const decodeAndTrim = (value) => {
+  const stripped = value.replace(/\/+$/, '');
+  try {
+    return decodeURIComponent(value).replace(/\/+$/, '');
+  } catch {
+    return stripped;
+  }
+};
+
 // Check if a string looks like a valid Swarm reference (64 or 128 hex characters)
 const isValidSwarmHash = (str) => /^[a-fA-F0-9]{64}([a-fA-F0-9]{64})?$/.test(str);
 
@@ -287,47 +298,39 @@ export const deriveDisplayValue = (
   }
 
   if (url.startsWith(bzzRoutePrefix)) {
-    const remainder = url.slice(bzzRoutePrefix.length);
-    try {
-      const decoded = decodeURIComponent(remainder).replace(/\/+$/, '');
-      return decoded ? `bzz://${decoded}` : '';
-    } catch {
-      const cleaned = remainder.replace(/\/+$/, '');
-      return cleaned ? `bzz://${cleaned}` : '';
-    }
+    const decoded = decodeAndTrim(url.slice(bzzRoutePrefix.length));
+    return decoded ? `bzz://${decoded}` : '';
   }
 
   if (ipfsRoutePrefix && url.startsWith(ipfsRoutePrefix)) {
-    const remainder = url.slice(ipfsRoutePrefix.length);
-    try {
-      const decoded = decodeURIComponent(remainder).replace(/\/+$/, '');
-      return decoded ? `ipfs://${decoded}` : '';
-    } catch {
-      const cleaned = remainder.replace(/\/+$/, '');
-      return cleaned ? `ipfs://${cleaned}` : '';
-    }
+    const decoded = decodeAndTrim(url.slice(ipfsRoutePrefix.length));
+    return decoded ? `ipfs://${decoded}` : '';
   }
 
   if (ipnsRoutePrefix && url.startsWith(ipnsRoutePrefix)) {
-    const remainder = url.slice(ipnsRoutePrefix.length);
+    const decoded = decodeAndTrim(url.slice(ipnsRoutePrefix.length));
+    return decoded ? `ipns://${decoded}` : '';
+  }
+
+  // Subdomain-gateway form (http://<cid>.ipfs.localhost:8080/path).
+  // Cheap substring check avoids a full URL parse on every unrelated navigation.
+  if (url.includes('.ipfs.localhost') || url.includes('.ipns.localhost')) {
     try {
-      const decoded = decodeURIComponent(remainder).replace(/\/+$/, '');
-      return decoded ? `ipns://${decoded}` : '';
+      const parsed = new URL(url);
+      const sub = matchIpfsSubdomain(parsed);
+      if (sub) {
+        return `${sub.namespace}://${sub.cid}${decodeAndTrim(
+          parsed.pathname + parsed.search + parsed.hash
+        )}`;
+      }
     } catch {
-      const cleaned = remainder.replace(/\/+$/, '');
-      return cleaned ? `ipns://${cleaned}` : '';
+      // Not a valid URL; fall through
     }
   }
 
   if (radicleApiPrefix && url.startsWith(radicleApiPrefix)) {
-    const remainder = url.slice(radicleApiPrefix.length);
-    try {
-      const decoded = decodeURIComponent(remainder).replace(/\/+$/, '');
-      return decoded ? `rad://${decoded}` : '';
-    } catch {
-      const cleaned = remainder.replace(/\/+$/, '');
-      return cleaned ? `rad://${cleaned}` : '';
-    }
+    const decoded = decodeAndTrim(url.slice(radicleApiPrefix.length));
+    return decoded ? `rad://${decoded}` : '';
   }
 
   return url;
@@ -397,9 +400,25 @@ export const parseIpfsInput = (rawInput, ipfsRoutePrefix) => {
 };
 
 /**
- * Derive IPFS base URL from a gateway URL
- * @param {string|URL} input - URL like "http://127.0.0.1:8080/ipfs/QmHash/path"
- * @returns {string|null} Base URL like "http://127.0.0.1:8080/ipfs/QmHash/"
+ * Recognise a Kubo subdomain-gateway URL and extract the CID + namespace.
+ * Matches hostnames like "<cid>.ipfs.localhost" or "<cid>.ipns.localhost".
+ * @param {URL} parsed
+ * @returns {{cid: string, namespace: 'ipfs'|'ipns'}|null}
+ */
+const matchIpfsSubdomain = (parsed) => {
+  if (!parsed) return null;
+  const hostname = parsed.hostname.toLowerCase();
+  const m = hostname.match(/^([a-z0-9]+)\.(ipfs|ipns)\.localhost$/);
+  if (!m) return null;
+  return { cid: m[1], namespace: m[2] };
+};
+
+/**
+ * Derive IPFS base URL from a gateway URL.
+ * Accepts both path-gateway form ("http://localhost:8080/ipfs/CID/path")
+ * and subdomain-gateway form ("http://CID.ipfs.localhost:8080/path").
+ * @param {string|URL} input
+ * @returns {string|null} Base URL with trailing slash
  */
 export const deriveIpfsBaseFromUrl = (input) => {
   if (!input) {
@@ -407,6 +426,10 @@ export const deriveIpfsBaseFromUrl = (input) => {
   }
   try {
     const parsed = typeof input === 'string' ? new URL(input) : input;
+    const sub = matchIpfsSubdomain(parsed);
+    if (sub) {
+      return ensureTrailingSlash(parsed.origin);
+    }
     const segments = parsed.pathname.split('/').filter(Boolean);
     if (segments.length >= 2) {
       const prefix = segments[0].toLowerCase();
@@ -666,14 +689,8 @@ export const deriveRadicleDisplayValue = (url, radicleApiPrefix) => {
   if (!url || !radicleApiPrefix) return url;
 
   if (url.startsWith(radicleApiPrefix)) {
-    const remainder = url.slice(radicleApiPrefix.length);
-    try {
-      const decoded = decodeURIComponent(remainder).replace(/\/+$/, '');
-      return decoded ? `rad://${decoded}` : '';
-    } catch {
-      const cleaned = remainder.replace(/\/+$/, '');
-      return cleaned ? `rad://${cleaned}` : '';
-    }
+    const decoded = decodeAndTrim(url.slice(radicleApiPrefix.length));
+    return decoded ? `rad://${decoded}` : '';
   }
 
   return url;

--- a/src/renderer/lib/url-utils.test.js
+++ b/src/renderer/lib/url-utils.test.js
@@ -335,6 +335,29 @@ describe('url-utils', () => {
         deriveDisplayValue(url, BZZ_ROUTE_PREFIX, HOME_URL, IPFS_ROUTE_PREFIX, IPNS_ROUTE_PREFIX)
       ).toBe('ipns://docs.ipfs.tech/index.html');
     });
+
+    test('converts ipfs subdomain-gateway url to ipfs://', () => {
+      const url =
+        'http://bafybeigh3oq6pwrkspwgj4jcguizd7muxw4zdyq6cckqi5vl72yixnzpvm.ipfs.localhost:8080/readme';
+      expect(
+        deriveDisplayValue(url, BZZ_ROUTE_PREFIX, HOME_URL, IPFS_ROUTE_PREFIX, IPNS_ROUTE_PREFIX)
+      ).toBe('ipfs://bafybeigh3oq6pwrkspwgj4jcguizd7muxw4zdyq6cckqi5vl72yixnzpvm/readme');
+    });
+
+    test('strips trailing slash on subdomain-gateway root', () => {
+      const url =
+        'http://bafybeigh3oq6pwrkspwgj4jcguizd7muxw4zdyq6cckqi5vl72yixnzpvm.ipfs.localhost:8080/';
+      expect(
+        deriveDisplayValue(url, BZZ_ROUTE_PREFIX, HOME_URL, IPFS_ROUTE_PREFIX, IPNS_ROUTE_PREFIX)
+      ).toBe('ipfs://bafybeigh3oq6pwrkspwgj4jcguizd7muxw4zdyq6cckqi5vl72yixnzpvm');
+    });
+
+    test('converts ipns subdomain-gateway url to ipns://', () => {
+      const url = 'http://k51qzi5uqu5dlvj.ipns.localhost:8080/foo';
+      expect(
+        deriveDisplayValue(url, BZZ_ROUTE_PREFIX, HOME_URL, IPFS_ROUTE_PREFIX, IPNS_ROUTE_PREFIX)
+      ).toBe('ipns://k51qzi5uqu5dlvj/foo');
+    });
   });
 
   // ============ IPFS Tests ============
@@ -452,6 +475,21 @@ describe('url-utils', () => {
     test('accepts URL object', () => {
       const url = new URL('http://127.0.0.1:8080/ipfs/QmTest/file.html');
       expect(deriveIpfsBaseFromUrl(url)).toBe('http://127.0.0.1:8080/ipfs/QmTest/');
+    });
+
+    test('extracts origin from ipfs subdomain-gateway url', () => {
+      const url =
+        'http://bafybeigh3oq6pwrkspwgj4jcguizd7muxw4zdyq6cckqi5vl72yixnzpvm.ipfs.localhost:8080/readme';
+      expect(deriveIpfsBaseFromUrl(url)).toBe(
+        'http://bafybeigh3oq6pwrkspwgj4jcguizd7muxw4zdyq6cckqi5vl72yixnzpvm.ipfs.localhost:8080/'
+      );
+    });
+
+    test('extracts origin from ipns subdomain-gateway url', () => {
+      const url = 'http://k51qzi5uqu5dlvj.ipns.localhost:8080/install';
+      expect(deriveIpfsBaseFromUrl(url)).toBe(
+        'http://k51qzi5uqu5dlvj.ipns.localhost:8080/'
+      );
     });
   });
 

--- a/src/renderer/lib/url-utils.test.js
+++ b/src/renderer/lib/url-utils.test.js
@@ -358,6 +358,30 @@ describe('url-utils', () => {
         deriveDisplayValue(url, BZZ_ROUTE_PREFIX, HOME_URL, IPFS_ROUTE_PREFIX, IPNS_ROUTE_PREFIX)
       ).toBe('ipns://k51qzi5uqu5dlvj/foo');
     });
+
+    test('reverses inline-DNSLink dashes back to dots on ipns subdomain', () => {
+      // Kubo's InlineDNSLink rule maps "docs.ipfs.tech" → "docs-ipfs-tech".
+      const url = 'http://docs-ipfs-tech.ipns.localhost:8080/install';
+      expect(
+        deriveDisplayValue(url, BZZ_ROUTE_PREFIX, HOME_URL, IPFS_ROUTE_PREFIX, IPNS_ROUTE_PREFIX)
+      ).toBe('ipns://docs.ipfs.tech/install');
+    });
+
+    test('reverses inline-DNSLink escaped dashes (-- → -)', () => {
+      // "foo-bar.baz" inlines to "foo--bar-baz" (dashes doubled first, then dots → dashes).
+      const url = 'http://foo--bar-baz.ipns.localhost:8080/';
+      expect(
+        deriveDisplayValue(url, BZZ_ROUTE_PREFIX, HOME_URL, IPFS_ROUTE_PREFIX, IPNS_ROUTE_PREFIX)
+      ).toBe('ipns://foo-bar.baz');
+    });
+
+    test('preserves dotted DNS name on ipns multi-label subdomain', () => {
+      // Kubo with InlineDNSLink disabled (default) keeps dots in the subdomain.
+      const url = 'http://docs.ipfs.tech.ipns.localhost:8080/install';
+      expect(
+        deriveDisplayValue(url, BZZ_ROUTE_PREFIX, HOME_URL, IPFS_ROUTE_PREFIX, IPNS_ROUTE_PREFIX)
+      ).toBe('ipns://docs.ipfs.tech/install');
+    });
   });
 
   // ============ IPFS Tests ============

--- a/src/renderer/pages/links.html
+++ b/src/renderer/pages/links.html
@@ -451,7 +451,7 @@
     <div class="test-section">
       <h2>Example IPFS/IPNS Links</h2>
       <div class="link-grid">
-        <a href="http://127.0.0.1:8080/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG">
+        <a href="ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG">
           <svg
             class="link-icon"
             viewBox="0 0 24 24"
@@ -466,7 +466,7 @@
           <span class="link-text">ipfs://QmYwAPJzv5... (IPFS webui)</span>
           <span class="badge">ipfs</span>
         </a>
-        <a href="http://127.0.0.1:8080/ipns/docs.ipfs.tech">
+        <a href="ipns://docs.ipfs.tech">
           <svg
             class="link-icon"
             viewBox="0 0 24 24"


### PR DESCRIPTION
# PR: Route IPFS through subdomain gateway so `_redirects` works

## Summary

Fixes #29 

Loading an ENS-hosted IPFS site like `ens://jthor.eth` was landing users on a broken fallback URL (`ens://jthor.eth/spg-notfound?path=/ipfs/Qmbnp…`). The site ships an IPFS `_redirects` file for SPA fallback, and Kubo only honours `_redirects` on the **subdomain** gateway — not the path gateway we were routing through.

Fix: switch the gateway hostname from `127.0.0.1` to `localhost`. Kubo's built-in `PublicGateways` entry for `localhost` then redirects `localhost:8080/ipfs/<CID>` to `<cidv1>.ipfs.localhost:8080/`, and `_redirects` resolves correctly.

## Why

Per the [IPFS path-gateway spec](https://specs.ipfs.tech/http-gateways/path-gateway/#redirects-file):

> The `_redirects` file can only be used with origin-isolated responses, such as subdomain and DNSLink gateways.

On the path gateway, `_redirects` rules either silently no-op or resolve to wrong paths relative to the CID root, producing exactly the broken URL the user reported.

Kubo ships a hardcoded default `PublicGateways` entry:

```go
"localhost": { Paths: ["/ipfs", "/ipns"], UseSubdomains: true }
```

It matches any port on hostname `localhost`, but **not** `127.0.0.1`. Chromium resolves `*.localhost` to loopback automatically (RFC 6761), so no `/etc/hosts` changes are needed.

## Approach

The whole fix reduces to flipping a hostname plus teaching the URL utilities about the resulting subdomain-form URLs. No new runtime dependencies, no IPC contract changes.

### Gateway hostname

Four call sites that hand out the IPFS gateway URL were flipped from `127.0.0.1` → `localhost`. The IPFS **API** (port 5001) stays on `127.0.0.1` — only the gateway needs the subdomain trick.

- `src/main/ipfs-manager.js:437,575`
- `src/main/service-registry.js:225`
- `src/main/preload.js:13`
- `src/renderer/lib/state.js:37`

### URL shape handling

After Kubo's 301 redirect the webview URL is `http://<cidv1>.ipfs.localhost:8080/…`, not `http://localhost:8080/ipfs/<CID>/…`. Two functions needed a new branch:

- `deriveIpfsBaseFromUrl` — now returns the subdomain origin (with trailing slash) as the base URL tracked in `activeIpfsBases` for request rewriting
- `deriveDisplayValue` — now collapses subdomain-form URLs back to `ipfs://<cid>/…` for the address bar, gated behind a cheap `url.includes('.ipfs.localhost')` check so unrelated navigations don't pay a URL parse

Both branches share a new `matchIpfsSubdomain` helper that extracts `{ cid, namespace }` from hostnames like `<cid>.ipfs.localhost` or `<cid>.ipns.localhost`.

While in there, the duplicated `try { decodeURIComponent(x).replace(/\/+$/, '') } catch { … }` pattern that appeared 5× across `deriveDisplayValue` and `deriveRadicleDisplayValue` got extracted into a single `decodeAndTrim` helper.

### ENS name preservation across CIDv0→CIDv1 redirect

ENS contenthashes for IPFS are usually CIDv0 (`Qm…`), but DNS labels are case-insensitive, so Kubo's subdomain gateway redirects to the CIDv1 base32 form (`bafybei…`) first. That breaks the reverse lookup in `knownEnsNames`, which is keyed by CID: after the redirect the address bar would show `ipfs://bafybei…` instead of `ens://jthor.eth`.

`extractEnsResolutionMetadata` now stores both the original CID and (when the input is CIDv0) the CIDv1 base32 form, so the address bar stays on `ens://name` regardless of which form the webview lands on.

### CIDv0 → CIDv1 base32 converter

New file: `src/renderer/lib/cid-utils.js`. ~80 lines of pure math — base58btc decode (BigInt), RFC 4648 base32 encode (lowercase, no padding), plus a `cidV0ToV1Base32` that validates the CIDv0 shape and prepends the CIDv1 version + dag-pb codec bytes before base32-encoding.

The obvious alternative was to use `multiformats/cid` (a transitive dep via `@ensdomains/content-hash`), but the sandboxed renderer has `nodeIntegration: false` and no bundler, so bare module specifiers like `multiformats/cid` don't resolve. Doing the conversion in the main process and plumbing the extra field through IPC would work but rippled through 3 files and a signature change for ~60 LOC of pure math — not a good trade for a bug fix. The inline converter is cross-checked against `multiformats` in its unit test.

## Side effects worth knowing

1. **Each IPFS site now has its own origin.** Cookies, localStorage, IndexedDB, service workers are scoped per-CID instead of shared across all IPFS content. This is the intended IPFS origin-isolation model and a latent security fix — previously a malicious IPFS site could read another's localStorage. Users may "lose" state from old sessions, but that state was already suspect.

2. **Old bookmarks still resolve.** Kubo continues to serve path-form URLs on both `127.0.0.1` and `localhost`; old `127.0.0.1:8080/ipfs/...` bookmarks just land on the path gateway without the redirect.

3. **Dev-tools URLs show `<cid>.ipfs.localhost` now.** Cosmetic.

## Tests

- Unit: `cid-utils.test.js` (new) cross-checks the converter against `multiformats` reference outputs; `url-utils.test.js` and `navigation-utils-helpers.test.js` gain subdomain-form cases; existing suites that hardcoded `127.0.0.1:8080` were updated.
- Integration: `src/main/__tests__/integration/ipfs-subdomain-gateway.test.js` (new) spawns Kubo in `--offline` mode, uploads a file, and asserts that hitting `localhost:<port>/ipfs/<CID>/` returns a 301 to `<cid>.ipfs.localhost:<port>/` while `127.0.0.1:<port>/ipfs/<CID>/` returns 200. Guards against a future Kubo upgrade silently breaking the load-bearing redirect assumption.
- Auto-skips in CI the same way every other real-daemon integration test does: `ipfs-bin/` isn't downloaded in the CI workflow, so `getIpfsBinaryPath()` returns null and `maybeTest = test.skip`.

899/899 tests pass. Lint clean.

## Files touched

- `src/main/{ipfs-manager,service-registry,preload}.js` — gateway hostname
- `src/renderer/lib/state.js` — gateway hostname default
- `src/renderer/lib/url-utils.js` — subdomain branches, `decodeAndTrim` cleanup
- `src/renderer/lib/navigation-utils.js` — dual CID storage
- `src/renderer/lib/cid-utils.js` — new, inline CIDv0→CIDv1 converter
- `src/main/__tests__/integration/ipfs-subdomain-gateway.test.js` — new integration test
- plus test updates for the above
