### PR TITLE
fix(renderer): allow bzz and ipfs schemes in protocol-test CSP

### DIFF
--- a/src/renderer/pages/protocol-test.html
+++ b/src/renderer/pages/protocol-test.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src * data:; media-src *;"
+      content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src * data: bzz: ipfs:; media-src * bzz: ipfs:;"
     />
     <title>Protocol Test</title>
     <style>


### PR DESCRIPTION
The CSP on freedom://protocol-test used `img-src *` and `media-src *`, which only matches network schemes (http/https/ws/wss). Custom schemes like `bzz:` and `ipfs:` must be listed explicitly, so the browser was blocking the Swarm and IPFS test resources the page is meant to load.

Add `bzz:` and `ipfs:` to `img-src` and `media-src` so the test page can actually exercise the custom protocol handlers.