### PR TITLE
fix(renderer): polish nodes menu width and radicle info

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -499,16 +499,12 @@
                 <span id="radicle-peers-count">0</span>
               </div>
               <div class="radicle-info-row">
-                <span class="radicle-info-label">Seeded Repos:</span>
+                <span class="radicle-info-label">Seeded Repositories:</span>
                 <span id="radicle-repos-count"></span>
               </div>
               <div class="radicle-info-row">
                 <span class="radicle-info-label">Version:</span>
                 <span id="radicle-version-text"></span>
-              </div>
-              <div class="radicle-info-row">
-                <span class="radicle-info-label">Node ID:</span>
-                <span id="radicle-node-id" class="node-id-truncated" title=""></span>
               </div>
             </div>
           </div>

--- a/src/renderer/lib/radicle-ui.js
+++ b/src/renderer/lib/radicle-ui.js
@@ -8,7 +8,6 @@ let radicleToggleSwitch = null;
 let radiclePeersCount = null;
 let radicleReposCount = null;
 let radicleVersionText = null;
-let radicleNodeId = null;
 let radicleInfoPanel = null;
 let radicleStatusRow = null;
 let radicleStatusLabel = null;
@@ -30,10 +29,6 @@ export const stopRadicleInfoPolling = () => {
   if (radiclePeersCount) radiclePeersCount.textContent = '0';
   if (radicleReposCount) radicleReposCount.textContent = '';
   if (radicleVersionText) radicleVersionText.textContent = state.radicleVersionFetched ? state.radicleVersionValue : '';
-  if (radicleNodeId) {
-    radicleNodeId.textContent = '';
-    radicleNodeId.title = '';
-  }
 };
 
 const updateRadicleSectionVisibility = () => {
@@ -83,27 +78,6 @@ const fetchRadicleInfo = async () => {
     if (radicleReposCount) radicleReposCount.textContent = '';
   }
 
-  // Fetch node ID from /api/v1/node (only once, it doesn't change)
-  if (radicleNodeId && !radicleNodeId.textContent.trim()) {
-    try {
-      const nodeResponse = await fetch(buildRadicleUrl('/api/v1/node'));
-      if (!radicleInfoPanel?.classList.contains('visible')) return;
-      if (nodeResponse.ok) {
-        const nodeInfo = await nodeResponse.json();
-        const fullId = nodeInfo?.id || '';
-        if (fullId && radicleNodeId) {
-          // Truncate: first 8 chars + ... + last 4 chars
-          const truncated = fullId.length > 16
-            ? `${fullId.slice(0, 8)}...${fullId.slice(-4)}`
-            : fullId;
-          radicleNodeId.textContent = truncated;
-          radicleNodeId.title = fullId; // Full ID on hover
-        }
-      }
-    } catch {
-      // Node ID fetch failed, leave empty while unknown
-    }
-  }
 };
 
 const fetchRadicleVersionOnce = async () => {
@@ -264,7 +238,6 @@ export const initRadicleUi = () => {
   radiclePeersCount = document.getElementById('radicle-peers-count');
   radicleReposCount = document.getElementById('radicle-repos-count');
   radicleVersionText = document.getElementById('radicle-version-text');
-  radicleNodeId = document.getElementById('radicle-node-id');
   radicleInfoPanel = document.querySelector('.radicle-info');
   radicleStatusRow = document.getElementById('radicle-status-row');
   radicleStatusLabel = document.getElementById('radicle-status-label');

--- a/src/renderer/lib/radicle-ui.test.js
+++ b/src/renderer/lib/radicle-ui.test.js
@@ -40,7 +40,6 @@ const loadRadicleModule = async (options = {}) => {
   const radiclePeersCount = createElement('span');
   const radicleReposCount = createElement('span');
   const radicleVersionText = createElement('span');
-  const radicleNodeId = createElement('span');
   const radicleInfoPanel = createElement('div', {
     classes: ['radicle-info'],
   });
@@ -58,7 +57,6 @@ const loadRadicleModule = async (options = {}) => {
       'radicle-peers-count': radiclePeersCount,
       'radicle-repos-count': radicleReposCount,
       'radicle-version-text': radicleVersionText,
-      'radicle-node-id': radicleNodeId,
       'radicle-status-row': radicleStatusRow,
       'radicle-status-label': radicleStatusLabel,
       'radicle-status-value': radicleStatusValue,
@@ -103,12 +101,6 @@ const loadRadicleModule = async (options = {}) => {
           json: async () => ({ repos: { total: 7 } }),
         };
       }
-      if (url.endsWith('/api/v1/node')) {
-        return {
-          ok: true,
-          json: async () => ({ id: 'rad123456789abcdef1234' }),
-        };
-      }
 
       return {
         ok: true,
@@ -149,7 +141,6 @@ const loadRadicleModule = async (options = {}) => {
       radiclePeersCount,
       radicleReposCount,
       radicleVersionText,
-      radicleNodeId,
       radicleInfoPanel,
       radicleStatusRow,
       radicleStatusLabel,
@@ -184,14 +175,11 @@ describe('radicle-ui', () => {
 
     expect(ctx.radicleApi.getConnections).toHaveBeenCalled();
     expect(ctx.buildRadicleUrl).toHaveBeenCalledWith('/api/v1/stats');
-    expect(ctx.buildRadicleUrl).toHaveBeenCalledWith('/api/v1/node');
     expect(ctx.buildRadicleUrl).toHaveBeenCalledWith('/');
     expect(ctx.elements.radicleInfoPanel.classList.contains('visible')).toBe(true);
     expect(ctx.elements.radiclePeersCount.textContent).toBe('5');
     expect(ctx.elements.radicleReposCount.textContent).toBe('7');
     expect(ctx.elements.radicleVersionText.textContent).toBe('1.2.3');
-    expect(ctx.elements.radicleNodeId.textContent).toBe('rad12345...1234');
-    expect(ctx.elements.radicleNodeId.title).toBe('rad123456789abcdef1234');
     expect(ctx.state.radicleVersionFetched).toBe(true);
     expect(ctx.setIntervalMock).toHaveBeenCalledWith(expect.any(Function), 2000);
 
@@ -202,7 +190,6 @@ describe('radicle-ui', () => {
     expect(ctx.elements.radiclePeersCount.textContent).toBe('0');
     expect(ctx.elements.radicleReposCount.textContent).toBe('');
     expect(ctx.elements.radicleVersionText.textContent).toBe('1.2.3');
-    expect(ctx.elements.radicleNodeId.textContent).toBe('');
   });
 
   test('updates Radicle status lines, toggle state, and running transitions', async () => {

--- a/src/renderer/styles/menus.css
+++ b/src/renderer/styles/menus.css
@@ -116,7 +116,8 @@
   z-index: 10000;
 }
 
-.menu-dropdown {
+.menu-dropdown,
+.bee-dropdown {
   min-width: 240px;
 }
 

--- a/src/renderer/styles/services.css
+++ b/src/renderer/styles/services.css
@@ -220,12 +220,6 @@
   color: var(--muted);
 }
 
-.node-id-truncated {
-  font-family: monospace;
-  font-size: 0.9em;
-  cursor: help;
-}
-
 /* Disable hover highlight on toggle menu items */
 .bee-toggle:hover,
 .ipfs-toggle:hover,


### PR DESCRIPTION
- Match the nodes (bee) dropdown min-width to the main menu (240px)
- Remove the Radicle Node ID row (and related JS/tests/CSS)
- Rename "Seeded Repos" label to "Seeded Repositories"