### PR TITLE
Release/0.7.0 {ens multi resolution}

### DIFF
--- a/src/main/ens-prefetch.js
+++ b/src/main/ens-prefetch.js
@@ -1,0 +1,96 @@
+const log = require('./logger');
+const { net } = require('electron');
+const { convertProtocolUrl } = require('./request-rewriter');
+
+// Hygiene timeout — not trust-critical. A misbehaving gateway shouldn't
+// hold a socket open forever for speculative content the user may never
+// see. Quorum outcomes typically tear prefetch down earlier via abort().
+const PREFETCH_TIMEOUT_MS = 10_000;
+
+const NOOP_HANDLE = Object.freeze({ abort: () => {} });
+
+/**
+ * Speculatively warm the local gateway cache for a bzz:// or ipfs:// URI
+ * while the public-quorum wave is still resolving. Returns an abort handle
+ * the consensus wave calls when the outcome isn't verified-data (so
+ * rejected or cancelled speculation doesn't keep a socket open).
+ *
+ * Never affects resolution state. Any failure (bad URI, ipns://, net
+ * error, thrown exception) degrades silently to a noop handle.
+ *
+ * @param {string} uri - decoded content URI (bzz:// or ipfs://)
+ * @returns {{ abort: () => void }}
+ */
+function prefetchGatewayUrl(uri) {
+  try {
+    if (process.env.ENS_DISABLE_PREFETCH === '1') return NOOP_HANDLE;
+    if (typeof uri !== 'string' || !uri) return NOOP_HANDLE;
+    // IPNS is a mutable two-hop resolution — speculating pre-consensus
+    // leaks interest in the name to more infrastructure than we need.
+    if (uri.startsWith('ipns://')) return NOOP_HANDLE;
+    if (!uri.startsWith('bzz://') && !uri.startsWith('ipfs://')) return NOOP_HANDLE;
+
+    const { converted, url } = convertProtocolUrl(uri);
+    if (!converted) return NOOP_HANDLE;
+
+    let aborted = false;
+    let request = null;
+    let timer = null;
+
+    const cleanup = () => {
+      if (timer) { clearTimeout(timer); timer = null; }
+      if (request) {
+        try { request.abort(); } catch { /* already done */ }
+        request = null;
+      }
+    };
+
+    const abort = () => {
+      if (aborted) return;
+      aborted = true;
+      log.info(`[ens-prefetch] aborted ${url}`);
+      cleanup();
+    };
+
+    // Request completed naturally — release the hygiene timer and drop
+    // the handle so abort() becomes a no-op. Don't call cleanup(), which
+    // would invoke abort() on an already-finished request.
+    const markFinished = () => {
+      if (timer) { clearTimeout(timer); timer = null; }
+      request = null;
+    };
+
+    request = net.request({ method: 'GET', url });
+    request.on('response', (response) => {
+      // Drain the body into /dev/null — the gateway parses + caches it on
+      // its side regardless. We just don't need the bytes in this process.
+      response.on('data', () => {});
+      response.on('end', markFinished);
+      response.on('error', markFinished);
+    });
+    request.on('error', (err) => {
+      log.info(`[ens-prefetch] ${url} — ${err.message}`);
+      markFinished();
+    });
+    request.end();
+
+    timer = setTimeout(() => {
+      if (!aborted) {
+        log.info(`[ens-prefetch] timeout ${url}`);
+        abort();
+      }
+    }, PREFETCH_TIMEOUT_MS);
+
+    log.info(`[ens-prefetch] warming ${url}`);
+    return { abort };
+  } catch (err) {
+    // Hard rule: prefetch can never break the caller.
+    log.warn(`[ens-prefetch] noop after throw: ${err.message}`);
+    return NOOP_HANDLE;
+  }
+}
+
+module.exports = {
+  prefetchGatewayUrl,
+  PREFETCH_TIMEOUT_MS,
+};

--- a/src/main/ens-prefetch.js
+++ b/src/main/ens-prefetch.js
@@ -1,6 +1,6 @@
 const log = require('./logger');
 const { net } = require('electron');
-const { convertProtocolUrl } = require('./request-rewriter');
+const { convertProtocolUrl, sanitizeUrlForLog } = require('./request-rewriter');
 
 // Hygiene timeout — not trust-critical. A misbehaving gateway shouldn't
 // hold a socket open forever for speculative content the user may never
@@ -48,7 +48,7 @@ function prefetchGatewayUrl(uri) {
     const abort = () => {
       if (aborted) return;
       aborted = true;
-      log.info(`[ens-prefetch] aborted ${url}`);
+      log.info(`[ens-prefetch] aborted ${sanitizeUrlForLog(url)}`);
       cleanup();
     };
 
@@ -69,19 +69,19 @@ function prefetchGatewayUrl(uri) {
       response.on('error', markFinished);
     });
     request.on('error', (err) => {
-      log.info(`[ens-prefetch] ${url} — ${err.message}`);
+      log.info(`[ens-prefetch] ${sanitizeUrlForLog(url)} — ${err.message}`);
       markFinished();
     });
     request.end();
 
     timer = setTimeout(() => {
       if (!aborted) {
-        log.info(`[ens-prefetch] timeout ${url}`);
+        log.info(`[ens-prefetch] timeout ${sanitizeUrlForLog(url)}`);
         abort();
       }
     }, PREFETCH_TIMEOUT_MS);
 
-    log.info(`[ens-prefetch] warming ${url}`);
+    log.info(`[ens-prefetch] warming ${sanitizeUrlForLog(url)}`);
     return { abort };
   } catch (err) {
     // Hard rule: prefetch can never break the caller.

--- a/src/main/ens-prefetch.js
+++ b/src/main/ens-prefetch.js
@@ -48,7 +48,7 @@ function prefetchGatewayUrl(uri) {
     const abort = () => {
       if (aborted) return;
       aborted = true;
-      log.info(`[ens-prefetch] aborted ${sanitizeUrlForLog(url)}`);
+      log.debug(`[ens-prefetch] aborted ${sanitizeUrlForLog(url)}`);
       cleanup();
     };
 
@@ -69,14 +69,14 @@ function prefetchGatewayUrl(uri) {
       response.on('error', markFinished);
     });
     request.on('error', (err) => {
-      log.info(`[ens-prefetch] ${sanitizeUrlForLog(url)} — ${err.message}`);
+      log.debug(`[ens-prefetch] ${sanitizeUrlForLog(url)} — ${err.message}`);
       markFinished();
     });
     request.end();
 
     timer = setTimeout(() => {
       if (!aborted) {
-        log.info(`[ens-prefetch] timeout ${sanitizeUrlForLog(url)}`);
+        log.debug(`[ens-prefetch] timeout ${sanitizeUrlForLog(url)}`);
         abort();
       }
     }, PREFETCH_TIMEOUT_MS);

--- a/src/main/ens-prefetch.js
+++ b/src/main/ens-prefetch.js
@@ -93,4 +93,5 @@ function prefetchGatewayUrl(uri) {
 module.exports = {
   prefetchGatewayUrl,
   PREFETCH_TIMEOUT_MS,
+  NOOP_HANDLE,
 };

--- a/src/main/ens-prefetch.test.js
+++ b/src/main/ens-prefetch.test.js
@@ -19,6 +19,7 @@ jest.mock('./logger', () => ({
   info: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),
+  debug: jest.fn(),
 }));
 
 const { prefetchGatewayUrl, PREFETCH_TIMEOUT_MS } = require('./ens-prefetch');

--- a/src/main/ens-prefetch.test.js
+++ b/src/main/ens-prefetch.test.js
@@ -1,0 +1,169 @@
+const mockAbort = jest.fn();
+const mockEnd = jest.fn();
+// Each test gets a fresh fake request whose event listeners are stored
+// so the test can simulate 'response' / 'error' / 'data' / 'end' events.
+let fakeRequest;
+const mockNetRequest = jest.fn(() => fakeRequest);
+
+jest.mock('electron', () => ({
+  net: { request: (opts) => mockNetRequest(opts) },
+}));
+
+jest.mock('./service-registry', () => ({
+  getBeeApiUrl: () => 'http://127.0.0.1:1633',
+  getIpfsGatewayUrl: () => 'http://localhost:8080',
+  getRadicleApiUrl: () => 'http://127.0.0.1:8780',
+}));
+
+jest.mock('./logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const { prefetchGatewayUrl, PREFETCH_TIMEOUT_MS } = require('./ens-prefetch');
+
+const makeFakeRequest = () => {
+  const listeners = new Map();
+  return {
+    on(event, cb) {
+      if (!listeners.has(event)) listeners.set(event, []);
+      listeners.get(event).push(cb);
+    },
+    emit(event, ...args) {
+      const ls = listeners.get(event) || [];
+      for (const cb of ls) cb(...args);
+    },
+    end: mockEnd,
+    abort: mockAbort,
+    listeners,
+  };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  fakeRequest = makeFakeRequest();
+  delete process.env.ENS_DISABLE_PREFETCH;
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('prefetchGatewayUrl', () => {
+  test('fires a GET against the bzz gateway for bzz:// URIs', () => {
+    const handle = prefetchGatewayUrl('bzz://' + 'a'.repeat(64));
+
+    expect(mockNetRequest).toHaveBeenCalledTimes(1);
+    expect(mockNetRequest).toHaveBeenCalledWith({
+      method: 'GET',
+      url: 'http://127.0.0.1:1633/bzz/' + 'a'.repeat(64),
+    });
+    expect(typeof handle.abort).toBe('function');
+  });
+
+  test('fires a GET against the ipfs gateway for ipfs:// URIs', () => {
+    const cid = 'QmW81r84Aihiqqi2Jw6nM1LnpeMfRCenRxtjwHNkXVkZYa';
+    prefetchGatewayUrl('ipfs://' + cid);
+
+    expect(mockNetRequest).toHaveBeenCalledWith({
+      method: 'GET',
+      url: 'http://localhost:8080/ipfs/' + cid,
+    });
+  });
+
+  test('ipns:// URIs return a noop handle without any network call', () => {
+    const handle = prefetchGatewayUrl('ipns://docs.ipfs.io');
+    expect(mockNetRequest).not.toHaveBeenCalled();
+    expect(typeof handle.abort).toBe('function');
+    // abort on the noop is idempotent and harmless
+    handle.abort();
+    handle.abort();
+  });
+
+  test('malformed URIs return a noop handle', () => {
+    prefetchGatewayUrl('');
+    prefetchGatewayUrl(null);
+    prefetchGatewayUrl('https://example.com');
+    prefetchGatewayUrl('bzz://not-a-hash');
+    prefetchGatewayUrl('ipfs://');
+    expect(mockNetRequest).not.toHaveBeenCalled();
+  });
+
+  test('ENS_DISABLE_PREFETCH=1 env var suppresses all network calls', () => {
+    process.env.ENS_DISABLE_PREFETCH = '1';
+    prefetchGatewayUrl('bzz://' + 'a'.repeat(64));
+    expect(mockNetRequest).not.toHaveBeenCalled();
+  });
+
+  test('only strict "1" disables prefetch — avoids the ENS_DISABLE_PREFETCH=0 foot-gun', () => {
+    // '0' and 'true' look like config intent but should NOT disable,
+    // matching the Unix convention used in other env flags.
+    for (const value of ['0', 'true', 'yes', 'TRUE', '']) {
+      process.env.ENS_DISABLE_PREFETCH = value;
+      mockNetRequest.mockClear();
+      fakeRequest = makeFakeRequest();
+      prefetchGatewayUrl('bzz://' + 'a'.repeat(64));
+      expect(mockNetRequest).toHaveBeenCalled();
+    }
+  });
+
+  test('abort() cancels the in-flight request and clears the timer', () => {
+    const handle = prefetchGatewayUrl('bzz://' + 'a'.repeat(64));
+    expect(mockAbort).not.toHaveBeenCalled();
+
+    handle.abort();
+
+    expect(mockAbort).toHaveBeenCalledTimes(1);
+
+    // Second abort is a no-op (idempotent).
+    handle.abort();
+    expect(mockAbort).toHaveBeenCalledTimes(1);
+  });
+
+  test('hygiene timeout fires after PREFETCH_TIMEOUT_MS and aborts', () => {
+    prefetchGatewayUrl('bzz://' + 'a'.repeat(64));
+    expect(mockAbort).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(PREFETCH_TIMEOUT_MS + 100);
+
+    expect(mockAbort).toHaveBeenCalledTimes(1);
+  });
+
+  test('completing naturally clears the timer (no late abort)', () => {
+    prefetchGatewayUrl('bzz://' + 'a'.repeat(64));
+
+    // Simulate response + end
+    const fakeResponse = {
+      on(event, cb) {
+        if (event === 'end') setTimeout(cb, 0);
+      },
+    };
+    fakeRequest.emit('response', fakeResponse);
+    jest.advanceTimersByTime(1); // flush the end callback
+
+    // Now advance past the hygiene timeout — abort should NOT fire.
+    jest.advanceTimersByTime(PREFETCH_TIMEOUT_MS + 100);
+
+    expect(mockAbort).not.toHaveBeenCalled();
+  });
+
+  test('request.error event cleans up without throwing', () => {
+    prefetchGatewayUrl('bzz://' + 'a'.repeat(64));
+
+    // Simulate a network error mid-flight.
+    expect(() => fakeRequest.emit('error', new Error('ECONNREFUSED'))).not.toThrow();
+  });
+
+  test('any thrown exception returns a noop handle (never breaks caller)', () => {
+    // Force convertProtocolUrl to throw by poisoning the mock.
+    mockNetRequest.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+
+    const handle = prefetchGatewayUrl('bzz://' + 'a'.repeat(64));
+    expect(typeof handle.abort).toBe('function');
+    handle.abort(); // does not throw
+  });
+});

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -38,16 +38,6 @@ const IPFS_CONTENTHASH_RE =
   /^0x(?<codecPrefix>e3010170|e5010172)(?<multihash>(?<mhCode>[0-9a-f]{2})(?<mhLen>[0-9a-f]{2})(?<digest>[0-9a-f]*))$/;
 const SWARM_CONTENTHASH_RE = /^0xe40101fa011b20(?<swarmHash>[0-9a-f]{64})$/;
 
-// Public RPC providers as fallbacks
-const PUBLIC_RPC_PROVIDERS = [
-  process.env.ETH_RPC,
-  'https://ethereum.publicnode.com',
-  'https://1rpc.io/eth',
-  'https://eth.drpc.org',
-  'https://eth-mainnet.public.blastapi.io',
-  'https://eth.merkle.io',
-].filter(Boolean);
-
 // Read effective custom RPC URL from settings (empty string = disabled/unset)
 function getCustomRpcUrl() {
   try {
@@ -59,13 +49,14 @@ function getCustomRpcUrl() {
   }
 }
 
-// Build the effective provider list: custom RPC first (if set), then public fallbacks
+// Build the effective provider list for the legacy single-source path
+// (reverse resolution). Sources from the same user-configured list the
+// quorum path uses, so a provider the user removed in settings is also
+// excluded here.
 function getRpcProviders() {
   const custom = getCustomRpcUrl();
-  if (custom) {
-    return [custom, ...PUBLIC_RPC_PROVIDERS];
-  }
-  return PUBLIC_RPC_PROVIDERS;
+  const publicList = getEffectivePublicProviders();
+  return custom ? [custom, ...publicList] : publicList;
 }
 
 // ---------------------------------------------------------------------------
@@ -507,16 +498,26 @@ async function getWorkingProvider() {
   throw new Error('All RPC providers failed. Check your network connection.');
 }
 
-// Invalidate cached provider (legacy path) AND the shuffled/quarantine pool
-// used by consensusResolve. Tests call this between cases; production callers
-// invoke it after settings edits so a re-tested RPC gets a fresh chance.
-function invalidateCachedProvider() {
+// Drop the cached single-provider used by getWorkingProvider. Cheap reset
+// for the legacy retry loop — keeps quorum-path state (shuffled order,
+// quarantine memory, pinned block anchor) intact, so a transient flake
+// during reverse resolution doesn't make the next quorum wave pay an
+// extra anchor RTT.
+function dropCachedProvider() {
   if (cachedProvider) {
     log.info(`[ens] Invalidating cached provider: ${cachedProviderUrl}`);
     cachedProvider.destroy();
     cachedProvider = null;
     cachedProviderUrl = null;
   }
+}
+
+// Full reset: drop the legacy cached provider AND wipe the quorum pool
+// (shuffled order, quarantine, pinned block). External callers use this
+// after a settings edit so a re-tested RPC gets a fresh chance; tests
+// call it between cases for a clean slate.
+function invalidateCachedProvider() {
+  dropCachedProvider();
   invalidateProviderPool();
 }
 
@@ -1270,7 +1271,7 @@ async function resolveWithCache(name, cache, doResolve, label) {
           log.warn(
             `[ens] ${label} provider error on attempt ${attempt}/${MAX_RESOLUTION_RETRIES}: ${err.message}`
           );
-          invalidateCachedProvider();
+          dropCachedProvider();
           continue;
         }
         throw err;

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -990,16 +990,30 @@ async function consensusResolve(normalizedName, callData, kind = 'content', opti
     onFirstData: options.onFirstData,
   });
 
-  // All-errored first wave → escalate once to remaining non-quarantined providers.
+  // First-wave settled without agreement → escalate once to remaining
+  // non-quarantined providers when they could plausibly do better.
+  //   - all_errored: any fresh response is an upgrade from "no evidence."
+  //   - unverified_data / unverified_not_found: replace ONLY if the second
+  //     wave actually reaches quorum. If the second wave also fails to
+  //     agree, the first wave's single data point is still our best
+  //     evidence; trading it for second-wave noise would be a downgrade.
   if (wave.outcome.kind === 'all_settled') {
     const verdict = classifyNoAgreement(wave);
-    if (verdict.kind === 'all_errored') {
+    const upgradable =
+      verdict.kind === 'all_errored' ||
+      verdict.kind === 'unverified_data' ||
+      verdict.kind === 'unverified_not_found';
+    if (upgradable) {
       const remaining = getAvailableProviders().filter((u) => !firstSelection.includes(u));
-      if (remaining.length > 0) {
+      // Unverified upgrades require enough fresh providers for the second
+      // wave alone to clear the quorum threshold; otherwise the escalation
+      // can only ever produce more unverified evidence.
+      const minRemaining = verdict.kind === 'all_errored' ? 1 : effectiveM;
+      if (remaining.length >= minRemaining) {
         const secondK = Math.min(desiredK, remaining.length);
         const secondSelection = remaining.slice(0, secondK);
         log.info(`[ens] consensus escalating to second wave providers=[${secondSelection.map(hostOf).join(',')}]`);
-        wave = await runConsensusWave({
+        const secondWave = await runConsensusWave({
           providers: secondSelection,
           name: normalizedName,
           callData,
@@ -1008,6 +1022,12 @@ async function consensusResolve(normalizedName, callData, kind = 'content', opti
           m: Math.min(desiredM, secondK),
           onFirstData: options.onFirstData,
         });
+        const secondAgreed =
+          secondWave.outcome.kind === 'agreed_data' ||
+          secondWave.outcome.kind === 'agreed_not_found';
+        if (verdict.kind === 'all_errored' || secondAgreed) {
+          wave = secondWave;
+        }
       }
     }
   }
@@ -1090,6 +1110,15 @@ async function resolveEnsContent(name) {
 
 // Decodes the UR's ABI-encoded return, parses the multicodec content hash,
 // and kicks off a gateway prefetch for bzz:// / ipfs:// (never ipns://).
+//
+// Caveat: prefetch fires on the FIRST responder's bytes, not the agreed
+// bytes. If the first responder is a lying RPC and the eventual quorum
+// outcome is `agreed_data` on different bytes (or `conflict`/unverified),
+// the warmed gateway entry is for content the renderer will never load.
+// That's bandwidth, not a trust hole — the gateway is content-addressed,
+// so a wrong-bytes warm doesn't poison the verified path. The "200–500ms
+// saving" assumes an honest first responder; under attack the optimization
+// degrades to a no-op (and may waste a small amount of gateway traffic).
 function prefetchOnFirstData(resolvedData) {
   try {
     const [inner] = ethers.AbiCoder.defaultAbiCoder().decode(['bytes'], resolvedData);

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -179,36 +179,95 @@ function invalidateProviderPool() {
 
 let pinnedBlockCache = null; // { anchor, number, hash, expiresAt }
 
-async function fetchAnchorFromProvider(url, anchor, timeoutMs) {
+// Safety depth (in blocks) subtracted from the corroborated head before the
+// anchor hash is fetched. Keeps the anchor past typical reorg depth and
+// gives providers time to converge on block availability.
+//   latest:     ~1.5min behind head (12s * 8)
+//   latest-32:  ~6.5min behind head — stronger but fresher than finalized
+//   finalized:  already settled on-chain; no additional depth needed
+const ANCHOR_SAFETY_DEPTH = { latest: 8, 'latest-32': 32, finalized: 0 };
+
+// Minimum provider count for the corroborated quorum path. With K<3 a
+// single lying provider can bias the anchor selection (median needs 3 to
+// tolerate 1 outlier), so fewer than 3 available providers falls through
+// to the single-source unverified path instead of claiming "verified".
+const MIN_QUORUM_PROVIDERS = 3;
+
+// Create a short-lived provider for a single scoped operation, wrap the
+// caller's work in withTimeout, and guarantee the provider is destroyed
+// on both success and timeout. `fn` receives the bound provider.
+async function withEphemeralProvider(url, timeoutMs, fn) {
   const provider = new ethers.JsonRpcProvider(url);
-  const cleanup = () => {
-    try { provider.destroy(); } catch { /* already torn down */ }
-  };
+  const cleanup = () => { try { provider.destroy(); } catch { /* already torn down */ } };
   try {
-    const fetchBlock = async () => {
-      if (anchor === 'latest-32') {
-        // ~3min behind head on mainnet — safe against typical reorgs but
-        // fresher than finalized. Two RTTs because getBlock(n-32) depends
-        // on the latest block number first.
-        const latest = await provider.getBlockNumber();
-        const block = await provider.getBlock(latest - 32);
-        if (!block) throw new Error(`block ${latest - 32} not available`);
-        return { number: block.number, hash: block.hash };
-      }
-      const block = await provider.getBlock(anchor);
-      if (!block) throw new Error(`block tag ${anchor} returned null`);
-      return { number: block.number, hash: block.hash };
-    };
-    return await withTimeout(fetchBlock(), timeoutMs, cleanup);
+    return await withTimeout(fn(provider), timeoutMs, cleanup);
   } finally {
     cleanup();
   }
 }
 
-// Race the first two available providers; pick the LOWER block number so
-// everyone querying at that (older) hash sees identical state even if one
-// provider is ahead. On all-failed, fall back sequentially to remaining
-// providers and quarantine each failure.
+// Step 1 of anchor corroboration: the head (or finalized) block NUMBER.
+// The finalized tag requires getBlock; everything else uses getBlockNumber.
+async function fetchProviderHead(url, anchor, timeoutMs) {
+  return withEphemeralProvider(url, timeoutMs, async (provider) => {
+    if (anchor === 'finalized') {
+      const block = await provider.getBlock('finalized');
+      if (!block) throw new Error('finalized tag returned null');
+      return block.number;
+    }
+    return provider.getBlockNumber();
+  });
+}
+
+// Step 2 of anchor corroboration: the canonical block HASH at a specific
+// block NUMBER. M providers must agree for the anchor to be usable.
+async function fetchProviderBlockHashAt(url, blockNumber, timeoutMs) {
+  return withEphemeralProvider(url, timeoutMs, async (provider) => {
+    const block = await provider.getBlock(blockNumber);
+    if (!block) throw new Error(`block ${blockNumber} not available`);
+    return block.hash;
+  });
+}
+
+// Single-source anchor: both steps (head → depth-safe target → block hash)
+// against one provider, reusing one provider instance. Used by paths that
+// explicitly opt out of cross-provider corroboration (user's custom RPC
+// and the degraded single-available-provider case).
+async function fetchSingleSourceAnchor(url, anchor, timeoutMs) {
+  return withEphemeralProvider(url, timeoutMs, async (provider) => {
+    let headNumber;
+    if (anchor === 'finalized') {
+      const block = await provider.getBlock('finalized');
+      if (!block) throw new Error('finalized tag returned null');
+      headNumber = block.number;
+    } else {
+      headNumber = await provider.getBlockNumber();
+    }
+    const safetyDepth = ANCHOR_SAFETY_DEPTH[anchor] ?? 8;
+    const targetNumber = headNumber - safetyDepth;
+    const block = await provider.getBlock(targetNumber);
+    if (!block) throw new Error(`block ${targetNumber} not available`);
+    return { number: targetNumber, hash: block.hash };
+  });
+}
+
+// Pick a head number robust to up to (K-1)/2 lying providers — i.e. the
+// median. Only called when heads.length ≥ 3 (the K<3 path bypasses
+// corroboration entirely and falls through to single-source unverified).
+function deriveCorroboratedHead(heads) {
+  if (heads.length < MIN_QUORUM_PROVIDERS) {
+    return { head: null, ok: false, reason: `need ≥${MIN_QUORUM_PROVIDERS} heads, got ${heads.length}` };
+  }
+  const sorted = heads.slice().sort((a, b) => a - b);
+  return { head: sorted[Math.floor(sorted.length / 2)], ok: true };
+}
+
+// Two-step anchor corroboration: collect heads from K providers, derive a
+// safety-deep target number from the median, then require M providers to
+// agree on the block hash AT that target. A single malicious RPC cannot
+// force a stale anchor — the median is robust to one outlier, and the
+// hash-quorum step rejects solo forgeries. No M-agreement on the hash
+// → throw rather than silently promote uncorroborated state to verified.
 async function getPinnedBlock() {
   const settings = loadSettings();
   const anchor = settings.ensBlockAnchor || 'latest';
@@ -216,6 +275,8 @@ async function getPinnedBlock() {
     ? settings.ensBlockAnchorTtlMs
     : 30_000;
   const timeoutMs = Number(settings.ensQuorumTimeoutMs) || 5000;
+  const desiredK = Math.max(2, Math.min(Number(settings.ensQuorumK) || 3, 9));
+  const desiredM = Math.max(2, Math.min(Number(settings.ensQuorumM) || 2, desiredK));
 
   if (pinnedBlockCache
       && pinnedBlockCache.anchor === anchor
@@ -224,53 +285,97 @@ async function getPinnedBlock() {
   }
 
   const available = getAvailableProviders();
-  if (available.length === 0) {
-    throw new Error('No available RPC providers for block anchor');
+  if (available.length < MIN_QUORUM_PROVIDERS) {
+    // Caller will fall through to the single-source unverified path.
+    return null;
   }
 
-  // First wave: race the top two (if available).
-  const firstWave = available.slice(0, 2);
-  const firstResults = await Promise.allSettled(
-    firstWave.map((url) =>
-      fetchAnchorFromProvider(url, anchor, timeoutMs).then(
-        (block) => ({ url, block }),
-        (err) => { markProviderFailure(url); throw err; }
-      )
+  const effectiveM = Math.min(desiredM, available.length);
+
+  // Step 1: probe every available provider for its head in parallel. Using
+  // the whole pool (not just the first K) makes the median more robust
+  // and means a single flaky provider can't sink the anchor step — there
+  // are typically several more healthy RPCs left to corroborate against.
+  const headResults = await Promise.allSettled(
+    available.map((url) =>
+      fetchProviderHead(url, anchor, timeoutMs)
+        .then((number) => ({ url, number }))
+        .catch((err) => { markProviderFailure(url); throw err; })
     )
   );
+  const heads = headResults
+    .filter((r) => r.status === 'fulfilled')
+    .map((r) => r.value);
+  for (const { url } of heads) markProviderSuccess(url);
 
-  const firstWins = firstResults
+  if (heads.length < MIN_QUORUM_PROVIDERS) {
+    // Runtime flakes left us without enough heads to corroborate. Caller
+    // degrades to single-source unverified rather than failing the whole
+    // resolution — the next retry will almost certainly hit the same
+    // degraded path once the failed providers are quarantined anyway.
+    log.info(`[ens] anchor infeasible: ${heads.length} of ${available.length} heads collected`);
+    return null;
+  }
+
+  const { head, ok, reason } = deriveCorroboratedHead(heads.map((h) => h.number));
+  if (!ok) {
+    log.info(`[ens] anchor head disagreement: ${reason}`);
+    return null;
+  }
+
+  const safetyDepth = ANCHOR_SAFETY_DEPTH[anchor] ?? 8;
+  const targetNumber = head - safetyDepth;
+
+  // Step 2: ask the same head-responders for the hash at the target. Any
+  // provider reachable moments ago is likely still reachable, which keeps
+  // the hash-quorum set as large as possible (harder for an attacker to
+  // form a fake majority).
+  const hashResults = await Promise.allSettled(
+    heads.map(({ url }) =>
+      fetchProviderBlockHashAt(url, targetNumber, timeoutMs)
+        .then((hash) => ({ url, hash }))
+        .catch((err) => { markProviderFailure(url); throw err; })
+    )
+  );
+  const hashes = hashResults
     .filter((r) => r.status === 'fulfilled')
     .map((r) => r.value);
 
-  for (const { url } of firstWins) markProviderSuccess(url);
+  const byHash = new Map();
+  for (const { url, hash } of hashes) {
+    const bucket = byHash.get(hash) || [];
+    bucket.push(url);
+    byHash.set(hash, bucket);
+  }
 
-  if (firstWins.length > 0) {
-    // Take the lower block number — conservative anchor, shared by all.
-    const chosen = firstWins.reduce((a, b) =>
-      a.block.number <= b.block.number ? a : b
-    ).block;
+  // Pick the hash with the MOST agreement (plurality) and require it to
+  // meet both the user-configured M AND a strict majority of actual
+  // respondents. "First bucket with ≥M" let a small collusion win via
+  // Map iteration order when the probe set exceeds K — two attackers in
+  // a 9-provider pool could be inserted first and satisfy M=2 even
+  // though seven honest providers agreed on a different hash. On a
+  // canonical chain honest providers all return the same hash, so the
+  // largest bucket is the honest one unless attackers form a majority
+  // (outside the threat model).
+  let winner = { hash: null, urls: [] };
+  for (const [hash, urls] of byHash) {
+    if (urls.length > winner.urls.length) {
+      winner = { hash, urls };
+    }
+  }
+  const majorityThreshold = Math.floor(hashes.length / 2) + 1;
+  const hashQuorumThreshold = Math.max(effectiveM, majorityThreshold);
+
+  if (winner.urls.length >= hashQuorumThreshold) {
+    for (const url of winner.urls) markProviderSuccess(url);
+    const chosen = { number: targetNumber, hash: winner.hash };
     pinnedBlockCache = { anchor, ...chosen, expiresAt: Date.now() + ttl };
     return chosen;
   }
 
-  // Both failed — try the rest sequentially.
-  let lastError = null;
-  for (const url of available.slice(2)) {
-    try {
-      const block = await fetchAnchorFromProvider(url, anchor, timeoutMs);
-      markProviderSuccess(url);
-      pinnedBlockCache = { anchor, ...block, expiresAt: Date.now() + ttl };
-      return block;
-    } catch (err) {
-      lastError = err;
-      markProviderFailure(url);
-      log.warn(`[ens] anchor fetch failed via ${url}: ${err.message}`);
-    }
-  }
-
   throw new Error(
-    `Could not pin block anchor (${anchor}): ${lastError?.message || 'all providers failed'}`
+    `Could not reach hash quorum at block ${targetNumber} ` +
+    `(largest bucket ${winner.urls.length} of ${hashes.length} responses, need ≥${hashQuorumThreshold})`
   );
 }
 
@@ -562,13 +667,15 @@ async function runQuorumLeg(url, name, callData, blockHash, timeoutMs, cancelTok
 }
 
 // Race K provider legs to an M-agreement. Returns early as soon as M legs
-// produce byte-identical `data` OR M legs produce `not_found`. Stragglers
-// still in flight are left to settle on their own (their connections are
-// already torn down on timeout; otherwise they just complete and discard).
+// produce byte-identical `data` OR M legs produce `not_found` with the
+// same reason. Mixed negative reasons (NO_RESOLVER vs NO_CONTENTHASH)
+// bucket separately — they describe different states, so conflating them
+// would let a transient CCIP failure combine with a real NO_RESOLVER to
+// forge a "verified not-found".
 async function runConsensusWave({ providers, name, callData, blockHash, timeoutMs, m }) {
-  const results = new Map(); // url → leg result
-  const byData = new Map();  // resolvedData bytes → Set<url>
-  const byNotFound = new Set();
+  const results = new Map();    // url → leg result
+  const byData = new Map();     // resolvedData bytes → Set<url>
+  const byNegative = new Map(); // reason (e.g. NO_RESOLVER) → Set<url>
   const queried = providers.map(hostOf);
 
   // Shared token so we can tear down straggler providers when M-agreement
@@ -586,9 +693,11 @@ async function runConsensusWave({ providers, name, callData, blockHash, timeoutM
         return true;
       }
     }
-    if (byNotFound.size >= m) {
-      earlyResolve({ kind: 'agreed_not_found', urls: Array.from(byNotFound) });
-      return true;
+    for (const [reason, urls] of byNegative) {
+      if (urls.size >= m) {
+        earlyResolve({ kind: 'agreed_not_found', reason, urls: Array.from(urls) });
+        return true;
+      }
     }
     return false;
   };
@@ -601,7 +710,10 @@ async function runConsensusWave({ providers, name, callData, blockHash, timeoutM
         bucket.add(url);
         byData.set(r.resolvedData, bucket);
       } else if (r.status === 'not_found') {
-        byNotFound.add(url);
+        const reason = r.reason || 'NO_RESOLVER';
+        const bucket = byNegative.get(reason) || new Set();
+        bucket.add(url);
+        byNegative.set(reason, bucket);
       }
       checkEarly();
     })
@@ -617,20 +729,7 @@ async function runConsensusWave({ providers, name, callData, blockHash, timeoutM
     for (const fn of cancelToken.cleanups) fn();
   }
 
-  return { outcome, results, byData, byNotFound, queried };
-}
-
-// Pick the most common value in an array (first wins on tie).
-function pluralityOf(values) {
-  const counts = new Map();
-  let best = values[0];
-  let bestCount = 0;
-  for (const v of values) {
-    const c = (counts.get(v) || 0) + 1;
-    counts.set(v, c);
-    if (c > bestCount) { best = v; bestCount = c; }
-  }
-  return best;
+  return { outcome, results, byData, byNegative, queried, mUsed: m };
 }
 
 // Build the trust metadata object the renderer surfaces on the shield.
@@ -648,13 +747,13 @@ function buildTrust({ level, agreed, dissented, queried, k, m, block }) {
 // Build the `groups` payload for conflict outcomes. Mixed bytes groups and
 // a single synthetic not_found group are surfaced so the interstitial can
 // show "these hosts said A, these said B, these said not-registered."
-function buildConflictGroups({ byData, byNotFound }) {
+function buildConflictGroups({ byData, byNegative }) {
   const groups = [];
   for (const [bytes, urls] of byData) {
     groups.push({ resolvedData: bytes, urls: Array.from(urls).map(hostOf) });
   }
-  if (byNotFound.size > 0) {
-    groups.push({ resolvedData: null, reason: 'NO_RESOLVER', urls: Array.from(byNotFound).map(hostOf) });
+  for (const [reason, urls] of byNegative) {
+    groups.push({ resolvedData: null, reason, urls: Array.from(urls).map(hostOf) });
   }
   return groups;
 }
@@ -663,7 +762,7 @@ function buildConflictGroups({ byData, byNotFound }) {
 // aggregate shape into `unverified` (exactly one semantic response),
 // `conflict` (two or more disagreeing responses), or `all_errored` (no
 // response at all — caller may escalate to a second wave).
-function classifyNoAgreement({ results, byData, byNotFound }) {
+function classifyNoAgreement({ results }) {
   let dataResponses = 0;
   let notFoundResponses = 0;
   let errorCount = 0;
@@ -686,7 +785,8 @@ function classifyNoAgreement({ results, byData, byNotFound }) {
     return { kind: 'unverified_not_found', leg: sole };
   }
 
-  // 2+ responses but no M-group → they disagreed.
+  // 2+ responses but no M-group (across any data bucket or any single
+  // negative-reason bucket) → they disagreed.
   return { kind: 'conflict' };
 }
 
@@ -700,7 +800,7 @@ async function tryCustomRpcFastPath(customRpc, name, callData, settings) {
   const timeoutMs = Number(settings.ensQuorumTimeoutMs) || 5000;
   let block;
   try {
-    block = await fetchAnchorFromProvider(customRpc, anchor, timeoutMs);
+    block = await fetchSingleSourceAnchor(customRpc, anchor, timeoutMs);
   } catch (err) {
     log.warn(`[ens] custom RPC anchor fetch failed (${hostOf(customRpc)}): ${err.message}`);
     return null;
@@ -733,6 +833,42 @@ async function tryCustomRpcFastPath(customRpc, name, callData, settings) {
   return { outcome: 'not_found', reason: leg.reason || 'NO_RESOLVER', trust, block };
 }
 
+// Degraded resolution against a single RPC. Shared by the K<3 config
+// paths and the runtime "anchor corroboration infeasible" fallback so
+// both produce the same `unverified` shape. Throws only when the single
+// provider itself errors.
+async function resolveSingleSourceUnverified(url, name, callData, anchor, timeoutMs) {
+  let block;
+  try {
+    block = await fetchSingleSourceAnchor(url, anchor, timeoutMs);
+  } catch (err) {
+    throw new Error(`Single-provider anchor fetch failed: ${err.message}`, { cause: err });
+  }
+  const legResult = await runQuorumLeg(url, name, callData, block.hash, timeoutMs);
+  const trust = buildTrust({
+    level: 'unverified',
+    agreed: [hostOf(url)],
+    dissented: [],
+    queried: [hostOf(url)],
+    k: 1,
+    m: 1,
+    block,
+  });
+  if (legResult.status === 'data') {
+    return {
+      outcome: 'data',
+      resolvedData: legResult.resolvedData,
+      resolverAddress: legResult.resolverAddress,
+      trust,
+      block,
+    };
+  }
+  if (legResult.status === 'not_found') {
+    return { outcome: 'not_found', reason: legResult.reason || 'NO_RESOLVER', trust, block };
+  }
+  throw legResult.error || new Error('Single-provider resolution failed');
+}
+
 // Returns one of:
 //   { outcome: 'data',       resolvedData, resolverAddress, trust, block }
 //   { outcome: 'not_found',  reason,                         trust, block }
@@ -750,51 +886,63 @@ async function consensusResolve(normalizedName, callData, kind = 'content') {
     if (customResult) return customResult;
   }
 
-  // Settings override: if user disabled quorum explicitly, take one
-  // non-quarantined provider and return as unverified. No corroboration.
   const quorumDisabled = settings.enableEnsQuorum === false;
-
-  // Pin a shared block for all legs so honest-but-unsynced providers don't
-  // produce false conflicts.
-  const block = await getPinnedBlock();
-
-  const desiredK = Math.max(2, Math.min(Number(settings.ensQuorumK) || 3, 9));
-  const desiredM = Math.max(2, Math.min(Number(settings.ensQuorumM) || 2, desiredK));
+  const desiredK = Math.max(1, Math.min(Number(settings.ensQuorumK) || 3, 9));
+  const desiredM = Math.max(1, Math.min(Number(settings.ensQuorumM) || 2, desiredK));
   const timeoutMs = Number(settings.ensQuorumTimeoutMs) || 5000;
+  const anchor = settings.ensBlockAnchor || 'latest';
 
   const available = getAvailableProviders();
   if (available.length === 0) {
     throw new Error('No available RPC providers for ENS consensus resolution');
   }
 
-  // Degraded single-provider path (only one non-quarantined provider, or
-  // quorum disabled by user). Outcome is always `unverified` because there
-  // is no second source to corroborate against.
-  if (quorumDisabled || available.length === 1) {
-    const url = available[0];
-    const legResult = await runQuorumLeg(url, normalizedName, callData, block.hash, timeoutMs);
-    const trust = buildTrust({
-      level: 'unverified',
-      agreed: [hostOf(url)],
-      dissented: [],
-      queried: [hostOf(url)],
-      k: 1,
-      m: desiredM,
-      block,
-    });
-    if (legResult.status === 'data') {
-      return { outcome: 'data', resolvedData: legResult.resolvedData, resolverAddress: legResult.resolverAddress, trust, block };
-    }
-    if (legResult.status === 'not_found') {
-      return { outcome: 'not_found', reason: legResult.reason || 'NO_RESOLVER', trust, block };
-    }
-    throw legResult.error || new Error('Single-provider resolution failed');
+  // Degraded single-source path. Taken when:
+  //   - user disabled quorum explicitly, OR
+  //   - fewer than 3 providers are non-quarantined (not enough to tolerate
+  //     one outlier via median), OR
+  //   - user configured sub-minimum K/M (K<3 or M<2). In that case the
+  //     corroborated path can't honestly produce `verified` anyway, so we
+  //     respect the user's intent and downgrade rather than hard-failing.
+  // A single liar within the drift window can bias a K=2 anchor into the
+  // past; we surface the outcome as `unverified` rather than minting a
+  // "verified" badge we can't defend.
+  const quorumUnderpowered =
+    desiredK < MIN_QUORUM_PROVIDERS || desiredM < 2;
+  if (quorumDisabled || available.length < MIN_QUORUM_PROVIDERS || quorumUnderpowered) {
+    return resolveSingleSourceUnverified(available[0], normalizedName, callData, anchor, timeoutMs);
   }
 
-  const effectiveK = Math.min(desiredK, available.length);
+  // Corroborated anchor required before the quorum wave — a malicious
+  // provider lying about the head cannot unilaterally pin stale state.
+  // Returns null when corroboration is infeasible at runtime (flakes
+  // leaving fewer than MIN_QUORUM_PROVIDERS heads); we degrade to the
+  // single-source unverified path rather than failing the whole request.
+  const block = await getPinnedBlock();
+  if (!block) {
+    const freshAvailable = getAvailableProviders();
+    const fallbackUrl = freshAvailable[0] || available[0];
+    return resolveSingleSourceUnverified(fallbackUrl, normalizedName, callData, anchor, timeoutMs);
+  }
+
+  // Refresh the available pool — anchor corroboration may have quarantined
+  // flaky providers, and reusing the pre-anchor snapshot would immediately
+  // retry them in the wave. Worst case: one bad responder plus two
+  // already-quarantined flakes in the first K would let classifyNoAgreement
+  // return unverified_data from a single (possibly malicious) source while
+  // the providers that carried anchor corroboration sit idle.
+  const waveAvailable = getAvailableProviders();
+  if (waveAvailable.length < MIN_QUORUM_PROVIDERS) {
+    return resolveSingleSourceUnverified(
+      waveAvailable[0] || available[0],
+      normalizedName, callData, anchor, timeoutMs
+    );
+  }
+
+  const effectiveK = Math.min(desiredK, waveAvailable.length);
   const effectiveM = Math.min(desiredM, effectiveK);
 
-  const firstSelection = available.slice(0, effectiveK);
+  const firstSelection = waveAvailable.slice(0, effectiveK);
 
   log.info(
     `[ens] consensus kind=${kind} name=${normalizedName} k=${effectiveK} m=${effectiveM} ` +
@@ -831,13 +979,15 @@ async function consensusResolve(normalizedName, callData, kind = 'content') {
     }
   }
 
-  // Wave-scoped trust builder — the four shared parts (queried, k, m, block)
-  // would otherwise repeat across every terminal branch.
+  // Wave-scoped trust builder — `m` comes from the wave that actually
+  // produced the answer (second-wave fallbacks run with a lower m when
+  // fewer providers remain; using the caller's effectiveM here would
+  // report an impossible k=2, m=3, achieved=true on those paths).
   const trustFor = (level, agreed, dissented = []) => buildTrust({
     level, agreed, dissented,
     queried: wave.queried,
     k: wave.queried.length,
-    m: effectiveM,
+    m: wave.mUsed,
     block,
   });
 
@@ -855,11 +1005,10 @@ async function consensusResolve(normalizedName, callData, kind = 'content') {
 
   if (wave.outcome.kind === 'agreed_not_found') {
     const agreedUrls = wave.outcome.urls;
-    const reasons = agreedUrls.map((u) => wave.results.get(u)?.reason || 'NO_RESOLVER');
     const firstAgreer = wave.results.get(agreedUrls[0]);
     return {
       outcome: 'not_found',
-      reason: pluralityOf(reasons),
+      reason: wave.outcome.reason,
       error: firstAgreer?.error?.message,
       trust: trustFor('verified', agreedUrls.map(hostOf)),
       block,

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -5,6 +5,7 @@ const { ens_normalize } = require('@adraffy/ens-normalize');
 const IPC = require('../shared/ipc-channels');
 const { success, failure } = require('./ipc-contract');
 const { loadSettings, DEFAULT_ENS_PUBLIC_RPC_PROVIDERS } = require('./settings-store');
+const { prefetchGatewayUrl } = require('./ens-prefetch');
 
 // Canonical ENS Universal Resolver — a DAO-owned proxy that delegates to
 // the current implementation, so future UR upgrades don't require a code
@@ -672,7 +673,9 @@ async function runQuorumLeg(url, name, callData, blockHash, timeoutMs, cancelTok
 // bucket separately — they describe different states, so conflating them
 // would let a transient CCIP failure combine with a real NO_RESOLVER to
 // forge a "verified not-found".
-async function runConsensusWave({ providers, name, callData, blockHash, timeoutMs, m }) {
+async function runConsensusWave({
+  providers, name, callData, blockHash, timeoutMs, m, onFirstData,
+}) {
   const results = new Map();    // url → leg result
   const byData = new Map();     // resolvedData bytes → Set<url>
   const byNegative = new Map(); // reason (e.g. NO_RESOLVER) → Set<url>
@@ -682,6 +685,24 @@ async function runConsensusWave({ providers, name, callData, blockHash, timeoutM
   // fires before all legs settle — keeps sockets + parsing work from
   // running uselessly in the background.
   const cancelToken = { cleanups: new Set() };
+
+  // First `data` response kicks off speculative prefetch (if caller wired
+  // one). Stored so we can abort on non-verified outcomes. Hard invariant:
+  // onFirstData errors must never affect quorum — hence the try/catch and
+  // the `?.abort` / noop fallback.
+  let firstDataSeen = false;
+  let prefetchHandle = null;
+  const NOOP_PREFETCH = { abort: () => {} };
+  const kickOffPrefetch = (resolvedData) => {
+    if (firstDataSeen || !onFirstData) return;
+    firstDataSeen = true;
+    try {
+      prefetchHandle = onFirstData(resolvedData) || NOOP_PREFETCH;
+    } catch (err) {
+      log.info(`[ens] onFirstData threw, skipping prefetch: ${err.message}`);
+      prefetchHandle = NOOP_PREFETCH;
+    }
+  };
 
   let earlyResolve;
   const earlyPromise = new Promise((res) => { earlyResolve = res; });
@@ -706,6 +727,7 @@ async function runConsensusWave({ providers, name, callData, blockHash, timeoutM
     runQuorumLeg(url, name, callData, blockHash, timeoutMs, cancelToken).then((r) => {
       results.set(url, r);
       if (r.status === 'data') {
+        kickOffPrefetch(r.resolvedData);
         const bucket = byData.get(r.resolvedData) || new Set();
         bucket.add(url);
         byData.set(r.resolvedData, bucket);
@@ -727,6 +749,15 @@ async function runConsensusWave({ providers, name, callData, blockHash, timeoutM
   // is a no-op.
   if (outcome.kind !== 'all_settled') {
     for (const fn of cancelToken.cleanups) fn();
+  }
+
+  // Prefetch is only useful for `agreed_data` — everything else either
+  // routes to an interstitial or throws, and the gateway fetch would be
+  // wasted (or would warm attacker-chosen content the renderer will never
+  // load). Aborting on anything-but-agreed_data is the safe default; the
+  // prefetch module's abort is idempotent so this is fire-and-forget.
+  if (outcome.kind !== 'agreed_data' && prefetchHandle) {
+    try { prefetchHandle.abort(); } catch { /* never propagate */ }
   }
 
   return { outcome, results, byData, byNegative, queried, mUsed: m };
@@ -874,7 +905,7 @@ async function resolveSingleSourceUnverified(url, name, callData, anchor, timeou
 //   { outcome: 'not_found',  reason,                         trust, block }
 //   { outcome: 'conflict',   groups,                         trust, block }
 // Throws when there are no providers or both waves all-errored.
-async function consensusResolve(normalizedName, callData, kind = 'content') {
+async function consensusResolve(normalizedName, callData, kind = 'content', options = {}) {
   const settings = loadSettings();
 
   // Custom RPC: try first, fall back to public quorum on any failure so
@@ -956,6 +987,7 @@ async function consensusResolve(normalizedName, callData, kind = 'content') {
     blockHash: block.hash,
     timeoutMs,
     m: effectiveM,
+    onFirstData: options.onFirstData,
   });
 
   // All-errored first wave → escalate once to remaining non-quarantined providers.
@@ -974,6 +1006,7 @@ async function consensusResolve(normalizedName, callData, kind = 'content') {
           blockHash: block.hash,
           timeoutMs,
           m: Math.min(desiredM, secondK),
+          onFirstData: options.onFirstData,
         });
       }
     }
@@ -1055,11 +1088,31 @@ async function resolveEnsContent(name) {
   return resolveWithCache(name, ensResultCache, doResolveEnsContent, 'content');
 }
 
+// Callback for the first `data` response in a contenthash wave. Decodes
+// the UR's ABI-encoded return, parses the multicodec content hash, and
+// kicks off a gateway prefetch for bzz:// / ipfs:// (never ipns://). Must
+// not throw — consensusResolve's caller is bulletproofed but the whole
+// safety story is "prefetch cannot affect resolution", so we redundantly
+// swallow errors here too.
+function prefetchOnFirstData(resolvedData) {
+  try {
+    const [inner] = ethers.AbiCoder.defaultAbiCoder().decode(['bytes'], resolvedData);
+    if (!inner || inner === '0x') return null;
+    const parsed = parseContentHashBytes(inner);
+    if (!parsed || !parsed.uri) return null;
+    return prefetchGatewayUrl(parsed.uri);
+  } catch {
+    return null;
+  }
+}
+
 async function doResolveEnsContent(normalized) {
   const node = ethers.namehash(normalized);
   const callData = CONTENTHASH_SELECTOR + node.slice(2);
 
-  const consensus = await consensusResolve(normalized, callData, 'content');
+  const consensus = await consensusResolve(normalized, callData, 'content', {
+    onFirstData: prefetchOnFirstData,
+  });
   const { trust } = consensus;
 
   if (consensus.outcome === 'conflict') {

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -4,7 +4,7 @@ const { ethers } = require('ethers');
 const { ens_normalize } = require('@adraffy/ens-normalize');
 const IPC = require('../shared/ipc-channels');
 const { success, failure } = require('./ipc-contract');
-const { loadSettings } = require('./settings-store');
+const { loadSettings, DEFAULT_ENS_PUBLIC_RPC_PROVIDERS } = require('./settings-store');
 
 // Canonical ENS Universal Resolver — a DAO-owned proxy that delegates to
 // the current implementation, so future UR upgrades don't require a code
@@ -67,16 +67,285 @@ function getRpcProviders() {
   return PUBLIC_RPC_PROVIDERS;
 }
 
+// ---------------------------------------------------------------------------
+// Session-shuffled public-RPC pool with per-provider quarantine. Backs the
+// `consensusResolve` primitive defined later; the one remaining caller of
+// the older `getWorkingProvider` path is reverse resolution.
+// ---------------------------------------------------------------------------
+
+// Per-provider sticky failure with exponential cooldown. In-memory only,
+// cleared on process restart and on settings change (via invalidateProviderPool).
+const quarantine = new Map(); // url → { failures, cooldownUntil }
+const QUARANTINE_BASE_MS = 60_000;
+const QUARANTINE_MAX_MS = 600_000;
+
+// Shuffle state: recomputed on first use and whenever the effective provider
+// list changes. `sourceKey` is the joined URL list we shuffled, so we can
+// detect settings edits without diffing array contents every call.
+let shuffledProviderOrder = null;
+let shuffledProviderSourceKey = null;
+
+// Fisher-Yates with Math.random — not adversarial, just load-spreading
+// across the user population so everyone doesn't hammer position 0.
+function shuffleInPlace(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+// Effective public-RPC list from settings, with ETH_RPC env override
+// prepended for dev convenience. Falls back to defaults if the saved list
+// is empty/missing — the settings UI will enforce non-emptiness, but
+// defense-in-depth here keeps resolution working if the file is corrupted.
+function getEffectivePublicProviders() {
+  const settings = loadSettings();
+  const saved =
+    Array.isArray(settings.ensPublicRpcProviders) && settings.ensPublicRpcProviders.length > 0
+      ? settings.ensPublicRpcProviders
+      : DEFAULT_ENS_PUBLIC_RPC_PROVIDERS;
+
+  const envOverride = (process.env.ETH_RPC || '').trim();
+  const list = envOverride ? [envOverride, ...saved] : [...saved];
+
+  // De-dupe by case-insensitive URL; drop empties.
+  const seen = new Set();
+  return list.filter((url) => {
+    if (typeof url !== 'string') return false;
+    const trimmed = url.trim();
+    if (!trimmed) return false;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+// Shuffled provider order, recomputed only when the effective list changes.
+function getShuffledPublicProviders() {
+  const effective = getEffectivePublicProviders();
+  const sourceKey = effective.join('|');
+  if (shuffledProviderSourceKey !== sourceKey) {
+    shuffledProviderOrder = shuffleInPlace([...effective]);
+    shuffledProviderSourceKey = sourceKey;
+  }
+  return shuffledProviderOrder;
+}
+
+function isQuarantined(url) {
+  const entry = quarantine.get(url);
+  if (!entry) return false;
+  if (Date.now() >= entry.cooldownUntil) {
+    quarantine.delete(url);
+    return false;
+  }
+  return true;
+}
+
+function markProviderFailure(url) {
+  const entry = quarantine.get(url) || { failures: 0, cooldownUntil: 0 };
+  entry.failures += 1;
+  const cooldown = Math.min(QUARANTINE_BASE_MS * 2 ** (entry.failures - 1), QUARANTINE_MAX_MS);
+  entry.cooldownUntil = Date.now() + cooldown;
+  quarantine.set(url, entry);
+}
+
+function markProviderSuccess(url) {
+  quarantine.delete(url);
+}
+
+// Returns providers in shuffled order, quarantined ones filtered out.
+function getAvailableProviders() {
+  return getShuffledPublicProviders().filter((url) => !isQuarantined(url));
+}
+
+// Reset all pool state. Settings-list changes are detected lazily by
+// `getShuffledPublicProviders` (source-key diff), so this is only needed
+// for tests and for the exported `invalidateCachedProvider` that external
+// code calls after a settings edit to also drop quarantine memory.
+function invalidateProviderPool() {
+  shuffledProviderOrder = null;
+  shuffledProviderSourceKey = null;
+  quarantine.clear();
+  pinnedBlockCache = null;
+}
+
+// ---------------------------------------------------------------------------
+// Block anchor: the shared (number, hash) all quorum legs query at, so
+// honest-but-unsynced providers don't produce false conflicts. Fetched from
+// one or two providers, cached for ensBlockAnchorTtlMs (default 30s).
+// ---------------------------------------------------------------------------
+
+let pinnedBlockCache = null; // { anchor, number, hash, expiresAt }
+
+async function fetchAnchorFromProvider(url, anchor, timeoutMs) {
+  const provider = new ethers.JsonRpcProvider(url);
+  const cleanup = () => {
+    try { provider.destroy(); } catch { /* already torn down */ }
+  };
+  try {
+    const fetchBlock = async () => {
+      if (anchor === 'latest-32') {
+        // ~3min behind head on mainnet — safe against typical reorgs but
+        // fresher than finalized. Two RTTs because getBlock(n-32) depends
+        // on the latest block number first.
+        const latest = await provider.getBlockNumber();
+        const block = await provider.getBlock(latest - 32);
+        if (!block) throw new Error(`block ${latest - 32} not available`);
+        return { number: block.number, hash: block.hash };
+      }
+      const block = await provider.getBlock(anchor);
+      if (!block) throw new Error(`block tag ${anchor} returned null`);
+      return { number: block.number, hash: block.hash };
+    };
+    return await withTimeout(fetchBlock(), timeoutMs, cleanup);
+  } finally {
+    cleanup();
+  }
+}
+
+// Race the first two available providers; pick the LOWER block number so
+// everyone querying at that (older) hash sees identical state even if one
+// provider is ahead. On all-failed, fall back sequentially to remaining
+// providers and quarantine each failure.
+async function getPinnedBlock() {
+  const settings = loadSettings();
+  const anchor = settings.ensBlockAnchor || 'latest';
+  const ttl = typeof settings.ensBlockAnchorTtlMs === 'number'
+    ? settings.ensBlockAnchorTtlMs
+    : 30_000;
+  const timeoutMs = Number(settings.ensQuorumTimeoutMs) || 5000;
+
+  if (pinnedBlockCache
+      && pinnedBlockCache.anchor === anchor
+      && Date.now() < pinnedBlockCache.expiresAt) {
+    return { number: pinnedBlockCache.number, hash: pinnedBlockCache.hash };
+  }
+
+  const available = getAvailableProviders();
+  if (available.length === 0) {
+    throw new Error('No available RPC providers for block anchor');
+  }
+
+  // First wave: race the top two (if available).
+  const firstWave = available.slice(0, 2);
+  const firstResults = await Promise.allSettled(
+    firstWave.map((url) =>
+      fetchAnchorFromProvider(url, anchor, timeoutMs).then(
+        (block) => ({ url, block }),
+        (err) => { markProviderFailure(url); throw err; }
+      )
+    )
+  );
+
+  const firstWins = firstResults
+    .filter((r) => r.status === 'fulfilled')
+    .map((r) => r.value);
+
+  for (const { url } of firstWins) markProviderSuccess(url);
+
+  if (firstWins.length > 0) {
+    // Take the lower block number — conservative anchor, shared by all.
+    const chosen = firstWins.reduce((a, b) =>
+      a.block.number <= b.block.number ? a : b
+    ).block;
+    pinnedBlockCache = { anchor, ...chosen, expiresAt: Date.now() + ttl };
+    return chosen;
+  }
+
+  // Both failed — try the rest sequentially.
+  let lastError = null;
+  for (const url of available.slice(2)) {
+    try {
+      const block = await fetchAnchorFromProvider(url, anchor, timeoutMs);
+      markProviderSuccess(url);
+      pinnedBlockCache = { anchor, ...block, expiresAt: Date.now() + ttl };
+      return block;
+    } catch (err) {
+      lastError = err;
+      markProviderFailure(url);
+      log.warn(`[ens] anchor fetch failed via ${url}: ${err.message}`);
+    }
+  }
+
+  throw new Error(
+    `Could not pin block anchor (${anchor}): ${lastError?.message || 'all providers failed'}`
+  );
+}
+
+// ethers v6 calls ignore AbortSignal, so on timeout we rely on the caller's
+// onTimeout callback to destroy the provider and tear down the request.
+function withTimeout(promise, ms, onTimeout) {
+  let timeoutId;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => {
+      if (onTimeout) {
+        try { onTimeout(); } catch { /* ignore teardown errors */ }
+      }
+      const err = new Error(`timeout after ${ms}ms`);
+      err.code = 'TIMEOUT';
+      reject(err);
+    }, ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    clearTimeout(timeoutId);
+  });
+}
+
 let cachedProvider = null;
 let cachedProviderUrl = null;
 
-const ENS_CACHE_TTL_MS = 15 * 60 * 1000;
+// Outcome-specific TTLs. Indexed by trust.level; the default fallback
+// applies to legacy code paths (e.g. reverse resolution) that don't carry
+// a trust field. Verified/user-configured outcomes are stable enough for
+// 15min; unverified answers expire in 60s so transient public-RPC noise
+// doesn't pin the user-facing result for long; conflict outcomes are
+// negative-cached for 10s purely to avoid re-entry storms on repeated
+// navigation attempts during an active lie.
+const TTL_BY_LEVEL = {
+  verified: 15 * 60 * 1000,
+  'user-configured': 15 * 60 * 1000,
+  unverified: 60 * 1000,
+  conflict: 10 * 1000,
+};
+const DEFAULT_CACHE_TTL_MS = 15 * 60 * 1000;
+
+function ttlForResult(result) {
+  const level = result?.trust?.level;
+  if (level && Object.prototype.hasOwnProperty.call(TTL_BY_LEVEL, level)) {
+    return TTL_BY_LEVEL[level];
+  }
+  return DEFAULT_CACHE_TTL_MS;
+}
+
+// Upper bound per cache. Long browsing sessions can accumulate thousands
+// of distinct ENS names; without a cap the caches grow unboundedly since
+// expired entries are only evicted on re-read. On set, if we're over the
+// cap, drop expired entries first, then fall back to FIFO eviction.
+const MAX_CACHE_ENTRIES = 500;
+
+function capCache(cache) {
+  if (cache.size <= MAX_CACHE_ENTRIES) return;
+  const now = Date.now();
+  for (const [key, entry] of cache) {
+    if (entry.expiresAt <= now) {
+      cache.delete(key);
+      if (cache.size <= MAX_CACHE_ENTRIES) return;
+    }
+  }
+  while (cache.size > MAX_CACHE_ENTRIES) {
+    const firstKey = cache.keys().next().value;
+    cache.delete(firstKey);
+  }
+}
+
 const ensResultCache = new Map();
 
 // Independent from ensResultCache so content and addr lookups don't evict each other.
 const ensAddressCache = new Map();
 
-// Address (lowercased 0x) → { result, timestamp } for reverse lookups.
+// Address (lowercased 0x) → { result, expiresAt } for reverse lookups.
 const ensReverseCache = new Map();
 
 // Get a working provider, trying each in sequence with fallback
@@ -132,7 +401,9 @@ async function getWorkingProvider() {
   throw new Error('All RPC providers failed. Check your network connection.');
 }
 
-// Invalidate cached provider so next call tries a fresh one
+// Invalidate cached provider (legacy path) AND the shuffled/quarantine pool
+// used by consensusResolve. Tests call this between cases; production callers
+// invoke it after settings edits so a re-tested RPC gets a fresh chance.
 function invalidateCachedProvider() {
   if (cachedProvider) {
     log.info(`[ens] Invalidating cached provider: ${cachedProviderUrl}`);
@@ -140,6 +411,7 @@ function invalidateCachedProvider() {
     cachedProvider = null;
     cachedProviderUrl = null;
   }
+  invalidateProviderPool();
 }
 
 // Check if an error is a provider/network error that warrants retry
@@ -210,23 +482,424 @@ function isReverseAddressMismatchError(err) {
 
 // Call the Universal Resolver's resolve(name, data). `callData` is the raw
 // ABI-encoded call the resolver would have received directly (selector +
-// args). Returns { bytes, resolverAddress } where `bytes` is the decoded
-// inner return value of that call.
+// args). Returns the raw ABI-encoded response — the caller must decode
+// per their function's return type (e.g. decode(['bytes'], ...) for
+// contenthash, or decode(['address'], ...) for addr). Returning pre-decoded
+// bytes here would silently work for dynamic returns and overflow for
+// static ones.
 //
 // CCIP-Read is opted into per-call here because ethers v6 doesn't enable it
 // by default — needed for .box domains resolved via 3DNS.
-// Call UR.resolve for an arbitrary resolver function. Returns the raw
-// ABI-encoded response — the caller must decode per their function's
-// return type (e.g. decode(['bytes'], ...) for contenthash, or
-// decode(['address'], ...) for addr). Returning pre-decoded bytes here
-// would silently work for dynamic returns and overflow for static ones.
-async function universalResolverCall(provider, name, callData) {
+//
+// `overrides` are merged into the call's overrides object (e.g. blockTag
+// for block-pinned consensus legs). Callers that pass nothing get the
+// default { enableCcipRead: true } shape.
+async function universalResolverCall(provider, name, callData, overrides = {}) {
   const ur = new ethers.Contract(UNIVERSAL_RESOLVER_ADDRESS, UR_ABI, provider);
   const encodedName = ethers.dnsEncode(name, 255);
   const [resolvedData, resolverAddress] = await ur.resolve(encodedName, callData, {
     enableCcipRead: true,
+    ...overrides,
   });
   return { resolvedData, resolverAddress };
+}
+
+// ---------------------------------------------------------------------------
+// Consensus resolution: hedged-quorum over K public RPCs at a shared pinned
+// block. Detects a lying RPC by requiring M byte-identical responses;
+// single-source responses are returned with trust.level='unverified'.
+// ---------------------------------------------------------------------------
+
+function hostOf(url) {
+  try { return new URL(url).host; }
+  catch { return url; }
+}
+
+// Run a single leg: construct provider, call UR at blockTag=hash, classify
+// result into one of:
+//   { status: 'data',      resolvedData, resolverAddress }
+//   { status: 'not_found', reason: 'NO_RESOLVER' | 'NO_CONTENTHASH', error? }
+//   { status: 'error',     error }   ← quarantined
+//
+// NO_CONTENTHASH covers the case where the UR reverts for a reason other
+// than ResolverNotFound (e.g. CCIP gateway failed for .box names). The
+// provider answered, just not usefully — not quarantined. Network/timeout
+// errors are the only class that quarantines.
+//
+// `cancelToken.cleanups` lets a caller (runConsensusWave) forcibly destroy
+// this leg's provider when early-quorum agreement makes the leg redundant.
+async function runQuorumLeg(url, name, callData, blockHash, timeoutMs, cancelToken) {
+  let provider;
+  const cleanup = () => {
+    if (provider) {
+      try { provider.destroy(); } catch { /* already torn down */ }
+      provider = null;
+    }
+  };
+  if (cancelToken) cancelToken.cleanups.add(cleanup);
+  try {
+    provider = new ethers.JsonRpcProvider(url);
+    const urCall = universalResolverCall(provider, name, callData, { blockTag: blockHash });
+    const result = await withTimeout(urCall, timeoutMs, cleanup);
+    markProviderSuccess(url);
+    return { url, status: 'data', resolvedData: result.resolvedData, resolverAddress: result.resolverAddress };
+  } catch (err) {
+    if (isResolverNotFoundError(err)) {
+      markProviderSuccess(url);
+      return { url, status: 'not_found', reason: 'NO_RESOLVER' };
+    }
+    if (isProviderError(err) || err.code === 'TIMEOUT') {
+      markProviderFailure(url);
+      return { url, status: 'error', error: err };
+    }
+    // Unknown UR revert — provider responded, response wasn't usable.
+    // Treat as semantic "no contenthash here" for quorum agreement.
+    markProviderSuccess(url);
+    return { url, status: 'not_found', reason: 'NO_CONTENTHASH', error: err };
+  } finally {
+    cleanup();
+  }
+}
+
+// Race K provider legs to an M-agreement. Returns early as soon as M legs
+// produce byte-identical `data` OR M legs produce `not_found`. Stragglers
+// still in flight are left to settle on their own (their connections are
+// already torn down on timeout; otherwise they just complete and discard).
+async function runConsensusWave({ providers, name, callData, blockHash, timeoutMs, m }) {
+  const results = new Map(); // url → leg result
+  const byData = new Map();  // resolvedData bytes → Set<url>
+  const byNotFound = new Set();
+  const queried = providers.map(hostOf);
+
+  // Shared token so we can tear down straggler providers when M-agreement
+  // fires before all legs settle — keeps sockets + parsing work from
+  // running uselessly in the background.
+  const cancelToken = { cleanups: new Set() };
+
+  let earlyResolve;
+  const earlyPromise = new Promise((res) => { earlyResolve = res; });
+
+  const checkEarly = () => {
+    for (const [bytes, urls] of byData) {
+      if (urls.size >= m) {
+        earlyResolve({ kind: 'agreed_data', bytes, urls: Array.from(urls) });
+        return true;
+      }
+    }
+    if (byNotFound.size >= m) {
+      earlyResolve({ kind: 'agreed_not_found', urls: Array.from(byNotFound) });
+      return true;
+    }
+    return false;
+  };
+
+  const legPromises = providers.map((url) =>
+    runQuorumLeg(url, name, callData, blockHash, timeoutMs, cancelToken).then((r) => {
+      results.set(url, r);
+      if (r.status === 'data') {
+        const bucket = byData.get(r.resolvedData) || new Set();
+        bucket.add(url);
+        byData.set(r.resolvedData, bucket);
+      } else if (r.status === 'not_found') {
+        byNotFound.add(url);
+      }
+      checkEarly();
+    })
+  );
+
+  const allSettled = Promise.allSettled(legPromises).then(() => ({ kind: 'all_settled' }));
+  const outcome = await Promise.race([earlyPromise, allSettled]);
+
+  // Tear down any still-open legs. Cleanups are idempotent (they null out
+  // provider on first call), so running them against already-settled legs
+  // is a no-op.
+  if (outcome.kind !== 'all_settled') {
+    for (const fn of cancelToken.cleanups) fn();
+  }
+
+  return { outcome, results, byData, byNotFound, queried };
+}
+
+// Pick the most common value in an array (first wins on tie).
+function pluralityOf(values) {
+  const counts = new Map();
+  let best = values[0];
+  let bestCount = 0;
+  for (const v of values) {
+    const c = (counts.get(v) || 0) + 1;
+    counts.set(v, c);
+    if (c > bestCount) { best = v; bestCount = c; }
+  }
+  return best;
+}
+
+// Build the trust metadata object the renderer surfaces on the shield.
+function buildTrust({ level, agreed, dissented, queried, k, m, block }) {
+  return {
+    level,
+    block,
+    agreed: agreed.slice(),
+    dissented: dissented.slice(),
+    queried: queried.slice(),
+    quorum: { k, m, achieved: level === 'verified' },
+  };
+}
+
+// Build the `groups` payload for conflict outcomes. Mixed bytes groups and
+// a single synthetic not_found group are surfaced so the interstitial can
+// show "these hosts said A, these said B, these said not-registered."
+function buildConflictGroups({ byData, byNotFound }) {
+  const groups = [];
+  for (const [bytes, urls] of byData) {
+    groups.push({ resolvedData: bytes, urls: Array.from(urls).map(hostOf) });
+  }
+  if (byNotFound.size > 0) {
+    groups.push({ resolvedData: null, reason: 'NO_RESOLVER', urls: Array.from(byNotFound).map(hostOf) });
+  }
+  return groups;
+}
+
+// Analyze a settled wave where no M-agreement emerged. Classifies the
+// aggregate shape into `unverified` (exactly one semantic response),
+// `conflict` (two or more disagreeing responses), or `all_errored` (no
+// response at all — caller may escalate to a second wave).
+function classifyNoAgreement({ results, byData, byNotFound }) {
+  let dataResponses = 0;
+  let notFoundResponses = 0;
+  let errorCount = 0;
+  for (const r of results.values()) {
+    if (r.status === 'data') dataResponses += 1;
+    else if (r.status === 'not_found') notFoundResponses += 1;
+    else errorCount += 1;
+  }
+  const total = dataResponses + notFoundResponses;
+
+  if (total === 0) return { kind: 'all_errored', errorCount };
+
+  // Exactly one semantic response across all legs → unverified.
+  if (total === 1) {
+    if (dataResponses === 1) {
+      const [sole] = Array.from(results.values()).filter((r) => r.status === 'data');
+      return { kind: 'unverified_data', leg: sole };
+    }
+    const [sole] = Array.from(results.values()).filter((r) => r.status === 'not_found');
+    return { kind: 'unverified_not_found', leg: sole };
+  }
+
+  // 2+ responses but no M-group → they disagreed.
+  return { kind: 'conflict' };
+}
+
+// Custom-RPC fast path: single leg against the user's own node, labelled
+// trust='user-configured'. On any failure, return null so the caller falls
+// back to the public quorum path (preserving existing graceful-degrade
+// behavior). Pinned block is fetched from the same custom RPC — we don't
+// want to send user-node requests to public RPCs behind their back.
+async function tryCustomRpcFastPath(customRpc, name, callData, settings) {
+  const anchor = settings.ensBlockAnchor || 'latest';
+  const timeoutMs = Number(settings.ensQuorumTimeoutMs) || 5000;
+  let block;
+  try {
+    block = await fetchAnchorFromProvider(customRpc, anchor, timeoutMs);
+  } catch (err) {
+    log.warn(`[ens] custom RPC anchor fetch failed (${hostOf(customRpc)}): ${err.message}`);
+    return null;
+  }
+
+  const leg = await runQuorumLeg(customRpc, name, callData, block.hash, timeoutMs);
+  if (leg.status === 'error') {
+    log.warn(`[ens] custom RPC leg failed (${hostOf(customRpc)}): ${leg.error?.message}`);
+    return null;
+  }
+
+  const trust = buildTrust({
+    level: 'user-configured',
+    agreed: [hostOf(customRpc)],
+    dissented: [],
+    queried: [hostOf(customRpc)],
+    k: 1,
+    m: 1,
+    block,
+  });
+  if (leg.status === 'data') {
+    return {
+      outcome: 'data',
+      resolvedData: leg.resolvedData,
+      resolverAddress: leg.resolverAddress,
+      trust,
+      block,
+    };
+  }
+  return { outcome: 'not_found', reason: leg.reason || 'NO_RESOLVER', trust, block };
+}
+
+// Returns one of:
+//   { outcome: 'data',       resolvedData, resolverAddress, trust, block }
+//   { outcome: 'not_found',  reason,                         trust, block }
+//   { outcome: 'conflict',   groups,                         trust, block }
+// Throws when there are no providers or both waves all-errored.
+async function consensusResolve(normalizedName, callData, kind = 'content') {
+  const settings = loadSettings();
+
+  // Custom RPC: try first, fall back to public quorum on any failure so
+  // users with a misbehaving own-node still resolve.
+  const customRpc =
+    settings.enableEnsCustomRpc && (settings.ensRpcUrl || '').trim();
+  if (customRpc) {
+    const customResult = await tryCustomRpcFastPath(customRpc, normalizedName, callData, settings);
+    if (customResult) return customResult;
+  }
+
+  // Settings override: if user disabled quorum explicitly, take one
+  // non-quarantined provider and return as unverified. No corroboration.
+  const quorumDisabled = settings.enableEnsQuorum === false;
+
+  // Pin a shared block for all legs so honest-but-unsynced providers don't
+  // produce false conflicts.
+  const block = await getPinnedBlock();
+
+  const desiredK = Math.max(2, Math.min(Number(settings.ensQuorumK) || 3, 9));
+  const desiredM = Math.max(2, Math.min(Number(settings.ensQuorumM) || 2, desiredK));
+  const timeoutMs = Number(settings.ensQuorumTimeoutMs) || 5000;
+
+  const available = getAvailableProviders();
+  if (available.length === 0) {
+    throw new Error('No available RPC providers for ENS consensus resolution');
+  }
+
+  // Degraded single-provider path (only one non-quarantined provider, or
+  // quorum disabled by user). Outcome is always `unverified` because there
+  // is no second source to corroborate against.
+  if (quorumDisabled || available.length === 1) {
+    const url = available[0];
+    const legResult = await runQuorumLeg(url, normalizedName, callData, block.hash, timeoutMs);
+    const trust = buildTrust({
+      level: 'unverified',
+      agreed: [hostOf(url)],
+      dissented: [],
+      queried: [hostOf(url)],
+      k: 1,
+      m: desiredM,
+      block,
+    });
+    if (legResult.status === 'data') {
+      return { outcome: 'data', resolvedData: legResult.resolvedData, resolverAddress: legResult.resolverAddress, trust, block };
+    }
+    if (legResult.status === 'not_found') {
+      return { outcome: 'not_found', reason: legResult.reason || 'NO_RESOLVER', trust, block };
+    }
+    throw legResult.error || new Error('Single-provider resolution failed');
+  }
+
+  const effectiveK = Math.min(desiredK, available.length);
+  const effectiveM = Math.min(desiredM, effectiveK);
+
+  const firstSelection = available.slice(0, effectiveK);
+
+  log.info(
+    `[ens] consensus kind=${kind} name=${normalizedName} k=${effectiveK} m=${effectiveM} ` +
+    `block=${block.hash}@${block.number} providers=[${firstSelection.map(hostOf).join(',')}]`
+  );
+
+  let wave = await runConsensusWave({
+    providers: firstSelection,
+    name: normalizedName,
+    callData,
+    blockHash: block.hash,
+    timeoutMs,
+    m: effectiveM,
+  });
+
+  // All-errored first wave → escalate once to remaining non-quarantined providers.
+  if (wave.outcome.kind === 'all_settled') {
+    const verdict = classifyNoAgreement(wave);
+    if (verdict.kind === 'all_errored') {
+      const remaining = getAvailableProviders().filter((u) => !firstSelection.includes(u));
+      if (remaining.length > 0) {
+        const secondK = Math.min(desiredK, remaining.length);
+        const secondSelection = remaining.slice(0, secondK);
+        log.info(`[ens] consensus escalating to second wave providers=[${secondSelection.map(hostOf).join(',')}]`);
+        wave = await runConsensusWave({
+          providers: secondSelection,
+          name: normalizedName,
+          callData,
+          blockHash: block.hash,
+          timeoutMs,
+          m: Math.min(desiredM, secondK),
+        });
+      }
+    }
+  }
+
+  // Wave-scoped trust builder — the four shared parts (queried, k, m, block)
+  // would otherwise repeat across every terminal branch.
+  const trustFor = (level, agreed, dissented = []) => buildTrust({
+    level, agreed, dissented,
+    queried: wave.queried,
+    k: wave.queried.length,
+    m: effectiveM,
+    block,
+  });
+
+  if (wave.outcome.kind === 'agreed_data') {
+    const agreedUrls = wave.outcome.urls;
+    const winningLeg = wave.results.get(agreedUrls[0]);
+    return {
+      outcome: 'data',
+      resolvedData: winningLeg.resolvedData,
+      resolverAddress: winningLeg.resolverAddress,
+      trust: trustFor('verified', agreedUrls.map(hostOf)),
+      block,
+    };
+  }
+
+  if (wave.outcome.kind === 'agreed_not_found') {
+    const agreedUrls = wave.outcome.urls;
+    const reasons = agreedUrls.map((u) => wave.results.get(u)?.reason || 'NO_RESOLVER');
+    const firstAgreer = wave.results.get(agreedUrls[0]);
+    return {
+      outcome: 'not_found',
+      reason: pluralityOf(reasons),
+      error: firstAgreer?.error?.message,
+      trust: trustFor('verified', agreedUrls.map(hostOf)),
+      block,
+    };
+  }
+
+  const verdict = classifyNoAgreement(wave);
+
+  if (verdict.kind === 'all_errored') {
+    throw new Error(`All ${wave.queried.length} RPC providers failed for ${normalizedName}`);
+  }
+
+  if (verdict.kind === 'unverified_data') {
+    const leg = verdict.leg;
+    return {
+      outcome: 'data',
+      resolvedData: leg.resolvedData,
+      resolverAddress: leg.resolverAddress,
+      trust: trustFor('unverified', [hostOf(leg.url)]),
+      block,
+    };
+  }
+
+  if (verdict.kind === 'unverified_not_found') {
+    const leg = verdict.leg;
+    return {
+      outcome: 'not_found',
+      reason: leg.reason || 'NO_RESOLVER',
+      error: leg.error?.message,
+      trust: trustFor('unverified', [hostOf(leg.url)]),
+      block,
+    };
+  }
+
+  return {
+    outcome: 'conflict',
+    groups: buildConflictGroups(wave),
+    trust: trustFor('conflict', [], wave.queried),
+    block,
+  };
 }
 
 async function resolveEnsContent(name) {
@@ -234,43 +907,44 @@ async function resolveEnsContent(name) {
 }
 
 async function doResolveEnsContent(normalized) {
-  const provider = await getWorkingProvider();
   const node = ethers.namehash(normalized);
   const callData = CONTENTHASH_SELECTOR + node.slice(2);
 
-  let urResult;
-  try {
-    urResult = await universalResolverCall(provider, normalized, callData);
-  } catch (err) {
-    if (isProviderError(err)) throw err;
-    if (isResolverNotFoundError(err)) {
-      return cacheContentResult(normalized, {
-        type: 'not_found',
-        reason: 'NO_RESOLVER',
-        name: normalized,
-      });
-    }
-    log.info(`[ens] UR resolve failed for ${normalized}: ${err.message}`);
+  const consensus = await consensusResolve(normalized, callData, 'content');
+  const { trust } = consensus;
+
+  if (consensus.outcome === 'conflict') {
     return cacheContentResult(normalized, {
-      type: 'not_found',
-      reason: 'NO_CONTENTHASH',
+      type: 'conflict',
       name: normalized,
-      error: err.message,
+      trust,
+      groups: consensus.groups,
     });
   }
 
-  // contenthash() returns dynamic `bytes` — ABI-unwrap to get the raw
-  // multicodec-prefixed content-hash bytes.
+  if (consensus.outcome === 'not_found') {
+    const out = {
+      type: 'not_found',
+      reason: consensus.reason || 'NO_RESOLVER',
+      name: normalized,
+      trust,
+    };
+    if (consensus.error) out.error = consensus.error;
+    return cacheContentResult(normalized, out);
+  }
+
+  // outcome === 'data' — decode ABI-wrapped `bytes` return of contenthash().
   let innerBytes;
   try {
-    [innerBytes] = ethers.AbiCoder.defaultAbiCoder().decode(['bytes'], urResult.resolvedData);
+    [innerBytes] = ethers.AbiCoder.defaultAbiCoder().decode(['bytes'], consensus.resolvedData);
   } catch (err) {
     log.warn(`[ens] Failed to decode contenthash bytes for ${normalized}: ${err.message}`);
     return cacheContentResult(normalized, {
       type: 'unsupported',
       reason: 'UNSUPPORTED_CONTENTHASH_FORMAT',
       name: normalized,
-      contentHash: urResult.resolvedData,
+      contentHash: consensus.resolvedData,
+      trust,
     });
   }
 
@@ -279,6 +953,7 @@ async function doResolveEnsContent(normalized) {
       type: 'not_found',
       reason: 'EMPTY_CONTENTHASH',
       name: normalized,
+      trust,
     });
   }
 
@@ -290,10 +965,11 @@ async function doResolveEnsContent(normalized) {
       reason: 'UNSUPPORTED_CONTENTHASH_FORMAT',
       name: normalized,
       contentHash: innerBytes,
+      trust,
     });
   }
 
-  return cacheContentResult(normalized, { type: 'ok', name: normalized, ...parsed });
+  return cacheContentResult(normalized, { type: 'ok', name: normalized, ...parsed, trust });
 }
 
 // Decode raw ENS contenthash bytes into our result shape. Mirrors ethers'
@@ -340,8 +1016,17 @@ async function resolveEnsAddress(name) {
   return resolveWithCache(name, ensAddressCache, doResolveEnsAddress, 'addr');
 }
 
-// Shared validation + cache + retry wrapper for the content-hash and
-// addr lookup paths.
+// Concurrent resolves of the same `${label}:${normalized}` share one
+// in-flight promise so address-bar + wallet lookups (or two rapid clicks)
+// don't fire two full quorum waves. Per-label key prevents content and
+// addr lookups for the same name from colliding — they query different
+// selectors and need independent caches.
+const inFlightResolves = new Map();
+
+// Shared validation + cache wrapper for the content-hash and addr lookup
+// paths. The consensusResolve primitive handles provider-error escalation
+// internally via its second-wave logic, so no outer retry loop is needed
+// for the new path. Legacy reverse-resolution uses its own retry below.
 //
 // Normalization goes through @adraffy/ens-normalize (UTS-46 / ENSIP-15),
 // not a bare .toLowerCase(). That's correct for unicode ENS names
@@ -358,61 +1043,95 @@ async function resolveWithCache(name, cache, doResolve, label) {
   const normalized = ens_normalize(trimmed);
 
   const cached = cache.get(normalized);
-  if (cached && Date.now() - cached.timestamp < ENS_CACHE_TTL_MS) {
+  if (cached && Date.now() < cached.expiresAt) {
     log.info(`[ens] ${label} cache hit for ${normalized}`);
     return cached.result;
   }
 
-  let lastError;
-  for (let attempt = 1; attempt <= MAX_RESOLUTION_RETRIES; attempt++) {
-    try {
-      return await doResolve(normalized);
-    } catch (err) {
-      lastError = err;
-      if (isProviderError(err) && attempt < MAX_RESOLUTION_RETRIES) {
-        log.warn(
-          `[ens] ${label} provider error on attempt ${attempt}/${MAX_RESOLUTION_RETRIES}: ${err.message}`
-        );
-        invalidateCachedProvider();
-        continue;
-      }
-      throw err;
-    }
+  const dedupKey = `${label}:${normalized}`;
+  const existing = inFlightResolves.get(dedupKey);
+  if (existing) {
+    log.info(`[ens] ${label} joining in-flight resolution for ${normalized}`);
+    return existing;
   }
-  throw lastError;
+
+  // consensusResolve (content/addr paths) handles provider-error escalation
+  // internally via its second-wave logic, so the outer retry loop only runs
+  // for the legacy reverse-resolution path.
+  const needsLegacyRetry = label === 'reverse';
+
+  const promise = (async () => {
+    if (!needsLegacyRetry) return doResolve(normalized);
+
+    let lastError;
+    for (let attempt = 1; attempt <= MAX_RESOLUTION_RETRIES; attempt++) {
+      try {
+        return await doResolve(normalized);
+      } catch (err) {
+        lastError = err;
+        if (isProviderError(err) && attempt < MAX_RESOLUTION_RETRIES) {
+          log.warn(
+            `[ens] ${label} provider error on attempt ${attempt}/${MAX_RESOLUTION_RETRIES}: ${err.message}`
+          );
+          invalidateCachedProvider();
+          continue;
+        }
+        throw err;
+      }
+    }
+    throw lastError;
+  })().finally(() => {
+    inFlightResolves.delete(dedupKey);
+  });
+
+  inFlightResolves.set(dedupKey, promise);
+  return promise;
 }
 
 async function doResolveEnsAddress(normalized) {
-  const provider = await getWorkingProvider();
   const node = ethers.namehash(normalized);
   const callData = ADDR_SELECTOR + node.slice(2);
 
-  let urResult;
-  try {
-    urResult = await universalResolverCall(provider, normalized, callData);
-  } catch (err) {
-    if (isProviderError(err)) throw err;
-    if (isResolverNotFoundError(err)) {
-      return cacheAddressResult(normalized, noAddressResult(normalized));
-    }
-    log.info(`[ens] UR addr resolve failed for ${normalized}: ${err.message}`);
+  const consensus = await consensusResolve(normalized, callData, 'addr');
+  const { trust } = consensus;
+
+  if (consensus.outcome === 'conflict') {
     return cacheAddressResult(normalized, {
       success: false,
       name: normalized,
-      reason: 'RESOLUTION_ERROR',
-      error: err.message,
+      reason: 'CONFLICT',
+      trust,
+      groups: consensus.groups,
     });
   }
 
-  // addr() returns `address` — the UR's resolvedData is the raw 32-byte
-  // ABI-encoded address, NOT bytes-wrapped. Decode directly.
-  if (!urResult.resolvedData || urResult.resolvedData === '0x') {
-    return cacheAddressResult(normalized, noAddressResult(normalized));
+  if (consensus.outcome === 'not_found') {
+    // addr() has NO_RESOLVER as the only well-defined "no address" path.
+    // A non-ResolverNotFound revert (NO_CONTENTHASH from the leg classifier)
+    // means the resolver answered but not usefully — surface as a resolution
+    // error rather than silently returning "no address", since sending to a
+    // name mid-transient-failure shouldn't be confused with "no account".
+    if (consensus.reason === 'NO_CONTENTHASH') {
+      return cacheAddressResult(normalized, {
+        success: false,
+        name: normalized,
+        reason: 'RESOLUTION_ERROR',
+        error: consensus.error,
+        trust,
+      });
+    }
+    return cacheAddressResult(normalized, { ...noAddressResult(normalized), trust });
+  }
+
+  // outcome === 'data' — addr() returns a plain 32-byte ABI-encoded address
+  // (static type, not bytes-wrapped).
+  if (!consensus.resolvedData || consensus.resolvedData === '0x') {
+    return cacheAddressResult(normalized, { ...noAddressResult(normalized), trust });
   }
 
   let address;
   try {
-    [address] = ethers.AbiCoder.defaultAbiCoder().decode(['address'], urResult.resolvedData);
+    [address] = ethers.AbiCoder.defaultAbiCoder().decode(['address'], consensus.resolvedData);
   } catch (err) {
     log.warn(`[ens] Failed to decode addr bytes for ${normalized}: ${err.message}`);
     return cacheAddressResult(normalized, {
@@ -420,17 +1139,19 @@ async function doResolveEnsAddress(normalized) {
       name: normalized,
       reason: 'RESOLUTION_ERROR',
       error: err.message,
+      trust,
     });
   }
 
   if (address === ethers.ZeroAddress) {
-    return cacheAddressResult(normalized, noAddressResult(normalized));
+    return cacheAddressResult(normalized, { ...noAddressResult(normalized), trust });
   }
 
   return cacheAddressResult(normalized, {
     success: true,
     name: normalized,
     address,
+    trust,
   });
 }
 
@@ -450,12 +1171,15 @@ function cacheAddressResult(normalized, result) {
 // Shared cache-set + log-and-return for both lookup paths. `okValue` is
 // the success-case display (uri for content, address for addr); passing
 // a truthy value logs "Resolved → <value>", otherwise logs the reason.
+// TTL is derived from the result's trust.level — see TTL_BY_LEVEL.
 function cacheAndLog(cache, normalized, result, okValue) {
-  cache.set(normalized, { result, timestamp: Date.now() });
+  const ttl = ttlForResult(result);
+  cache.set(normalized, { result, expiresAt: Date.now() + ttl });
+  capCache(cache);
   if (okValue) {
-    log.info(`[ens] Resolved: ${normalized} → ${okValue}`);
+    log.info(`[ens] Resolved: ${normalized} → ${okValue} (ttl=${ttl}ms)`);
   } else {
-    log.info(`[ens] ${result.reason} for ${normalized}`);
+    log.info(`[ens] ${result.reason || result.type} for ${normalized} (ttl=${ttl}ms)`);
   }
   return result;
 }
@@ -622,6 +1346,16 @@ function registerEnsIpc() {
   });
 }
 
+// Test-only: drop all cached resolution results so tests can share ENS
+// names across cases without cross-pollution. Safe to call from production
+// (equivalent to waiting out the TTLs), but not exposed over IPC.
+function clearEnsCachesForTest() {
+  ensResultCache.clear();
+  ensAddressCache.clear();
+  ensReverseCache.clear();
+  inFlightResolves.clear();
+}
+
 module.exports = {
   registerEnsIpc,
   resolveEnsContent,
@@ -631,4 +1365,5 @@ module.exports = {
   invalidateCachedProvider,
   universalResolverCall,
   isResolverNotFoundError,
+  clearEnsCachesForTest,
 };

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -5,7 +5,7 @@ const { ens_normalize } = require('@adraffy/ens-normalize');
 const IPC = require('../shared/ipc-channels');
 const { success, failure } = require('./ipc-contract');
 const { loadSettings, DEFAULT_ENS_PUBLIC_RPC_PROVIDERS } = require('./settings-store');
-const { prefetchGatewayUrl } = require('./ens-prefetch');
+const { prefetchGatewayUrl, NOOP_HANDLE: NOOP_PREFETCH } = require('./ens-prefetch');
 
 // Canonical ENS Universal Resolver — a DAO-owned proxy that delegates to
 // the current implementation, so future UR upgrades don't require a code
@@ -692,7 +692,6 @@ async function runConsensusWave({
   // the `?.abort` / noop fallback.
   let firstDataSeen = false;
   let prefetchHandle = null;
-  const NOOP_PREFETCH = { abort: () => {} };
   const kickOffPrefetch = (resolvedData) => {
     if (firstDataSeen || !onFirstData) return;
     firstDataSeen = true;
@@ -1088,12 +1087,8 @@ async function resolveEnsContent(name) {
   return resolveWithCache(name, ensResultCache, doResolveEnsContent, 'content');
 }
 
-// Callback for the first `data` response in a contenthash wave. Decodes
-// the UR's ABI-encoded return, parses the multicodec content hash, and
-// kicks off a gateway prefetch for bzz:// / ipfs:// (never ipns://). Must
-// not throw — consensusResolve's caller is bulletproofed but the whole
-// safety story is "prefetch cannot affect resolution", so we redundantly
-// swallow errors here too.
+// Decodes the UR's ABI-encoded return, parses the multicodec content hash,
+// and kicks off a gateway prefetch for bzz:// / ipfs:// (never ipns://).
 function prefetchOnFirstData(resolvedData) {
   try {
     const [inner] = ethers.AbiCoder.defaultAbiCoder().decode(['bytes'], resolvedData);

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -3,33 +3,86 @@ jest.mock('electron', () => ({
   ipcMain: { handle: jest.fn() },
 }));
 
-// Mock settings-store
-const mockLoadSettings = jest.fn(() => ({ enableEnsCustomRpc: false, ensRpcUrl: '' }));
+// Mock settings-store. Test provider list is small (3 URLs) so the quorum
+// wave is bounded regardless of test input. Individual tests override
+// mockLoadSettings when they need different values.
+const TEST_PROVIDERS = [
+  'https://test-a.example.com',
+  'https://test-b.example.com',
+  'https://test-c.example.com',
+];
+const mockLoadSettings = jest.fn(() => ({
+  enableEnsCustomRpc: false,
+  ensRpcUrl: '',
+  enableEnsQuorum: true,
+  ensQuorumK: 3,
+  ensQuorumM: 2,
+  ensQuorumTimeoutMs: 5000,
+  ensBlockAnchor: 'latest',
+  ensBlockAnchorTtlMs: 30000,
+  ensPublicRpcProviders: TEST_PROVIDERS,
+}));
 jest.mock('./settings-store', () => ({
   loadSettings: (...args) => mockLoadSettings(...args),
+  DEFAULT_ENS_PUBLIC_RPC_PROVIDERS: [
+    'https://default-a.example.com',
+    'https://default-b.example.com',
+    'https://default-c.example.com',
+  ],
 }));
 
-// Mock ethers with controllable provider and resolver behavior
+// Mock ethers with controllable provider and resolver behavior.
+// `mockUrResolve` is shared across all Contract instances — this is fine
+// for tests that use `mockResolvedValue(X)` (every quorum leg returns X
+// and consensus reaches agreement). Tests that need per-provider behavior
+// use `setProviderResolveMap(url → result)` to differentiate.
 const mockGetBlockNumber = jest.fn();
+const mockGetBlock = jest.fn();
 const mockDestroy = jest.fn();
 const mockGetResolver = jest.fn();
 const mockResolveName = jest.fn();
 const mockUrResolve = jest.fn();
 const mockUrReverse = jest.fn();
 
+// Last URL passed to JsonRpcProvider — lets per-provider test helpers know
+// which URL they're being called on during the current ur.resolve invocation.
+let lastProviderUrl = null;
+
+// Per-URL response routing for quorum tests. When set, the Contract mock's
+// resolve function consults this map based on the underlying provider's URL
+// and returns the mapped response instead of delegating to mockUrResolve.
+// Leave null for tests that don't need per-provider differentiation — those
+// use mockUrResolve.mockResolvedValue() directly.
+let mockProviderRouteMap = null;
+
 jest.mock('ethers', () => {
   const actual = jest.requireActual('ethers').ethers;
   return {
     ethers: {
-      JsonRpcProvider: jest.fn().mockImplementation(() => ({
-        getBlockNumber: mockGetBlockNumber,
-        getResolver: mockGetResolver,
-        resolveName: mockResolveName,
-        destroy: mockDestroy,
-      })),
-      Contract: jest.fn().mockImplementation(() => ({
-        resolve: mockUrResolve,
-        reverse: mockUrReverse,
+      JsonRpcProvider: jest.fn().mockImplementation((url) => {
+        lastProviderUrl = url;
+        return {
+          url,
+          getBlockNumber: mockGetBlockNumber,
+          getBlock: mockGetBlock,
+          getResolver: mockGetResolver,
+          resolveName: mockResolveName,
+          destroy: mockDestroy,
+        };
+      }),
+      Contract: jest.fn().mockImplementation((_addr, _abi, provider) => ({
+        resolve: (...args) => {
+          // Per-URL routing takes precedence; otherwise the shared mock.
+          if (mockProviderRouteMap) {
+            const entry = mockProviderRouteMap.get(provider?.url);
+            if (entry) {
+              if (entry.kind === 'reject') return Promise.reject(entry.payload);
+              return Promise.resolve(entry.payload);
+            }
+          }
+          return mockUrResolve(...args);
+        },
+        reverse: (...args) => mockUrReverse(...args),
       })),
       // Pure helpers — use the real implementations so the UR helper's
       // encoding and the inline contenthash decoder are actually exercised.
@@ -53,20 +106,42 @@ const {
   invalidateCachedProvider,
   universalResolverCall,
   isResolverNotFoundError,
+  clearEnsCachesForTest,
 } = require('./ens-resolver');
+
+// Fake block anchor — stable hash so consensus legs querying the same
+// block get deterministic agreement.
+const FAKE_BLOCK = { number: 12345678, hash: '0xabcdef0000000000000000000000000000000000000000000000000000000000' };
 
 beforeEach(() => {
   jest.clearAllMocks();
   invalidateCachedProvider();
-  // Default: provider connects successfully
-  mockGetBlockNumber.mockResolvedValue(12345678);
-  // Default: resolver returns null (no resolver found)
+  clearEnsCachesForTest();
+  lastProviderUrl = null;
+  mockProviderRouteMap = null;
+  mockGetBlockNumber.mockResolvedValue(FAKE_BLOCK.number);
+  mockGetBlock.mockResolvedValue(FAKE_BLOCK);
   mockGetResolver.mockResolvedValue(null);
-  // Default: resolveName returns null (no addr record)
   mockResolveName.mockResolvedValue(null);
-  // Default: no custom RPC
-  mockLoadSettings.mockReturnValue({ enableEnsCustomRpc: false, ensRpcUrl: '' });
+  mockLoadSettings.mockReturnValue({
+    enableEnsCustomRpc: false,
+    ensRpcUrl: '',
+    enableEnsQuorum: true,
+    ensQuorumK: 3,
+    ensQuorumM: 2,
+    ensQuorumTimeoutMs: 5000,
+    ensBlockAnchor: 'latest',
+    ensBlockAnchorTtlMs: 30000,
+    ensPublicRpcProviders: TEST_PROVIDERS,
+  });
 });
+
+// Set up per-URL response routing for quorum tests. Map values:
+//   { kind: 'data',   payload: [resolvedData, resolverAddress] }
+//   { kind: 'reject', payload: Error }
+function routeByProvider(map) {
+  mockProviderRouteMap = map;
+}
 
 // Helpers for building mocked UR responses. The UR returns
 // [resolvedData, resolverAddress] where resolvedData is the RAW
@@ -119,7 +194,7 @@ describe('ens-resolver', () => {
 
       const result = await resolveEnsContent('vitalik.eth');
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         type: 'ok',
         name: 'vitalik.eth',
         codec: 'ipfs-ns',
@@ -127,6 +202,8 @@ describe('ens-resolver', () => {
         uri: `ipfs://${IPFS_V0}`,
         decoded: IPFS_V0,
       });
+      expect(result.trust.level).toBe('verified');
+      expect(result.trust.quorum).toEqual({ k: 3, m: 2, achieved: true });
     });
 
     test('decodes swarm contenthash', async () => {
@@ -135,7 +212,7 @@ describe('ens-resolver', () => {
 
       const result = await resolveEnsContent('mysite.box');
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         type: 'ok',
         name: 'mysite.box',
         codec: 'swarm-ns',
@@ -143,6 +220,7 @@ describe('ens-resolver', () => {
         uri: `bzz://${swarmHash}`,
         decoded: swarmHash,
       });
+      expect(result.trust.level).toBe('verified');
     });
 
     test('decodes ipns contenthash', async () => {
@@ -161,11 +239,12 @@ describe('ens-resolver', () => {
 
       const result = await resolveEnsContent('unreg.box');
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         type: 'not_found',
         reason: 'NO_RESOLVER',
         name: 'unreg.box',
       });
+      expect(result.trust.level).toBe('verified');
     });
 
     test('maps generic UR revert to NO_CONTENTHASH', async () => {
@@ -185,11 +264,12 @@ describe('ens-resolver', () => {
 
       const result = await resolveEnsContent('empty.box');
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         type: 'not_found',
         reason: 'EMPTY_CONTENTHASH',
         name: 'empty.box',
       });
+      expect(result.trust.level).toBe('verified');
     });
 
     test('returns UNSUPPORTED_CONTENTHASH_FORMAT for unknown bytes', async () => {
@@ -233,38 +313,47 @@ describe('ens-resolver', () => {
       await expect(resolveEnsContent('   ')).rejects.toThrow('ENS name is empty');
     });
 
-    test('retries on provider error then succeeds', async () => {
+    test('verified outcome survives one provider erroring (others still reach M)', async () => {
+      // K=3 legs, M=2. Route one provider to error and two to return valid
+      // bytes — quorum should still reach agreement on the valid bytes.
       const providerError = new Error('server error');
       providerError.code = 'SERVER_ERROR';
+      const goodBytes = urReturnsBytes(ipfsContenthashFor(IPFS_V0));
 
-      mockUrResolve
-        .mockRejectedValueOnce(providerError)
-        .mockResolvedValueOnce(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
+      routeByProvider(new Map([
+        [TEST_PROVIDERS[0], { kind: 'reject', payload: providerError }],
+        [TEST_PROVIDERS[1], { kind: 'data', payload: goodBytes }],
+        [TEST_PROVIDERS[2], { kind: 'data', payload: goodBytes }],
+      ]));
 
       const result = await resolveEnsContent('retry.box');
 
       expect(result.type).toBe('ok');
       expect(result.uri).toBe(`ipfs://${IPFS_V0}`);
-      expect(mockUrResolve).toHaveBeenCalledTimes(2);
+      expect(result.trust.level).toBe('verified');
+      expect(result.trust.agreed.length).toBeGreaterThanOrEqual(2);
     });
 
-    test('caches successful resolutions', async () => {
+    test('caches successful resolutions (warm resolution skips RPC entirely)', async () => {
       mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
 
       const first = await resolveEnsContent('cached.box');
+      const callsAfterCold = mockUrResolve.mock.calls.length;
       const second = await resolveEnsContent('cached.box');
 
       expect(first.type).toBe('ok');
       expect(second.uri).toBe(`ipfs://${IPFS_V0}`);
-      expect(mockUrResolve).toHaveBeenCalledTimes(1);
+      // Cold path hits K=3 legs; warm path hits 0 (cache).
+      expect(mockUrResolve.mock.calls.length).toBe(callsAfterCold);
     });
 
-    test('makes exactly one UR call per cold resolution (perf regression guard)', async () => {
+    test('makes K UR calls per cold resolution (one per quorum leg)', async () => {
       mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
 
       await resolveEnsContent('oneshot.eth');
 
-      expect(mockUrResolve).toHaveBeenCalledTimes(1);
+      // Default test settings: K=3, matching TEST_PROVIDERS.length.
+      expect(mockUrResolve).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -333,11 +422,12 @@ describe('ens-resolver', () => {
 
       const result = await resolveEnsAddress('vitalik.eth');
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         success: true,
         name: 'vitalik.eth',
         address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
       });
+      expect(result.trust.level).toBe('verified');
     });
 
     test('normalizes mixed-case input to lowercase', async () => {
@@ -356,12 +446,13 @@ describe('ens-resolver', () => {
 
       const result = await resolveEnsAddress('no-addr.eth');
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         success: false,
         name: 'no-addr.eth',
         reason: 'NO_ADDRESS',
         error: 'No address record set for no-addr.eth',
       });
+      expect(result.trust.level).toBe('verified');
     });
 
     test('maps UR ResolverNotFound revert to NO_ADDRESS', async () => {
@@ -390,54 +481,58 @@ describe('ens-resolver', () => {
       await expect(resolveEnsAddress('   ')).rejects.toThrow('ENS name is empty');
     });
 
-    test('retries on provider error then succeeds', async () => {
+    test('verified addr outcome survives one provider erroring (others still reach M)', async () => {
       const providerError = new Error('server error');
       providerError.code = 'SERVER_ERROR';
+      const good = urReturnsAddress('0x0000000000000000000000000000000000000001');
 
-      mockUrResolve
-        .mockRejectedValueOnce(providerError)
-        .mockResolvedValueOnce(urReturnsAddress('0x0000000000000000000000000000000000000001'));
+      routeByProvider(new Map([
+        [TEST_PROVIDERS[0], { kind: 'reject', payload: providerError }],
+        [TEST_PROVIDERS[1], { kind: 'data', payload: good }],
+        [TEST_PROVIDERS[2], { kind: 'data', payload: good }],
+      ]));
 
       const result = await resolveEnsAddress('retry.eth');
 
       expect(result.success).toBe(true);
       expect(result.address).toBe('0x0000000000000000000000000000000000000001');
-      expect(mockUrResolve).toHaveBeenCalledTimes(2);
+      expect(result.trust.level).toBe('verified');
     });
 
-    test('caches successful resolutions', async () => {
+    test('caches successful resolutions (warm lookup skips RPC)', async () => {
       mockUrResolve.mockResolvedValue(
         urReturnsAddress('0x1111111111111111111111111111111111111111')
       );
 
       const first = await resolveEnsAddress('cached-addr.eth');
+      const callsAfterCold = mockUrResolve.mock.calls.length;
       const second = await resolveEnsAddress('cached-addr.eth');
 
       expect(first.address).toBe('0x1111111111111111111111111111111111111111');
       expect(second.address).toBe('0x1111111111111111111111111111111111111111');
-      expect(mockUrResolve).toHaveBeenCalledTimes(1);
+      expect(mockUrResolve.mock.calls.length).toBe(callsAfterCold);
     });
 
     test('caches negative results too (NO_ADDRESS misses)', async () => {
       mockUrResolve.mockResolvedValue(urReturnsAddress('0x0000000000000000000000000000000000000000'));
 
       const first = await resolveEnsAddress('no-addr-cached.eth');
+      const callsAfterCold = mockUrResolve.mock.calls.length;
       const second = await resolveEnsAddress('no-addr-cached.eth');
 
       expect(first.reason).toBe('NO_ADDRESS');
       expect(second.reason).toBe('NO_ADDRESS');
-      // Second call hit the cache, no second RPC round-trip.
-      expect(mockUrResolve).toHaveBeenCalledTimes(1);
+      expect(mockUrResolve.mock.calls.length).toBe(callsAfterCold);
     });
 
-    test('makes exactly one UR call per cold resolution (perf regression guard)', async () => {
+    test('makes K UR calls per cold resolution (one per quorum leg)', async () => {
       mockUrResolve.mockResolvedValue(
         urReturnsAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
       );
 
       await resolveEnsAddress('oneshot-addr.eth');
 
-      expect(mockUrResolve).toHaveBeenCalledTimes(1);
+      expect(mockUrResolve).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -710,6 +805,289 @@ describe('ens-resolver', () => {
       const err = new Error('execution reverted: ReverseAddressMismatch');
       err.data = '0xef9c03ce00000000';
       expect(isResolverNotFoundError(err)).toBe(false);
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // Quorum-path tests (Phase 1). Covers consensus outcomes that don't
+  // exist in the legacy single-provider flow: conflict, degraded K=1
+  // unverified, user-configured fast-path labelling, block pinning.
+  // --------------------------------------------------------------------
+  describe('consensus quorum', () => {
+    const IPFS_HASH = 'QmW81r84Aihiqqi2Jw6nM1LnpeMfRCenRxtjwHNkXVkZYa';
+
+    test('conflict: ≥2 providers return different bytes → type=conflict with groups', async () => {
+      const hashA = 'a'.repeat(64);
+      const hashB = 'b'.repeat(64);
+      routeByProvider(new Map([
+        [TEST_PROVIDERS[0], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashA)) }],
+        [TEST_PROVIDERS[1], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashB)) }],
+        [TEST_PROVIDERS[2], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashA + '').slice(0, 4) + 'cc'.repeat(40)) }],
+      ]));
+
+      const result = await resolveEnsContent('conflict.box');
+
+      expect(result.type).toBe('conflict');
+      expect(result.trust.level).toBe('conflict');
+      expect(result.trust.quorum.achieved).toBe(false);
+      expect(result.groups.length).toBeGreaterThanOrEqual(2);
+      // Groups each reference at least one test provider hostname.
+      const allUrls = result.groups.flatMap((g) => g.urls);
+      expect(allUrls.length).toBe(3);
+    });
+
+    test('conflict: honest vs lying provider → type=conflict', async () => {
+      const honest = urReturnsBytes(ipfsContenthashFor(IPFS_HASH));
+      const liar = urReturnsBytes(swarmContenthashFor('f'.repeat(64)));
+      // Two providers return different data, third errors — no M-group on data.
+      routeByProvider(new Map([
+        [TEST_PROVIDERS[0], { kind: 'data', payload: honest }],
+        [TEST_PROVIDERS[1], { kind: 'data', payload: liar }],
+        [TEST_PROVIDERS[2], { kind: 'reject', payload: Object.assign(new Error('ECONNREFUSED'), { code: 'NETWORK_ERROR' }) }],
+      ]));
+
+      const result = await resolveEnsContent('liar.eth');
+
+      expect(result.type).toBe('conflict');
+      expect(result.groups.length).toBe(2);
+    });
+
+    test('conflict is NOT positively cached (re-resolves on next call)', async () => {
+      const hashA = 'a'.repeat(64);
+      const hashB = 'b'.repeat(64);
+      // Conflict setup.
+      routeByProvider(new Map([
+        [TEST_PROVIDERS[0], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashA)) }],
+        [TEST_PROVIDERS[1], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashB)) }],
+        [TEST_PROVIDERS[2], { kind: 'reject', payload: Object.assign(new Error('ECONNREFUSED'), { code: 'NETWORK_ERROR' }) }],
+      ]));
+
+      const first = await resolveEnsContent('conflict-cache.box');
+      expect(first.type).toBe('conflict');
+
+      // Conflict cache is negative-only for 10s — advance past that window.
+      const realNow = Date.now;
+      try {
+        Date.now = () => realNow() + 11_000;
+        // Switch to agreement on B after the cache window.
+        routeByProvider(new Map([
+          [TEST_PROVIDERS[0], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashB)) }],
+          [TEST_PROVIDERS[1], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashB)) }],
+          [TEST_PROVIDERS[2], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashB)) }],
+        ]));
+
+        const second = await resolveEnsContent('conflict-cache.box');
+        expect(second.type).toBe('ok');
+        expect(second.trust.level).toBe('verified');
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    test('verified cache is honored on warm lookup (15m TTL)', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const first = await resolveEnsContent('ttl-verified.eth');
+      expect(first.trust.level).toBe('verified');
+
+      // Simulate 10min elapsed — well under 15min verified TTL.
+      const realNow = Date.now;
+      try {
+        Date.now = () => realNow() + 10 * 60 * 1000;
+        jest.clearAllMocks();
+        const second = await resolveEnsContent('ttl-verified.eth');
+        expect(second.type).toBe('ok');
+        expect(mockUrResolve).not.toHaveBeenCalled(); // cache hit
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    test('unverified cache expires after 60s (re-resolves on next call)', async () => {
+      // Force unverified by giving only 1 non-quarantined provider.
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: false,
+        ensRpcUrl: '',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: [TEST_PROVIDERS[0]], // just one
+      });
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const first = await resolveEnsContent('ttl-unverified.eth');
+      expect(first.trust.level).toBe('unverified');
+
+      const realNow = Date.now;
+      try {
+        // 90s elapsed — past the 60s unverified TTL.
+        Date.now = () => realNow() + 90_000;
+        const coldCallsBefore = mockUrResolve.mock.calls.length;
+        const second = await resolveEnsContent('ttl-unverified.eth');
+        expect(second.type).toBe('ok');
+        expect(mockUrResolve.mock.calls.length).toBeGreaterThan(coldCallsBefore);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    test('degraded: only 1 non-quarantined provider → outcome=unverified', async () => {
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: false,
+        ensRpcUrl: '',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: [TEST_PROVIDERS[0]],
+      });
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('single-source.eth');
+
+      expect(result.type).toBe('ok');
+      expect(result.trust.level).toBe('unverified');
+      expect(result.trust.queried.length).toBe(1);
+    });
+
+    test('quorum disabled: outcome=unverified even with K providers available', async () => {
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: false,
+        ensRpcUrl: '',
+        enableEnsQuorum: false, // explicit opt-out
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: TEST_PROVIDERS,
+      });
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('no-quorum.eth');
+
+      expect(result.type).toBe('ok');
+      expect(result.trust.level).toBe('unverified');
+      // Only one leg fired despite 3 available providers.
+      expect(mockUrResolve).toHaveBeenCalledTimes(1);
+    });
+
+    test('custom RPC fast-path: trust=user-configured, skips public quorum', async () => {
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: true,
+        ensRpcUrl: 'http://my-node.local:8545',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: TEST_PROVIDERS,
+      });
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('my-node.eth');
+
+      expect(result.type).toBe('ok');
+      expect(result.trust.level).toBe('user-configured');
+      expect(result.trust.queried).toEqual(['my-node.local:8545']);
+      // Only one leg fired against the custom RPC; public quorum untouched.
+      expect(mockUrResolve).toHaveBeenCalledTimes(1);
+    });
+
+    test('custom RPC failure falls back to public quorum', async () => {
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: true,
+        ensRpcUrl: 'http://my-node.local:8545',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: TEST_PROVIDERS,
+      });
+      const bytes = urReturnsBytes(ipfsContenthashFor(IPFS_HASH));
+      const networkErr = Object.assign(new Error('ECONNREFUSED'), { code: 'NETWORK_ERROR' });
+      routeByProvider(new Map([
+        ['http://my-node.local:8545', { kind: 'reject', payload: networkErr }],
+        [TEST_PROVIDERS[0], { kind: 'data', payload: bytes }],
+        [TEST_PROVIDERS[1], { kind: 'data', payload: bytes }],
+        [TEST_PROVIDERS[2], { kind: 'data', payload: bytes }],
+      ]));
+
+      const result = await resolveEnsContent('fallback-to-public.eth');
+
+      expect(result.type).toBe('ok');
+      // Fell back to public quorum — trust level reflects that, not user-configured.
+      expect(result.trust.level).toBe('verified');
+    });
+
+    test('all providers error → throws (no positive result)', async () => {
+      const err = Object.assign(new Error('ECONNREFUSED'), { code: 'NETWORK_ERROR' });
+      routeByProvider(new Map([
+        [TEST_PROVIDERS[0], { kind: 'reject', payload: err }],
+        [TEST_PROVIDERS[1], { kind: 'reject', payload: err }],
+        [TEST_PROVIDERS[2], { kind: 'reject', payload: err }],
+      ]));
+
+      await expect(resolveEnsContent('all-down.eth')).rejects.toThrow(/providers failed/i);
+    });
+
+    test('block pinning is cached within TTL (next resolve skips block fetch)', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      await resolveEnsContent('block-cache-a.eth');
+      const callsAfterFirst = mockGetBlock.mock.calls.length;
+
+      // Different name → bypasses result cache but block anchor is still cached.
+      await resolveEnsContent('block-cache-b.eth');
+
+      // Anchor wave fetches from up to 2 providers in parallel on miss;
+      // on cache hit it fetches 0. First resolve = N, second = N (no extra fetches).
+      expect(mockGetBlock.mock.calls.length).toBe(callsAfterFirst);
+    });
+
+    test('in-flight dedup: concurrent resolves of same name share one quorum wave', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const [a, b, c] = await Promise.all([
+        resolveEnsContent('concurrent.eth'),
+        resolveEnsContent('concurrent.eth'),
+        resolveEnsContent('concurrent.eth'),
+      ]);
+
+      expect(a.type).toBe('ok');
+      expect(b).toBe(a); // same promise result
+      expect(c).toBe(a);
+      // Only K legs fired (not 3 × K), proving dedup.
+      expect(mockUrResolve).toHaveBeenCalledTimes(3);
+    });
+
+    test('dedup key separates content from addr lookups for same name', async () => {
+      mockUrResolve.mockImplementation((encodedName, callData) => {
+        // Dispatch by call selector: 0xbc1c58d1 = contenthash, 0x3b3b57de = addr.
+        if (callData.startsWith('0xbc1c58d1')) {
+          return Promise.resolve(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+        }
+        return Promise.resolve(urReturnsAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'));
+      });
+
+      const [contentResult, addrResult] = await Promise.all([
+        resolveEnsContent('dual.eth'),
+        resolveEnsAddress('dual.eth'),
+      ]);
+
+      expect(contentResult.type).toBe('ok');
+      expect(addrResult.success).toBe(true);
+      // Both paths fired their own K legs; 6 total, proving the kind prefix
+      // differentiates in-flight keys.
+      expect(mockUrResolve).toHaveBeenCalledTimes(6);
     });
   });
 });

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -1543,6 +1543,139 @@ describe('ens-resolver', () => {
     });
   });
 
+  describe('second-wave escalation on unverified', () => {
+    const IPFS_HASH = 'QmW81r84Aihiqqi2Jw6nM1LnpeMfRCenRxtjwHNkXVkZYa';
+    const ALT_HASH = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+
+    function fivePoolWithDeterministicOrder(extraSettings = {}) {
+      const fiveProviders = [
+        ...TEST_PROVIDERS,
+        'https://test-d.example.com',
+        'https://test-e.example.com',
+      ];
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: false,
+        ensRpcUrl: '',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: fiveProviders,
+        ...extraSettings,
+      });
+      // Disable shuffle so firstSelection is the first 3 providers and
+      // remaining is the last 2 — deterministic for test assertions.
+      const origRandom = Math.random;
+      Math.random = () => 0.999;
+      invalidateCachedProvider();
+      return { fiveProviders, restore: () => { Math.random = origRandom; } };
+    }
+
+    test('1 data + 2 errors → escalates and reaches verified via fresh providers', async () => {
+      const { restore } = fivePoolWithDeterministicOrder();
+      try {
+        const flakyErr = Object.assign(new Error('ECONNREFUSED'), { code: 'NETWORK_ERROR' });
+        const goodPayload = urReturnsBytes(ipfsContenthashFor(IPFS_HASH));
+        routeByProvider(new Map([
+          [TEST_PROVIDERS[0], { kind: 'data', payload: goodPayload }],
+          [TEST_PROVIDERS[1], { kind: 'reject', payload: flakyErr }],
+          [TEST_PROVIDERS[2], { kind: 'reject', payload: flakyErr }],
+          ['https://test-d.example.com', { kind: 'data', payload: goodPayload }],
+          ['https://test-e.example.com', { kind: 'data', payload: goodPayload }],
+        ]));
+
+        const result = await resolveEnsContent('flaky-network-upgrade.eth');
+
+        expect(result.type).toBe('ok');
+        expect(result.trust.level).toBe('verified');
+        // Trust metadata reflects the second wave that actually agreed.
+        expect(result.trust.queried).toEqual([
+          'test-d.example.com',
+          'test-e.example.com',
+        ]);
+      } finally {
+        restore();
+      }
+    });
+
+    test('1 data + 2 errors with too few fresh providers → no escalation, stays unverified', async () => {
+      // 4-provider pool: first wave runs against 3, leaving only 1
+      // fresh provider — below effectiveM=2, so escalation must not run.
+      const fourProviders = [
+        ...TEST_PROVIDERS,
+        'https://test-d.example.com',
+      ];
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: false,
+        ensRpcUrl: '',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: fourProviders,
+      });
+      const origRandom = Math.random;
+      Math.random = () => 0.999;
+      try {
+        invalidateCachedProvider();
+        const flakyErr = Object.assign(new Error('ECONNREFUSED'), { code: 'NETWORK_ERROR' });
+        const goodPayload = urReturnsBytes(ipfsContenthashFor(IPFS_HASH));
+        routeByProvider(new Map([
+          [TEST_PROVIDERS[0], { kind: 'data', payload: goodPayload }],
+          [TEST_PROVIDERS[1], { kind: 'reject', payload: flakyErr }],
+          [TEST_PROVIDERS[2], { kind: 'reject', payload: flakyErr }],
+          // Even though this provider would have agreed, the guard
+          // prevents a second wave from running against it alone.
+          ['https://test-d.example.com', { kind: 'data', payload: goodPayload }],
+        ]));
+
+        const result = await resolveEnsContent('insufficient-remaining.eth');
+
+        expect(result.type).toBe('ok');
+        expect(result.trust.level).toBe('unverified');
+      } finally {
+        Math.random = origRandom;
+      }
+    });
+
+    test('second wave also unverified → keep first-wave evidence (no downgrade)', async () => {
+      const { restore } = fivePoolWithDeterministicOrder();
+      try {
+        const flakyErr = Object.assign(new Error('ECONNREFUSED'), { code: 'NETWORK_ERROR' });
+        const firstPayload = urReturnsBytes(ipfsContenthashFor(IPFS_HASH));
+        const altPayload = urReturnsBytes(ipfsContenthashFor(ALT_HASH));
+        routeByProvider(new Map([
+          // First wave: 1 data + 2 errors → unverified_data with IPFS_HASH.
+          [TEST_PROVIDERS[0], { kind: 'data', payload: firstPayload }],
+          [TEST_PROVIDERS[1], { kind: 'reject', payload: flakyErr }],
+          [TEST_PROVIDERS[2], { kind: 'reject', payload: flakyErr }],
+          // Second wave: 1 data (different hash) + 1 error → unverified
+          // again. Replacing first wave with this would downgrade the
+          // single piece of evidence we already had.
+          ['https://test-d.example.com', { kind: 'data', payload: altPayload }],
+          ['https://test-e.example.com', { kind: 'reject', payload: flakyErr }],
+        ]));
+
+        const result = await resolveEnsContent('second-wave-no-quorum.eth');
+
+        expect(result.type).toBe('ok');
+        expect(result.trust.level).toBe('unverified');
+        // First-wave provider's bytes are preserved.
+        expect(result.trust.queried).toEqual([
+          'test-a.example.com',
+          'test-b.example.com',
+          'test-c.example.com',
+        ]);
+      } finally {
+        restore();
+      }
+    });
+  });
+
   describe('speculative gateway prefetch', () => {
     const IPFS_HASH = 'QmW81r84Aihiqqi2Jw6nM1LnpeMfRCenRxtjwHNkXVkZYa';
 

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -152,8 +152,6 @@ beforeEach(() => {
   lastProviderUrl = null;
   mockProviderRouteMap = null;
   mockProviderAnchorMap = null;
-  // Default prefetch mock: each call returns a fresh handle whose abort
-  // function is a spy — tests can assert on both call count and aborts.
   mockPrefetchGatewayUrl.mockImplementation(() => ({ abort: jest.fn() }));
   mockGetBlockNumber.mockResolvedValue(FAKE_BLOCK.number);
   mockGetBlock.mockResolvedValue(FAKE_BLOCK);

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -3,6 +3,15 @@ jest.mock('electron', () => ({
   ipcMain: { handle: jest.fn() },
 }));
 
+// Mock ens-prefetch so tests can assert when it fires and when it aborts,
+// without spinning up a real net.request. Default impl returns a fresh
+// abort-recording handle each call.
+const mockPrefetchGatewayUrl = jest.fn();
+jest.mock('./ens-prefetch', () => ({
+  prefetchGatewayUrl: (...args) => mockPrefetchGatewayUrl(...args),
+  PREFETCH_TIMEOUT_MS: 10_000,
+}));
+
 // Mock settings-store. Test provider list is small (3 URLs) so the quorum
 // wave is bounded regardless of test input. Individual tests override
 // mockLoadSettings when they need different values.
@@ -143,6 +152,9 @@ beforeEach(() => {
   lastProviderUrl = null;
   mockProviderRouteMap = null;
   mockProviderAnchorMap = null;
+  // Default prefetch mock: each call returns a fresh handle whose abort
+  // function is a spy — tests can assert on both call count and aborts.
+  mockPrefetchGatewayUrl.mockImplementation(() => ({ abort: jest.fn() }));
   mockGetBlockNumber.mockResolvedValue(FAKE_BLOCK.number);
   mockGetBlock.mockResolvedValue(FAKE_BLOCK);
   mockGetResolver.mockResolvedValue(null);
@@ -1530,6 +1542,122 @@ describe('ens-resolver', () => {
       expect(result.type).toBe('ok');
       expect(result.trust.level).toBe('unverified');
       expect(result.trust.queried.length).toBe(1);
+    });
+  });
+
+  describe('speculative gateway prefetch', () => {
+    const IPFS_HASH = 'QmW81r84Aihiqqi2Jw6nM1LnpeMfRCenRxtjwHNkXVkZYa';
+
+    test('verified content resolution kicks off prefetch once, does not abort', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('prefetch-happy.eth');
+
+      expect(result.type).toBe('ok');
+      expect(mockPrefetchGatewayUrl).toHaveBeenCalledTimes(1);
+      expect(mockPrefetchGatewayUrl).toHaveBeenCalledWith(`ipfs://${IPFS_HASH}`);
+      // On verified, we let prefetch complete naturally — no abort.
+      const handle = mockPrefetchGatewayUrl.mock.results[0].value;
+      expect(handle.abort).not.toHaveBeenCalled();
+    });
+
+    test('conflict outcome aborts the in-flight prefetch', async () => {
+      const hashA = 'a'.repeat(64);
+      const hashB = 'b'.repeat(64);
+      const hashC = 'c'.repeat(64);
+      routeByProvider(new Map([
+        [TEST_PROVIDERS[0], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashA)) }],
+        [TEST_PROVIDERS[1], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashB)) }],
+        [TEST_PROVIDERS[2], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashC)) }],
+      ]));
+
+      const result = await resolveEnsContent('prefetch-conflict.box');
+
+      expect(result.type).toBe('conflict');
+      expect(mockPrefetchGatewayUrl).toHaveBeenCalledTimes(1);
+      const handle = mockPrefetchGatewayUrl.mock.results[0].value;
+      expect(handle.abort).toHaveBeenCalledTimes(1);
+    });
+
+    test('addr-path resolution never prefetches (only content lookups do)', async () => {
+      mockUrResolve.mockResolvedValue(
+        urReturnsAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
+      );
+
+      await resolveEnsAddress('prefetch-addr.eth');
+
+      expect(mockPrefetchGatewayUrl).not.toHaveBeenCalled();
+    });
+
+    test('custom-RPC fast path does not prefetch (single source is already fast)', async () => {
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: true,
+        ensRpcUrl: 'http://my-node.local:8545',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: TEST_PROVIDERS,
+      });
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('prefetch-custom.eth');
+
+      expect(result.trust.level).toBe('user-configured');
+      expect(mockPrefetchGatewayUrl).not.toHaveBeenCalled();
+    });
+
+    test('cache hit does not re-prefetch', async () => {
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      await resolveEnsContent('prefetch-cached.eth');
+      expect(mockPrefetchGatewayUrl).toHaveBeenCalledTimes(1);
+
+      await resolveEnsContent('prefetch-cached.eth');
+      // Second call is served from cache — consensusResolve isn't reached,
+      // so prefetch isn't fired either.
+      expect(mockPrefetchGatewayUrl).toHaveBeenCalledTimes(1);
+    });
+
+    test('unverified (single-source degraded) aborts prefetch', async () => {
+      // One provider only → degraded single-source path. In this path we
+      // DO call consensusResolve's inner leg directly, but the onFirstData
+      // hook is only wired for the wave path — so prefetch should not
+      // fire at all. (The degraded single-source path was chosen as NOT
+      // prefetch-worthy: the user will see an interstitial either way.)
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: false,
+        ensRpcUrl: '',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: [TEST_PROVIDERS[0]],
+      });
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('prefetch-degraded.eth');
+
+      expect(result.trust.level).toBe('unverified');
+      expect(mockPrefetchGatewayUrl).not.toHaveBeenCalled();
+    });
+
+    test('onFirstData errors do not break resolution (never affect quorum)', async () => {
+      // Simulate a pathological prefetch that throws. The wave must still
+      // complete normally and the result must still be `ok`.
+      mockPrefetchGatewayUrl.mockImplementation(() => {
+        throw new Error('prefetch internal error');
+      });
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('prefetch-throws.eth');
+
+      expect(result.type).toBe('ok');
+      expect(result.trust.level).toBe('verified');
     });
   });
 });

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -55,6 +55,11 @@ let lastProviderUrl = null;
 // use mockUrResolve.mockResolvedValue() directly.
 let mockProviderRouteMap = null;
 
+// Per-URL anchor routing. Values: { headNumber, getBlock(tagOrNumber) }.
+// headNumber can be a number or an Error (rejects). getBlock is a function
+// the provider.getBlock proxy delegates to — typically returns {number, hash}.
+let mockProviderAnchorMap = null;
+
 jest.mock('ethers', () => {
   const actual = jest.requireActual('ethers').ethers;
   return {
@@ -63,8 +68,26 @@ jest.mock('ethers', () => {
         lastProviderUrl = url;
         return {
           url,
-          getBlockNumber: mockGetBlockNumber,
-          getBlock: mockGetBlock,
+          // getBlockNumber and getBlock consult mockProviderAnchorMap first
+          // for anchor-corroboration regression tests; otherwise delegate
+          // to the shared mocks that cover the common case.
+          getBlockNumber: () => {
+            if (mockProviderAnchorMap) {
+              const entry = mockProviderAnchorMap.get(url);
+              if (entry && 'headNumber' in entry) {
+                if (entry.headNumber instanceof Error) return Promise.reject(entry.headNumber);
+                return Promise.resolve(entry.headNumber);
+              }
+            }
+            return mockGetBlockNumber();
+          },
+          getBlock: (blockTagOrNumber) => {
+            if (mockProviderAnchorMap) {
+              const entry = mockProviderAnchorMap.get(url);
+              if (entry?.getBlock) return entry.getBlock(blockTagOrNumber);
+            }
+            return mockGetBlock(blockTagOrNumber);
+          },
           getResolver: mockGetResolver,
           resolveName: mockResolveName,
           destroy: mockDestroy,
@@ -119,6 +142,7 @@ beforeEach(() => {
   clearEnsCachesForTest();
   lastProviderUrl = null;
   mockProviderRouteMap = null;
+  mockProviderAnchorMap = null;
   mockGetBlockNumber.mockResolvedValue(FAKE_BLOCK.number);
   mockGetBlock.mockResolvedValue(FAKE_BLOCK);
   mockGetResolver.mockResolvedValue(null);
@@ -375,21 +399,32 @@ describe('ens-resolver', () => {
       mockLoadSettings.mockReturnValue({
         enableEnsCustomRpc: true,
         ensRpcUrl: 'http://localhost:8545',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: TEST_PROVIDERS,
       });
 
-      let callCount = 0;
+      // Custom RPC returns ECONNREFUSED for every head fetch → fast-path
+      // returns null → falls through to public quorum.
       mockGetBlockNumber.mockImplementation(() => {
-        callCount++;
-        if (callCount === 1) return Promise.reject(new Error('ECONNREFUSED'));
+        if (lastProviderUrl === 'http://localhost:8545') {
+          return Promise.reject(new Error('ECONNREFUSED'));
+        }
         return Promise.resolve(12345678);
       });
 
       mockUrResolve.mockResolvedValue(urReturnsBytes('0xe30101701220' + 'ab'.repeat(32)));
 
-      await resolveEnsContent('fallback.eth');
+      const result = await resolveEnsContent('fallback-to-public-legacy.eth');
 
-      expect(ethers.JsonRpcProvider).toHaveBeenCalledTimes(2);
+      // First provider constructed is the custom RPC (fast-path attempt).
       expect(ethers.JsonRpcProvider.mock.calls[0][0]).toBe('http://localhost:8545');
+      // Resolution reached a public-quorum verified outcome.
+      expect(result.trust.level).toBe('verified');
     });
 
     test('clearing custom RPC reverts to default behavior', async () => {
@@ -853,13 +888,17 @@ describe('ens-resolver', () => {
     });
 
     test('conflict is NOT positively cached (re-resolves on next call)', async () => {
+      // All three providers respond but disagree → conflict, no
+      // quarantine. The re-resolve then has all 3 still available.
       const hashA = 'a'.repeat(64);
       const hashB = 'b'.repeat(64);
-      // Conflict setup.
+      const hashC = 'c'.repeat(64);
+      const bytesB = urReturnsBytes(swarmContenthashFor(hashB));
+
       routeByProvider(new Map([
         [TEST_PROVIDERS[0], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashA)) }],
-        [TEST_PROVIDERS[1], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashB)) }],
-        [TEST_PROVIDERS[2], { kind: 'reject', payload: Object.assign(new Error('ECONNREFUSED'), { code: 'NETWORK_ERROR' }) }],
+        [TEST_PROVIDERS[1], { kind: 'data', payload: bytesB }],
+        [TEST_PROVIDERS[2], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashC)) }],
       ]));
 
       const first = await resolveEnsContent('conflict-cache.box');
@@ -869,11 +908,10 @@ describe('ens-resolver', () => {
       const realNow = Date.now;
       try {
         Date.now = () => realNow() + 11_000;
-        // Switch to agreement on B after the cache window.
         routeByProvider(new Map([
-          [TEST_PROVIDERS[0], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashB)) }],
-          [TEST_PROVIDERS[1], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashB)) }],
-          [TEST_PROVIDERS[2], { kind: 'data', payload: urReturnsBytes(swarmContenthashFor(hashB)) }],
+          [TEST_PROVIDERS[0], { kind: 'data', payload: bytesB }],
+          [TEST_PROVIDERS[1], { kind: 'data', payload: bytesB }],
+          [TEST_PROVIDERS[2], { kind: 'data', payload: bytesB }],
         ]));
 
         const second = await resolveEnsContent('conflict-cache.box');
@@ -1088,6 +1126,410 @@ describe('ens-resolver', () => {
       // Both paths fired their own K legs; 6 total, proving the kind prefix
       // differentiates in-flight keys.
       expect(mockUrResolve).toHaveBeenCalledTimes(6);
+    });
+  });
+
+  describe('security regressions', () => {
+    const IPFS_HASH = 'QmW81r84Aihiqqi2Jw6nM1LnpeMfRCenRxtjwHNkXVkZYa';
+    const HONEST_HEAD = 20_000_000;
+    const CURRENT_HASH = '0x' + 'c'.repeat(64);
+    const STALE_HASH = '0x' + 's'.repeat(64);
+
+    // A malicious RPC returning a valid-but-old block number must not be
+    // able to pin stale ENS state: corroborated selection uses median +
+    // M-quorum on the hash, so a single lying provider cannot force an
+    // old anchor.
+    test('single malicious RPC returning an old head cannot pin stale state', async () => {
+      // 2 honest providers at current head + 1 attacker claiming head 1M
+      // blocks ago. Median = honest head. At target = head - 8 the honest
+      // providers return the current hash; attacker returns a stale hash
+      // → hash quorum is M=2 of honest → verified at current state.
+      mockProviderAnchorMap = new Map([
+        [TEST_PROVIDERS[0], {
+          headNumber: HONEST_HEAD - 1_000_000,
+          getBlock: () => Promise.resolve({ number: HONEST_HEAD - 1_000_008, hash: STALE_HASH }),
+        }],
+        [TEST_PROVIDERS[1], {
+          headNumber: HONEST_HEAD,
+          getBlock: () => Promise.resolve({ number: HONEST_HEAD - 8, hash: CURRENT_HASH }),
+        }],
+        [TEST_PROVIDERS[2], {
+          headNumber: HONEST_HEAD + 1,
+          getBlock: () => Promise.resolve({ number: HONEST_HEAD - 7, hash: CURRENT_HASH }),
+        }],
+      ]);
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('anti-stale.eth');
+
+      expect(result.type).toBe('ok');
+      expect(result.trust.level).toBe('verified');
+      expect(result.trust.block.hash).toBe(CURRENT_HASH);
+    });
+
+    // Same attack, but now the attacker colludes with itself by also
+    // returning the stale hash at the honest target. With only one liar,
+    // hash quorum still requires M=2 honest, so verification succeeds and
+    // the result reflects the honest block, not the attacker's.
+    test('lone malicious RPC cannot forge anchor hash quorum', async () => {
+      mockProviderAnchorMap = new Map([
+        [TEST_PROVIDERS[0], {
+          headNumber: HONEST_HEAD - 500_000,
+          getBlock: () => Promise.resolve({ number: HONEST_HEAD - 500_008, hash: STALE_HASH }),
+        }],
+        [TEST_PROVIDERS[1], {
+          headNumber: HONEST_HEAD,
+          getBlock: () => Promise.resolve({ number: HONEST_HEAD - 8, hash: CURRENT_HASH }),
+        }],
+        [TEST_PROVIDERS[2], {
+          headNumber: HONEST_HEAD,
+          getBlock: () => Promise.resolve({ number: HONEST_HEAD - 8, hash: CURRENT_HASH }),
+        }],
+      ]);
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('anti-stale-2.eth');
+
+      expect(result.trust.level).toBe('verified');
+      expect(result.trust.block.hash).toBe(CURRENT_HASH);
+    });
+
+    // If all providers disagree on the anchor hash, we refuse rather than
+    // silently picking one.
+    test('no hash quorum at anchor → resolution throws', async () => {
+      mockProviderAnchorMap = new Map([
+        [TEST_PROVIDERS[0], {
+          headNumber: HONEST_HEAD,
+          getBlock: () => Promise.resolve({ number: HONEST_HEAD - 8, hash: '0x' + 'a'.repeat(64) }),
+        }],
+        [TEST_PROVIDERS[1], {
+          headNumber: HONEST_HEAD,
+          getBlock: () => Promise.resolve({ number: HONEST_HEAD - 8, hash: '0x' + 'b'.repeat(64) }),
+        }],
+        [TEST_PROVIDERS[2], {
+          headNumber: HONEST_HEAD,
+          getBlock: () => Promise.resolve({ number: HONEST_HEAD - 8, hash: '0x' + 'c'.repeat(64) }),
+        }],
+      ]);
+
+      await expect(resolveEnsContent('anchor-conflict.eth')).rejects.toThrow(/hash quorum/);
+    });
+
+    // Negative responses bucket by exact reason: M agreeing NO_RESOLVER
+    // responses reach quorum even if a third provider returned a different
+    // negative reason (here CCIP failure classed as NO_CONTENTHASH). The
+    // odd-one-out does not block the verified outcome.
+    test('2 NO_RESOLVER + 1 NO_CONTENTHASH → verified NO_RESOLVER (quorum still reached)', async () => {
+      const resolverNotFoundErr = new Error('execution reverted: ResolverNotFound("foo.box")');
+      const ccipErr = new Error('response not found during CCIP fetch: 3dns CCIP_001');
+      routeByProvider(new Map([
+        [TEST_PROVIDERS[0], { kind: 'reject', payload: resolverNotFoundErr }],
+        [TEST_PROVIDERS[1], { kind: 'reject', payload: resolverNotFoundErr }],
+        [TEST_PROVIDERS[2], { kind: 'reject', payload: ccipErr }],
+      ]));
+
+      const result = await resolveEnsContent('mixed-negative.eth');
+
+      expect(result.type).toBe('not_found');
+      expect(result.reason).toBe('NO_RESOLVER');
+      expect(result.trust.level).toBe('verified');
+    });
+
+    // Three distinct responses — no bucket reaches M. Each surfaces as
+    // its own conflict group; the renderer can show what each provider
+    // claimed without silently collapsing mixed failures into a single
+    // fake "verified" negative.
+    test('1 NO_RESOLVER + 1 NO_CONTENTHASH + 1 data bytes → conflict (three distinct groups)', async () => {
+      const resolverNotFoundErr = new Error('execution reverted: ResolverNotFound("foo.eth")');
+      const ccipErr = new Error('response not found during CCIP fetch');
+      routeByProvider(new Map([
+        [TEST_PROVIDERS[0], { kind: 'reject', payload: resolverNotFoundErr }],
+        [TEST_PROVIDERS[1], { kind: 'reject', payload: ccipErr }],
+        [TEST_PROVIDERS[2], { kind: 'data', payload: urReturnsBytes(ipfsContenthashFor(IPFS_HASH)) }],
+      ]));
+
+      const result = await resolveEnsContent('three-way-split.eth');
+
+      expect(result.type).toBe('conflict');
+      // Three distinct groups: data bytes, NO_RESOLVER, NO_CONTENTHASH.
+      expect(result.groups.length).toBe(3);
+      const reasons = result.groups.filter((g) => g.reason).map((g) => g.reason).sort();
+      expect(reasons).toEqual(['NO_CONTENTHASH', 'NO_RESOLVER']);
+    });
+
+    // K=2 cannot safely produce a `verified` outcome: a single lying
+    // provider within the drift window can shift the anchor into the
+    // past, after which the honest provider faithfully returns the
+    // historical hash, forming a fake agreement. The fix is structural —
+    // K<3 falls through to the single-source unverified path.
+    test('K=2 agreeing providers do not produce a verified outcome', async () => {
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: false,
+        ensRpcUrl: '',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: [TEST_PROVIDERS[0], TEST_PROVIDERS[1]], // K=2
+      });
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('k2-unverified.eth');
+
+      expect(result.type).toBe('ok');
+      expect(result.trust.level).toBe('unverified');
+      expect(result.trust.queried.length).toBe(1);
+      expect(result.trust.quorum.achieved).toBe(false);
+    });
+
+    // Even when K=2 providers would naturally agree on current-head
+    // state, an attacker claiming a head within the safety-depth window
+    // should not force a "verified" stale answer. Structural downgrade
+    // to unverified makes this scenario safe by construction — the
+    // trust shield reflects the genuine uncertainty.
+    test('K=2 attacker-lowered head cannot produce verified stale state', async () => {
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: false,
+        ensRpcUrl: '',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: [TEST_PROVIDERS[0], TEST_PROVIDERS[1]],
+      });
+      mockProviderAnchorMap = new Map([
+        [TEST_PROVIDERS[0], {
+          // Attacker claims 10 blocks in the past (within a hypothetical
+          // drift tolerance that the OLD K=2 logic allowed).
+          headNumber: HONEST_HEAD - 10,
+          getBlock: () => Promise.resolve({ number: HONEST_HEAD - 18, hash: STALE_HASH }),
+        }],
+        [TEST_PROVIDERS[1], {
+          headNumber: HONEST_HEAD,
+          getBlock: () => Promise.resolve({ number: HONEST_HEAD - 8, hash: CURRENT_HASH }),
+        }],
+      ]);
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('k2-attacker-lower.eth');
+
+      expect(result.trust.level).toBe('unverified');
+      expect(result.trust.quorum.achieved).toBe(false);
+    });
+
+    // Reliability regression: a single flaky provider in the initial
+    // selection used to cascade into a hard-fail because the anchor step
+    // only probed effectiveK URLs. The fix probes the whole available
+    // pool, so healthy providers in the remainder still corroborate.
+    test('one flaky provider in anchor pool does not fail resolution', async () => {
+      const fiveProviders = [
+        ...TEST_PROVIDERS,
+        'https://test-d.example.com',
+        'https://test-e.example.com',
+      ];
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: false,
+        ensRpcUrl: '',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: fiveProviders,
+      });
+      // First provider in the pool errors on getBlockNumber; the other
+      // four all respond cleanly. Resolution should still succeed.
+      const flakyErr = Object.assign(new Error('ECONNREFUSED'), { code: 'NETWORK_ERROR' });
+      mockProviderAnchorMap = new Map([
+        [TEST_PROVIDERS[0], { headNumber: flakyErr }],
+      ]);
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('one-flaky.eth');
+
+      expect(result.type).toBe('ok');
+      expect(result.trust.level).toBe('verified');
+    });
+
+    // Runtime reliability: with exactly MIN_QUORUM_PROVIDERS in the pool,
+    // a single flake during head collection used to throw because only 2
+    // heads came back. Since the failed provider gets quarantined and a
+    // retry would have degraded anyway, we downgrade on the first call
+    // rather than surfacing a spurious error.
+    test('3-provider pool with one flake downgrades to unverified (no throw)', async () => {
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: false,
+        ensRpcUrl: '',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: TEST_PROVIDERS, // exactly 3
+      });
+      const flakyErr = Object.assign(new Error('ECONNREFUSED'), { code: 'NETWORK_ERROR' });
+      mockProviderAnchorMap = new Map([
+        [TEST_PROVIDERS[0], { headNumber: flakyErr }], // one provider flakes
+      ]);
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('3-pool-one-flake.eth');
+
+      expect(result.type).toBe('ok');
+      expect(result.trust.level).toBe('unverified');
+    });
+
+    // With the full-pool anchor probe, a "first bucket with ≥M" check
+    // would let two colluding attackers anywhere in the pool pin a stale
+    // hash if their bucket landed first in Map iteration order. The fix
+    // picks the LARGEST bucket subject to a majority-of-respondents
+    // threshold, so small collusions lose to the honest majority.
+    test('2 colluders in 9-provider pool cannot poison anchor (plurality wins)', async () => {
+      const nineProviders = [
+        ...TEST_PROVIDERS,
+        'https://test-d.example.com',
+        'https://test-e.example.com',
+        'https://test-f.example.com',
+        'https://test-g.example.com',
+        'https://test-h.example.com',
+        'https://test-i.example.com',
+      ];
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: false,
+        ensRpcUrl: '',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: nineProviders,
+      });
+      // 7 honest providers: head = HONEST_HEAD, canonical hash at target.
+      // 2 colluding attackers: head = HONEST_HEAD, STALE hash at target.
+      const honestAnchor = {
+        headNumber: HONEST_HEAD,
+        getBlock: () => Promise.resolve({ number: HONEST_HEAD - 8, hash: CURRENT_HASH }),
+      };
+      const attackerAnchor = {
+        headNumber: HONEST_HEAD,
+        getBlock: () => Promise.resolve({ number: HONEST_HEAD - 8, hash: STALE_HASH }),
+      };
+      mockProviderAnchorMap = new Map([
+        // Attackers at the front of the pool — matches worst-case Map
+        // iteration order the old code was vulnerable to.
+        [TEST_PROVIDERS[0], attackerAnchor],
+        [TEST_PROVIDERS[1], attackerAnchor],
+        [TEST_PROVIDERS[2], honestAnchor],
+        ['https://test-d.example.com', honestAnchor],
+        ['https://test-e.example.com', honestAnchor],
+        ['https://test-f.example.com', honestAnchor],
+        ['https://test-g.example.com', honestAnchor],
+        ['https://test-h.example.com', honestAnchor],
+        ['https://test-i.example.com', honestAnchor],
+      ]);
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('anchor-plurality.eth');
+
+      expect(result.type).toBe('ok');
+      expect(result.trust.level).toBe('verified');
+      expect(result.trust.block.hash).toBe(CURRENT_HASH);
+    });
+
+    // The anchor step can quarantine flaky providers during its head
+    // probe. If the wave then uses the pre-anchor snapshot of `available`,
+    // it immediately retries those bad providers and may land on
+    // unverified_data from a single (potentially malicious) responder
+    // while healthy providers sit idle in the later positions. The fix
+    // refreshes `available` after getPinnedBlock so the wave selects from
+    // the post-anchor, actually-healthy set.
+    test('anchor-quarantined providers are excluded from the wave selection', async () => {
+      const fiveProviders = [
+        ...TEST_PROVIDERS, // p0, p1, p2
+        'https://test-d.example.com',
+        'https://test-e.example.com',
+      ];
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: false,
+        ensRpcUrl: '',
+        enableEnsQuorum: true,
+        ensQuorumK: 3,
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: fiveProviders,
+      });
+      // Disable the provider-pool shuffle so the pre-anchor snapshot
+      // deterministically has the flaky providers at positions 0 and 1,
+      // which is exactly the case the pre-fix code mishandled.
+      const origRandom = Math.random;
+      Math.random = () => 0.999;
+      try {
+        invalidateCachedProvider(); // force re-shuffle with new Math.random
+        const flakyErr = Object.assign(new Error('ECONNREFUSED'), { code: 'NETWORK_ERROR' });
+        mockProviderAnchorMap = new Map([
+          // Flake on head probe → quarantined by the anchor step.
+          [TEST_PROVIDERS[0], { headNumber: flakyErr }],
+          [TEST_PROVIDERS[1], { headNumber: flakyErr }],
+        ]);
+        // Same providers also fail the Contract.resolve call, mirroring
+        // real flaky nodes (they don't become healthy between anchor and
+        // wave). Without the fix the wave would include p0 and p1 here
+        // and land on unverified_data from the single healthy leg; with
+        // the fix they're filtered out and three healthy providers reach
+        // a verified quorum.
+        routeByProvider(new Map([
+          [TEST_PROVIDERS[0], { kind: 'reject', payload: flakyErr }],
+          [TEST_PROVIDERS[1], { kind: 'reject', payload: flakyErr }],
+          [TEST_PROVIDERS[2], { kind: 'data', payload: urReturnsBytes(ipfsContenthashFor(IPFS_HASH)) }],
+          ['https://test-d.example.com', { kind: 'data', payload: urReturnsBytes(ipfsContenthashFor(IPFS_HASH)) }],
+          ['https://test-e.example.com', { kind: 'data', payload: urReturnsBytes(ipfsContenthashFor(IPFS_HASH)) }],
+        ]));
+
+        const result = await resolveEnsContent('anchor-quarantine.eth');
+
+        expect(result.type).toBe('ok');
+        expect(result.trust.level).toBe('verified');
+        expect(result.trust.queried.length).toBe(3);
+      } finally {
+        Math.random = origRandom;
+      }
+    });
+
+    // Config regression: user-set ensQuorumK=2 no longer hard-fails at
+    // the anchor step. Degrades to single-source unverified instead.
+    test('ensQuorumK=2 with ample providers degrades to unverified, not error', async () => {
+      const fiveProviders = [
+        ...TEST_PROVIDERS,
+        'https://test-d.example.com',
+        'https://test-e.example.com',
+      ];
+      mockLoadSettings.mockReturnValue({
+        enableEnsCustomRpc: false,
+        ensRpcUrl: '',
+        enableEnsQuorum: true,
+        ensQuorumK: 2, // below the structural minimum of 3
+        ensQuorumM: 2,
+        ensQuorumTimeoutMs: 5000,
+        ensBlockAnchor: 'latest',
+        ensBlockAnchorTtlMs: 30000,
+        ensPublicRpcProviders: fiveProviders,
+      });
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_HASH)));
+
+      const result = await resolveEnsContent('k2-configured.eth');
+
+      expect(result.type).toBe('ok');
+      expect(result.trust.level).toBe('unverified');
+      expect(result.trust.queried.length).toBe(1);
     });
   });
 });

--- a/src/main/request-rewriter.js
+++ b/src/main/request-rewriter.js
@@ -307,4 +307,5 @@ module.exports = {
   buildRewriteTarget,
   convertProtocolUrl,
   shouldBlockInvalidBzzRequest,
+  sanitizeUrlForLog,
 };

--- a/src/main/settings-store.js
+++ b/src/main/settings-store.js
@@ -58,6 +58,11 @@ const DEFAULT_SETTINGS = {
   ensBlockAnchor: 'latest',
   ensBlockAnchorTtlMs: 30000,
   ensPublicRpcProviders: DEFAULT_ENS_PUBLIC_RPC_PROVIDERS,
+  // When true, navigation to an ENS name that resolved with trust.level =
+  // 'unverified' is gated behind an interstitial with a single-use
+  // "Continue once" option. Turn off to navigate straight through with
+  // only the amber shield for signal.
+  blockUnverifiedEns: true,
   sidebarOpen: false,
   sidebarWidth: 320,
 };

--- a/src/main/settings-store.js
+++ b/src/main/settings-store.js
@@ -16,6 +16,23 @@ function applyNativeTheme(theme) {
 }
 
 const SETTINGS_FILE = 'settings.json';
+
+// Default public Ethereum RPC endpoints used for ENS quorum resolution when no
+// custom RPC is configured. Users can edit this list in settings (add/remove).
+// Operator diversity note: URL count != operator count — several of these may
+// proxy to the same backend (Alchemy, Infura). Documented in threat model.
+const DEFAULT_ENS_PUBLIC_RPC_PROVIDERS = [
+  'https://ethereum.publicnode.com',
+  'https://1rpc.io/eth',
+  'https://eth.drpc.org',
+  'https://eth-mainnet.public.blastapi.io',
+  'https://eth.merkle.io',
+  'https://cloudflare-eth.com',
+  'https://rpc.ankr.com/eth',
+  'https://rpc.flashbots.net',
+  'https://eth.llamarpc.com',
+];
+
 const DEFAULT_SETTINGS = {
   theme: 'system',
   enableRadicleIntegration: false,
@@ -28,9 +45,26 @@ const DEFAULT_SETTINGS = {
   showBookmarkBar: false,
   enableEnsCustomRpc: false,
   ensRpcUrl: '',
+  // ENS public-RPC quorum resolution (active when enableEnsCustomRpc=false).
+  // Detects RPC lying by requiring ensQuorumM of K parallel providers to
+  // return byte-identical data at a pinned block. See docs/ens-resolution.md.
+  enableEnsQuorum: true,
+  ensQuorumK: 3,
+  ensQuorumM: 2,
+  ensQuorumTimeoutMs: 5000,
+  // Block tag all quorum legs query at, so honest-but-unsynced providers
+  // don't produce false conflicts. 'latest' is near-real-time; 'finalized'
+  // is ~12min behind head but strongest; 'latest-32' is ~3min behind.
+  ensBlockAnchor: 'latest',
+  ensBlockAnchorTtlMs: 30000,
+  ensPublicRpcProviders: DEFAULT_ENS_PUBLIC_RPC_PROVIDERS,
   sidebarOpen: false,
   sidebarWidth: 320,
 };
+
+// Settings keys whose value is an array rather than a primitive. The
+// saveSettings validator uses JSON-equality for these instead of ===.
+const ARRAY_SETTINGS_KEYS = new Set(['ensPublicRpcProviders']);
 
 let cachedSettings = null;
 
@@ -75,8 +109,9 @@ function broadcastSettingsUpdated(merged) {
 
 // Walks DEFAULT_SETTINGS keys in one pass: drops unknown input keys (defense
 // against a buggy or compromised internal page persisting junk to disk) and
-// detects no-op saves at the same time. Relies on every settings value being
-// a primitive — revisit if a nested value is ever added.
+// detects no-op saves at the same time. Array-valued keys (see
+// ARRAY_SETTINGS_KEYS) compare by JSON-equality; all other keys must be
+// primitive and compare by === .
 function saveSettings(newSettings) {
   try {
     const previous = loadSettings();
@@ -85,11 +120,22 @@ function saveSettings(newSettings) {
 
     if (newSettings && typeof newSettings === 'object') {
       for (const key of Object.keys(DEFAULT_SETTINGS)) {
-        if (
-          Object.prototype.hasOwnProperty.call(newSettings, key) &&
-          newSettings[key] !== previous[key]
-        ) {
-          merged[key] = newSettings[key];
+        if (!Object.prototype.hasOwnProperty.call(newSettings, key)) continue;
+
+        const nextValue = newSettings[key];
+        const prevValue = previous[key];
+
+        let differs;
+        if (ARRAY_SETTINGS_KEYS.has(key)) {
+          // Reject non-arrays for array-typed keys to keep disk state sane.
+          if (!Array.isArray(nextValue)) continue;
+          differs = JSON.stringify(prevValue) !== JSON.stringify(nextValue);
+        } else {
+          differs = prevValue !== nextValue;
+        }
+
+        if (differs) {
+          merged[key] = nextValue;
           changed = true;
         }
       }
@@ -128,4 +174,5 @@ module.exports = {
   loadSettings,
   saveSettings,
   registerSettingsIpc,
+  DEFAULT_ENS_PUBLIC_RPC_PROVIDERS,
 };

--- a/src/main/webview-preload.js
+++ b/src/main/webview-preload.js
@@ -112,6 +112,18 @@ contextBridge.exposeInMainWorld('freedomAPI', {
     ipcRenderer.invoke('internal:open-url-in-new-tab', url)
   ),
 
+  // Signals from ENS interstitial pages back to the address-bar shell.
+  // Uses sendToHost because the shell is the webview's parent frame, not
+  // the main process — shorter, avoids a main round-trip. Channel names
+  // mirror ENS_CONTINUE_UNVERIFIED / ENS_OPEN_SETTINGS in ipc-channels.js
+  // (kept hardcoded here because preload's sandbox blocks relative require).
+  ensContinueUnverified: guardInternal('ensContinueUnverified', (name) => {
+    ipcRenderer.sendToHost('ens:continue-unverified', { name });
+  }),
+  ensOpenSettings: guardInternal('ensOpenSettings', () => {
+    ipcRenderer.sendToHost('ens:open-settings');
+  }),
+
   // Favicons
   getCachedFavicon: guardInternal('getCachedFavicon', (url) =>
     ipcRenderer.invoke('favicon:get-cached', url)

--- a/src/main/webview-preload.js
+++ b/src/main/webview-preload.js
@@ -114,9 +114,10 @@ contextBridge.exposeInMainWorld('freedomAPI', {
 
   // Signals from ENS interstitial pages back to the address-bar shell.
   // Uses sendToHost because the shell is the webview's parent frame, not
-  // the main process — shorter, avoids a main round-trip. Channel names
-  // mirror ENS_CONTINUE_UNVERIFIED / ENS_OPEN_SETTINGS in ipc-channels.js
-  // (kept hardcoded here because preload's sandbox blocks relative require).
+  // the main process — shorter, avoids a main round-trip. Both sides of
+  // this channel are renderer code; preload's sandbox blocks relative
+  // require, and navigation.js is ESM and can't import the CommonJS
+  // shared module — strings are kept hardcoded on both ends.
   ensContinueUnverified: guardInternal('ensContinueUnverified', (name) => {
     ipcRenderer.sendToHost('ens:continue-unverified', { name });
   }),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -156,6 +156,59 @@
       <form id="nav-form" autocomplete="off">
         <div class="address-bar-container">
           <div class="address-wrapper">
+            <button
+              id="trust-shield"
+              class="trust-shield"
+              type="button"
+              aria-label="ENS resolution trust status"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+              aria-controls="trust-popover"
+              hidden
+            >
+              <!-- Verified: filled green shield -->
+              <svg class="icon-verified" viewBox="0 0 24 24" fill="currentColor" stroke="none">
+                <path d="M12 2 L4 6 L4 12 C4 17 7.5 21 12 22 C16.5 21 20 17 20 12 L20 6 Z" />
+              </svg>
+              <!-- User-configured: green shield with dot -->
+              <svg class="icon-user-configured" viewBox="0 0 24 24" fill="currentColor" stroke="none">
+                <path d="M12 2 L4 6 L4 12 C4 17 7.5 21 12 22 C16.5 21 20 17 20 12 L20 6 Z" />
+                <circle cx="12" cy="12" r="2.2" fill="white" />
+              </svg>
+              <!-- Unverified: amber outline -->
+              <svg class="icon-unverified" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 2 L4 6 L4 12 C4 17 7.5 21 12 22 C16.5 21 20 17 20 12 L20 6 Z" />
+                <line x1="12" y1="8" x2="12" y2="13" />
+                <circle cx="12" cy="17" r="0.5" fill="currentColor" />
+              </svg>
+              <!-- Conflict: red with slash -->
+              <svg class="icon-conflict" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 2 L4 6 L4 12 C4 17 7.5 21 12 22 C16.5 21 20 17 20 12 L20 6 Z" />
+                <line x1="7" y1="8" x2="17" y2="16" />
+              </svg>
+            </button>
+            <div id="trust-popover" class="trust-popover" role="dialog" aria-label="ENS trust details" hidden>
+              <div class="trust-popover-header">
+                <div class="trust-popover-title" id="trust-popover-title"></div>
+                <div class="trust-popover-subtitle" id="trust-popover-subtitle"></div>
+              </div>
+              <p class="trust-popover-summary" id="trust-popover-summary"></p>
+              <div class="trust-popover-section">
+                <div class="trust-popover-section-label">Block</div>
+                <div class="trust-popover-section-value" id="trust-popover-block"></div>
+              </div>
+              <div class="trust-popover-section" id="trust-popover-agreed-section">
+                <div class="trust-popover-section-label">Agreed</div>
+                <div class="trust-popover-section-value" id="trust-popover-agreed"></div>
+              </div>
+              <div class="trust-popover-section" id="trust-popover-dissented-section" hidden>
+                <div class="trust-popover-section-label">Dissented</div>
+                <div class="trust-popover-section-value" id="trust-popover-dissented"></div>
+              </div>
+              <a class="trust-popover-learn" href="https://docs.freedombrowser.eth" target="_blank" rel="noreferrer">
+                Learn more →
+              </a>
+            </div>
             <span id="protocol-icon" class="protocol-icon" aria-hidden="true">
               <!-- Swarm icon (official logo) -->
               <svg class="icon-swarm" viewBox="18 34 44 45" fill="currentColor">

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -205,9 +205,6 @@
                 <div class="trust-popover-section-label">Dissented</div>
                 <div class="trust-popover-section-value" id="trust-popover-dissented"></div>
               </div>
-              <a class="trust-popover-learn" href="https://docs.freedombrowser.eth" target="_blank" rel="noreferrer">
-                Learn more →
-              </a>
             </div>
             <span id="protocol-icon" class="protocol-icon" aria-hidden="true">
               <!-- Swarm icon (official logo) -->

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -1,5 +1,5 @@
 // Renderer process entry point
-import { updateRegistry, setRadicleIntegrationEnabled } from './lib/state.js';
+import { updateRegistry, setRadicleIntegrationEnabled, setBlockUnverifiedEns } from './lib/state.js';
 import { initBeeUi, updateBeeStatusLine, updateBeeToggleState } from './lib/bee-ui.js';
 import { initIpfsUi, updateIpfsStatusLine, updateIpfsToggleState } from './lib/ipfs-ui.js';
 import {
@@ -187,11 +187,14 @@ window.addEventListener('DOMContentLoaded', async () => {
   try {
     const settings = await electronAPI.getSettings();
     setRadicleIntegrationEnabled(settings?.enableRadicleIntegration === true);
+    setBlockUnverifiedEns(settings?.blockUnverifiedEns !== false);
   } catch {
     setRadicleIntegrationEnabled(false);
+    setBlockUnverifiedEns(true);
   }
   window.addEventListener('settings:updated', (event) => {
     setRadicleIntegrationEnabled(event.detail?.enableRadicleIntegration === true);
+    setBlockUnverifiedEns(event.detail?.blockUnverifiedEns !== false);
   });
 
   initMenuBackdrop(closeAllOverlays);

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -2,6 +2,35 @@ import { applyEnsNamePreservation, deriveDisplayValue } from './url-utils.js';
 import { getInternalPageName } from './page-urls.js';
 import { cidV0ToV1Base32 } from './cid-utils.js';
 
+// Extract the ENS name from an address bar value, or null if the value isn't
+// an ENS resolution input (ens://, .eth, .box). Shared by the protocol icon
+// and trust-shield helpers. Distinct from `parseEnsInput` in `page-urls.js`:
+// the latter is the canonical parser used during navigation (trims, regex,
+// allocates {name, suffix}); this helper is the render-loop fast path that
+// accepts already-lowercased input and returns just the name.
+const extractEnsName = (normalizedValue) => {
+  if (normalizedValue.startsWith('ens://')) {
+    return normalizedValue.slice(6).split('/')[0];
+  }
+  if (normalizedValue.endsWith('.eth') || normalizedValue.endsWith('.box')) {
+    return normalizedValue.split('/')[0];
+  }
+  return null;
+};
+
+// Trust-shield state for the address bar. Returns `null` to hide the shield
+// (non-ENS URLs, or ENS name we haven't resolved this session). Otherwise
+// returns `{ level, name, trust }` so the shield can render and the popover
+// can fill in details.
+export const resolveTrustBadge = ({ value = '', ensTrustByName = new Map() } = {}) => {
+  const normalizedValue = value.toLowerCase();
+  const ensName = extractEnsName(normalizedValue);
+  if (!ensName) return null;
+  const trust = ensTrustByName.get(ensName);
+  if (!trust || !trust.level) return null;
+  return { level: trust.level, name: ensName, trust };
+};
+
 export const resolveProtocolIconType = ({
   value = '',
   ensProtocols = new Map(),
@@ -11,10 +40,8 @@ export const resolveProtocolIconType = ({
   const normalizedValue = value.toLowerCase();
   let protocol = 'http';
 
-  if (normalizedValue.startsWith('ens://') || normalizedValue.endsWith('.eth') || normalizedValue.endsWith('.box')) {
-    const ensName = normalizedValue.startsWith('ens://')
-      ? normalizedValue.slice(6).split('/')[0]
-      : normalizedValue.split('/')[0];
+  const ensName = extractEnsName(normalizedValue);
+  if (ensName) {
     protocol = ensProtocols.get(ensName) || 'http';
   } else if (normalizedValue.startsWith('bzz://')) {
     protocol = 'swarm';

--- a/src/renderer/lib/navigation-utils.test.js
+++ b/src/renderer/lib/navigation-utils.test.js
@@ -81,6 +81,80 @@ describe('navigation-utils', () => {
     });
   });
 
+  describe('resolveTrustBadge', () => {
+    const verifiedTrust = { level: 'verified', agreed: ['a', 'b'], queried: ['a', 'b', 'c'] };
+    const conflictTrust = { level: 'conflict', agreed: [], dissented: ['a', 'b'] };
+
+    test('returns null for non-ENS URLs', async () => {
+      const { resolveTrustBadge } = await loadNavigationUtils();
+      const ensTrustByName = new Map([['vitalik.eth', verifiedTrust]]);
+
+      expect(resolveTrustBadge({ value: 'https://example.com', ensTrustByName })).toBeNull();
+      expect(resolveTrustBadge({ value: 'bzz://hash', ensTrustByName })).toBeNull();
+      expect(resolveTrustBadge({ value: 'freedom://history', ensTrustByName })).toBeNull();
+      expect(resolveTrustBadge({ value: '', ensTrustByName })).toBeNull();
+    });
+
+    test('returns null when the ENS name has no trust entry', async () => {
+      const { resolveTrustBadge } = await loadNavigationUtils();
+      const ensTrustByName = new Map([['other.eth', verifiedTrust]]);
+
+      expect(resolveTrustBadge({ value: 'ens://vitalik.eth', ensTrustByName })).toBeNull();
+    });
+
+    test('returns badge for ens:// URLs with trust entry', async () => {
+      const { resolveTrustBadge } = await loadNavigationUtils();
+      const ensTrustByName = new Map([['vitalik.eth', verifiedTrust]]);
+
+      const badge = resolveTrustBadge({ value: 'ens://vitalik.eth', ensTrustByName });
+
+      expect(badge).toEqual({
+        level: 'verified',
+        name: 'vitalik.eth',
+        trust: verifiedTrust,
+      });
+    });
+
+    test('returns badge for bare .eth and .box URLs', async () => {
+      const { resolveTrustBadge } = await loadNavigationUtils();
+      const ensTrustByName = new Map([
+        ['vitalik.eth', verifiedTrust],
+        ['example.box', conflictTrust],
+      ]);
+
+      expect(resolveTrustBadge({ value: 'vitalik.eth', ensTrustByName }).level).toBe('verified');
+      expect(resolveTrustBadge({ value: 'example.box', ensTrustByName }).level).toBe('conflict');
+    });
+
+    test('strips path and is case-insensitive', async () => {
+      const { resolveTrustBadge } = await loadNavigationUtils();
+      const ensTrustByName = new Map([['vitalik.eth', verifiedTrust]]);
+
+      expect(resolveTrustBadge({ value: 'ens://vitalik.eth/profile', ensTrustByName }).level).toBe(
+        'verified'
+      );
+      expect(resolveTrustBadge({ value: 'VITALIK.ETH', ensTrustByName }).level).toBe('verified');
+      expect(resolveTrustBadge({ value: 'ENS://Vitalik.ETH/x', ensTrustByName }).level).toBe(
+        'verified'
+      );
+    });
+
+    test('tolerates missing / empty arguments', async () => {
+      const { resolveTrustBadge } = await loadNavigationUtils();
+
+      expect(resolveTrustBadge()).toBeNull();
+      expect(resolveTrustBadge({})).toBeNull();
+      expect(resolveTrustBadge({ value: 'ens://x.eth' })).toBeNull();
+    });
+
+    test('returns null when trust has no level (defensive)', async () => {
+      const { resolveTrustBadge } = await loadNavigationUtils();
+      const ensTrustByName = new Map([['vitalik.eth', { agreed: ['a'] }]]);
+
+      expect(resolveTrustBadge({ value: 'ens://vitalik.eth', ensTrustByName })).toBeNull();
+    });
+  });
+
   describe('getRadicleDisplayUrl', () => {
     test('reconstructs rad urls from rad-browser pages', async () => {
       const { getRadicleDisplayUrl } = await loadNavigationUtils();

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -171,8 +171,12 @@ const toggleTrustPopover = () => {
 
   if (title) title.textContent = name;
   if (subtitle) {
+    // Full resolved URI (e.g. bzz://<hash>, ipfs://<CID>) — the content
+    // address the ENS record points at. Falls back to protocol-only if
+    // the URI wasn't captured (shouldn't happen for successful resolves).
+    const uri = state.ensUriByName.get(name);
     const proto = state.ensProtocols.get(name);
-    subtitle.textContent = proto ? `Resolved as ${proto}://…` : '';
+    subtitle.textContent = uri || (proto ? `Resolved as ${proto}://…` : '');
   }
   if (summary) {
     const buildSummary = TRUST_SUMMARY[level];
@@ -532,6 +536,9 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
 
         if (result.trust) {
           state.ensTrustByName.set(ens.name, result.trust);
+        }
+        if (result.uri) {
+          state.ensUriByName.set(ens.name, result.uri);
         }
 
         // Conflict = hard block. Render the interstitial with the disputed

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -117,8 +117,9 @@ let currentPageSecure = false;
 const TRUST_SUMMARY = {
   verified: (trust) => {
     const agreed = (trust.agreed || []).length;
-    const queried = (trust.queried || []).length;
-    return queried ? `Verified — ${agreed} of ${queried} public RPCs agreed.` : 'Verified.';
+    return agreed > 0
+      ? `Verified: quorum reached with ${agreed} matching public RPC responses.`
+      : 'Verified.';
   },
   'user-configured': () => 'Resolved via your configured RPC. Single source — no cross-check performed.',
   unverified: () => 'Only one RPC answered in time. The browser could not cross-check this resolution.',

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -14,6 +14,7 @@ import {
   getOriginalUrlFromErrorPage,
   getRadicleDisplayUrl,
   resolveProtocolIconType,
+  resolveTrustBadge,
 } from './navigation-utils.js';
 import {
   formatBzzUrl,
@@ -43,6 +44,7 @@ import {
   isHistoryRecordable,
   getInternalPageName,
   parseEnsInput,
+  buildInternalPageUrl,
 } from './page-urls.js';
 import { parseEthereumUri } from './ethereum-uri.js';
 import { openSendFlow } from './wallet-ui.js';
@@ -65,6 +67,8 @@ let reloadBtn = null;
 let homeBtn = null;
 let bookmarksBar = null;
 let protocolIcon = null;
+let trustShield = null;
+let trustPopover = null;
 
 // Bookmark bar toggle state: true = always show, false = hide on non-home pages (default)
 let bookmarkBarOverride = false;
@@ -107,23 +111,146 @@ const storeEnsResolutionMetadata = (targetUri, ensName, { trackProtocol = true }
 // Track certificate status for current page
 let currentPageSecure = false;
 
-// Update protocol icon based on address bar value
-const updateProtocolIcon = () => {
-  if (!protocolIcon) return;
+// Copy map for the trust popover — each level gets a short, user-facing
+// sentence. Phrased as cross-check language ("RPCs agreed") rather than
+// "trusted" / "safe", per the threat model discussion.
+const TRUST_SUMMARY = {
+  verified: (trust) => {
+    const agreed = (trust.agreed || []).length;
+    const queried = (trust.queried || []).length;
+    return queried ? `Verified — ${agreed} of ${queried} public RPCs agreed.` : 'Verified.';
+  },
+  'user-configured': () => 'Resolved via your configured RPC. Single source — no cross-check performed.',
+  unverified: () => 'Only one RPC answered in time. The browser could not cross-check this resolution.',
+  conflict: () => 'RPC servers disagreed. Navigation was blocked.',
+};
 
-  const protocol = resolveProtocolIconType({
+// Screen-reader label for the shield button, keyed on trust level. Updated
+// alongside the data-trust attribute so assistive tech announces the state.
+const TRUST_ARIA_LABEL = {
+  verified: 'ENS resolution trust: verified',
+  'user-configured': 'ENS resolution trust: user-configured',
+  unverified: 'ENS resolution trust: unverified',
+  conflict: 'ENS resolution trust: conflict',
+};
+
+// Build display text for the popover. The resolver's trust shape has
+// `agreed` and `queried` hostname arrays; we surface counts in the summary
+// and full lists in the sections below.
+const setTrustPopoverOpen = (open) => {
+  if (!trustPopover || !trustShield) return;
+  trustPopover.hidden = !open;
+  trustShield.setAttribute('aria-expanded', open ? 'true' : 'false');
+};
+
+const toggleTrustPopover = () => {
+  if (!trustPopover || !trustShield) return;
+  if (!trustPopover.hidden) {
+    setTrustPopoverOpen(false);
+    return;
+  }
+
+  const badge = resolveTrustBadge({
     value: addressInput?.value || '',
-    ensProtocols: state.ensProtocols,
-    enableRadicleIntegration: state.enableRadicleIntegration,
-    currentPageSecure,
+    ensTrustByName: state.ensTrustByName,
   });
+  if (!badge) return;
 
-  if (protocol) {
-    protocolIcon.setAttribute('data-protocol', protocol);
-    protocolIcon.classList.add('visible');
-  } else {
-    protocolIcon.removeAttribute('data-protocol');
-    protocolIcon.classList.remove('visible');
+  const { trust, name, level } = badge;
+  trustPopover.setAttribute('data-trust', level);
+
+  const title = document.getElementById('trust-popover-title');
+  const subtitle = document.getElementById('trust-popover-subtitle');
+  const summary = document.getElementById('trust-popover-summary');
+  const blockEl = document.getElementById('trust-popover-block');
+  const agreedEl = document.getElementById('trust-popover-agreed');
+  const dissentedEl = document.getElementById('trust-popover-dissented');
+  const dissentedSection = document.getElementById('trust-popover-dissented-section');
+  const agreedSection = document.getElementById('trust-popover-agreed-section');
+
+  if (title) title.textContent = name;
+  if (subtitle) {
+    const proto = state.ensProtocols.get(name);
+    subtitle.textContent = proto ? `Resolved as ${proto}://…` : '';
+  }
+  if (summary) {
+    const buildSummary = TRUST_SUMMARY[level];
+    if (!buildSummary) {
+      console.warn('[trust] unknown trust level:', level);
+      summary.textContent = 'Unknown trust state.';
+    } else {
+      summary.textContent = buildSummary(trust);
+    }
+  }
+  if (blockEl) {
+    if (trust.block?.number) {
+      const hash = trust.block.hash || '';
+      const short = hash ? `${hash.slice(0, 10)}…${hash.slice(-4)}` : '';
+      blockEl.textContent = `#${trust.block.number}${short ? '  ' + short : ''}`;
+    } else {
+      blockEl.textContent = '(not recorded)';
+    }
+  }
+  if (agreedEl && agreedSection) {
+    const agreed = trust.agreed || [];
+    if (agreed.length > 0) {
+      agreedEl.textContent = agreed.join(', ');
+      agreedSection.hidden = false;
+    } else {
+      agreedSection.hidden = true;
+    }
+  }
+  if (dissentedEl && dissentedSection) {
+    const dissented = trust.dissented || [];
+    if (dissented.length > 0) {
+      dissentedEl.textContent = dissented.join(', ');
+      dissentedSection.hidden = false;
+    } else {
+      dissentedSection.hidden = true;
+    }
+  }
+
+  setTrustPopoverOpen(true);
+};
+
+// Update protocol icon AND trust shield from the current address-bar value.
+// Called from every site that might change either (nav events, tab switches,
+// address-bar edits). Trust shield is hidden for non-ENS URLs; the protocol
+// icon keeps indicating bzz://, ipfs://, https://, etc. as before.
+const updateProtocolIcon = () => {
+  if (protocolIcon) {
+    const protocol = resolveProtocolIconType({
+      value: addressInput?.value || '',
+      ensProtocols: state.ensProtocols,
+      enableRadicleIntegration: state.enableRadicleIntegration,
+      currentPageSecure,
+    });
+    if (protocol) {
+      protocolIcon.setAttribute('data-protocol', protocol);
+      protocolIcon.classList.add('visible');
+    } else {
+      protocolIcon.removeAttribute('data-protocol');
+      protocolIcon.classList.remove('visible');
+    }
+  }
+
+  if (trustShield) {
+    const badge = resolveTrustBadge({
+      value: addressInput?.value || '',
+      ensTrustByName: state.ensTrustByName,
+    });
+    if (badge) {
+      trustShield.setAttribute('data-trust', badge.level);
+      trustShield.setAttribute(
+        'aria-label',
+        TRUST_ARIA_LABEL[badge.level] || 'ENS resolution trust status'
+      );
+      trustShield.hidden = false;
+    } else {
+      trustShield.removeAttribute('data-trust');
+      trustShield.setAttribute('aria-label', 'ENS resolution trust status');
+      trustShield.hidden = true;
+    }
   }
 };
 
@@ -280,7 +407,10 @@ const handleEthereumUri = (value) => {
   }
 };
 
-export const loadTarget = (value, displayOverride = null, targetWebview = null) => {
+export const loadTarget = (value, displayOverride = null, targetWebview = null, options = {}) => {
+  // `options.allowUnverifiedOnce` — skip the unverified-ENS interstitial
+  // for this single call. Set by the ens-unverified page's "Continue once"
+  // handler. Scope is this single loadTarget invocation.
   // Use provided webview or fall back to active webview
   const webview = targetWebview || getActiveWebview();
   const navState = getNavState();
@@ -399,6 +529,28 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null) 
           return;
         }
 
+        if (result.trust) {
+          state.ensTrustByName.set(ens.name, result.trust);
+        }
+
+        // Conflict = hard block. Render the interstitial with the disputed
+        // groups so the user can see which providers claimed what; no
+        // attempt to load the resolved URI.
+        if (result.type === 'conflict') {
+          // Defensive cap: the resolver already bounds groups by K (≤9),
+          // but a malformed payload shouldn't be able to explode the URL.
+          const groups = (result.groups || []).slice(0, 10);
+          pushDebug(`ENS conflict for ${ens.name}: ${groups.length} groups`);
+          capturedWebview.loadURL(
+            buildInternalPageUrl('ens-conflict.html', {
+              name: ens.name,
+              block: JSON.stringify(result.trust?.block || {}),
+              groups: JSON.stringify(groups),
+            })
+          );
+          return;
+        }
+
         if (result.type !== 'ok') {
           const reason = result.reason || 'Unknown error';
           pushDebug(`ENS resolution failed for ${ens.name}: ${reason}`);
@@ -415,6 +567,20 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null) 
         }
 
         const targetUri = applyEnsSuffix(result.uri, ens.suffix);
+
+        // Unverified = soft block. Interstitial lets the user continue once,
+        // bypassing this check for the follow-up load.
+        if (
+          result.trust?.level === 'unverified'
+          && state.blockUnverifiedEns
+          && !options.allowUnverifiedOnce
+        ) {
+          pushDebug(`ENS unverified for ${ens.name} → interstitial`);
+          capturedWebview.loadURL(
+            buildInternalPageUrl('ens-unverified.html', { name: ens.name, uri: targetUri })
+          );
+          return;
+        }
 
         pushDebug(`ENS resolved: ${ens.name} -> ${targetUri}`);
 
@@ -861,6 +1027,26 @@ export const initNavigation = () => {
   homeBtn = document.getElementById('home-btn');
   bookmarksBar = document.querySelector('.bookmarks');
   protocolIcon = document.getElementById('protocol-icon');
+  trustShield = document.getElementById('trust-shield');
+  trustPopover = document.getElementById('trust-popover');
+
+  if (trustShield) {
+    trustShield.addEventListener('click', (e) => {
+      e.stopPropagation();
+      toggleTrustPopover();
+    });
+  }
+  document.addEventListener('click', (e) => {
+    if (!trustPopover || trustPopover.hidden) return;
+    if (trustPopover.contains(e.target)) return;
+    if (trustShield && trustShield.contains(e.target)) return;
+    setTrustPopoverOpen(false);
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && trustPopover && !trustPopover.hidden) {
+      setTrustPopoverOpen(false);
+    }
+  });
 
   // Load bookmark bar visibility from saved settings
   electronAPI?.getSettings?.().then((settings) => {
@@ -1172,6 +1358,19 @@ export const initNavigation = () => {
         ensureWebContentsId();
         pushDebug('Webview ready.');
         break;
+
+      case 'ipc-message': {
+        if (data.channel === 'ens:continue-unverified') {
+          const name = data.args?.[0]?.name;
+          if (name) {
+            pushDebug(`ENS continue-unverified requested for ${name}`);
+            loadTarget('ens://' + name, null, webview, { allowUnverifiedOnce: true });
+          }
+        } else if (data.channel === 'ens:open-settings') {
+          loadTarget('freedom://settings', null, webview);
+        }
+        break;
+      }
 
       case 'tab-switched':
         // Save address bar state to previous tab before switching

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -1047,6 +1047,13 @@ export const initNavigation = () => {
       setTrustPopoverOpen(false);
     }
   });
+  // Clicks inside the <webview> don't bubble to the main renderer's
+  // document (out-of-process frame), so a document-click listener alone
+  // misses them. window.blur fires when focus shifts to the webview,
+  // which covers any click into loaded page content.
+  window.addEventListener('blur', () => {
+    if (trustPopover && !trustPopover.hidden) setTrustPopoverOpen(false);
+  });
 
   // Load bookmark bar visibility from saved settings
   electronAPI?.getSettings?.().then((settings) => {

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -1095,100 +1095,12 @@ export const initNavigation = () => {
   // Form submission (navigate)
   navForm.addEventListener('submit', (event) => {
     event.preventDefault();
-    const raw = addressInput.value;
-
-    // Handle freedom:// protocol for internal pages
-    const fbMatch = raw.match(/^freedom:\/\/([a-zA-Z0-9-]+)$/i);
-    if (fbMatch) {
-      const pageName = fbMatch[1].toLowerCase();
-      const pageUrl = internalPages[pageName];
-      if (pageUrl) {
-        const webview = getActiveWebview();
-        if (webview) {
-          webview.loadURL(pageUrl);
-          pushDebug(`Loading internal page: ${pageName}`);
-        }
-      } else {
-        pushDebug(`Unknown internal page: ${pageName}`);
-        alert(
-          `Unknown internal page: ${pageName}\nAvailable: ${Object.keys(internalPages).join(', ')}`
-        );
-      }
-      addressInput.blur();
-      return;
-    }
-
-    const ens = parseEnsInput(raw);
-
-    if (ens && electronAPI?.resolveEns) {
-      // Capture the webview reference before async operation to prevent loading in wrong tab
-      const capturedWebview = getActiveWebview();
-      setLoading(true);
-      pushDebug(`Resolving ENS name: ${ens.name}`);
-      electronAPI
-        .resolveEns(ens.name)
-        .then((result) => {
-          setLoading(false);
-          if (!result) {
-            alert('ENS resolution failed: no response');
-            return;
-          }
-
-          if (result.type !== 'ok') {
-            const reason = result.reason || 'Unknown error';
-            pushDebug(`ENS resolution failed for ${ens.name}: ${reason}`);
-            alert(`ENS resolution failed for ${ens.name}: ${reason}`);
-            return;
-          }
-
-          // Support both Swarm (bzz) and IPFS protocols
-          if (
-            result.protocol !== 'bzz' &&
-            result.protocol !== 'ipfs' &&
-            result.protocol !== 'ipns'
-          ) {
-            pushDebug(`ENS content for ${ens.name} uses unsupported protocol ${result.protocol}`);
-            alert(
-              `ENS content uses unsupported protocol "${result.protocol}". Supported: Swarm (bzz), IPFS, IPNS.`
-            );
-            return;
-          }
-
-          const targetUri = applyEnsSuffix(result.uri, ens.suffix);
-
-          pushDebug(`ENS resolved: ${ens.name} -> ${targetUri}`);
-
-          storeEnsResolutionMetadata(targetUri, ens.name);
-
-          // Pass captured webview to ensure we load in the correct tab
-          loadTarget(targetUri, 'ens://' + ens.name + (ens.suffix || ''), capturedWebview);
-          addressInput.blur();
-        })
-        .catch((err) => {
-          setLoading(false);
-          console.error('ENS resolution error', err);
-          pushDebug(`ENS resolution error for ${ens.name}: ${err.message}`);
-          alert(`ENS resolution error for ${ens.name}: ${err.message}`);
-        });
-    } else {
-      const target = formatBzzUrl(raw, state.bzzRoutePrefix);
-      if (target) {
-        let hashToCheck = null;
-        if (target.targetUrl.startsWith('bzz://')) {
-          const match = target.targetUrl.match(/^bzz:\/\/([a-fA-F0-9]+)/);
-          if (match) hashToCheck = match[1];
-        } else if (target.baseUrl) {
-          const match = target.baseUrl.match(/\/bzz\/([a-fA-F0-9]+)/);
-          if (match) hashToCheck = match[1];
-        }
-        if (hashToCheck) {
-          state.knownEnsNames.delete(hashToCheck.toLowerCase());
-        }
-      }
-
-      loadTarget(raw);
-      addressInput.blur();
-    }
+    // loadTarget handles all protocol dispatch (ENS, freedom://, bzz://,
+    // ipfs://, https://, rad://) and owns the ENS trust state mutation.
+    // Earlier this handler duplicated the ENS path, which bypassed the
+    // trust updates and left the shield empty for typed-address flows.
+    loadTarget(addressInput.value);
+    addressInput.blur();
   });
 
   // Navigation buttons

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -72,6 +72,8 @@ const loadNavigationModule = async (options = {}) => {
     currentRadicleStatus: options.currentRadicleStatus || 'running',
     knownEnsNames: new Map(),
     ensProtocols: new Map(),
+    ensTrustByName: new Map(),
+    blockUnverifiedEns: options.blockUnverifiedEns !== false,
   };
   const debugMocks = {
     pushDebug: jest.fn(),
@@ -140,6 +142,16 @@ const loadNavigationModule = async (options = {}) => {
       if (value?.startsWith('rad://') && state.enableRadicleIntegration) return 'radicle';
       return value ? 'http' : 'http';
     }),
+    resolveTrustBadge: jest.fn(({ value, ensTrustByName }) => {
+      // Mirror the production helper's shape. Tests that need specific
+      // trust levels populate ensTrustByName; default is null.
+      const m = value?.toLowerCase().match(/^(?:ens:\/\/)?([^/]+\.(?:eth|box))/);
+      if (!m) return null;
+      const name = m[1];
+      const trust = ensTrustByName?.get?.(name);
+      if (!trust?.level) return null;
+      return { level: trust.level, name, trust };
+    }),
   };
   const urlUtilsMocks = {
     formatBzzUrl: jest.fn((input, prefix) => {
@@ -178,6 +190,7 @@ const loadNavigationModule = async (options = {}) => {
     errorUrlBase,
     internalPages: {
       history: historyUrl,
+      settings: 'file:///app/pages/settings.html',
     },
     detectProtocol: jest.fn(() => 'https'),
     isHistoryRecordable: jest.fn((displayUrl, internalUrl) => {
@@ -190,6 +203,12 @@ const loadNavigationModule = async (options = {}) => {
     }),
     getInternalPageName: jest.fn((url) => (url === historyUrl ? 'history' : null)),
     parseEnsInput: jest.fn(() => null),
+    buildInternalPageUrl: jest.fn((file, params = null) => {
+      const base = `file:///app/pages/${file}`;
+      if (!params) return base;
+      const qs = new URLSearchParams(params).toString();
+      return qs ? `${base}?${qs}` : base;
+    }),
   };
   const settingsState = options.initialSettings || { showBookmarkBar: true };
   const electronHandlers = {};
@@ -210,6 +229,7 @@ const loadNavigationModule = async (options = {}) => {
     onToggleBookmarkBar: jest.fn((handler) => {
       electronHandlers.toggleBookmarkBar = handler;
     }),
+    resolveEns: jest.fn(),
   };
 
   const addressInput = createElement('input');
@@ -220,6 +240,16 @@ const loadNavigationModule = async (options = {}) => {
   const homeBtn = createElement('button');
   const bookmarksBar = createElement('div', { classes: ['hidden'] });
   const protocolIcon = createElement('div');
+  const trustShield = createElement('button');
+  const trustPopover = createElement('div');
+  const trustPopoverTitle = createElement('div');
+  const trustPopoverSubtitle = createElement('div');
+  const trustPopoverSummary = createElement('p');
+  const trustPopoverBlock = createElement('div');
+  const trustPopoverAgreed = createElement('div');
+  const trustPopoverAgreedSection = createElement('div');
+  const trustPopoverDissented = createElement('div');
+  const trustPopoverDissentedSection = createElement('div');
   const document = createDocument({
     elementsById: {
       'address-input': addressInput,
@@ -229,6 +259,16 @@ const loadNavigationModule = async (options = {}) => {
       'reload-btn': reloadBtn,
       'home-btn': homeBtn,
       'protocol-icon': protocolIcon,
+      'trust-shield': trustShield,
+      'trust-popover': trustPopover,
+      'trust-popover-title': trustPopoverTitle,
+      'trust-popover-subtitle': trustPopoverSubtitle,
+      'trust-popover-summary': trustPopoverSummary,
+      'trust-popover-block': trustPopoverBlock,
+      'trust-popover-agreed': trustPopoverAgreed,
+      'trust-popover-agreed-section': trustPopoverAgreedSection,
+      'trust-popover-dissented': trustPopoverDissented,
+      'trust-popover-dissented-section': trustPopoverDissentedSection,
     },
   });
 
@@ -306,6 +346,8 @@ const loadNavigationModule = async (options = {}) => {
       homeBtn,
       bookmarksBar,
       protocolIcon,
+      trustShield,
+      trustPopover,
     },
   };
 };
@@ -550,5 +592,206 @@ describe('navigation', () => {
     });
 
     expect(ctx.elements.addressInput.focus).toHaveBeenCalled();
+  });
+
+  describe('ENS trust dispatch', () => {
+    // setupEnsDispatch: bootstrap the navigation module with a realistic
+    // parseEnsInput mock (mirrors the production regex; real helper is
+    // unit-tested in page-urls.test.js), then run initNavigation so
+    // setWebviewEventHandler is registered. All dispatch tests start here.
+    const setupEnsDispatch = async (options = {}) => {
+      const ctx = await loadNavigationModule(options);
+      ctx.pageUrlsMocks.parseEnsInput.mockImplementation((value) => {
+        const m = value.match(/^(?:ens:\/\/)?([^?/]+\.(?:eth|box))(.*)?$/i);
+        return m ? { name: m[1].toLowerCase(), suffix: m[2] || '' } : null;
+      });
+      await ctx.mod.initNavigation();
+      return ctx;
+    };
+
+    // Drive one ENS resolution through loadTarget. Returns the webview's
+    // loadURL call history after the resolver promise settles so tests
+    // can inspect which interstitial (if any) was chosen.
+    const dispatchEns = async (ctx, url, result, options = {}) => {
+      ctx.electronAPI.resolveEns.mockResolvedValue(result);
+      ctx.mod.loadTarget(url, null, null, options);
+      await flushMicrotasks();
+      return ctx.activeRef.tab.webview.loadURL.mock.calls;
+    };
+
+    test('conflict result routes to ens-conflict interstitial', async () => {
+      const ctx = await setupEnsDispatch();
+      const conflictResult = {
+        type: 'conflict',
+        name: 'bad.eth',
+        trust: { level: 'conflict', block: { number: 123, hash: '0xabc' } },
+        groups: [
+          { resolvedData: '0x111', urls: ['a'] },
+          { resolvedData: '0x222', urls: ['b'] },
+        ],
+      };
+
+      const loadCalls = await dispatchEns(ctx, 'ens://bad.eth', conflictResult);
+
+      const interstitialCall = loadCalls.find(([u]) => u.includes('ens-conflict.html'));
+      expect(interstitialCall).toBeDefined();
+      const url = new URL(interstitialCall[0]);
+      expect(url.searchParams.get('name')).toBe('bad.eth');
+      const groups = JSON.parse(url.searchParams.get('groups'));
+      expect(groups).toEqual(conflictResult.groups);
+      expect(ctx.state.ensTrustByName.get('bad.eth')).toEqual(conflictResult.trust);
+    });
+
+    test('unverified result routes to ens-unverified interstitial when setting is on', async () => {
+      const ctx = await setupEnsDispatch({ blockUnverifiedEns: true });
+      const loadCalls = await dispatchEns(ctx, 'ens://lonely.eth', {
+        type: 'ok',
+        name: 'lonely.eth',
+        protocol: 'ipfs',
+        uri: 'ipfs://QmFake',
+        trust: { level: 'unverified', queried: ['a'], agreed: ['a'] },
+      });
+
+      const interstitialCall = loadCalls.find(([u]) => u.includes('ens-unverified.html'));
+      expect(interstitialCall).toBeDefined();
+      const url = new URL(interstitialCall[0]);
+      expect(url.searchParams.get('name')).toBe('lonely.eth');
+      expect(url.searchParams.get('uri')).toContain('ipfs://QmFake');
+    });
+
+    test('unverified proceeds normally when blockUnverifiedEns is off', async () => {
+      const ctx = await setupEnsDispatch({ blockUnverifiedEns: false });
+      const loadCalls = await dispatchEns(ctx, 'ens://ok.eth', {
+        type: 'ok',
+        name: 'ok.eth',
+        protocol: 'ipfs',
+        uri: 'ipfs://QmOk',
+        trust: { level: 'unverified', queried: ['a'], agreed: ['a'] },
+      });
+
+      expect(loadCalls.find(([u]) => u.includes('ens-unverified.html'))).toBeUndefined();
+    });
+
+    test('allowUnverifiedOnce option bypasses the unverified interstitial for one call', async () => {
+      const ctx = await setupEnsDispatch({ blockUnverifiedEns: true });
+      const loadCalls = await dispatchEns(
+        ctx,
+        'ens://once.eth',
+        {
+          type: 'ok',
+          name: 'once.eth',
+          protocol: 'ipfs',
+          uri: 'ipfs://QmOnce',
+          trust: { level: 'unverified', queried: ['a'], agreed: ['a'] },
+        },
+        { allowUnverifiedOnce: true }
+      );
+
+      expect(loadCalls.find(([u]) => u.includes('ens-unverified.html'))).toBeUndefined();
+    });
+
+    test('verified result proceeds normally and stores trust metadata', async () => {
+      const ctx = await setupEnsDispatch();
+      const verifiedTrust = { level: 'verified', queried: ['a', 'b', 'c'], agreed: ['a', 'b'] };
+
+      const loadCalls = await dispatchEns(ctx, 'ens://vitalik.eth', {
+        type: 'ok',
+        name: 'vitalik.eth',
+        protocol: 'ipfs',
+        uri: 'ipfs://QmVitalik',
+        trust: verifiedTrust,
+      });
+
+      expect(ctx.state.ensTrustByName.get('vitalik.eth')).toEqual(verifiedTrust);
+      expect(loadCalls.find(([u]) => u.includes('ens-conflict.html'))).toBeUndefined();
+      expect(loadCalls.find(([u]) => u.includes('ens-unverified.html'))).toBeUndefined();
+    });
+
+    test('ipc-message ens:continue-unverified re-dispatches with allow flag', async () => {
+      const ctx = await setupEnsDispatch({ blockUnverifiedEns: true });
+      const unverifiedResult = {
+        type: 'ok',
+        name: 'retry.eth',
+        protocol: 'ipfs',
+        uri: 'ipfs://QmRetry',
+        trust: { level: 'unverified', queried: ['a'], agreed: ['a'] },
+      };
+      ctx.electronAPI.resolveEns.mockResolvedValue(unverifiedResult);
+
+      // First load: blocked → interstitial.
+      ctx.mod.loadTarget('ens://retry.eth');
+      await flushMicrotasks();
+      expect(
+        ctx.activeRef.tab.webview.loadURL.mock.calls.find(([u]) => u.includes('ens-unverified.html'))
+      ).toBeDefined();
+
+      // Simulate interstitial "Continue once" sendToHost → tabs routes to
+      // the ipc-message webview event. The handler should re-dispatch with
+      // allowUnverifiedOnce=true, which bypasses the block and would call
+      // resolveEns again (we verify the follow-up resolveEns call).
+      ctx.electronAPI.resolveEns.mockClear();
+      ctx.tabsMocks.webviewEventHandler('ipc-message', {
+        tabId: ctx.activeRef.tab.id,
+        channel: 'ens:continue-unverified',
+        args: [{ name: 'retry.eth' }],
+      });
+      await flushMicrotasks();
+
+      expect(ctx.electronAPI.resolveEns).toHaveBeenCalledWith('retry.eth');
+    });
+
+    test('ipc-message ens:open-settings navigates to freedom://settings', async () => {
+      const ctx = await setupEnsDispatch();
+
+      ctx.tabsMocks.webviewEventHandler('ipc-message', {
+        tabId: ctx.activeRef.tab.id,
+        channel: 'ens:open-settings',
+        args: [],
+      });
+      await flushMicrotasks();
+
+      expect(ctx.activeRef.tab.webview.loadURL).toHaveBeenCalledWith(
+        'file:///app/pages/settings.html'
+      );
+    });
+  });
+
+  describe('trust shield', () => {
+    test('shows verified badge with aria-label when stored trust is verified', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      ctx.state.ensTrustByName.set('vitalik.eth', {
+        level: 'verified',
+        queried: ['a', 'b'],
+        agreed: ['a', 'b'],
+      });
+      ctx.elements.addressInput.value = 'ens://vitalik.eth';
+      ctx.elements.addressInput.dispatch('input');
+
+      expect(ctx.elements.trustShield.getAttribute('data-trust')).toBe('verified');
+      expect(ctx.elements.trustShield.getAttribute('aria-label')).toContain('verified');
+      expect(ctx.elements.trustShield.hidden).toBe(false);
+    });
+
+    test('hides for non-ENS URLs', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      ctx.elements.addressInput.value = 'https://example.com';
+      ctx.elements.addressInput.dispatch('input');
+
+      expect(ctx.elements.trustShield.hidden).toBe(true);
+    });
+
+    test('hides when ENS name has no stored trust', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      ctx.elements.addressInput.value = 'ens://unknown.eth';
+      ctx.elements.addressInput.dispatch('input');
+
+      expect(ctx.elements.trustShield.hidden).toBe(true);
+    });
   });
 });

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -73,6 +73,7 @@ const loadNavigationModule = async (options = {}) => {
     knownEnsNames: new Map(),
     ensProtocols: new Map(),
     ensTrustByName: new Map(),
+    ensUriByName: new Map(),
     blockUnverifiedEns: options.blockUnverifiedEns !== false,
   };
   const debugMocks = {

--- a/src/renderer/lib/page-urls.js
+++ b/src/renderer/lib/page-urls.js
@@ -18,6 +18,21 @@ export const internalPages = Object.fromEntries(
   ])
 );
 
+// Build a file:// URL for an internal page with optional query parameters.
+// `params` is a plain object; values are stringified. Used by navigation
+// dispatch (interstitials, error pages, etc.) — centralises the pattern so
+// page-name strings don't proliferate.
+export const buildInternalPageUrl = (pageFile, params = null) => {
+  const url = new URL(`pages/${pageFile}`, window.location.href);
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null) continue;
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+};
+
 // Detect protocol from display URL for history recording
 export const detectProtocol = (url) => {
   if (!url) return 'unknown';

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -54,6 +54,7 @@ export const state = {
   knownEnsNames: new Map(), // Maps hash/CID -> ENS name
   ensProtocols: new Map(), // Maps ENS name -> resolved protocol (swarm/ipfs/ipns)
   ensTrustByName: new Map(), // Maps ENS name -> trust object from last resolution
+  ensUriByName: new Map(), // Maps ENS name -> full resolved content URI (bzz://HASH, ipfs://CID, ipns://NAME)
   addressBarSnapshot: '',
 
   // Webview

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -53,6 +53,7 @@ export const state = {
   currentIpfsBase: null,
   knownEnsNames: new Map(), // Maps hash/CID -> ENS name
   ensProtocols: new Map(), // Maps ENS name -> resolved protocol (swarm/ipfs/ipns)
+  ensTrustByName: new Map(), // Maps ENS name -> trust object from last resolution
   addressBarSnapshot: '',
 
   // Webview
@@ -96,6 +97,7 @@ export const state = {
 
   // Feature flags
   enableRadicleIntegration: false,
+  blockUnverifiedEns: true, // When true, unverified ENS resolutions route through an interstitial
 };
 
 // Build Bee URL using registry or fallback to defaults
@@ -137,6 +139,10 @@ export const updateRegistry = (newRegistry) => {
 
 export const setRadicleIntegrationEnabled = (enabled) => {
   state.enableRadicleIntegration = enabled === true;
+};
+
+export const setBlockUnverifiedEns = (enabled) => {
+  state.blockUnverifiedEns = enabled !== false;
 };
 
 // Get display message for a service (temp message takes priority)

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -379,6 +379,15 @@ const createWebview = (tabId, initialUrl) => {
         onWebviewEvent('certificate-error', { tabId, event });
       }
     },
+    'ipc-message': (event) => {
+      // Messages from internal pages (e.g. ens-unverified interstitial
+      // bubbling a "Continue once" signal). Route through the registered
+      // onWebviewEvent handler so navigation.js can stay the sole owner
+      // of tab-state mutations.
+      if (tabId === tabState.activeTabId && onWebviewEvent) {
+        onWebviewEvent('ipc-message', { tabId, channel: event.channel, args: event.args });
+      }
+    },
   };
 
   // Attach event listeners

--- a/src/renderer/pages/ens-conflict.html
+++ b/src/renderer/pages/ens-conflict.html
@@ -4,46 +4,12 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src data:;"
+      content="default-src 'none'; script-src 'self'; style-src 'self'; img-src data:;"
     />
     <title>RPC servers disagreed</title>
     <link rel="stylesheet" href="styles/interstitial.css" />
-    <style>
-      h1 { color: #ff5e5e; }
-      @media (prefers-color-scheme: light) { h1 { color: #cf222e; } }
-      .groups {
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-        margin-bottom: 24px;
-      }
-      .group {
-        background: #1a1a1a;
-        border: 1px solid #2c2c2c;
-        border-radius: 8px;
-        padding: 12px 16px;
-      }
-      .group-hosts {
-        font-family: monospace;
-        font-size: 12px;
-        color: #8fbcff;
-        margin-bottom: 4px;
-      }
-      .group-value {
-        font-family: monospace;
-        font-size: 13px;
-        color: #ccc;
-        word-break: break-all;
-      }
-      .group-reason { color: #d7a77c; }
-      @media (prefers-color-scheme: light) {
-        .group { background: #f6f8fa; border-color: #d0d7de; }
-        .group-value { color: #57606a; }
-        .group-hosts { color: #0969da; }
-      }
-    </style>
   </head>
-  <body>
+  <body class="conflict">
     <div class="container">
       <h1>
         <svg class="shield" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -74,8 +40,6 @@
         If you trust one of the answers above and want to proceed anyway, configure that server as
         your custom RPC in settings. The browser will trust it as a single source and skip the
         cross-check.
-        <br /><br />
-        <a href="https://docs.freedombrowser.eth" target="_blank">Learn more about RPC verification →</a>
       </p>
     </div>
     <script src="scripts/ens-conflict.js"></script>

--- a/src/renderer/pages/ens-conflict.html
+++ b/src/renderer/pages/ens-conflict.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src data:;"
+    />
+    <title>RPC servers disagreed</title>
+    <link rel="stylesheet" href="styles/interstitial.css" />
+    <style>
+      h1 { color: #ff5e5e; }
+      @media (prefers-color-scheme: light) { h1 { color: #cf222e; } }
+      .groups {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        margin-bottom: 24px;
+      }
+      .group {
+        background: #1a1a1a;
+        border: 1px solid #2c2c2c;
+        border-radius: 8px;
+        padding: 12px 16px;
+      }
+      .group-hosts {
+        font-family: monospace;
+        font-size: 12px;
+        color: #8fbcff;
+        margin-bottom: 4px;
+      }
+      .group-value {
+        font-family: monospace;
+        font-size: 13px;
+        color: #ccc;
+        word-break: break-all;
+      }
+      .group-reason { color: #d7a77c; }
+      @media (prefers-color-scheme: light) {
+        .group { background: #f6f8fa; border-color: #d0d7de; }
+        .group-value { color: #57606a; }
+        .group-hosts { color: #0969da; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>
+        <svg class="shield" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M12 2 L4 6 L4 12 C4 17 7.5 21 12 22 C16.5 21 20 17 20 12 L20 6 Z" />
+          <line x1="7" y1="8" x2="17" y2="16" />
+        </svg>
+        RPC servers disagreed
+      </h1>
+      <p>
+        Two or more public RPC servers returned different answers for this ENS name. One of them
+        may be lying. To protect you from navigating to attacker-chosen content, the browser has
+        blocked this load.
+      </p>
+
+      <div class="name-block">
+        <div class="name" id="name-el"></div>
+        <div class="block" id="block-el"></div>
+      </div>
+
+      <div class="groups" id="groups-el"></div>
+
+      <div class="buttons">
+        <button id="back-btn" class="button-primary">← Go back</button>
+        <button id="settings-btn">Set up your own RPC</button>
+      </div>
+
+      <p class="learn-more">
+        If you trust one of the answers above and want to proceed anyway, configure that server as
+        your custom RPC in settings. The browser will trust it as a single source and skip the
+        cross-check.
+        <br /><br />
+        <a href="https://docs.freedombrowser.eth" target="_blank">Learn more about RPC verification →</a>
+      </p>
+    </div>
+    <script src="scripts/ens-conflict.js"></script>
+  </body>
+</html>

--- a/src/renderer/pages/ens-unverified.html
+++ b/src/renderer/pages/ens-unverified.html
@@ -4,16 +4,12 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src data:;"
+      content="default-src 'none'; script-src 'self'; style-src 'self'; img-src data:;"
     />
     <title>ENS resolution not cross-checked</title>
     <link rel="stylesheet" href="styles/interstitial.css" />
-    <style>
-      h1 { color: #d7a77c; }
-      @media (prefers-color-scheme: light) { h1 { color: #9a6700; } }
-    </style>
   </head>
-  <body>
+  <body class="unverified">
     <div class="container">
       <h1>
         <svg class="shield" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -44,8 +40,6 @@
         You can disable this warning globally in Settings (not recommended on public Wi-Fi).
         Running your own Ethereum node as a custom RPC is the strongest option — your own node
         becomes the single trusted source and this warning stops appearing.
-        <br /><br />
-        <a href="https://docs.freedombrowser.eth" target="_blank">Learn more about RPC verification →</a>
       </p>
     </div>
     <script src="scripts/ens-unverified.js"></script>

--- a/src/renderer/pages/ens-unverified.html
+++ b/src/renderer/pages/ens-unverified.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src data:;"
+    />
+    <title>ENS resolution not cross-checked</title>
+    <link rel="stylesheet" href="styles/interstitial.css" />
+    <style>
+      h1 { color: #d7a77c; }
+      @media (prefers-color-scheme: light) { h1 { color: #9a6700; } }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>
+        <svg class="shield" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M12 2 L4 6 L4 12 C4 17 7.5 21 12 22 C16.5 21 20 17 20 12 L20 6 Z" />
+          <line x1="12" y1="8" x2="12" y2="13" />
+          <circle cx="12" cy="17" r="0.5" fill="currentColor" />
+        </svg>
+        Resolution not cross-checked
+      </h1>
+      <p>
+        Only one RPC server answered this ENS resolution, so the browser couldn't cross-check the
+        answer against independent sources. The destination may be correct, but a single malicious
+        server could have chosen it — we can't tell.
+      </p>
+
+      <div class="name-block">
+        <div class="name" id="name-el"></div>
+        <div class="uri" id="uri-el"></div>
+      </div>
+
+      <div class="buttons">
+        <button id="continue-btn" class="button-primary">Continue once</button>
+        <button id="back-btn">← Go back</button>
+        <button id="settings-btn">Set up your own RPC</button>
+      </div>
+
+      <p class="learn-more">
+        You can disable this warning globally in Settings (not recommended on public Wi-Fi).
+        Running your own Ethereum node as a custom RPC is the strongest option — your own node
+        becomes the single trusted source and this warning stops appearing.
+        <br /><br />
+        <a href="https://docs.freedombrowser.eth" target="_blank">Learn more about RPC verification →</a>
+      </p>
+    </div>
+    <script src="scripts/ens-unverified.js"></script>
+  </body>
+</html>

--- a/src/renderer/pages/scripts/ens-conflict.js
+++ b/src/renderer/pages/scripts/ens-conflict.js
@@ -1,0 +1,70 @@
+const params = new URLSearchParams(window.location.search);
+const name = params.get('name') || '';
+const blockJson = params.get('block');
+const groupsJson = params.get('groups');
+
+document.getElementById('name-el').textContent = name;
+
+let block = null;
+try {
+  block = blockJson ? JSON.parse(blockJson) : null;
+} catch (err) {
+  console.warn('[ens-conflict] failed to parse block payload', err);
+}
+if (block && block.number) {
+  const short = block.hash ? block.hash.slice(0, 10) + '…' + block.hash.slice(-4) : '';
+  document.getElementById('block-el').textContent =
+    `at block #${block.number}${short ? '  ' + short : ''}`;
+}
+
+let groups = [];
+try {
+  groups = groupsJson ? JSON.parse(groupsJson) : [];
+} catch (err) {
+  console.warn('[ens-conflict] failed to parse groups payload', err);
+}
+
+// Show raw content-hash bytes (truncated) for display only. The renderer
+// shell owns the canonical decoding path; a second decoder here would
+// drift out of sync and the strict CSP blocks the base58 library anyway.
+function preview(hex) {
+  if (!hex || hex === '0x') return '(empty)';
+  const h = String(hex).toLowerCase();
+  // Swarm manifest is the one codec we can render verbatim — the tail IS
+  // the canonical bzz:// hash and fits on a line.
+  const swarm = h.match(/^0xe40101fa011b20([0-9a-f]{64})$/);
+  if (swarm) return 'bzz://' + swarm[1];
+  if (h.length > 28) return h.slice(0, 16) + '…' + h.slice(-10);
+  return h;
+}
+
+const groupsEl = document.getElementById('groups-el');
+for (const g of groups) {
+  const valueText = g.reason
+    ? `(${g.reason}) — no content hash returned`
+    : preview(g.resolvedData);
+
+  const groupDiv = document.createElement('div');
+  groupDiv.className = 'group';
+  const hostsDiv = document.createElement('div');
+  hostsDiv.className = 'group-hosts';
+  hostsDiv.textContent = (g.urls || []).join(', ');
+  const valueDiv = document.createElement('div');
+  valueDiv.className = 'group-value' + (g.reason ? ' group-reason' : '');
+  valueDiv.textContent = valueText;
+  groupDiv.appendChild(hostsDiv);
+  groupDiv.appendChild(valueDiv);
+  groupsEl.appendChild(groupDiv);
+}
+
+document.getElementById('back-btn').onclick = () => {
+  if (window.history.length > 1) {
+    window.history.back();
+  } else {
+    window.location.href = 'home.html';
+  }
+};
+
+document.getElementById('settings-btn').onclick = () => {
+  window.freedomAPI?.ensOpenSettings?.();
+};

--- a/src/renderer/pages/scripts/ens-unverified.js
+++ b/src/renderer/pages/scripts/ens-unverified.js
@@ -1,0 +1,27 @@
+const params = new URLSearchParams(window.location.search);
+const name = params.get('name') || '';
+const uri = params.get('uri') || '';
+
+document.getElementById('name-el').textContent = name;
+document.getElementById('uri-el').textContent = uri;
+
+const continueBtn = document.getElementById('continue-btn');
+continueBtn.onclick = () => {
+  // Guard against double-click: second activation is a no-op visually and
+  // avoids firing a duplicate sendToHost that would trigger two loadTarget
+  // calls on the shell side.
+  continueBtn.disabled = true;
+  window.freedomAPI?.ensContinueUnverified?.(name);
+};
+
+document.getElementById('back-btn').onclick = () => {
+  if (window.history.length > 1) {
+    window.history.back();
+  } else {
+    window.location.href = 'home.html';
+  }
+};
+
+document.getElementById('settings-btn').onclick = () => {
+  window.freedomAPI?.ensOpenSettings?.();
+};

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -543,6 +543,119 @@
               <p id="ens-rpc-status" class="rpc-status"></p>
             </div>
           </div>
+
+          <!-- Cross-RPC verification — only active when no custom RPC is set -->
+          <h2 class="section-title" style="margin-top: 32px">Cross-RPC verification</h2>
+          <p class="row-help" style="margin-bottom: 16px">
+            When using public RPCs, Freedom asks multiple servers and only trusts answers where
+            several agree. A single malicious RPC cannot silently redirect an ENS name.
+          </p>
+          <div class="card">
+            <div class="row">
+              <div class="row-body">
+                <p class="row-label">Block unverified ENS navigation</p>
+                <p class="row-help">
+                  Show a warning page when only one RPC answers (no cross-check possible). Turn
+                  off to navigate directly with only the amber shield indicator.
+                </p>
+              </div>
+              <div class="row-control">
+                <label class="toggle">
+                  <input type="checkbox" id="block-unverified-ens" />
+                  <span class="slider"></span>
+                </label>
+              </div>
+            </div>
+            <div class="row">
+              <div class="row-body">
+                <p class="row-label">Cross-check across multiple public RPCs</p>
+                <p class="row-help">
+                  Disable only if you want single-source behavior without setting a custom RPC.
+                </p>
+              </div>
+              <div class="row-control">
+                <label class="toggle">
+                  <input type="checkbox" id="enable-ens-quorum" />
+                  <span class="slider"></span>
+                </label>
+              </div>
+            </div>
+
+            <details class="rpc-block" id="ens-quorum-advanced" style="border-top: 1px solid var(--border)">
+              <summary style="cursor: pointer; color: var(--text-muted); font-size: 13px">
+                Advanced quorum parameters
+              </summary>
+              <div class="row sub">
+                <div class="row-body">
+                  <p class="row-label">Providers per wave (K)</p>
+                  <p class="row-help">Number of RPCs queried in parallel per lookup. Minimum 3 for verified outcomes.</p>
+                </div>
+                <div class="row-control">
+                  <input type="number" id="ens-quorum-k" class="rpc-input" style="max-width: 80px" min="1" max="9" />
+                </div>
+              </div>
+              <div class="row sub">
+                <div class="row-body">
+                  <p class="row-label">Agreement threshold (M)</p>
+                  <p class="row-help">How many providers must return byte-identical answers. Must be ≤ K.</p>
+                </div>
+                <div class="row-control">
+                  <input type="number" id="ens-quorum-m" class="rpc-input" style="max-width: 80px" min="1" max="9" />
+                </div>
+              </div>
+              <div class="row sub">
+                <div class="row-body">
+                  <p class="row-label">Per-call timeout (ms)</p>
+                  <p class="row-help">Slow providers are skipped after this time.</p>
+                </div>
+                <div class="row-control">
+                  <input type="number" id="ens-quorum-timeout" class="rpc-input" style="max-width: 100px" min="500" max="30000" step="500" />
+                </div>
+              </div>
+              <div class="row sub">
+                <div class="row-body">
+                  <p class="row-label">Block anchor</p>
+                  <p class="row-help">
+                    All providers query at this block. <code>latest</code> is ~1.5 min behind head;
+                    <code>finalized</code> is ~12 min behind but strongest.
+                  </p>
+                </div>
+                <div class="row-control">
+                  <select id="ens-block-anchor" class="rpc-input" style="max-width: 140px">
+                    <option value="latest">latest</option>
+                    <option value="latest-32">latest-32</option>
+                    <option value="finalized">finalized</option>
+                  </select>
+                </div>
+              </div>
+              <div class="row sub">
+                <div class="row-body">
+                  <p class="row-label">Anchor cache TTL (ms)</p>
+                  <p class="row-help">How long one pinned block is reused across resolutions.</p>
+                </div>
+                <div class="row-control">
+                  <input type="number" id="ens-anchor-ttl" class="rpc-input" style="max-width: 100px" min="1000" max="600000" step="1000" />
+                </div>
+              </div>
+            </details>
+          </div>
+
+          <!-- Public RPC providers list editor -->
+          <h2 class="section-title" style="margin-top: 32px">Public RPC providers</h2>
+          <p class="row-help" style="margin-bottom: 16px">
+            Edit the list of Ethereum RPCs Freedom uses for cross-checking. Fewer than 3 entries
+            means every resolution will be marked unverified.
+          </p>
+          <div class="card">
+            <div id="ens-provider-list" class="rpc-block" style="border-top: none"></div>
+            <div class="rpc-block" style="border-top: 1px solid var(--border)">
+              <button type="button" id="ens-provider-add" class="btn">+ Add provider</button>
+              <button type="button" id="ens-provider-reset" class="btn" style="margin-left: 8px">
+                Reset to defaults
+              </button>
+              <p id="ens-provider-status" class="rpc-status"></p>
+            </div>
+          </div>
         </section>
 
         <!-- Experimental -->
@@ -627,12 +740,38 @@
         ensRpcUrl: $('ens-rpc-url'),
         ensRpcTest: $('ens-rpc-test'),
         ensRpcStatus: $('ens-rpc-status'),
+        blockUnverifiedEns: $('block-unverified-ens'),
+        enableEnsQuorum: $('enable-ens-quorum'),
+        ensQuorumK: $('ens-quorum-k'),
+        ensQuorumM: $('ens-quorum-m'),
+        ensQuorumTimeout: $('ens-quorum-timeout'),
+        ensBlockAnchor: $('ens-block-anchor'),
+        ensAnchorTtl: $('ens-anchor-ttl'),
+        ensProviderList: $('ens-provider-list'),
+        ensProviderAdd: $('ens-provider-add'),
+        ensProviderReset: $('ens-provider-reset'),
+        ensProviderStatus: $('ens-provider-status'),
         enableRadicle: $('enable-radicle-integration'),
         startRadicleRow: $('start-radicle-row'),
         startRadicle: $('start-radicle-at-launch'),
         enableIdentity: $('enable-identity-wallet'),
         autoUpdate: $('auto-update'),
       };
+
+      // Mirrors DEFAULT_ENS_PUBLIC_RPC_PROVIDERS in settings-store.js — kept
+      // in the page so "Reset to defaults" doesn't need a backend round-trip.
+      // Update both places when adding/removing a default RPC.
+      const ENS_DEFAULT_PROVIDERS = [
+        'https://ethereum.publicnode.com',
+        'https://1rpc.io/eth',
+        'https://eth.drpc.org',
+        'https://eth-mainnet.public.blastapi.io',
+        'https://eth.merkle.io',
+        'https://cloudflare-eth.com',
+        'https://rpc.ankr.com/eth',
+        'https://rpc.flashbots.net',
+        'https://eth.llamarpc.com',
+      ];
 
       const swarmModeHelp = $('swarm-mode-help');
       const swarmModeBtn = $('swarm-mode-action-btn');
@@ -703,6 +842,47 @@
         fields.ensRpcStatus.className = 'rpc-status' + (type ? ' ' + type : '');
       };
 
+      const setProviderStatus = (text, type) => {
+        fields.ensProviderStatus.textContent = text;
+        fields.ensProviderStatus.className = 'rpc-status' + (type ? ' ' + type : '');
+      };
+
+      // Shared Test-button runner for the custom-RPC field and per-provider
+      // rows. Returns immediately if `url` is blank.
+      const runRpcTest = async (url, btn, setStatus, prefix = '') => {
+        const u = (url || '').trim();
+        if (!u) {
+          setStatus('Enter a URL to test', 'error');
+          return;
+        }
+        setStatus((prefix ? prefix + ' — ' : '') + 'testing…', 'testing');
+        btn.disabled = true;
+        try {
+          const r = await freedomAPI.testEnsRpc(u);
+          if (r?.success) {
+            setStatus((prefix ? prefix + ' — ' : '') + 'connected (block #' + r.blockNumber + ')', 'success');
+          } else {
+            setStatus((prefix ? prefix + ' — ' : '') + (r?.error?.message || 'connection failed'), 'error');
+          }
+        } catch (err) {
+          setStatus((prefix ? prefix + ' — ' : '') + (err?.message || 'test failed'), 'error');
+        } finally {
+          btn.disabled = false;
+        }
+      };
+
+      const clampNumberInput = (input, min, max) => {
+        const n = Number(input.value);
+        if (!Number.isFinite(n)) return;
+        if (n < min) input.value = String(min);
+        else if (n > max) input.value = String(max);
+      };
+
+      const collectProviderUrls = () =>
+        [...fields.ensProviderList.querySelectorAll('.provider-input')]
+          .map((input) => (input.value || '').trim())
+          .filter((url) => url.length > 0);
+
       const currentFormState = () => ({
         theme: fields.themeMode.value || 'system',
         startBeeAtLaunch: fields.startBee.checked,
@@ -713,6 +893,14 @@
         autoUpdate: fields.autoUpdate.checked,
         enableEnsCustomRpc: fields.enableEnsCustomRpc.checked,
         ensRpcUrl: (fields.ensRpcUrl.value || '').trim(),
+        blockUnverifiedEns: fields.blockUnverifiedEns.checked,
+        enableEnsQuorum: fields.enableEnsQuorum.checked,
+        ensQuorumK: Number(fields.ensQuorumK.value) || 3,
+        ensQuorumM: Number(fields.ensQuorumM.value) || 2,
+        ensQuorumTimeoutMs: Number(fields.ensQuorumTimeout.value) || 5000,
+        ensBlockAnchor: fields.ensBlockAnchor.value || 'latest',
+        ensBlockAnchorTtlMs: Number(fields.ensAnchorTtl.value) || 30000,
+        ensPublicRpcProviders: collectProviderUrls(),
       });
 
       const applyFormState = (settings) => {
@@ -726,9 +914,86 @@
         fields.autoUpdate.checked = settings.autoUpdate !== false;
         fields.enableEnsCustomRpc.checked = settings.enableEnsCustomRpc === true;
         fields.ensRpcUrl.value = settings.ensRpcUrl || '';
+        fields.blockUnverifiedEns.checked = settings.blockUnverifiedEns !== false;
+        fields.enableEnsQuorum.checked = settings.enableEnsQuorum !== false;
+        fields.ensQuorumK.value = settings.ensQuorumK ?? 3;
+        fields.ensQuorumM.value = settings.ensQuorumM ?? 2;
+        fields.ensQuorumTimeout.value = settings.ensQuorumTimeoutMs ?? 5000;
+        fields.ensBlockAnchor.value = settings.ensBlockAnchor || 'latest';
+        fields.ensAnchorTtl.value = settings.ensBlockAnchorTtlMs ?? 30000;
+        renderProviderList(
+          Array.isArray(settings.ensPublicRpcProviders) && settings.ensPublicRpcProviders.length > 0
+            ? settings.ensPublicRpcProviders
+            : ENS_DEFAULT_PROVIDERS
+        );
         setEnsRpcBlockVisible(fields.enableEnsCustomRpc.checked);
         setFieldEnabled(fields.enableRadicle, fields.startRadicleRow, fields.startRadicle);
         setEnsRpcStatus('', '');
+        setProviderStatus('', '');
+      };
+
+      // Render the provider list. Each row owns its own Test + Remove handlers
+      // via a closure over its row element; no delegated event wiring.
+      const renderProviderList = (urls) => {
+        fields.ensProviderList.textContent = '';
+        for (const url of urls) appendProviderRow(url);
+        updateProviderListEmptyHint();
+      };
+
+      const updateProviderListEmptyHint = () => {
+        const count = fields.ensProviderList.querySelectorAll('.provider-input').length;
+        if (count === 0) {
+          fields.ensProviderList.innerHTML =
+            '<p class="rpc-hint" style="margin: 8px 0">' +
+            'No providers configured — falling back to the built-in default list. ' +
+            'Click <strong>Reset to defaults</strong> to restore the list.' +
+            '</p>';
+        }
+      };
+
+      const appendProviderRow = (url = '') => {
+        // First append wipes the empty-state hint that `renderProviderList`
+        // may have left behind, so we don't end up with hint + rows.
+        if (fields.ensProviderList.querySelector('.rpc-hint') &&
+            !fields.ensProviderList.querySelector('.provider-input')) {
+          fields.ensProviderList.textContent = '';
+        }
+
+        const row = document.createElement('div');
+        row.className = 'rpc-row';
+        row.style.marginBottom = '8px';
+
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'rpc-input provider-input';
+        input.placeholder = 'https://...';
+        input.spellcheck = false;
+        input.value = url;
+        input.setAttribute('aria-label', 'Public RPC provider URL');
+        input.addEventListener('blur', save);
+
+        const testBtn = document.createElement('button');
+        testBtn.type = 'button';
+        testBtn.className = 'btn';
+        testBtn.textContent = 'Test';
+        testBtn.addEventListener('click', () => {
+          runRpcTest(input.value, testBtn, setProviderStatus, input.value.trim());
+        });
+
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'btn';
+        removeBtn.textContent = '✕';
+        removeBtn.title = 'Remove provider';
+        removeBtn.setAttribute('aria-label', 'Remove provider');
+        removeBtn.addEventListener('click', () => {
+          row.remove();
+          updateProviderListEmptyHint();
+          save();
+        });
+
+        row.append(input, testBtn, removeBtn);
+        fields.ensProviderList.appendChild(row);
       };
 
       let cachedSettings = null;
@@ -845,32 +1110,57 @@
       fields.ensRpcUrl.addEventListener('input', () => setEnsRpcStatus('', ''));
       fields.ensRpcUrl.addEventListener('blur', save);
 
-      fields.ensRpcTest.addEventListener('click', async () => {
-        const url = (fields.ensRpcUrl.value || '').trim();
-        if (!url) {
-          setEnsRpcStatus('Enter a URL to test', 'error');
-          return;
-        }
-        setEnsRpcStatus('Testing...', 'testing');
-        fields.ensRpcTest.disabled = true;
-        try {
-          const result = await freedomAPI.testEnsRpc(url);
-          if (result?.success) {
-            setEnsRpcStatus('Connected (block #' + result.blockNumber + ')', 'success');
-          } else {
-            setEnsRpcStatus(result?.error?.message || 'Connection failed', 'error');
-          }
-        } catch (err) {
-          setEnsRpcStatus(err?.message || 'Test failed', 'error');
-        } finally {
-          fields.ensRpcTest.disabled = false;
-        }
+      fields.blockUnverifiedEns.addEventListener('change', save);
+      fields.enableEnsQuorum.addEventListener('change', save);
+
+      // Clamp number inputs to their declared min/max before saving so the
+      // UI reflects the same value the backend will store (backend also
+      // clamps, so the UI would otherwise drift until the next settings:
+      // updated broadcast).
+      fields.ensQuorumK.addEventListener('change', () => {
+        clampNumberInput(fields.ensQuorumK, 1, 9);
+        save();
+      });
+      fields.ensQuorumM.addEventListener('change', () => {
+        clampNumberInput(fields.ensQuorumM, 1, 9);
+        save();
+      });
+      fields.ensQuorumTimeout.addEventListener('change', () => {
+        clampNumberInput(fields.ensQuorumTimeout, 500, 30000);
+        save();
+      });
+      fields.ensBlockAnchor.addEventListener('change', save);
+      fields.ensAnchorTtl.addEventListener('change', () => {
+        clampNumberInput(fields.ensAnchorTtl, 1000, 600000);
+        save();
+      });
+
+      fields.ensProviderAdd.addEventListener('click', () => {
+        appendProviderRow();
+        setProviderStatus('', '');
+        // Focus the new input so the user can type immediately.
+        const rows = fields.ensProviderList.querySelectorAll('.provider-input');
+        rows[rows.length - 1]?.focus();
+      });
+
+      fields.ensProviderReset.addEventListener('click', () => {
+        renderProviderList(ENS_DEFAULT_PROVIDERS);
+        save();
+        setProviderStatus('Reset to default provider list', 'success');
+      });
+
+      fields.ensRpcTest.addEventListener('click', () => {
+        runRpcTest(fields.ensRpcUrl.value, fields.ensRpcTest, setEnsRpcStatus);
       });
 
       const formStateMatches = (settings) => {
         const form = currentFormState();
         for (const key of Object.keys(form)) {
-          if (form[key] !== settings[key]) return false;
+          if (Array.isArray(form[key])) {
+            if (JSON.stringify(form[key]) !== JSON.stringify(settings[key])) return false;
+          } else if (form[key] !== settings[key]) {
+            return false;
+          }
         }
         return true;
       };

--- a/src/renderer/pages/styles/interstitial.css
+++ b/src/renderer/pages/styles/interstitial.css
@@ -1,0 +1,147 @@
+/* Shared base styles for ENS interstitial pages (conflict, unverified). */
+html,
+body {
+  height: 100%;
+  margin: 0;
+}
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(ellipse at top left, #1f1f1f 0%, #141414 60%);
+  color: #f5f5f5;
+  padding: 48px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: left;
+  box-sizing: border-box;
+}
+.container {
+  max-width: 640px;
+  width: 100%;
+}
+h1 {
+  font-size: 24px;
+  margin: 0 0 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.shield {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+}
+p {
+  line-height: 1.6;
+  margin: 0 0 16px;
+  color: #ccc;
+}
+.name-block {
+  background: #1a1a1a;
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  font-family: monospace;
+  font-size: 14px;
+  word-break: break-all;
+}
+.name-block .name {
+  color: #f5f5f5;
+  font-size: 16px;
+}
+.name-block .block,
+.name-block .uri {
+  font-size: 12px;
+  margin-top: 4px;
+}
+.name-block .block {
+  color: #888;
+}
+.name-block .uri {
+  color: #8fbcff;
+}
+.buttons {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+button,
+.button-link {
+  padding: 10px 20px;
+  background: #2c2c2c;
+  color: white;
+  border: 1px solid #444;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  text-decoration: none;
+  display: inline-block;
+  font-family: inherit;
+}
+button:hover,
+.button-link:hover {
+  background: #3a3a3a;
+}
+button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.button-primary {
+  background: #3a6fff;
+  border-color: #3a6fff;
+}
+.button-primary:hover {
+  background: #558bff;
+}
+.learn-more {
+  margin-top: 24px;
+  font-size: 13px;
+  color: #666;
+}
+.learn-more a {
+  color: #8fbcff;
+}
+
+/* Light theme */
+@media (prefers-color-scheme: light) {
+  body {
+    background: radial-gradient(ellipse at top left, #f6f8fa 0%, #ffffff 60%);
+    color: #24292f;
+  }
+  p {
+    color: #57606a;
+  }
+  .name-block {
+    background: #f6f8fa;
+    border: 1px solid #d0d7de;
+  }
+  .name-block .name {
+    color: #24292f;
+  }
+  .name-block .block {
+    color: #57606a;
+  }
+  .name-block .uri,
+  .learn-more a {
+    color: #0969da;
+  }
+  button,
+  .button-link {
+    background: #f6f8fa;
+    border-color: #d0d7de;
+    color: #24292f;
+  }
+  button:hover,
+  .button-link:hover {
+    background: #e8eaed;
+  }
+  .button-primary {
+    background: #0969da;
+    color: white;
+    border-color: #0969da;
+  }
+  .button-primary:hover {
+    background: #0860c7;
+  }
+}

--- a/src/renderer/pages/styles/interstitial.css
+++ b/src/renderer/pages/styles/interstitial.css
@@ -26,6 +26,35 @@ h1 {
   align-items: center;
   gap: 12px;
 }
+body.conflict h1 { color: #ff5e5e; }
+body.unverified h1 { color: #d7a77c; }
+.groups {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+.group {
+  background: #1a1a1a;
+  border: 1px solid #2c2c2c;
+  border-radius: 8px;
+  padding: 12px 16px;
+}
+.group-hosts {
+  font-family: monospace;
+  font-size: 12px;
+  color: #8fbcff;
+  margin-bottom: 4px;
+}
+.group-value {
+  font-family: monospace;
+  font-size: 13px;
+  color: #ccc;
+  word-break: break-all;
+}
+.group-reason {
+  color: #d7a77c;
+}
 .shield {
   width: 28px;
   height: 28px;
@@ -109,6 +138,8 @@ button[disabled] {
     background: radial-gradient(ellipse at top left, #f6f8fa 0%, #ffffff 60%);
     color: #24292f;
   }
+  body.conflict h1 { color: #cf222e; }
+  body.unverified h1 { color: #9a6700; }
   p {
     color: #57606a;
   }
@@ -124,6 +155,16 @@ button[disabled] {
   }
   .name-block .uri,
   .learn-more a {
+    color: #0969da;
+  }
+  .group {
+    background: #f6f8fa;
+    border-color: #d0d7de;
+  }
+  .group-value {
+    color: #57606a;
+  }
+  .group-hosts {
     color: #0969da;
   }
   button,

--- a/src/renderer/styles/toolbar.css
+++ b/src/renderer/styles/toolbar.css
@@ -98,6 +98,167 @@
   flex: 1;
 }
 
+/* Trust shield for ENS resolutions (sits to the LEFT of the protocol icon
+   when both are visible). Click opens the trust details popover. */
+.trust-shield {
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: transparent;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 2;
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
+}
+
+.trust-shield[hidden] {
+  display: none !important;
+}
+
+.trust-shield:not([hidden]) {
+  display: flex;
+}
+
+.trust-shield:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.trust-shield svg {
+  width: 16px;
+  height: 16px;
+  display: none;
+}
+
+.trust-shield[data-trust='verified'] .icon-verified,
+.trust-shield[data-trust='user-configured'] .icon-user-configured,
+.trust-shield[data-trust='unverified'] .icon-unverified,
+.trust-shield[data-trust='conflict'] .icon-conflict {
+  display: block;
+}
+
+.trust-shield[data-trust='verified'] .icon-verified {
+  color: #2ea043;
+}
+.trust-shield[data-trust='user-configured'] .icon-user-configured {
+  color: #2ea043;
+}
+.trust-shield[data-trust='unverified'] .icon-unverified {
+  color: #d29922;
+}
+.trust-shield[data-trust='conflict'] .icon-conflict {
+  color: #cf222e;
+}
+
+/* Trust details popover, anchored below the address bar when the shield
+   is clicked. Populated by navigation.js from state.ensTrustByName. */
+.trust-popover {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 6px;
+  min-width: 280px;
+  max-width: min(400px, calc(100vw - 24px));
+  background: var(--menu-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  z-index: 10000;
+  padding: 14px 16px;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.trust-popover[hidden] {
+  display: none !important;
+}
+
+.trust-popover-header {
+  margin-bottom: 10px;
+}
+
+.trust-popover-title {
+  font-weight: 600;
+  word-break: break-all;
+}
+
+.trust-popover-subtitle {
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 2px;
+  word-break: break-all;
+}
+
+.trust-popover-summary {
+  margin: 0 0 12px;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.trust-popover[data-trust='verified'] .trust-popover-summary,
+.trust-popover[data-trust='user-configured'] .trust-popover-summary {
+  color: #4ac267;
+}
+.trust-popover[data-trust='unverified'] .trust-popover-summary {
+  color: #d29922;
+}
+.trust-popover[data-trust='conflict'] .trust-popover-summary {
+  color: #ff5e5e;
+}
+
+.trust-popover-section {
+  margin-top: 8px;
+}
+
+.trust-popover-section-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin-bottom: 3px;
+}
+
+.trust-popover-section-value {
+  font-family: monospace;
+  font-size: 12px;
+  color: var(--text);
+  word-break: break-all;
+}
+
+.trust-popover-learn {
+  display: inline-block;
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.trust-popover-learn:hover {
+  text-decoration: underline;
+}
+
+/* Shift the protocol icon right to make room for the shield when both show. */
+.address-wrapper:has(.trust-shield:not([hidden])) .protocol-icon {
+  left: 36px;
+}
+
+/* Address input padding accounts for whichever of the two icons is visible. */
+.address-wrapper:has(.trust-shield:not([hidden])) .address-input {
+  padding-left: 36px;
+}
+.address-wrapper:has(.trust-shield:not([hidden])):has(.protocol-icon.visible) .address-input {
+  padding-left: 62px;
+}
+
 /* Protocol icon in address bar */
 .protocol-icon {
   position: absolute;
@@ -112,7 +273,8 @@
   z-index: 2;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 0.2s ease;
+  transition: opacity 0.2s ease,
+    left 0.2s ease;
 }
 
 .protocol-icon svg {

--- a/src/shared/internal-pages.json
+++ b/src/shared/internal-pages.json
@@ -7,5 +7,5 @@
     "publish": "publish.html",
     "settings": "settings.html"
   },
-  "other": ["error.html", "rad-browser.html"]
+  "other": ["error.html", "rad-browser.html", "ens-conflict.html", "ens-unverified.html"]
 }

--- a/src/shared/ipc-channels.js
+++ b/src/shared/ipc-channels.js
@@ -39,6 +39,10 @@ module.exports = {
   ENS_RESOLVE_REVERSE: 'ens:resolve-reverse',
   ENS_TEST_RPC: 'ens:test-rpc',
 
+  // ENS interstitial → shell (webview sendToHost channels)
+  ENS_CONTINUE_UNVERIFIED: 'ens:continue-unverified',
+  ENS_OPEN_SETTINGS: 'ens:open-settings',
+
   // Settings
   SETTINGS_GET: 'settings:get',
   SETTINGS_SAVE: 'settings:save',

--- a/src/shared/ipc-channels.js
+++ b/src/shared/ipc-channels.js
@@ -39,10 +39,6 @@ module.exports = {
   ENS_RESOLVE_REVERSE: 'ens:resolve-reverse',
   ENS_TEST_RPC: 'ens:test-rpc',
 
-  // ENS interstitial → shell (webview sendToHost channels)
-  ENS_CONTINUE_UNVERIFIED: 'ens:continue-unverified',
-  ENS_OPEN_SETTINGS: 'ens:open-settings',
-
   // Settings
   SETTINGS_GET: 'settings:get',
   SETTINGS_SAVE: 'settings:save',


### PR DESCRIPTION
# PR: Cross-Provider ENS Resolution with Trust UI

## What this PR does

Replaces single-trusted-RPC ENS resolution with a hedged K-of-M quorum across the default public RPC pool, surfaces the resulting trust state in the address bar (shield + popover, conflict and unverified interstitials), adds a full settings section for the quorum parameters and provider list, and wires speculative gateway prefetch into the wave so the local Bee/Kubo cache warms while consensus is still resolving.

Eleven commits on `release/0.7.0-{ens-multi-resolution}`. Net: 1055 tests, lint clean.

## Why

Before this PR the resolver walked the public RPC list and trusted the first responder. A single compromised or malicious public RPC in that list could silently redirect any `ens://` navigation to a `bzz://<attacker-hash>` or `ipfs://<attacker-cid>` target — the browser would render the phishing content with no warning, because nothing else ever asked a second RPC to cross-check.

The goal of this work: make it structurally impossible for a single lying RPC to produce a navigable result that claims to be verified. Users on the default pool get cross-provider corroboration with the outcome surfaced to the UI; users who run their own node keep their existing single-source trust model (relabelled `user-configured`, not `verified`).

## What's in scope

- **Resolver core** (`src/main/ens-resolver.js`)
  - `consensusResolve(name, callData, kind)` primitive with hedged K-of-M quorum + early termination
  - Two-step anchor corroboration (`getPinnedBlock`): full-pool head probe → median head → plurality + strict-majority hash agreement
  - Negative-outcome bucketing by exact reason (`NO_RESOLVER` vs `NO_CONTENTHASH`) — mixed reasons produce `conflict`, not fake verified-not-found
  - `mUsed` threading so degraded / second-wave trust metadata never reports impossible quorum ratios
  - Per-provider quarantine with exponential backoff, session-shuffled pool, wave re-selection after anchor quarantines flaky providers
  - Outcome-specific cache TTLs (verified/user-configured 15m, unverified 60s, conflict 10s); in-flight dedup keyed by `kind:name`
  - Custom-RPC fast path preserved and relabelled `user-configured`, falls through to public quorum on failure
- **Trust UI** (renderer)
  - Address-bar shield with four states (`verified` / `user-configured` / `unverified` / `conflict`), hidden for non-ENS URLs; aria-labelled per state
  - Shield popover showing name, resolved URI, pinned block, and agreed/dissented provider hostnames
  - `freedom://` conflict interstitial (hard block) and unverified interstitial (soft block with "Continue once")
  - Both interstitials run under strict CSP (no `unsafe-inline`), external scripts only
  - Both are signalled back to the shell via `ipcRenderer.sendToHost` + a new `ipc-message` webview route
- **Settings UI** (`src/renderer/pages/settings.html`)
  - New "Cross-RPC verification" card under Ethereum RPC
  - All new settings are user-editable: `enableEnsQuorum`, `ensQuorumK`, `ensQuorumM`, `ensQuorumTimeoutMs`, `ensBlockAnchor`, `ensBlockAnchorTtlMs`, `ensPublicRpcProviders`, `blockUnverifiedEns`
  - Provider list editor with per-row RPC test button, empty-list hint, and aria-labels
- **Speculative gateway prefetch** (`src/main/ens-prefetch.js`)
  - Kicks off a `net.request` against the local Bee/Kubo gateway as soon as the first wave responder lands
  - Aborts on any non-`agreed_data` outcome; never affects resolution state (three-layer defense-in-depth try/catch)
  - `bzz://` and `ipfs://` only; `ipns://` deliberately skipped to avoid pre-consensus leakage
  - `ENS_DISABLE_PREFETCH=1` strict env kill switch (not truthy-match)
  - All logged URLs run through `sanitizeUrlForLog` — the file-persisted `electron-log` transport no longer records CIDs or Swarm hashes

## What's out of scope (deferred)

- **`addr()` quorum rollout.** The `consensusResolve` primitive already accepts a `kind` parameter and handles `addr` correctly; the wallet send-to flow still calls the legacy path. Extending that call site + UI affordance is a follow-up.
- **Reverse resolution (address → name).** Still single-provider; the UR contract's forward-verification keeps successful results self-consistent, but the call is not cross-checked.
- **zk-verified provider adapter.** When state-proof RPCs are available, the result shape has a slot for a `zk-verified` trust level.
- **Persistent quarantine across restarts.** Currently in-memory only.
- **Operator-diversity indicator.** We count URLs, not upstream operators (some defaults proxy to the same backend).

## Threat model summary

In scope: a single malicious public RPC serving bogus `contenthash` data; a single malicious RPC serving a stale or fake block anchor to steer honest providers toward attacker-chosen state; transient provider flakiness; settings-level misconfiguration.

Out of scope: attacker-majority collusion (any K-of-M loses once more than half the pool lies); operator diversity (distinct URLs ≠ distinct operators); active mainnet chain forks (genuine hash disagreement throws rather than picking a side).

"Verified" specifically means ≥M public RPCs returned byte-identical Universal Resolver `resolvedData` payloads at a shared corroborated block hash. It does not mean "proven correct" — only "cross-checked against independent sources."

## User-visible changes

- New shield icon in the address bar to the left of the protocol icon. Hidden on non-ENS URLs.
  - Green filled shield — `verified` (public quorum agreed)
  - Green shield with dot — `user-configured` (custom RPC)
  - Amber outline shield — `unverified` (single source; quorum disabled, K<3, or anchor infeasible)
  - Red shield with slash — `conflict` (providers disagreed; navigation blocked)
- Clicking the shield opens a popover with the full resolved URI (`bzz://HASH` / `ipfs://CID` / `ipns://NAME`), the pinned block, and the agreed and dissented provider hostnames. Verified summary reads "Verified: quorum reached with N matching public RPC responses."
- Full-page interstitial on `conflict` — styled like an invalid-certificate page, blocks navigation, primary action is Go back.
- Full-page interstitial on `unverified` when `blockUnverifiedEns` is on — single-click "Continue once" bypasses this navigation only.
- New Settings → Ethereum RPC → Cross-RPC verification section exposes the full quorum configuration and the public provider list.

## Testing

- 1055 tests total on the branch, lint clean.
- New suites: `src/main/ens-prefetch.test.js` (11 tests), security-regression block in `src/main/ens-resolver.test.js` (8 tests, one per closed attack), reliability/config block (4 tests), prefetch hooks in the resolver (7 tests), navigation trust-shield and dispatch (17 tests in `navigation.test.js` and `navigation-utils.test.js`).
- Pre-existing bee/ipfs integration flakes are environment-bound (local node lifecycle) and are not introduced or affected by this PR.

## Manual smoke test

1. Load `ens://vitalik.eth` in a fresh profile. Wait for the page to settle. Confirm the address bar shows the green filled shield. Click it and confirm the popover shows the full resolved content URI and a list of agreed providers.
2. Open Settings → Ethereum RPC, edit `ensPublicRpcProviders` down to a single entry, save. Reload `ens://vitalik.eth`. Confirm the unverified interstitial renders. Click "Continue once"; confirm the amber shield appears on the loaded page.
3. Restore the provider list. Set a custom RPC URL (Ethereum RPC toggle). Reload an ENS name. Confirm the shield renders in the `user-configured` state (green with dot).
4. Temporarily point one provider in `ensPublicRpcProviders` at an RPC that serves different bytes (or wait for a real flake). Navigate to any ENS name. Confirm the conflict interstitial renders with the competing groups.
5. Launch with `ENS_DISABLE_PREFETCH=1`, reload an `ens://` name pointing at Swarm/IPFS content, and confirm the first cold load is measurably slower than the same navigation without the env var (expected prefetch saving: ~200–500ms on cold-path verified navigations).

## Commits

| SHA | Scope | Summary |
|---|---|---|
| `64f9158` | resolver | feat(ens): quorum-based resolution with trust metadata |
| `95779c5` | resolver | fix(ens): harden anchor corroboration against RPC manipulation |
| `8c08c1a` | UI | feat(ens): surface trust state via shield + interstitials |
| `f2bfee2` | UI | fix(ens): route typed-address ENS through loadTarget (shield + interstitials) |
| `d2d1423` | UI | fix(ens): close trust popover on webview clicks, drop Learn more link |
| `798a5e1` | settings | add new settings to settings page |
| `6e27c63` | prefetch | feat(ens): speculative gateway prefetch during public-quorum waves |
| `d49fbac` | prefetch | refactor(ens): dedupe NOOP_HANDLE + trim narrating comments |
| `53e2142` | prefetch | fix(ens-prefetch): sanitize URLs in persisted info logs |
| `ad377e6` | UI | copy(ens): tighten verified shield phrasing |
| `09af782` | UI | feat(ens): show full resolved URI in shield popover |
