### PR TITLE
Feat/radicle all platforms

### DIFF
--- a/scripts/fetch-radicle.js
+++ b/scripts/fetch-radicle.js
@@ -10,19 +10,16 @@ const OUTPUT_DIR = path.join(__dirname, '..', 'radicle-bin');
 const MAIN_RELEASES_URL = 'https://files.radicle.xyz/releases/latest';
 const HTTPD_RELEASES_URL = 'https://files.radicle.xyz/releases/radicle-httpd/latest';
 
-// Target mapping: Freedom platform naming to Radicle target triple
-// Freedom uses mac-arm64/mac-x64/linux-arm64/linux-x64 (matching bee/ipfs)
-const PLATFORM_MAP = {
-  darwin: 'mac',
-  linux: 'linux',
-};
-
+// Freedom platform naming (matching bee/ipfs) -> Radicle target triple
+// Radicle does not publish Windows builds.
 const TARGETS = {
   'mac-arm64': 'aarch64-apple-darwin',
   'mac-x64': 'x86_64-apple-darwin',
   'linux-arm64': 'aarch64-unknown-linux-musl',
   'linux-x64': 'x86_64-unknown-linux-musl',
 };
+
+const REQUIRED_BINARIES = ['rad', 'radicle-node', 'radicle-httpd', 'git-remote-rad'];
 
 async function fetchJson(url) {
   return new Promise((resolve, reject) => {
@@ -82,140 +79,146 @@ function extractTarXz(archivePath, destDir) {
   execSync(`tar -xJf "${archivePath}" -C "${destDir}"`, { stdio: 'inherit' });
 }
 
+function findBinaries(searchDir, binaries) {
+  const found = {};
+  const search = (dir) => {
+    if (!fs.existsSync(dir)) return;
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isFile() && binaries.includes(entry.name)) {
+        found[entry.name] = fullPath;
+      } else if (entry.isDirectory()) {
+        search(fullPath);
+      }
+    }
+  };
+  search(searchDir);
+  return found;
+}
+
+async function installTarget(targetKey, radicleTarget, mainVersion, httpdVersion) {
+  console.log(`\n=== ${targetKey} (${radicleTarget}) ===`);
+
+  const targetDir = path.join(OUTPUT_DIR, targetKey);
+  if (!fs.existsSync(targetDir)) {
+    fs.mkdirSync(targetDir, { recursive: true });
+  }
+
+  // Main bundle (rad, radicle-node, git-remote-rad)
+  const mainBundleName = mainVersion
+    ? `radicle-${mainVersion}-${radicleTarget}.tar.xz`
+    : `radicle-${radicleTarget}.tar.xz`;
+  const mainBundleUrl = `${MAIN_RELEASES_URL}/${mainBundleName}`;
+  const mainBundleDest = path.join(targetDir, mainBundleName);
+
+  await downloadFile(mainBundleUrl, mainBundleDest);
+  extractTarXz(mainBundleDest, targetDir);
+  fs.unlinkSync(mainBundleDest);
+
+  // Httpd bundle (separate release path)
+  const httpdBundleName = httpdVersion
+    ? `radicle-httpd-${httpdVersion}-${radicleTarget}.tar.xz`
+    : `radicle-httpd-${radicleTarget}.tar.xz`;
+  const httpdBundleUrl = `${HTTPD_RELEASES_URL}/${httpdBundleName}`;
+  const httpdBundleDest = path.join(targetDir, httpdBundleName);
+
+  await downloadFile(httpdBundleUrl, httpdBundleDest);
+  extractTarXz(httpdBundleDest, targetDir);
+  fs.unlinkSync(httpdBundleDest);
+
+  const foundBinaries = findBinaries(targetDir, REQUIRED_BINARIES);
+  for (const [name, srcPath] of Object.entries(foundBinaries)) {
+    const destPath = path.join(targetDir, name);
+    if (srcPath !== destPath) {
+      if (fs.existsSync(destPath)) {
+        fs.unlinkSync(destPath);
+      }
+      fs.renameSync(srcPath, destPath);
+    }
+    fs.chmodSync(destPath, '755');
+  }
+
+  // Clean up extracted subdirectories
+  const entries = fs.readdirSync(targetDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      fs.rmSync(path.join(targetDir, entry.name), { recursive: true, force: true });
+    }
+  }
+
+  const missing = REQUIRED_BINARIES.filter(
+    (name) => !fs.existsSync(path.join(targetDir, name))
+  );
+  if (missing.length > 0) {
+    console.warn(`Warning: Missing binaries for ${targetKey}: ${missing.join(', ')}`);
+    return false;
+  }
+
+  for (const name of REQUIRED_BINARIES) {
+    console.log(`  installed: ${name}`);
+  }
+  return true;
+}
+
 async function main() {
   try {
-    const platform = PLATFORM_MAP[process.platform] || process.platform;
-    const arch = process.arch;
-    const targetKey = `${platform}-${arch}`;
+    // Determine which targets to fetch. By default, fetch all; allow overriding
+    // via RADICLE_TARGET=mac-arm64 (or a comma-separated list) for host-only builds
+    // used by Docker dist jobs.
+    const requested = (process.env.RADICLE_TARGET || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
 
-    const radicleTarget = TARGETS[targetKey];
-    if (!radicleTarget) {
-      console.error(`Unsupported platform: ${targetKey}`);
-      console.error(`Supported platforms: ${Object.keys(TARGETS).join(', ')}`);
-      process.exit(1);
+    const targetKeys =
+      requested.length > 0 ? requested : Object.keys(TARGETS);
+
+    for (const key of targetKeys) {
+      if (!TARGETS[key]) {
+        console.error(`Unknown target: ${key}`);
+        console.error(`Supported: ${Object.keys(TARGETS).join(', ')}`);
+        process.exit(1);
+      }
     }
 
-    console.log(`Platform: ${targetKey} -> Radicle target: ${radicleTarget}`);
-
-    // Create target directory
-    const targetDir = path.join(OUTPUT_DIR, targetKey);
-    if (!fs.existsSync(targetDir)) {
-      fs.mkdirSync(targetDir, { recursive: true });
-    }
-
-    // Fetch main bundle version info
-    console.log('\nFetching Radicle main bundle version info...');
-    let mainVersion;
+    console.log('Fetching Radicle main bundle version info...');
+    let mainVersion = null;
     try {
       const versionInfo = await fetchJson(`${MAIN_RELEASES_URL}/radicle.json`);
       mainVersion = versionInfo.version;
       console.log(`Main bundle version: ${mainVersion}`);
     } catch (err) {
       console.warn(`Could not fetch main version info: ${err.message}`);
-      mainVersion = null;
     }
 
-    // Download main bundle (rad, radicle-node, git-remote-rad)
-    // Use version-less filename as fallback (symlinked to latest)
-    const mainBundleName = mainVersion
-      ? `radicle-${mainVersion}-${radicleTarget}.tar.xz`
-      : `radicle-${radicleTarget}.tar.xz`;
-    const mainBundleUrl = `${MAIN_RELEASES_URL}/${mainBundleName}`;
-    const mainBundleDest = path.join(targetDir, mainBundleName);
-
-    await downloadFile(mainBundleUrl, mainBundleDest);
-    extractTarXz(mainBundleDest, targetDir);
-    fs.unlinkSync(mainBundleDest);
-
-    // Fetch httpd version info (different release path!)
-    console.log('\nFetching Radicle httpd version info...');
-    let httpdVersion;
+    console.log('Fetching Radicle httpd version info...');
+    let httpdVersion = null;
     try {
       const httpdVersionInfo = await fetchJson(`${HTTPD_RELEASES_URL}/radicle-httpd.json`);
       httpdVersion = httpdVersionInfo.version;
       console.log(`HTTPD version: ${httpdVersion}`);
     } catch (err) {
       console.warn(`Could not fetch httpd version info: ${err.message}`);
-      httpdVersion = null;
     }
 
-    // Download httpd bundle (separate release path)
-    const httpdBundleName = httpdVersion
-      ? `radicle-httpd-${httpdVersion}-${radicleTarget}.tar.xz`
-      : `radicle-httpd-${radicleTarget}.tar.xz`;
-    const httpdBundleUrl = `${HTTPD_RELEASES_URL}/${httpdBundleName}`;
-    const httpdBundleDest = path.join(targetDir, httpdBundleName);
-
-    await downloadFile(httpdBundleUrl, httpdBundleDest);
-    extractTarXz(httpdBundleDest, targetDir);
-    fs.unlinkSync(httpdBundleDest);
-
-    // Find and move binaries to target directory root
-    // Radicle tarballs extract to a subdirectory with bin/ folder
-    const findAndMoveBinaries = (searchDir, binaries) => {
-      const found = {};
-
-      const search = (dir) => {
-        if (!fs.existsSync(dir)) return;
-        const entries = fs.readdirSync(dir, { withFileTypes: true });
-        for (const entry of entries) {
-          const fullPath = path.join(dir, entry.name);
-          if (entry.isFile() && binaries.includes(entry.name)) {
-            found[entry.name] = fullPath;
-          } else if (entry.isDirectory()) {
-            search(fullPath);
-          }
-        }
-      };
-
-      search(searchDir);
-      return found;
-    };
-
-    const requiredBinaries = ['rad', 'radicle-node', 'radicle-httpd', 'git-remote-rad'];
-    const foundBinaries = findAndMoveBinaries(targetDir, requiredBinaries);
-
-    // Move binaries to target directory root and set permissions
-    for (const [name, srcPath] of Object.entries(foundBinaries)) {
-      const destPath = path.join(targetDir, name);
-      if (srcPath !== destPath) {
-        if (fs.existsSync(destPath)) {
-          fs.unlinkSync(destPath);
-        }
-        fs.renameSync(srcPath, destPath);
-      }
-      fs.chmodSync(destPath, '755');
-      console.log(`Installed: ${name}`);
+    const results = [];
+    for (const key of targetKeys) {
+      const ok = await installTarget(key, TARGETS[key], mainVersion, httpdVersion);
+      results.push({ key, ok });
     }
 
-    // Clean up extracted subdirectories
-    const entries = fs.readdirSync(targetDir, { withFileTypes: true });
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        fs.rmSync(path.join(targetDir, entry.name), { recursive: true, force: true });
-      }
+    console.log('\nSummary:');
+    for (const { key, ok } of results) {
+      console.log(`  ${ok ? 'OK' : 'FAIL'}  ${key}`);
     }
 
-    // Verify required binaries
-    const missing = requiredBinaries.filter(name => !fs.existsSync(path.join(targetDir, name)));
-    if (missing.length > 0) {
-      console.warn(`\nWarning: Missing binaries: ${missing.join(', ')}`);
+    const failed = results.filter((r) => !r.ok);
+    if (failed.length > 0) {
+      process.exit(1);
     }
-
-    console.log(`\nRadicle binaries installed to ${targetDir}`);
-    console.log('Installed binaries:');
-    for (const name of requiredBinaries) {
-      const binPath = path.join(targetDir, name);
-      if (fs.existsSync(binPath)) {
-        console.log(`  ✓ ${name}`);
-      } else {
-        console.log(`  ✗ ${name} (missing)`);
-      }
-    }
-
     console.log('\nRadicle download complete.');
     process.exit(0);
-
   } catch (err) {
     console.error('Error:', err.message);
     process.exit(1);

--- a/src/main/radicle-manager.js
+++ b/src/main/radicle-manager.js
@@ -69,6 +69,13 @@ let radicleHttpdProcess = null;
 let healthCheckInterval = null;
 let pendingStart = false;
 let forceKillTimeout = null;
+// Timestamp (ms since epoch) of the most recent transition into RUNNING. Used by
+// getConnections to suppress transient `rad node status` errors while the node
+// is still bootstrapping its control socket.
+let runningSinceMs = null;
+// Grace period during which getConnections treats command failures as a silent
+// zero-peer count instead of logging a warning.
+const CONNECTIONS_STARTUP_GRACE_MS = 30_000;
 
 // Identity injection flag - when true, skip rad auth and use pre-injected identity
 let useInjectedIdentity = false;
@@ -217,6 +224,11 @@ function ensureIdentity(radHome) {
 
 function updateState(newState, error = null) {
   log.info('[Radicle] State change:', currentState, '->', newState, error ? `(error: ${error})` : '');
+  if (newState === STATUS.RUNNING && currentState !== STATUS.RUNNING) {
+    runningSinceMs = Date.now();
+  } else if (newState !== STATUS.RUNNING) {
+    runningSinceMs = null;
+  }
   currentState = newState;
   lastError = error;
   // Broadcast to all windows
@@ -1100,6 +1112,17 @@ async function getConnections() {
 
     return success({ count: connectedCount });
   } catch (err) {
+    // During the first few seconds after the node process starts, `rad node
+    // status` can exit non-zero because the control socket is not yet
+    // listening. Polling UIs call this every ~2s, which would otherwise flood
+    // the log with transient failures. Treat it as zero peers silently until
+    // the grace period elapses.
+    const withinStartupGrace =
+      runningSinceMs !== null &&
+      Date.now() - runningSinceMs < CONNECTIONS_STARTUP_GRACE_MS;
+    if (withinStartupGrace) {
+      return success({ count: 0 });
+    }
     log.error('[Radicle] Failed to get connections:', err.message);
     return failure('GET_CONNECTIONS_FAILED', err.message, undefined, { count: 0 });
   }

--- a/src/main/radicle-manager.test.js
+++ b/src/main/radicle-manager.test.js
@@ -547,6 +547,71 @@ describe('radicle-manager', () => {
     await ctx.mod.stopRadicle();
   });
 
+  test('getConnections silently reports zero peers while the node is still within the startup grace period', async () => {
+    jest.spyOn(global, 'setInterval').mockReturnValue(1);
+    jest.spyOn(global, 'clearInterval').mockImplementation(() => {});
+
+    let nodeStatusCalls = 0;
+    const execFileAsync = jest.fn((binary, args) => {
+      if (args[0] === 'node' && args[1] === 'status') {
+        nodeStatusCalls += 1;
+        const err = new Error(`Command failed: ${binary} node status`);
+        err.code = 1;
+        return Promise.reject(err);
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+
+    const baseTime = 1_700_000_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTime);
+
+    const ctx = loadRadicleManagerModule({
+      execFileAsync,
+      portSequence: [true],
+      httpResponse: (url) => {
+        if (url === 'http://127.0.0.1:8780/') {
+          return { statusCode: 200, body: { version: '0.1.0' } };
+        }
+        return { statusCode: 404, body: '' };
+      },
+    });
+
+    ctx.mod.registerRadicleIpc();
+
+    await ctx.mod.startRadicle();
+    await flushMicrotasks();
+
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_GET_STATUS)).resolves.toEqual({
+      status: 'running',
+      error: null,
+    });
+
+    // Well within the 30s startup grace — the transient failure should be
+    // swallowed and reported as zero peers with no error log.
+    nowSpy.mockReturnValue(baseTime + 5_000);
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_GET_CONNECTIONS)).resolves.toEqual(
+      success({ count: 0 })
+    );
+    expect(nodeStatusCalls).toBe(1);
+    expect(ctx.log.error).not.toHaveBeenCalledWith(
+      '[Radicle] Failed to get connections:',
+      expect.any(String)
+    );
+
+    // After the grace period the failure should surface as an error.
+    nowSpy.mockReturnValue(baseTime + 45_000);
+    await expect(ctx.ipcMain.invoke(IPC.RADICLE_GET_CONNECTIONS)).resolves.toEqual(
+      failure('GET_CONNECTIONS_FAILED', expect.any(String), undefined, { count: 0 })
+    );
+    expect(ctx.log.error).toHaveBeenCalledWith(
+      '[Radicle] Failed to get connections:',
+      expect.any(String)
+    );
+
+    nowSpy.mockRestore();
+    await ctx.mod.stopRadicle();
+  });
+
   test('starts a bundled node on a fallback port after a conflict and stops both processes cleanly', async () => {
     const execFileAsync = jest.fn().mockResolvedValue({ stdout: '', stderr: '' });
     const ctx = loadRadicleManagerModule({


### PR DESCRIPTION
## Summary

Two small Radicle-related improvements:

- **`scripts/fetch-radicle.js` now populates every supported platform in one run.** Previously it only fetched binaries for the host (`process.platform`/`process.arch`), relying on Docker-based `dist:linux:*:docker` jobs to cover the rest. It now iterates over all four entries in `TARGETS` (`mac-arm64`, `mac-x64`, `linux-arm64`, `linux-x64` — the full set upstream publishes; Radicle has no Windows builds), matching how `fetch-bee.js` and `fetch-ipfs.js` already work. Version metadata is fetched once and reused. A new `RADICLE_TARGET` env variable (single key or comma-separated list) restricts the run to specific platforms for CI/dist jobs that want the old single-target behavior.

- **`getConnections()` no longer logs transient errors while the Radicle node is still bootstrapping.** The Radicle info panel polls `rad node status` every ~2s, but for the first few seconds after the node process starts the control socket is not yet bound and the command exits non-zero. Previously each probe during that window produced `[Radicle] Failed to get connections: Command failed` in the main-process log. The manager now records the timestamp of the last `starting -> running` transition inside `updateState`, and `getConnections()` swallows command failures (returning `success({ count: 0 })`) for the first 30s after that transition. After the grace window the original behavior (log + `GET_CONNECTIONS_FAILED`) is unchanged.

No API, IPC, or public-interface changes. `radicle-bin/` remains gitignored.

## Test plan

- [x] `npm run lint`
- [x] `npm test` (55 suites, 960 tests — all pass, including the new grace-period test covering both the in-grace silent-zero and post-grace error-logged paths)
- [x] `rm -rf radicle-bin && npm run radicle:download` populates all four platform directories (`mac-arm64`, `mac-x64`, `linux-arm64`, `linux-x64`) with `rad`, `radicle-node`, `radicle-httpd`, `git-remote-rad`
- [x] `RADICLE_TARGET=mac-arm64 npm run radicle:download` restricts the run to a single target
- [x] Launched the app (`npm start`); Radicle 1.8.0 / httpd 0.24.0 boot cleanly and the `Failed to get connections` log lines that previously appeared during the first ~35s of startup no longer occur