### PR TITLE
docs: drop empty [Unreleased] section between releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 All notable changes to Freedom will be documented in this file.
 
-## [Unreleased]
-
 ## [0.7.0] - 2026-04-19
 
 ### Added

--- a/docs/agent-playbooks/changelog-process.md
+++ b/docs/agent-playbooks/changelog-process.md
@@ -25,7 +25,7 @@ Use this playbook when asked to update `CHANGELOG.md` for a new version.
 6. Merge related commits into a single user-facing entry.
 7. Inspect PR merge commits by reviewing underlying commits.
 8. Re-run the git log before editing to catch late commits.
-9. Prepend the new version section above the previous one.
+9. Prepend the new version section above the previous one. If a `## [Unreleased]` heading is present, replace it with `## [<version>] - <YYYY-MM-DD>`. If it is absent (expected immediately after a release, per `release-process.md`), add the new version heading directly. When writing the first user-facing change after a release, re-introduce a `## [Unreleased]` heading above the latest released version.
 
 ## Output Style
 

--- a/docs/agent-playbooks/release-process.md
+++ b/docs/agent-playbooks/release-process.md
@@ -49,7 +49,7 @@ Follow `changelog-process.md` in full. Key points for release branches:
 
 - The baseline for `git log` is the last `package.json` version bump commit.
 - Replace the `## [Unreleased]` heading with `## [<version>] - <YYYY-MM-DD>` using the date from `git show -s --format="%ad" --date=short HEAD`.
-- Leave a fresh empty `## [Unreleased]` section above it for the next cycle.
+- Do **not** leave an empty `## [Unreleased]` section behind. The first user-facing change after the release re-introduces the heading above the latest version.
 
 Commit style:
 
@@ -114,7 +114,10 @@ npm run dist -- --win --x64
 ## 5. Upload binaries and update the website
 
 1. Upload the generated artifacts from `dist/` to `https://freedom.baby/downloads`, including the `latest*.yml` manifests so existing installs pick up the update via `electron-updater` (which is configured with `publish.provider = generic` pointing at that URL).
-2. Update the Freedom website (download links, version string, release notes link) to point at the new version.
+2. Update the Freedom website to point at the new version:
+   - Download links and per-platform file-size metadata.
+   - Version string in the downloads intro (e.g. `Alpha release (<version>)`).
+   - `Changelog` link — pin to the release branch so the page shows the CHANGELOG state that matches the binaries being served: `https://github.com/solardev-xyz/freedom-browser/blob/release/<version>/CHANGELOG.md`. Do not link to `main`, which will absorb future releases' in-progress notes.
 
 Do this **before** tagging — if an upload reveals a broken artifact, you want to be able to fix it on the release branch without already having a tag pointing at a broken commit.
 


### PR DESCRIPTION
## Summary

- Remove the empty `## [Unreleased]` section at the top of `CHANGELOG.md` that was left behind by the 0.7.0 release.
- Flip the convention in `release-process.md` §2 so future releases don't seed an empty `[Unreleased]` heading.
- Update `changelog-process.md` step 9 so the first post-release change re-introduces the `[Unreleased]` heading above the latest version.
- Expand `release-process.md` §5.2 to pin the website's `Changelog` link to `blob/release/<version>/CHANGELOG.md` on each release, so the downloads page always shows a CHANGELOG view that matches the binaries being served.

## Why

Immediately after publishing a release, an empty `## [Unreleased]` above the just-cut version reads as noise to anyone opening `CHANGELOG.md` from the downloads page. Pairing the convention flip with a release-branch-pinned website link keeps the download page's "Changelog" view honest: it shows exactly the release state of the file, never an in-progress mix.

## Follow-up (out of PR scope)

- Cherry-pick commit 1 of this PR onto `release/0.7.0` so the branch tip has the clean CHANGELOG state too.
- Update `freedom.baby/index.html` `Changelog` link to `blob/release/0.7.0/CHANGELOG.md`.
