### PR TITLE
docs(agents): add release-process playbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Before executing task-specific work, read the corresponding playbook:
 - Architecture-sensitive changes *(adding files to `src/main/` or `src/renderer/`, creating new IPC channels, moving logic between processes)*: `docs/agent-playbooks/architecture-boundaries.md`
 - Commit message conventions *(any git commit)*: `docs/agent-playbooks/commit-messages.md`
 - Changelog updates *(version bumps, release prep)*: `docs/agent-playbooks/changelog-process.md`
+- Cutting a release *(release branch, version bump, tag, build, publish)*: `docs/agent-playbooks/release-process.md`
 - Security checklist *(before commit or PR)*: `docs/agent-playbooks/security-checklist.md`
 
 If multiple categories apply, read all relevant playbooks.

--- a/docs/agent-playbooks/README.md
+++ b/docs/agent-playbooks/README.md
@@ -8,6 +8,7 @@ Use these files on demand:
 - `code-style-and-linting.md`: lint-aware implementation workflow.
 - `commit-messages.md`: commit title/body conventions.
 - `changelog-process.md`: release changelog procedure.
+- `release-process.md`: release branch, version bump, tag, build, and publish steps.
 - `security-checklist.md`: pre-commit and pre-PR security checks.
 
 Keep `AGENTS.md` short and stable. Put detailed examples and process notes here.

--- a/docs/agent-playbooks/release-process.md
+++ b/docs/agent-playbooks/release-process.md
@@ -1,0 +1,149 @@
+# Release Process Playbook
+
+Use this playbook when cutting a new Freedom release (any `MAJOR.MINOR.PATCH` bump).
+
+It complements `changelog-process.md` — that playbook covers the mechanics of writing `CHANGELOG.md`; this one covers the surrounding branch, version-bump, build, tag, and publish steps.
+
+## 0. Create a release branch first
+
+All release work happens on a dedicated branch off `main`, never on `main` directly.
+
+Naming convention (matches prior releases like `release/0.6.2`):
+
+```
+release/<version>
+```
+
+For example, for 0.7.0:
+
+```
+git checkout main
+git pull --ff-only
+git checkout -b release/0.7.0
+```
+
+Rationale:
+
+- Keeps `main` unblocked while the release is being stabilized.
+- Gives a clear target for last-minute build/changelog fixups without polluting feature history.
+- The artifacts you build, upload, and tag all come from this branch, so a broken build can be fixed here before anything lands on `main`.
+
+## 1. Bump the version
+
+Update the version string in exactly these two files:
+
+- `package.json` — top-level `"version"`.
+- `package-lock.json` — the two top-level `"version"` entries (root object and the `""` package entry). Ignore any `0.X.Y` strings inside transitive dependency version ranges (e.g. `iconv-lite`).
+
+No other source file hard-codes the version — the renderer, `electron-builder`, and `electron-updater` all read it from `package.json` at runtime/build time.
+
+Commit style (matches prior releases):
+
+```
+chore(release): bump version to <version>
+```
+
+## 2. Finalize the changelog
+
+Follow `changelog-process.md` in full. Key points for release branches:
+
+- The baseline for `git log` is the last `package.json` version bump commit.
+- Replace the `## [Unreleased]` heading with `## [<version>] - <YYYY-MM-DD>` using the date from `git show -s --format="%ad" --date=short HEAD`.
+- Leave a fresh empty `## [Unreleased]` section above it for the next cycle.
+
+Commit style:
+
+```
+docs(changelog): add user-facing <version> release notes
+```
+
+## 3. Verify before building
+
+On the release branch, with a clean working tree:
+
+```
+npm ci
+npm run lint
+npm test
+npm run check-binaries
+```
+
+Spot-check the app once (`npm start`) and confirm the About/version surface reflects the new number.
+
+## 4. Build distributables
+
+Run from the release branch. All builds read the version from `package.json`.
+
+### macOS (signed + notarized, inline)
+
+```
+npm run dist -- --mac
+```
+
+`build.mac.notarize: true` in `package.json` makes `electron-builder` submit and staple the notarization in the same invocation. The command blocks until Apple finishes notarizing — expect several minutes. This is the default mac release flow.
+
+**Fallback — async notarization.** If notarization is slow or flaky and you need to do it out-of-band (for example to retry or to free the terminal), use the split scripts instead:
+
+```
+npm run dist:mac:prepare-notary     # builds with --no-notarize
+npm run dist:mac:submit-notary      # uploads to Apple
+npm run dist:mac:notary-status      # polls status
+npm run dist:mac:notary-log         # fetch log if it fails
+npm run dist:mac:staple-notary      # staple once accepted
+```
+
+These require `.env` credentials via `dotenv-cli` and are implemented in `scripts/macos-notary.js`.
+
+### Linux
+
+```
+npm run dist:linux:x64:docker
+npm run dist:linux:arm64:docker
+```
+
+Both run `electron-builder` inside a Linux container and download the matching Radicle binaries for the target arch.
+
+### Windows
+
+```
+npm run dist -- --win --x64
+```
+
+`electron-builder` cross-builds the Windows NSIS installer and zip from the mac host — no Windows machine required. Windows builds intentionally ship without Radicle (see `README.md`).
+
+## 5. Upload binaries and update the website
+
+1. Upload the generated artifacts from `dist/` to `https://freedom.baby/downloads`, including the `latest*.yml` manifests so existing installs pick up the update via `electron-updater` (which is configured with `publish.provider = generic` pointing at that URL).
+2. Update the Freedom website (download links, version string, release notes link) to point at the new version.
+
+Do this **before** tagging — if an upload reveals a broken artifact, you want to be able to fix it on the release branch without already having a tag pointing at a broken commit.
+
+## 6. Tag the release
+
+On the release branch, from the commit you actually built and shipped:
+
+```
+git tag -a v<version> -m "Release <version>"
+```
+
+Tag format is `v<version>` (lowercase `v`), matching `v0.6.2`. Do not push the tag yet — push it together with the merge in the next step so `main` and the tag move as one.
+
+## 7. Merge the release branch into main
+
+Optionally open a PR from `release/<version>` into `main` for review. Otherwise merge directly:
+
+```
+git checkout main
+git pull --ff-only
+git merge --no-ff release/<version>
+git push origin main
+git push origin v<version>
+```
+
+The `--no-ff` is deliberate — it preserves the release branch as a visible bubble in `main`'s history, which matches how earlier releases landed.
+
+## 8. Post-release housekeeping
+
+- Confirm the GitHub release page lists the correct artifacts and release notes.
+- Keep the `release/<version>` branch around (do not delete) — it matches the historical pattern and is the natural base for a `hotfix/<version>.<patch>` branch later if needed.
+- Any build-only fixes that land after the version bump should be committed on the release branch with `fix(build): ...` messages, same as the `0.6.2` cycle did.


### PR DESCRIPTION
## Summary

- Add `docs/agent-playbooks/release-process.md` documenting the end-to-end release flow: release branch (`release/<version>`) → version bump in `package.json` + `package-lock.json` → changelog finalization → verify → build (mac inline notarize, linux docker, windows cross-build) → upload + website update → tag on the release branch → `--no-ff` merge into `main`.
- Document the async `dist:mac:*` notarization scripts as a fallback path, keeping the inline `npm run dist -- --mac` as the default.
- Wire the new playbook into `AGENTS.md` (Task Routing) and `docs/agent-playbooks/README.md` (index).

## Test plan

- [ ] Skim `docs/agent-playbooks/release-process.md` and confirm steps match the intended flow.
- [ ] Confirm `AGENTS.md` Task Routing lists the new playbook.
- [ ] Confirm `docs/agent-playbooks/README.md` lists the new playbook.
- [ ] Merge before cutting `release/0.7.0` so the playbook is in-tree when the release branch is created.