### PR TITLE
Implement `ens://` protocol hint for ipns-backed contenthash sites.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Freedom will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Address bar shows `ens://<name>` for IPNS-backed ENS sites (previously reverted to `ipns://<hash>` after the IPFS gateway redirect)
+
 ## [0.7.0] - 2026-04-19
 
 ### Added

--- a/src/renderer/lib/cid-utils.js
+++ b/src/renderer/lib/cid-utils.js
@@ -1,8 +1,10 @@
-// Minimal CIDv0 → CIDv1 base32 converter.
+// Minimal CIDv0 → CIDv1 base32 converter, plus an IPNS base58-multihash →
+// CIDv1 libp2p-key base36 converter.
 //
-// Needed because Kubo's subdomain gateway redirects requests from
-// `localhost:8080/ipfs/<CIDv0>` to `<CIDv1-base32>.ipfs.localhost:8080`
-// (DNS labels are case-insensitive, so base58btc CIDv0 is not subdomain-safe).
+// Needed because Kubo's subdomain gateway redirects:
+//   - `localhost:8080/ipfs/<CIDv0>`  → `<CIDv1-base32>.ipfs.localhost:8080`
+//   - `localhost:8080/ipns/<base58>` → `<CIDv1-base36>.ipns.localhost:8080`
+// DNS labels are case-insensitive, so base58btc is not subdomain-safe.
 //
 // Kept inline because the renderer has no bundler — bare module specifiers
 // like `multiformats/cid` don't resolve, and the sandboxed renderer can't
@@ -75,4 +77,42 @@ export const cidV0ToV1Base32 = (cidV0) => {
   v1[1] = 0x70; // dag-pb codec (varint, <128 so one byte)
   v1.set(mh, 2);
   return 'b' + base32Encode(v1);
+};
+
+// Base36 encode for multibase 'k' — lowercase, no padding, leading zero
+// bytes preserved as '0' chars (matches the multiformats basex convention).
+const base36Encode = (bytes) => {
+  let num = 0n;
+  for (let i = 0; i < bytes.length; i++) {
+    num = (num << 8n) | BigInt(bytes[i]);
+  }
+  const body = num === 0n ? '' : num.toString(36);
+  let leadingZeros = 0;
+  while (leadingZeros < bytes.length && bytes[leadingZeros] === 0) leadingZeros++;
+  return '0'.repeat(leadingZeros) + body;
+};
+
+/**
+ * Convert a base58btc IPNS multihash (peer-ID shape: "12D3Koo..." for
+ * Ed25519, "Qm..." for sha2-256) to the CIDv1 libp2p-key base36 form
+ * ("k51qzi..." / "k2k4...") used by Kubo's subdomain gateway. Accepts
+ * any well-formed multihash — not just sha2-256 — because Ed25519 peer
+ * IDs use the identity multihash (0x00). Returns null on malformed input.
+ */
+export const ipnsMhToCidV1Base36 = (mhBase58) => {
+  if (typeof mhBase58 !== 'string') return null;
+  const mh = base58Decode(mhBase58);
+  // Multihash = 1-byte code + 1-byte digest length + digest. We only accept
+  // single-byte-varint code/length (<128); fine for every code a libp2p peer
+  // ID can use (identity 0x00, sha2-256 0x12) and any realistic digest size.
+  if (!mh || mh.length < 3) return null;
+  const code = mh[0];
+  const digestLen = mh[1];
+  if (code >= 0x80 || digestLen >= 0x80) return null;
+  if (mh.length !== 2 + digestLen) return null;
+  const v1 = new Uint8Array(mh.length + 2);
+  v1[0] = 0x01; // CIDv1 version
+  v1[1] = 0x72; // libp2p-key codec
+  v1.set(mh, 2);
+  return 'k' + base36Encode(v1);
 };

--- a/src/renderer/lib/cid-utils.test.js
+++ b/src/renderer/lib/cid-utils.test.js
@@ -1,4 +1,4 @@
-import { cidV0ToV1Base32 } from './cid-utils.js';
+import { cidV0ToV1Base32, ipnsMhToCidV1Base36 } from './cid-utils.js';
 
 describe('cidV0ToV1Base32', () => {
   // Expected values cross-checked against multiformats CID.parse(v0).toV1().toString().
@@ -21,5 +21,35 @@ describe('cidV0ToV1Base32', () => {
     expect(cidV0ToV1Base32('bafybeigh3oq6pwrkspwgj4jcguizd7muxw4zdyq6cckqi5vl72yixnzpvm')).toBeNull();
     expect(cidV0ToV1Base32('Qmshort')).toBeNull();
     expect(cidV0ToV1Base32('QmContainsInvalidChar!abcdefghijklmnopqrstuvwxyz0123')).toBeNull();
+  });
+});
+
+describe('ipnsMhToCidV1Base36', () => {
+  // Expected values cross-checked against multiformats:
+  //   CID.createV1(0x72, Multihash(base58btc.decode('z' + peerId))).toString(base36)
+  test('converts Ed25519 identity-multihash peer IDs to base36 CIDv1 libp2p-key', () => {
+    // jalil.eth's IPNS contenthash, as returned by the ENS resolver.
+    expect(ipnsMhToCidV1Base36('12D3KooWAsDaZWCkCEUN3myg49NoCMmrYYivmJVwjg7DVJBvWdaX')).toBe(
+      'k51qzi5uqu5dgkkr5wjh0m796f9u3tou74wn2q2u3shgh6yn52ce4hitig3if4'
+    );
+    expect(ipnsMhToCidV1Base36('12D3KooWRBy97UB4aJeyegkr4DvfjShtp5g83Gd1zQ77gNeYvbnc')).toBe(
+      'k51qzi5uqu5dlvj2baxnohg4sf7y8vid1gtqsm1k7bkvrjsnzjz1tiexq761bp'
+    );
+  });
+
+  test('converts sha2-256 peer IDs (RSA-style "Qm..." names) to base36 CIDv1 libp2p-key', () => {
+    expect(ipnsMhToCidV1Base36('QmNYWqRg2uVWKpwpQ4Q4tu4xrE8kTVNG4aiEvX2wzLgPbh')).toBe(
+      'k2k4r8jhqpcrorgyes4mlic3t752f7oigcsb9tmxnly54cu2f6ijjzks'
+    );
+  });
+
+  test('returns null for malformed input', () => {
+    expect(ipnsMhToCidV1Base36(null)).toBeNull();
+    expect(ipnsMhToCidV1Base36(undefined)).toBeNull();
+    expect(ipnsMhToCidV1Base36('')).toBeNull();
+    expect(ipnsMhToCidV1Base36('12')).toBeNull();
+    expect(ipnsMhToCidV1Base36('12D3!invalid')).toBeNull();
+    // Non-base58 chars (contains '0' and 'O' and 'I' and 'l').
+    expect(ipnsMhToCidV1Base36('0OIl')).toBeNull();
   });
 });

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -1,6 +1,6 @@
 import { applyEnsNamePreservation, deriveDisplayValue } from './url-utils.js';
 import { getInternalPageName } from './page-urls.js';
-import { cidV0ToV1Base32 } from './cid-utils.js';
+import { cidV0ToV1Base32, ipnsMhToCidV1Base36 } from './cid-utils.js';
 
 export const resolveProtocolIconType = ({
   value = '',
@@ -94,7 +94,15 @@ export const extractEnsResolutionMetadata = (targetUri, ensName) => {
 
   const ipnsMatch = targetUri.match(/^ipns:\/\/([A-Za-z0-9.-]+)/);
   if (ipnsMatch) {
-    knownEnsPairs.push([ipnsMatch[1], ensName]);
+    const ipnsId = ipnsMatch[1];
+    knownEnsPairs.push([ipnsId, ensName]);
+    // Same as IPFS above: Kubo's subdomain gateway rewrites base58btc
+    // IPNS names ("12D3Koo...", "Qm...") to CIDv1 libp2p-key base36
+    // ("k51qzi..." / "k2k4...") — store both forms.
+    if (ipnsId.startsWith('12D3Koo') || ipnsId.startsWith('Qm')) {
+      const cidV1 = ipnsMhToCidV1Base36(ipnsId);
+      if (cidV1) knownEnsPairs.push([cidV1, ensName]);
+    }
     resolvedProtocol = 'ipfs';
   }
 

--- a/src/renderer/lib/navigation-utils.test.js
+++ b/src/renderer/lib/navigation-utils.test.js
@@ -81,6 +81,56 @@ describe('navigation-utils', () => {
     });
   });
 
+  describe('extractEnsResolutionMetadata', () => {
+    test('records both CIDv0 and CIDv1 forms for IPFS contenthashes', async () => {
+      const { extractEnsResolutionMetadata } = await loadNavigationUtils();
+
+      const { knownEnsPairs, resolvedProtocol } = extractEnsResolutionMetadata(
+        'ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/',
+        'evmnow.eth'
+      );
+
+      expect(resolvedProtocol).toBe('ipfs');
+      expect(knownEnsPairs).toEqual([
+        ['QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG', 'evmnow.eth'],
+        ['bafybeie5nqv6kd3qnfjupgvz34woh3oksc3iau6abmyajn7qvtf6d2ho34', 'evmnow.eth'],
+      ]);
+    });
+
+    test('records both base58 multihash and base36 CIDv1 for IPNS contenthashes', async () => {
+      const { extractEnsResolutionMetadata } = await loadNavigationUtils();
+
+      // The ENS resolver decodes jalil.eth's IPNS contenthash to this base58
+      // multihash; Kubo's subdomain gateway then redirects to the base36 CIDv1.
+      const { knownEnsPairs, resolvedProtocol } = extractEnsResolutionMetadata(
+        'ipns://12D3KooWAsDaZWCkCEUN3myg49NoCMmrYYivmJVwjg7DVJBvWdaX',
+        'jalil.eth'
+      );
+
+      expect(resolvedProtocol).toBe('ipfs');
+      expect(knownEnsPairs).toEqual([
+        ['12D3KooWAsDaZWCkCEUN3myg49NoCMmrYYivmJVwjg7DVJBvWdaX', 'jalil.eth'],
+        ['k51qzi5uqu5dgkkr5wjh0m796f9u3tou74wn2q2u3shgh6yn52ce4hitig3if4', 'jalil.eth'],
+      ]);
+    });
+
+    test('does not crash when the IPNS name is already a base36 CIDv1', async () => {
+      // If someone hand-crafts an ens:// mapping to a CIDv1 IPNS name, we
+      // only record the raw form — we don't try to invert base36 back to
+      // a base58 multihash.
+      const { extractEnsResolutionMetadata } = await loadNavigationUtils();
+
+      const { knownEnsPairs } = extractEnsResolutionMetadata(
+        'ipns://k51qzi5uqu5dgkkr5wjh0m796f9u3tou74wn2q2u3shgh6yn52ce4hitig3if4',
+        'jalil.eth'
+      );
+
+      expect(knownEnsPairs).toEqual([
+        ['k51qzi5uqu5dgkkr5wjh0m796f9u3tou74wn2q2u3shgh6yn52ce4hitig3if4', 'jalil.eth'],
+      ]);
+    });
+  });
+
   describe('getRadicleDisplayUrl', () => {
     test('reconstructs rad urls from rad-browser pages', async () => {
       const { getRadicleDisplayUrl } = await loadNavigationUtils();


### PR DESCRIPTION
before:
<img width="1956" height="1040" alt="screenshot-2026-04-21_00-32-30" src="https://github.com/user-attachments/assets/1a54abae-e260-4912-a736-656eb3bbac9f" />

after:
<img width="2556" height="1068" alt="image" src="https://github.com/user-attachments/assets/caf3e9f6-1d03-4e87-9b5b-0c8633fcce94" />
