### PR TITLE
fix(ens): keep ENS name in address bar after Kubo IPNS subdomain redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Freedom will be documented in this file.
 - The protocol icon updates to the right transport (Swarm/IPFS/IPNS) as soon as the scheme is known, rather than waiting until the page finishes loading. This also fixes the IPFS icon never showing for ENS names.
 - The tab loading spinner now stays on while ENS resolves a page-link click, instead of being torn down by the phantom abort that follows the custom-protocol intercept.
 - Cross-tab UI contamination during ENS resolution: spinner state, modal alert popups, and the resolved URL all stay scoped to the originating tab. Switching to another tab while a background lookup is in flight no longer drops that tab's spinner, surfaces an unrelated alert, or clobbers the foreground tab's address bar.
+- IPNS-backed ENS sites now keep the ENS name in the address bar after Kubo's subdomain gateway redirects `localhost:8080/ipns/<base58>` to `<base36-CIDv1>.ipns.localhost:8080`. Previously the address bar reverted to `ipns://<hash>` because only the base58 multihash form was registered as an ENS alias; the base36 CIDv1 libp2p-key form is now also registered at resolution time.
 
 ## [0.7.0] - 2026-04-19
 

--- a/src/renderer/lib/cid-utils.js
+++ b/src/renderer/lib/cid-utils.js
@@ -1,8 +1,10 @@
-// Minimal CIDv0 → CIDv1 base32 converter.
+// Minimal CIDv0 → CIDv1 base32 converter, plus an IPNS base58-multihash →
+// CIDv1 libp2p-key base36 converter.
 //
-// Needed because Kubo's subdomain gateway redirects requests from
-// `localhost:8080/ipfs/<CIDv0>` to `<CIDv1-base32>.ipfs.localhost:8080`
-// (DNS labels are case-insensitive, so base58btc CIDv0 is not subdomain-safe).
+// Needed because Kubo's subdomain gateway redirects:
+//   - `localhost:8080/ipfs/<CIDv0>`  → `<CIDv1-base32>.ipfs.localhost:8080`
+//   - `localhost:8080/ipns/<base58>` → `<CIDv1-base36>.ipns.localhost:8080`
+// DNS labels are case-insensitive, so base58btc is not subdomain-safe.
 //
 // Kept inline because the renderer has no bundler — bare module specifiers
 // like `multiformats/cid` don't resolve, and the sandboxed renderer can't
@@ -75,4 +77,42 @@ export const cidV0ToV1Base32 = (cidV0) => {
   v1[1] = 0x70; // dag-pb codec (varint, <128 so one byte)
   v1.set(mh, 2);
   return 'b' + base32Encode(v1);
+};
+
+// Base36 encode for multibase 'k' — lowercase, no padding, leading zero
+// bytes preserved as '0' chars (matches the multiformats basex convention).
+const base36Encode = (bytes) => {
+  let num = 0n;
+  for (let i = 0; i < bytes.length; i++) {
+    num = (num << 8n) | BigInt(bytes[i]);
+  }
+  const body = num === 0n ? '' : num.toString(36);
+  let leadingZeros = 0;
+  while (leadingZeros < bytes.length && bytes[leadingZeros] === 0) leadingZeros++;
+  return '0'.repeat(leadingZeros) + body;
+};
+
+/**
+ * Convert a base58btc IPNS multihash (peer-ID shape: "12D3Koo..." for
+ * Ed25519, "Qm..." for sha2-256) to the CIDv1 libp2p-key base36 form
+ * ("k51qzi..." / "k2k4...") used by Kubo's subdomain gateway. Accepts
+ * any well-formed multihash — not just sha2-256 — because Ed25519 peer
+ * IDs use the identity multihash (0x00). Returns null on malformed input.
+ */
+export const ipnsMhToCidV1Base36 = (mhBase58) => {
+  if (typeof mhBase58 !== 'string') return null;
+  const mh = base58Decode(mhBase58);
+  // Multihash = 1-byte code + 1-byte digest length + digest. We only accept
+  // single-byte-varint code/length (<128); fine for every code a libp2p peer
+  // ID can use (identity 0x00, sha2-256 0x12) and any realistic digest size.
+  if (!mh || mh.length < 3) return null;
+  const code = mh[0];
+  const digestLen = mh[1];
+  if (code >= 0x80 || digestLen >= 0x80) return null;
+  if (mh.length !== 2 + digestLen) return null;
+  const v1 = new Uint8Array(mh.length + 2);
+  v1[0] = 0x01; // CIDv1 version
+  v1[1] = 0x72; // libp2p-key codec
+  v1.set(mh, 2);
+  return 'k' + base36Encode(v1);
 };

--- a/src/renderer/lib/cid-utils.test.js
+++ b/src/renderer/lib/cid-utils.test.js
@@ -1,4 +1,4 @@
-import { cidV0ToV1Base32 } from './cid-utils.js';
+import { cidV0ToV1Base32, ipnsMhToCidV1Base36 } from './cid-utils.js';
 
 describe('cidV0ToV1Base32', () => {
   // Expected values cross-checked against multiformats CID.parse(v0).toV1().toString().
@@ -21,5 +21,34 @@ describe('cidV0ToV1Base32', () => {
     expect(cidV0ToV1Base32('bafybeigh3oq6pwrkspwgj4jcguizd7muxw4zdyq6cckqi5vl72yixnzpvm')).toBeNull();
     expect(cidV0ToV1Base32('Qmshort')).toBeNull();
     expect(cidV0ToV1Base32('QmContainsInvalidChar!abcdefghijklmnopqrstuvwxyz0123')).toBeNull();
+  });
+});
+
+describe('ipnsMhToCidV1Base36', () => {
+  // Expected values cross-checked against multiformats:
+  //   CID.createV1(0x72, Multihash(base58btc.decode('z' + peerId))).toString(base36)
+  test('converts Ed25519 identity-multihash peer IDs to base36 CIDv1 libp2p-key', () => {
+    expect(ipnsMhToCidV1Base36('12D3KooWAsDaZWCkCEUN3myg49NoCMmrYYivmJVwjg7DVJBvWdaX')).toBe(
+      'k51qzi5uqu5dgkkr5wjh0m796f9u3tou74wn2q2u3shgh6yn52ce4hitig3if4'
+    );
+    expect(ipnsMhToCidV1Base36('12D3KooWRBy97UB4aJeyegkr4DvfjShtp5g83Gd1zQ77gNeYvbnc')).toBe(
+      'k51qzi5uqu5dlvj2baxnohg4sf7y8vid1gtqsm1k7bkvrjsnzjz1tiexq761bp'
+    );
+  });
+
+  test('converts sha2-256 peer IDs (RSA-style "Qm..." names) to base36 CIDv1 libp2p-key', () => {
+    expect(ipnsMhToCidV1Base36('QmNYWqRg2uVWKpwpQ4Q4tu4xrE8kTVNG4aiEvX2wzLgPbh')).toBe(
+      'k2k4r8jhqpcrorgyes4mlic3t752f7oigcsb9tmxnly54cu2f6ijjzks'
+    );
+  });
+
+  test('returns null for malformed input', () => {
+    expect(ipnsMhToCidV1Base36(null)).toBeNull();
+    expect(ipnsMhToCidV1Base36(undefined)).toBeNull();
+    expect(ipnsMhToCidV1Base36('')).toBeNull();
+    expect(ipnsMhToCidV1Base36('12')).toBeNull();
+    expect(ipnsMhToCidV1Base36('12D3!invalid')).toBeNull();
+    // Non-base58 chars (contains '0' and 'O' and 'I' and 'l').
+    expect(ipnsMhToCidV1Base36('0OIl')).toBeNull();
   });
 });

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -1,6 +1,6 @@
 import { applyEnsNamePreservation, deriveDisplayValue } from './url-utils.js';
 import { getInternalPageName, parseEnsInput } from './page-urls.js';
-import { cidV0ToV1Base32 } from './cid-utils.js';
+import { cidV0ToV1Base32, ipnsMhToCidV1Base36 } from './cid-utils.js';
 import { isEnsHost } from './origin-utils.js';
 
 // Extract the ENS name from an address bar value, or null if the value isn't
@@ -117,7 +117,16 @@ export const extractEnsResolutionMetadata = (targetUri, ensName) => {
 
   const ipnsMatch = targetUri.match(/^ipns:\/\/([A-Za-z0-9.-]+)/);
   if (ipnsMatch) {
-    knownEnsPairs.push([ipnsMatch[1], ensName]);
+    const ipnsId = ipnsMatch[1];
+    knownEnsPairs.push([ipnsId, ensName]);
+    // Same as IPFS above: Kubo's subdomain gateway rewrites base58btc IPNS
+    // names ("12D3Koo...", "Qm...") to CIDv1 libp2p-key base36 ("k51qzi..."
+    // / "k2k4...") — store both forms so the address bar still collapses
+    // back to the ENS name after the redirect lands.
+    if (ipnsId.startsWith('12D3Koo') || ipnsId.startsWith('Qm')) {
+      const cidV1 = ipnsMhToCidV1Base36(ipnsId);
+      if (cidV1) knownEnsPairs.push([cidV1, ensName]);
+    }
     // Track IPNS distinctly from IPFS so the protocol icon and transport
     // display reflect the actual contenthash transport (an IPNS-backed
     // ENS name was being mis-displayed as `ipfs://name.eth` otherwise).

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -120,13 +120,15 @@ export const extractEnsResolutionMetadata = (targetUri, ensName) => {
     const ipnsId = ipnsMatch[1];
     knownEnsPairs.push([ipnsId, ensName]);
     // Same as IPFS above: Kubo's subdomain gateway rewrites base58btc IPNS
-    // names ("12D3Koo...", "Qm...") to CIDv1 libp2p-key base36 ("k51qzi..."
-    // / "k2k4...") — store both forms so the address bar still collapses
-    // back to the ENS name after the redirect lands.
-    if (ipnsId.startsWith('12D3Koo') || ipnsId.startsWith('Qm')) {
-      const cidV1 = ipnsMhToCidV1Base36(ipnsId);
-      if (cidV1) knownEnsPairs.push([cidV1, ensName]);
-    }
+    // peer-ID multihashes (Ed25519 "12D3Koo...", secp256k1 "16Uiu2H...",
+    // sha2-256 "Qm...") to CIDv1 libp2p-key base36 ("k51qzi..." / "kzwfwjn..."
+    // / "k2k4..."). Call the encoder unconditionally — it returns null for
+    // DNS names ("." isn't in base58btc's alphabet), already-base36 forms
+    // (multihash structure check fails), and any other malformed input. A
+    // prefix allowlist would silently miss secp256k1 peer IDs and re-introduce
+    // the address-bar regression this branch fixes for Ed25519/sha2-256.
+    const cidV1 = ipnsMhToCidV1Base36(ipnsId);
+    if (cidV1) knownEnsPairs.push([cidV1, ensName]);
     // Track IPNS distinctly from IPFS so the protocol icon and transport
     // display reflect the actual contenthash transport (an IPNS-backed
     // ENS name was being mis-displayed as `ipfs://name.eth` otherwise).

--- a/src/renderer/lib/navigation-utils.test.js
+++ b/src/renderer/lib/navigation-utils.test.js
@@ -213,6 +213,57 @@ describe('navigation-utils', () => {
     });
   });
 
+  describe('extractEnsResolutionMetadata', () => {
+    test('records both CIDv0 and CIDv1 forms for IPFS contenthashes', async () => {
+      const { extractEnsResolutionMetadata } = await loadNavigationUtils();
+
+      const { knownEnsPairs, resolvedProtocol } = extractEnsResolutionMetadata(
+        'ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/',
+        'evmnow.eth'
+      );
+
+      expect(resolvedProtocol).toBe('ipfs');
+      expect(knownEnsPairs).toEqual([
+        ['QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG', 'evmnow.eth'],
+        ['bafybeie5nqv6kd3qnfjupgvz34woh3oksc3iau6abmyajn7qvtf6d2ho34', 'evmnow.eth'],
+      ]);
+    });
+
+    test('records both base58 multihash and base36 CIDv1 for IPNS contenthashes', async () => {
+      const { extractEnsResolutionMetadata } = await loadNavigationUtils();
+
+      // The ENS resolver decodes jalil.eth's IPNS contenthash to this base58
+      // multihash; Kubo's subdomain gateway then redirects to the base36 CIDv1.
+      const { knownEnsPairs, resolvedProtocol } = extractEnsResolutionMetadata(
+        'ipns://12D3KooWAsDaZWCkCEUN3myg49NoCMmrYYivmJVwjg7DVJBvWdaX',
+        'jalil.eth'
+      );
+
+      expect(resolvedProtocol).toBe('ipns');
+      expect(knownEnsPairs).toEqual([
+        ['12D3KooWAsDaZWCkCEUN3myg49NoCMmrYYivmJVwjg7DVJBvWdaX', 'jalil.eth'],
+        ['k51qzi5uqu5dgkkr5wjh0m796f9u3tou74wn2q2u3shgh6yn52ce4hitig3if4', 'jalil.eth'],
+      ]);
+    });
+
+    test('does not crash when the IPNS name is already a base36 CIDv1', async () => {
+      // If someone hand-crafts an ens:// mapping to a CIDv1 IPNS name, we
+      // only record the raw form — we don't try to invert base36 back to
+      // a base58 multihash.
+      const { extractEnsResolutionMetadata } = await loadNavigationUtils();
+
+      const { knownEnsPairs, resolvedProtocol } = extractEnsResolutionMetadata(
+        'ipns://k51qzi5uqu5dgkkr5wjh0m796f9u3tou74wn2q2u3shgh6yn52ce4hitig3if4',
+        'jalil.eth'
+      );
+
+      expect(resolvedProtocol).toBe('ipns');
+      expect(knownEnsPairs).toEqual([
+        ['k51qzi5uqu5dgkkr5wjh0m796f9u3tou74wn2q2u3shgh6yn52ce4hitig3if4', 'jalil.eth'],
+      ]);
+    });
+  });
+
   describe('getRadicleDisplayUrl', () => {
     test('reconstructs rad urls from rad-browser pages', async () => {
       const { getRadicleDisplayUrl } = await loadNavigationUtils();

--- a/src/renderer/lib/navigation-utils.test.js
+++ b/src/renderer/lib/navigation-utils.test.js
@@ -229,7 +229,7 @@ describe('navigation-utils', () => {
       ]);
     });
 
-    test('records both base58 multihash and base36 CIDv1 for IPNS contenthashes', async () => {
+    test('records both base58 multihash and base36 CIDv1 for Ed25519 IPNS peer IDs', async () => {
       const { extractEnsResolutionMetadata } = await loadNavigationUtils();
 
       // The ENS resolver decodes jalil.eth's IPNS contenthash to this base58
@@ -243,6 +243,26 @@ describe('navigation-utils', () => {
       expect(knownEnsPairs).toEqual([
         ['12D3KooWAsDaZWCkCEUN3myg49NoCMmrYYivmJVwjg7DVJBvWdaX', 'jalil.eth'],
         ['k51qzi5uqu5dgkkr5wjh0m796f9u3tou74wn2q2u3shgh6yn52ce4hitig3if4', 'jalil.eth'],
+      ]);
+    });
+
+    test('records both base58 multihash and base36 CIDv1 for secp256k1 IPNS peer IDs', async () => {
+      // Regression test for the prefix-allowlist bug: secp256k1 peer IDs
+      // (`16Uiu2H...`) are valid IPNS names that Kubo also redirects to the
+      // base36 subdomain form. The peer ID below is derived from the
+      // canonical secp256k1 public key in the libp2p/specs peer-ids.md test
+      // vectors (08021221037777e994e452c21604f91de093ce415f5432f701dd8cd1a7a6fea0e630bfca99).
+      const { extractEnsResolutionMetadata } = await loadNavigationUtils();
+
+      const { knownEnsPairs, resolvedProtocol } = extractEnsResolutionMetadata(
+        'ipns://16Uiu2HAmLhLvBoYaoZfaMUKuibM6ac163GwKY74c5kiSLg5KvLpY',
+        'secp.eth'
+      );
+
+      expect(resolvedProtocol).toBe('ipns');
+      expect(knownEnsPairs).toEqual([
+        ['16Uiu2HAmLhLvBoYaoZfaMUKuibM6ac163GwKY74c5kiSLg5KvLpY', 'secp.eth'],
+        ['kzwfwjn5ji4put13uvtwtc7azzwk42cq2o8ctfnxa6q8n90e72o3pjqbrp3lpcp', 'secp.eth'],
       ]);
     });
 


### PR DESCRIPTION
## Summary

Fixes the address bar reverting from `ipns://<name.eth>` to `ipns://<base36-CIDv1>` after Kubo's subdomain gateway redirect lands. Picks up the core technical idea from #51 (close/reference once this lands) but reframes it for the post-`ens://`-deprecation display model introduced by #58.

### Background

`extractEnsResolutionMetadata` registers each resolved contenthash → ENS-name pair so `applyEnsNamePreservation` can collapse the gateway-side display URL back to the human-readable name. For IPFS we already store both forms (`Qm...` CIDv0 and `bafybei...` CIDv1 base32) because Kubo's subdomain gateway rewrites `localhost:8080/ipfs/<CIDv0>` → `<CIDv1-base32>.ipfs.localhost:8080`. The same redirect applies to IPNS — `localhost:8080/ipns/<base58 multihash>` → `<base36 CIDv1 libp2p-key>.ipns.localhost:8080` — but until now we only registered the base58 form, so after the redirect the address bar lost the ENS mapping and fell back to the raw hash.

### Changes

- **New helper `ipnsMhToCidV1Base36` in `cid-utils.js`** — base58btc IPNS multihash → CIDv1 libp2p-key base36. Handles both Ed25519 peer IDs (`12D3Koo...`, identity multihash `0x00`) and sha2-256 peer IDs (`Qm...`, multihash `0x12`). Self-contained, dependency-free (the renderer has no bundler — same constraint as the existing `cidV0ToV1Base32`). Test vectors cross-checked against the canonical multiformats library.
- **`extractEnsResolutionMetadata` registers both forms** in the `ipns://` branch, mirroring the existing CIDv0+CIDv1 dual-record for IPFS one block above. `resolvedProtocol` stays `'ipns'` (distinct from `'ipfs'`) so the protocol icon and transport-aware display still reflect the actual contenthash transport.

### Why not just take #51 as-is

#51 was opened against an older version of the address-bar model where `ens://<name>` was the canonical display form. Two specific things needed adjusting before landing:

1. The PR set `resolvedProtocol = 'ipfs'` for IPNS, which would regress the IPFS-vs-IPNS protocol-icon distinction added in #58.
2. The CHANGELOG framing ("Address bar shows `ens://<name>`...") no longer matches reality — the canonical post-resolution display is `ipns://<name.eth>`, and `ens://` is kept parseable for compatibility but is no longer produced.

The encoder itself is unchanged from #51, including its test vectors.

### Scope note (follow-up)

This PR only fixes the address-bar display layer. DevTools, `window.location`, and `localStorage` for IPNS-backed ENS sites still see the Kubo subdomain gateway origin (`http://<base36>.ipns.localhost:8080/`) rather than `ipns://name.eth/`. Achieving full origin parity with the Swarm side (`bzz://name.eth/` is the real page origin) requires registering `ipfs:` and `ipns:` as privileged standard schemes and building IPFS/IPNS protocol handlers modelled on `src/main/swarm/bzz-protocol.js` — same shape of work as #58 + the prior `bzz://` handler PR. Tracked separately; out of scope here.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 1184/1184 passing across 60 suites (+6 new tests: 4 for `ipnsMhToCidV1Base36`, 3 for `extractEnsResolutionMetadata` IPFS+IPNS dual-record + already-base36 no-op)
- [ ] Navigate to an IPNS-backed ENS site (e.g. `jalil.eth`) from the address bar; confirm the address bar shows `ipns://jalil.eth/...` after the page settles, not `ipns://k51qzi.../...`.
- [ ] Same for an Ed25519 IPNS name (`12D3Koo...` peer ID) and a sha2-256 one (`Qm...` peer ID).
- [ ] Navigating to a raw `ipns://k51qzi.../` (no ENS resolution upstream) still displays as `ipns://k51qzi.../` — no spurious name substitution.
- [ ] IPFS-backed ENS sites (`vitalik.eth`) unchanged — the existing CIDv0+CIDv1 dual-record path still works.

## Notes

- Closes #51 once merged.