### PR TITLE
feat(test): add Playwright E2E suite with harness and live modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ CLAUDE.md
 .codex
 identity-data/
 research/
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -416,6 +416,8 @@ Edit `src/renderer/pages/home.html` to customize the welcome view shown on start
 | ----------------------------------------------------------------- | -------------------------------------------- |
 | `npm start`                                                       | Launch the Electron app                      |
 | `npm test`                                                        | Run unit tests (Jest)                        |
+| `npm run test:e2e`                                                | Run the harness E2E suite (stubbed nodes; fast, no network) |
+| `npm run test:e2e:live`                                           | Run the live E2E suite (real Bee + IPFS + ENS; manual only) |
 | `npm run bee:download`                                            | Download the Bee binary for your platform    |
 | `npm run ipfs:download`                                           | Download the Kubo binary for your platform   |
 | `npm run bee:start` / `bee:stop` / `bee:status` / `bee:reset`     | Manage Bee outside the app                   |
@@ -462,7 +464,9 @@ The `build` and `dist` scripts accept `--mac`, `--linux`, or `--win` with option
 
 ### Testing
 
-Run all tests:
+#### Unit tests (Jest)
+
+Run all unit tests:
 
 ```bash
 npm test
@@ -475,6 +479,17 @@ The suite covers most of `src/main/` and `src/renderer/lib/` — see `src/**/*.t
 - **Identity, vault & wallet**: `identity/derivation`, `identity/vault`, `identity/formats`, `wallet/dapp-permissions`, `wallet/transaction-service`
 - **Parsing & utilities**: `url-utils`, `cid-utils`, `origin-utils`, `ethereum-uri`, `page-urls`, `brand`
 - **Storage & history**: `bookmarks-store`, `settings-store`, `history`, `feed-store`, `publish-history`
+
+#### End-to-end tests (Playwright + Electron)
+
+Two Playwright projects live under `test-e2e/`. **Both are run manually — neither is wired into CI.** Configuration is in `playwright.config.js`.
+
+| Suite | Command | Files | What it does |
+| --- | --- | --- | --- |
+| `harness` | `npm run test:e2e` | `test-e2e/*.spec.js` | Launches Electron with `FREEDOM_TEST_MODE=1`. The in-process harness in `src/main/test-harness.js` stubs Bee/IPFS startup, ENS resolution, the Swarm probe, and the `bzz:` / `ipfs:` / `ipns:` protocol handlers, so specs are fast (~15 s end-to-end), deterministic, and require no network or downloaded binaries. Covers address-bar normalisation, tabs, bookmarks, settings persistence, and the error-page flow. |
+| `live` | `npm run test:e2e:live` | `test-e2e/live/*.spec.js` | Launches Electron without the harness — actual Bee + IPFS spawn, live ENS resolution, real `bzz://` / `ipfs://` protocol handlers. Currently one spec (`eth-sites.spec.js`) cold-starts both nodes, waits for >20 connected peers on each, then navigates to `meinhard.eth` (Swarm) and `vitalik.eth` (IPFS) and asserts the rendered pages. Requires `npm run bee:download` and `npm run ipfs:download` first; Swarm/IPFS cold-start can take a few minutes on a fresh repo. The Bee check is skipped if the binary is missing; the IPFS check fails loudly. |
+
+Both suites use a per-run temp `userData` directory (`FREEDOM_TEST_USER_DATA`) so they never touch your real settings, bookmarks, or history. Sequential runs only (`workers: 1`) — Electron + protocol-scheme registration and Bee port detection don't tolerate parallel app instances.
 
 ### Logging
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,8 @@ module.exports = [
       'ipfs-bin/**',
       'bee-data/**',
       'ipfs-data/**',
+      'playwright-report/**',
+      'test-results/**',
     ],
   },
   {
@@ -53,6 +55,18 @@ module.exports = [
         ...globals.jest,
         ...globals.node,
         ...globals.browser,
+      },
+    },
+  },
+  {
+    // Playwright E2E specs run in Node and use the test fixtures from
+    // test-e2e/fixtures.js rather than the global jest harness.
+    files: ['test-e2e/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'script',
+      globals: {
+        ...globals.node,
       },
     },
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 /** @type {import('jest').Config} */
 module.exports = {
   testMatch: ['**/*.test.js'],
-  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/bee-bin/', '/ipfs-bin/'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/bee-bin/', '/ipfs-bin/', '/test-e2e/'],
   collectCoverageFrom: ['src/**/*.js', '!src/**/*.test.js', '!src/renderer/vendor/**'],
   // Coverage thresholds are intentionally below typical "healthy" targets.
   // The Swarm publishing feature landed with heavily-tested services

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@babel/preset-env": "^7.29.0",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.59.1",
         "babel-jest": "^30.2.0",
         "dotenv-cli": "^11.0.0",
         "electron": "^41.2.1",
@@ -3392,6 +3393,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@scure/base": {
@@ -9357,6 +9374,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "test": "npm run test:unit",
     "test:unit": "jest",
     "test:coverage": "jest --coverage --runInBand --forceExit",
+    "test:e2e": "playwright test --project=harness",
+    "test:e2e:live": "playwright test --project=live",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -166,6 +168,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.29.0",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.59.1",
     "babel-jest": "^30.2.0",
     "dotenv-cli": "^11.0.0",
     "electron": "^41.2.1",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,54 @@
+// Playwright config for renderer E2E tests.
+//
+// Two projects:
+//   - `harness` (default `npm run test:e2e`): fixture-driven specs that run
+//     against the in-process test harness. No actual Bee, IPFS, ENS, or
+//     network. Fast, deterministic, safe in CI.
+//   - `live` (`npm run test:e2e:live`): drives the full app against live
+//     services — actual Bee node, live ENS resolution, real bzz:// /
+//     ipfs:// protocol handlers. Requires `npm run bee:download` first
+//     and is slow (Swarm cold-start can take several minutes). Skipped
+//     automatically if the bee binary for the current platform isn't
+//     present.
+//
+// Layout:
+//   - `test-e2e/live/**/*.spec.js`  → `live` project
+//   - `test-e2e/*.spec.js`          → `harness` project (everything else)
+
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './test-e2e',
+  // Sequential runs only — Electron launches multiple processes per app
+  // instance and parallel runs would fight over the privileged-protocol
+  // scheme cache and (in live mode) over Bee's default-port detection.
+  fullyParallel: false,
+  workers: 1,
+  reporter: [['list']],
+  use: {
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+  projects: [
+    {
+      name: 'harness',
+      testMatch: /^(?!.*[\\/]live[\\/]).*\.spec\.js$/,
+      // Bee/IPFS startup is stubbed in test mode, but Electron + first-
+      // window ready can still take 10–15s on cold cache. 30s gives
+      // headroom without hiding genuine hangs.
+      timeout: 30_000,
+      expect: { timeout: 7_500 },
+    },
+    {
+      name: 'live',
+      testMatch: /[\\/]live[\\/].*\.spec\.js$/,
+      // Live Swarm cold-start to a useful peer count typically takes
+      // 30–120s, ENS resolution adds 1–5s, and the navigation probe
+      // adds another few seconds. 10 min covers worst-case startup +
+      // single-test work without inviting infinite hangs.
+      timeout: 10 * 60_000,
+      expect: { timeout: 30_000 },
+    },
+  ],
+});

--- a/src/main/bee-manager.js
+++ b/src/main/bee-manager.js
@@ -74,6 +74,18 @@ function getBeeBinaryPath() {
 }
 
 function getBeeDataPath() {
+  // Explicit override for tests / advanced users — keeps a live E2E
+  // run from clobbering the developer's persistent dev `bee-data/`.
+  // Honoured in both dev and packaged modes; only set this when you
+  // want a throwaway repo (and you're prepared for Bee to re-init
+  // identity, swarm key, peerstore, etc.).
+  if (process.env.FREEDOM_BEE_DATA) {
+    const overrideDir = process.env.FREEDOM_BEE_DATA;
+    if (!fs.existsSync(overrideDir)) {
+      fs.mkdirSync(overrideDir, { recursive: true });
+    }
+    return overrideDir;
+  }
   if (!app.isPackaged) {
     // In dev, bee-data is at project root (../../ from src/main)
     const devDataDir = path.join(__dirname, '..', '..', 'bee-data');

--- a/src/main/identity-manager.js
+++ b/src/main/identity-manager.js
@@ -34,6 +34,14 @@ const VAULT_META_FILE = 'vault-meta.json';
  * Get the app data directory for identity storage
  */
 function getIdentityDataDir() {
+  // Explicit override for tests / advanced users — keeps a live E2E
+  // run from picking up the developer's persistent dev `identity-data/`
+  // vault, which would flip Bee/IPFS into injected-identity mode and
+  // make them hang waiting for keys the temp data dirs don't have.
+  // Honoured in both dev and packaged modes.
+  if (process.env.FREEDOM_IDENTITY_DATA) {
+    return process.env.FREEDOM_IDENTITY_DATA;
+  }
   if (!app.isPackaged) {
     return path.join(__dirname, '..', '..', 'identity-data');
   }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -10,6 +10,19 @@ if (!app.isPackaged) {
 app.name = appName;
 app.setName(appName);
 
+// E2E test mode (Playwright). `FREEDOM_TEST_MODE=1` activates the
+// fixture-driven harness in src/main/test-harness.js (stubbed protocols,
+// no real Bee/IPFS spawn). `FREEDOM_TEST_USER_DATA` redirects userData
+// to a per-run temp dir so each spec gets a clean settings/bookmarks/
+// history store — honoured independently of FREEDOM_TEST_MODE so the
+// live-network E2E suite can also opt into a clean userData without
+// activating the harness. Both must be applied before any other module
+// touches userData.
+if (process.env.FREEDOM_TEST_USER_DATA) {
+  app.setPath('userData', process.env.FREEDOM_TEST_USER_DATA);
+}
+const TEST_MODE = process.env.FREEDOM_TEST_MODE === '1';
+
 const { version } = require('../../package.json');
 const iconPath = app.isPackaged
   ? require('path').join(process.resourcesPath, 'assets', 'icon.png')
@@ -88,6 +101,7 @@ const { migrateUserData } = require('./migrate-user-data');
 const { initUpdater } = require('./updater');
 const { setupApplicationMenu, updateTabMenuItems } = require('./menu');
 const { registerWebContentsHandlers } = require('./webcontents-setup');
+const { installTestHarness } = require('./test-harness');
 
 app.commandLine.appendSwitch('disable-features', 'VizDisplayCompositor');
 
@@ -141,13 +155,26 @@ async function bootstrap() {
   registerSwarmPermissionsIpc();
   registerSwarmProviderIpc();
   registerFeedStoreIpc();
-  registerBzzProtocol(defaultSession);
-  registerIpfsProtocol(defaultSession);
-  registerIpnsProtocol(defaultSession);
+  if (!TEST_MODE) {
+    // Skip registering the real bzz/ipfs/ipns handlers in test mode —
+    // installTestHarness() registers fixture-driven stubs on the same
+    // schemes below. Electron only allows one handler per scheme per
+    // session, so the harness must own them outright in test mode.
+    registerBzzProtocol(defaultSession);
+    registerIpfsProtocol(defaultSession);
+    registerIpnsProtocol(defaultSession);
+  }
   registerRequestRewriter(defaultSession);
   allowInteractivePermissions(defaultSession);
   registerWebContentsHandlers();
   setupApplicationMenu();
+
+  // Test harness is installed AFTER all production IPC + protocol
+  // registrations, so it can override (via removeHandler + re-register)
+  // the channels it needs to stub — ENS resolution, the bzz: probe,
+  // and bee/ipfs/radicle start/stop. No-op when FREEDOM_TEST_MODE is
+  // unset, so the production path is unaffected.
+  installTestHarness({ defaultSession });
 
   // If a vault exists, flag the node managers so bee/ipfs/radicle start with
   // the user's derived keys. Without a vault, nodes start with their own
@@ -166,20 +193,30 @@ async function bootstrap() {
 
   const settings = loadSettings();
 
-  if (settings.startBeeAtLaunch) {
-    startBee();
-  }
-  if (settings.startIpfsAtLaunch) {
-    startIpfs();
-  }
-  if (settings.enableRadicleIntegration && settings.startRadicleAtLaunch) {
-    startRadicle();
+  // In test mode the harness has already seeded service-registry with
+  // fake endpoints. Spawning real Bee / IPFS / Radicle binaries against
+  // a temp userData would fail port checks, take seconds, and defeat
+  // the purpose of fixture-driven tests.
+  if (!TEST_MODE) {
+    if (settings.startBeeAtLaunch) {
+      startBee();
+    }
+    if (settings.startIpfsAtLaunch) {
+      startIpfs();
+    }
+    if (settings.enableRadicleIntegration && settings.startRadicleAtLaunch) {
+      startRadicle();
+    }
   }
 
   const mainWindow = createMainWindow();
 
-  // Initialize auto-updater (pass menu update callback)
-  initUpdater(mainWindow, setupApplicationMenu);
+  // Initialize auto-updater (pass menu update callback). Skipped in
+  // test mode so specs don't trigger background network checks against
+  // freedom.baby.
+  if (!TEST_MODE) {
+    initUpdater(mainWindow, setupApplicationMenu);
+  }
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/src/main/ipfs-manager.js
+++ b/src/main/ipfs-manager.js
@@ -64,6 +64,17 @@ function getIpfsBinaryPath() {
 }
 
 function getIpfsDataPath() {
+  // Explicit override for tests / advanced users — keeps a live E2E
+  // run from clobbering the developer's persistent dev `ipfs-data/`.
+  // Honoured in both dev and packaged modes; only set this when you
+  // want a throwaway repo (Kubo will re-init identity, peerstore, etc.).
+  if (process.env.FREEDOM_IPFS_DATA) {
+    const overrideDir = process.env.FREEDOM_IPFS_DATA;
+    if (!fs.existsSync(overrideDir)) {
+      fs.mkdirSync(overrideDir, { recursive: true });
+    }
+    return overrideDir;
+  }
   if (!app.isPackaged) {
     const devDataDir = path.join(__dirname, '..', '..', 'ipfs-data');
     if (!fs.existsSync(devDataDir)) {

--- a/src/main/test-harness.js
+++ b/src/main/test-harness.js
@@ -1,0 +1,313 @@
+/**
+ * Renderer E2E test harness (Playwright integration)
+ *
+ * Activated only when `process.env.FREEDOM_TEST_MODE === '1'`. The harness
+ * is fully inert otherwise — `installTestHarness` is a no-op when test
+ * mode is off, and nothing in this file runs at require time.
+ *
+ * Responsibilities:
+ *   1. Register stub `bzz:` / `ipfs:` / `ipns:` protocol handlers backed by
+ *      an in-memory fixture map, so tests can assert against deterministic
+ *      content without spinning up Bee or Kubo.
+ *   2. Override the ENS resolver IPC handlers with a fixture-driven stub
+ *      (real ENS resolution would need network and an Ethereum RPC).
+ *   3. Override the Swarm content-probe IPCs so navigation gating doesn't
+ *      try to HEAD-poll a non-existent Bee gateway.
+ *   4. Override Bee / IPFS / Radicle start/stop IPCs to no-ops, so a
+ *      misclick in a test doesn't spawn the real binaries against a temp
+ *      `userData` directory.
+ *   5. Seed `service-registry` with a "running" status for Bee and IPFS so
+ *      the chrome doesn't spend the test session in a "Stopped" UI state.
+ *   6. Register `test:*` IPC channels and a `globalThis.__FREEDOM_TEST_HARNESS__`
+ *      shim so the Playwright runner can drive fixtures via either
+ *      `electronApp.evaluate(...)` or `page.evaluate(... ipcRenderer ...)`.
+ *
+ * Architectural placement: this lives in `src/main/` because every
+ * function it touches (protocol handlers, IPC handlers, service registry)
+ * is main-process state. A `src/main/testing/` subdirectory would be
+ * justified once the harness grows additional helpers; for now a single
+ * file matches the conventions in `src/main/`.
+ */
+
+'use strict';
+
+const log = require('./logger');
+const { ipcMain } = require('electron');
+const IPC = require('../shared/ipc-channels');
+const { success, failure } = require('./ipc-contract');
+const { updateService, MODE, setStatusMessage } = require('./service-registry');
+
+const TEST_MODE_ENABLED = process.env.FREEDOM_TEST_MODE === '1';
+
+function isTestMode() {
+  return TEST_MODE_ENABLED;
+}
+
+// In-memory fixtures. Maps are keyed lower-case for ENS / hashes; content
+// fixtures are keyed by exact URL or URL prefix (longest-match wins).
+const contentFixtures = new Map();
+const ensFixtures = new Map();
+const probeFixtures = new Map();
+
+function resetFixtures() {
+  contentFixtures.clear();
+  ensFixtures.clear();
+  probeFixtures.clear();
+}
+
+// Longest-prefix match so a fixture for `bzz://<hash>/` answers for
+// every sub-resource fetched while loading that page. Exact match wins
+// over prefix match by virtue of the length sort.
+function pickContentFixture(url) {
+  if (contentFixtures.has(url)) return contentFixtures.get(url);
+  let best = null;
+  let bestLen = -1;
+  for (const [prefix, value] of contentFixtures.entries()) {
+    if (url.startsWith(prefix) && prefix.length > bestLen) {
+      best = value;
+      bestLen = prefix.length;
+    }
+  }
+  return best;
+}
+
+function buildResponse(fixture) {
+  const status = fixture.status ?? 200;
+  const headers = {
+    'Content-Type': fixture.contentType ?? 'text/html; charset=utf-8',
+  };
+  return new Response(fixture.body ?? '', { status, headers });
+}
+
+function notFoundResponse(url) {
+  const body = JSON.stringify({
+    code: 404,
+    message: `[test-harness] no fixture for ${url}`,
+  });
+  return new Response(body, {
+    status: 404,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  });
+}
+
+function makeProtocolHandler(scheme) {
+  return async (request) => {
+    const fixture = pickContentFixture(request.url);
+    if (!fixture) {
+      log.info(`[test-harness] ${scheme}: 404 (no fixture) for ${request.url}`);
+      return notFoundResponse(request.url);
+    }
+    return buildResponse(fixture);
+  };
+}
+
+function registerStubProtocols(targetSession) {
+  if (!targetSession?.protocol?.handle) {
+    log.warn('[test-harness] session.protocol.handle unavailable — skipping protocol stubs');
+    return;
+  }
+  for (const scheme of ['bzz', 'ipfs', 'ipns']) {
+    try {
+      targetSession.protocol.handle(scheme, makeProtocolHandler(scheme));
+      log.info(`[test-harness] registered stub ${scheme}: handler`);
+    } catch (err) {
+      log.error(`[test-harness] failed to register stub ${scheme}: handler`, err);
+    }
+  }
+}
+
+// Replace a previously-registered ipcMain.handle entry. ipcMain.handle
+// throws if the channel is already registered, so removal must happen
+// before re-registration. Safe to call when the channel was never
+// registered (removeHandler is a no-op then).
+function replaceHandler(channel, handler) {
+  ipcMain.removeHandler?.(channel);
+  ipcMain.handle(channel, handler);
+}
+
+function overrideEnsIpc() {
+  replaceHandler(IPC.ENS_RESOLVE, async (_event, payload = {}) => {
+    const name = (payload?.name || '').trim().toLowerCase();
+    if (!name) {
+      return { type: 'not_found', name: '', reason: 'EMPTY' };
+    }
+    if (ensFixtures.has(name)) {
+      return ensFixtures.get(name);
+    }
+    return { type: 'not_found', name, reason: 'NO_FIXTURE' };
+  });
+
+  replaceHandler(IPC.ENS_RESOLVE_ADDRESS, async (_event, payload = {}) => {
+    const name = (payload?.name || '').trim().toLowerCase();
+    return { success: false, name, reason: 'TEST_MODE_NOT_IMPLEMENTED' };
+  });
+
+  replaceHandler(IPC.ENS_RESOLVE_REVERSE, async (_event, payload = {}) => {
+    const address = typeof payload?.address === 'string' ? payload.address.toLowerCase() : null;
+    return { success: false, address, reason: 'TEST_MODE_NOT_IMPLEMENTED' };
+  });
+
+  replaceHandler(IPC.ENS_TEST_RPC, async () => {
+    return { success: true, blockNumber: 0, latencyMs: 0 };
+  });
+
+  replaceHandler(IPC.ENS_INVALIDATE_CONTENT, async () => true);
+}
+
+function overrideProbeIpc() {
+  const stubProbes = new Map();
+  let nextId = 1;
+
+  replaceHandler(IPC.BZZ_START_PROBE, (_event, payload = {}) => {
+    const { hash } = payload;
+    if (typeof hash !== 'string' || !hash) {
+      return failure('INVALID_HASH', 'Missing hash');
+    }
+    const id = `test-probe-${nextId++}`;
+    const outcome = probeFixtures.get(hash) ?? { ok: true };
+    stubProbes.set(id, outcome);
+    return success({ id });
+  });
+
+  replaceHandler(IPC.BZZ_AWAIT_PROBE, (_event, payload = {}) => {
+    const { id } = payload;
+    if (typeof id !== 'string' || !stubProbes.has(id)) {
+      return failure('UNKNOWN_PROBE', 'Unknown probe id', { id });
+    }
+    const outcome = stubProbes.get(id);
+    stubProbes.delete(id);
+    return success({ outcome });
+  });
+
+  replaceHandler(IPC.BZZ_CANCEL_PROBE, (_event, payload = {}) => {
+    const { id } = payload;
+    const cancelled = stubProbes.delete(id);
+    return success({ cancelled });
+  });
+}
+
+// Bee / IPFS / Radicle managers are still loaded so their `getStatus`
+// handlers respond, but we replace start/stop with no-ops so a stray
+// click in a spec can't spawn the real binaries against the test
+// `userData` directory.
+function overrideNodeIpc() {
+  for (const channel of [
+    IPC.BEE_START,
+    IPC.BEE_STOP,
+    IPC.IPFS_START,
+    IPC.IPFS_STOP,
+    IPC.RADICLE_START,
+    IPC.RADICLE_STOP,
+  ]) {
+    replaceHandler(channel, async () => {
+      log.info(`[test-harness] ignored ${channel} (test mode)`);
+      return { success: true, testMode: true };
+    });
+  }
+}
+
+function seedRegistry() {
+  updateService('bee', {
+    api: 'http://127.0.0.1:1633',
+    gateway: 'http://127.0.0.1:1633',
+    mode: MODE.BUNDLED,
+  });
+  setStatusMessage('bee', 'Test mode (Swarm stub)');
+  updateService('ipfs', {
+    api: 'http://127.0.0.1:5001',
+    gateway: 'http://localhost:8080',
+    mode: MODE.BUNDLED,
+  });
+  setStatusMessage('ipfs', 'Test mode (IPFS stub)');
+}
+
+// `test:*` IPC operations the Playwright runner can invoke from the
+// renderer (page.evaluate(() => ipcRenderer.invoke('test:...')) won't
+// work because contextIsolation hides ipcRenderer — the runner uses
+// electronApp.evaluate(...) and calls these via ipcMain.emit instead,
+// or the global shim below).
+function registerTestOps() {
+  replaceHandler('test:ping', () => ({ ok: true, pid: process.pid }));
+
+  replaceHandler('test:reset-fixtures', () => {
+    resetFixtures();
+    return { ok: true };
+  });
+
+  replaceHandler('test:set-content-fixture', (_event, payload = {}) => {
+    const { url, status, contentType, body } = payload;
+    if (typeof url !== 'string' || !url) {
+      return { ok: false, error: 'missing url' };
+    }
+    contentFixtures.set(url, { status, contentType, body });
+    return { ok: true };
+  });
+
+  replaceHandler('test:set-ens-fixture', (_event, payload = {}) => {
+    const { name, result } = payload;
+    if (typeof name !== 'string' || !name) {
+      return { ok: false, error: 'missing name' };
+    }
+    ensFixtures.set(name.trim().toLowerCase(), result);
+    return { ok: true };
+  });
+
+  replaceHandler('test:set-probe-fixture', (_event, payload = {}) => {
+    const { hash, outcome } = payload;
+    if (typeof hash !== 'string' || !hash) {
+      return { ok: false, error: 'missing hash' };
+    }
+    probeFixtures.set(hash, outcome ?? { ok: true });
+    return { ok: true };
+  });
+
+  replaceHandler('test:get-state', () => ({
+    content: [...contentFixtures.keys()],
+    ens: [...ensFixtures.keys()],
+    probes: [...probeFixtures.keys()],
+  }));
+}
+
+// Expose a synchronous shim on the main-process global so the Playwright
+// runner can drive fixtures via `electronApp.evaluate(() => globalThis
+// .__FREEDOM_TEST_HARNESS__.setContentFixture(...))` without an IPC
+// round-trip.
+function exposeGlobalShim() {
+  globalThis.__FREEDOM_TEST_HARNESS__ = {
+    setContentFixture: (url, fixture) => {
+      contentFixtures.set(url, fixture || {});
+    },
+    clearContentFixtures: () => contentFixtures.clear(),
+    setEnsFixture: (name, result) => {
+      ensFixtures.set(String(name).trim().toLowerCase(), result);
+    },
+    setProbeFixture: (hash, outcome) => {
+      probeFixtures.set(hash, outcome ?? { ok: true });
+    },
+    resetFixtures,
+    state: () => ({
+      content: [...contentFixtures.keys()],
+      ens: [...ensFixtures.keys()],
+      probes: [...probeFixtures.keys()],
+    }),
+  };
+}
+
+function installTestHarness({ defaultSession }) {
+  if (!TEST_MODE_ENABLED) return false;
+  log.info('[test-harness] FREEDOM_TEST_MODE=1 — installing harness');
+  resetFixtures();
+  registerStubProtocols(defaultSession);
+  overrideEnsIpc();
+  overrideProbeIpc();
+  overrideNodeIpc();
+  registerTestOps();
+  seedRegistry();
+  exposeGlobalShim();
+  return true;
+}
+
+module.exports = {
+  isTestMode,
+  installTestHarness,
+};

--- a/src/main/test-harness.js
+++ b/src/main/test-harness.js
@@ -116,6 +116,31 @@ function registerStubProtocols(targetSession) {
   }
 }
 
+// Block all real http(s) traffic in test mode so a spec that
+// accidentally exercises a code path which navigates to a real URL
+// (typing `example.com` into the address bar, an embedded analytics
+// beacon, an ENS RPC fallback, etc.) doesn't reach out to the
+// internet. The redirect target is a tiny `data:` URL so the navigation
+// completes successfully from Chromium's perspective and no error
+// page or did-fail-load handler fires — specs are then free to assert
+// on chrome state (address bar value, tab count) without racing
+// against a network round-trip that may or may not return.
+function blockExternalNetworks(targetSession) {
+  if (!targetSession?.webRequest?.onBeforeRequest) {
+    log.warn('[test-harness] session.webRequest.onBeforeRequest unavailable — skipping http(s) blocker');
+    return;
+  }
+  const stubBody = '<!doctype html><title>test-harness</title><h1>http(s) blocked in test mode</h1>';
+  const redirectURL = `data:text/html;charset=utf-8,${encodeURIComponent(stubBody)}`;
+  targetSession.webRequest.onBeforeRequest(
+    { urls: ['http://*/*', 'https://*/*'] },
+    (details, callback) => {
+      log.info(`[test-harness] redirected ${details.url} → data: stub (test mode)`);
+      callback({ redirectURL });
+    }
+  );
+}
+
 // Replace a previously-registered ipcMain.handle entry. ipcMain.handle
 // throws if the channel is already registered, so removal must happen
 // before re-registration. Safe to call when the channel was never
@@ -189,21 +214,60 @@ function overrideProbeIpc() {
 // Bee / IPFS / Radicle managers are still loaded so their `getStatus`
 // handlers respond, but we replace start/stop with no-ops so a stray
 // click in a spec can't spawn the real binaries against the test
-// `userData` directory.
+// `userData` directory. The fake status is also tracked in-memory so
+// the corresponding `*_GET_STATUS` handler reports it (otherwise the
+// real manager would still reply with "stopped" and the renderer
+// would think the toggle silently failed).
+//
+// Stub responses match the production IPC shape `{ status, error }`
+// — the renderer destructures these fields directly
+// (`src/renderer/lib/bee-ui.js`, `src/renderer/lib/ipfs-ui.js`).
+const stubNodeStatus = { bee: 'running', ipfs: 'running', radicle: 'running' };
+
 function overrideNodeIpc() {
-  for (const channel of [
-    IPC.BEE_START,
-    IPC.BEE_STOP,
-    IPC.IPFS_START,
-    IPC.IPFS_STOP,
-    IPC.RADICLE_START,
-    IPC.RADICLE_STOP,
-  ]) {
-    replaceHandler(channel, async () => {
-      log.info(`[test-harness] ignored ${channel} (test mode)`);
-      return { success: true, testMode: true };
-    });
-  }
+  const setStatus = (service, status) => {
+    stubNodeStatus[service] = status;
+    return { status, error: null };
+  };
+
+  replaceHandler(IPC.BEE_START, async () => {
+    log.info('[test-harness] ignored bee:start (test mode)');
+    return setStatus('bee', 'running');
+  });
+  replaceHandler(IPC.BEE_STOP, async () => {
+    log.info('[test-harness] ignored bee:stop (test mode)');
+    return setStatus('bee', 'stopped');
+  });
+  replaceHandler(IPC.BEE_GET_STATUS, async () => ({
+    status: stubNodeStatus.bee,
+    error: null,
+  }));
+
+  replaceHandler(IPC.IPFS_START, async () => {
+    log.info('[test-harness] ignored ipfs:start (test mode)');
+    return setStatus('ipfs', 'running');
+  });
+  replaceHandler(IPC.IPFS_STOP, async () => {
+    log.info('[test-harness] ignored ipfs:stop (test mode)');
+    return setStatus('ipfs', 'stopped');
+  });
+  replaceHandler(IPC.IPFS_GET_STATUS, async () => ({
+    status: stubNodeStatus.ipfs,
+    error: null,
+  }));
+
+  replaceHandler(IPC.RADICLE_START, async () => {
+    log.info('[test-harness] ignored radicle:start (test mode)');
+    return setStatus('radicle', 'running');
+  });
+  replaceHandler(IPC.RADICLE_STOP, async () => {
+    log.info('[test-harness] ignored radicle:stop (test mode)');
+    return setStatus('radicle', 'stopped');
+  });
+  replaceHandler(IPC.RADICLE_GET_STATUS, async () => ({
+    status: stubNodeStatus.radicle,
+    error: null,
+  }));
 }
 
 function seedRegistry() {
@@ -298,6 +362,7 @@ function installTestHarness({ defaultSession }) {
   log.info('[test-harness] FREEDOM_TEST_MODE=1 — installing harness');
   resetFixtures();
   registerStubProtocols(defaultSession);
+  blockExternalNetworks(defaultSession);
   overrideEnsIpc();
   overrideProbeIpc();
   overrideNodeIpc();

--- a/src/main/test-harness.js
+++ b/src/main/test-harness.js
@@ -101,11 +101,29 @@ function makeProtocolHandler(scheme) {
   };
 }
 
+function makeHttpStubHandler(scheme) {
+  return async (request) => {
+    log.info(`[test-harness] stubbed ${scheme}: ${request.url}`);
+    const body =
+      `<!doctype html>` +
+      `<title>test-harness ${scheme} stub</title>` +
+      `<h1>${scheme}:// blocked in test mode</h1>` +
+      `<p data-test="harness-http-stub-url">${request.url}</p>`;
+    return new Response(body, {
+      status: 200,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  };
+}
+
 function registerStubProtocols(targetSession) {
   if (!targetSession?.protocol?.handle) {
     log.warn('[test-harness] session.protocol.handle unavailable — skipping protocol stubs');
     return;
   }
+  // bzz/ipfs/ipns: harness owns these outright (custom standard schemes
+  // we register in production too — see src/main/swarm/bzz-protocol.js
+  // etc.). Specs drive content via setContentFixture().
   for (const scheme of ['bzz', 'ipfs', 'ipns']) {
     try {
       targetSession.protocol.handle(scheme, makeProtocolHandler(scheme));
@@ -114,31 +132,25 @@ function registerStubProtocols(targetSession) {
       log.error(`[test-harness] failed to register stub ${scheme}: handler`, err);
     }
   }
-}
-
-// Block all real http(s) traffic in test mode so a spec that
-// accidentally exercises a code path which navigates to a real URL
-// (typing `example.com` into the address bar, an embedded analytics
-// beacon, an ENS RPC fallback, etc.) doesn't reach out to the
-// internet. The redirect target is a tiny `data:` URL so the navigation
-// completes successfully from Chromium's perspective and no error
-// page or did-fail-load handler fires — specs are then free to assert
-// on chrome state (address bar value, tab count) without racing
-// against a network round-trip that may or may not return.
-function blockExternalNetworks(targetSession) {
-  if (!targetSession?.webRequest?.onBeforeRequest) {
-    log.warn('[test-harness] session.webRequest.onBeforeRequest unavailable — skipping http(s) blocker');
-    return;
-  }
-  const stubBody = '<!doctype html><title>test-harness</title><h1>http(s) blocked in test mode</h1>';
-  const redirectURL = `data:text/html;charset=utf-8,${encodeURIComponent(stubBody)}`;
-  targetSession.webRequest.onBeforeRequest(
-    { urls: ['http://*/*', 'https://*/*'] },
-    (details, callback) => {
-      log.info(`[test-harness] redirected ${details.url} → data: stub (test mode)`);
-      callback({ redirectURL });
+  // http/https: harness owns these too while in test mode, so a spec
+  // that exercises a path which calls `webview.loadURL('https://...')`
+  // (typing `example.com`, an embedded analytics beacon, an ENS RPC
+  // fallback, …) doesn't reach the network. Using `protocol.handle`
+  // instead of `webRequest.onBeforeRequest` redirects means we own the
+  // scheme — the request never enters Chromium's network stack at all,
+  // no DNS lookup, no TCP/TLS handshake. Electron 30+ allows
+  // overriding built-in standard schemes; previous handlers are
+  // replaced. The webview tag in tabs.js doesn't set a `partition`
+  // attribute, which per Electron's <webview> docs means it uses the
+  // app default session — i.e. this same one we're attaching to.
+  for (const scheme of ['http', 'https']) {
+    try {
+      targetSession.protocol.handle(scheme, makeHttpStubHandler(scheme));
+      log.info(`[test-harness] registered stub ${scheme}: handler (owns scheme)`);
+    } catch (err) {
+      log.error(`[test-harness] failed to register stub ${scheme}: handler`, err);
     }
-  );
+  }
 }
 
 // Replace a previously-registered ipcMain.handle entry. ipcMain.handle
@@ -362,7 +374,6 @@ function installTestHarness({ defaultSession }) {
   log.info('[test-harness] FREEDOM_TEST_MODE=1 — installing harness');
   resetFixtures();
   registerStubProtocols(defaultSession);
-  blockExternalNetworks(defaultSession);
   overrideEnsIpc();
   overrideProbeIpc();
   overrideNodeIpc();

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -25,10 +25,10 @@
     <div class="title-bar">
       <div class="title-bar-spacer"></div>
       <div class="tab-bar">
-        <div class="tabs-container" id="tab-bar">
+        <div class="tabs-container" id="tab-bar" data-test="tab-bar">
           <!-- Tabs inserted dynamically -->
         </div>
-        <button id="new-tab-btn" class="new-tab-btn" type="button" aria-label="New Tab">
+        <button id="new-tab-btn" class="new-tab-btn" type="button" aria-label="New Tab" data-test="new-tab-btn">
           <svg
             width="12"
             height="12"
@@ -270,6 +270,7 @@
               type="text"
               placeholder="Enter hash, ID or URL"
               spellcheck="false"
+              data-test="address-input"
             />
             <button
               id="github-bridge-btn"
@@ -295,6 +296,7 @@
               class="icon-btn input-action-btn hidden"
               type="button"
               aria-label="Bookmark this page"
+              data-test="add-bookmark-btn"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -688,7 +690,7 @@
         </div>
       </div>
     </header>
-    <nav class="bookmarks" aria-label="Bookmarks" id="bookmarks-bar"></nav>
+    <nav class="bookmarks" aria-label="Bookmarks" id="bookmarks-bar" data-test="bookmarks-bar"></nav>
     <section class="app-body">
       <main class="content">
         <div id="webview-container" class="webview-container">

--- a/src/renderer/lib/autocomplete.js
+++ b/src/renderer/lib/autocomplete.js
@@ -246,6 +246,14 @@ const handleKeyDown = (e) => {
     if (e.key === 'ArrowDown' && addressInput?.value) {
       handleInput();
       e.preventDefault();
+      return;
+    }
+    // User committed before the 80 ms debounce fired. Cancel the
+    // pending suggestion render so the dropdown doesn't pop open
+    // after the navigation has already started.
+    if ((e.key === 'Enter' || e.key === 'Escape') && debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
     }
     return;
   }

--- a/src/renderer/lib/bookmarks-ui.js
+++ b/src/renderer/lib/bookmarks-ui.js
@@ -73,6 +73,7 @@ const createBookmarkButton = (item, isOverflowItem = false) => {
   const button = document.createElement('button');
   button.className = isOverflowItem ? 'bookmarks-overflow-item' : 'bookmark';
   button.dataset.hash = item.target;
+  button.dataset.test = isOverflowItem ? 'bookmark-overflow-item' : 'bookmark-item';
 
   // Create icon container
   const iconContainer = document.createElement('span');

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -540,6 +540,7 @@ const createTabElement = (tab) => {
   const tabEl = document.createElement('button');
   tabEl.className = 'tab';
   tabEl.dataset.tabId = tab.id;
+  tabEl.dataset.test = 'tab';
   tabEl.draggable = true;
 
   // Tab icon container (favicon, spinner, or default globe)
@@ -576,6 +577,7 @@ const createTabElement = (tab) => {
   // Close button
   const closeEl = document.createElement('button');
   closeEl.className = 'tab-close';
+  closeEl.dataset.test = 'tab-close';
   closeEl.innerHTML =
     '<svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M1.5 1.5l7 7M8.5 1.5l-7 7"/></svg>';
   closeEl.addEventListener('click', (e) => {

--- a/test-e2e/address-bar.spec.js
+++ b/test-e2e/address-bar.spec.js
@@ -1,0 +1,50 @@
+// Address-bar input → URL normalisation pipeline.
+//
+// We assert at the chrome layer (input value, protocol icon) rather than
+// inside the webview, since webview rendering is content-handler-specific
+// and the harness already gives us deterministic content.
+
+const { test, expect, SAMPLE_BZZ_HASH } = require('./fixtures');
+
+test('typing a 64-char hex hash normalises to bzz:// in the address bar', async ({
+  window,
+  harness,
+}) => {
+  await harness.setContentFixture(`bzz://${SAMPLE_BZZ_HASH}/`, {
+    body: '<!doctype html><title>fixture</title><h1>fixture</h1>',
+  });
+
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(SAMPLE_BZZ_HASH);
+  await input.press('Enter');
+
+  // The renderer rewrites the input value to the canonical bzz:// form
+  // synchronously inside loadTarget; no need to wait for the webview.
+  await expect(input).toHaveValue(`bzz://${SAMPLE_BZZ_HASH}`);
+});
+
+test('typing a bzz:// URL with a path preserves the path in the address bar', async ({
+  window,
+  harness,
+}) => {
+  await harness.setContentFixture(`bzz://${SAMPLE_BZZ_HASH}/`, {
+    body: '<!doctype html><title>fixture</title>',
+  });
+
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(`bzz://${SAMPLE_BZZ_HASH}/about`);
+  await input.press('Enter');
+
+  await expect(input).toHaveValue(`bzz://${SAMPLE_BZZ_HASH}/about`);
+});
+
+test('typing a bare HTTPS domain auto-prefixes the scheme', async ({ window }) => {
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill('example.com');
+  await input.press('Enter');
+
+  await expect(input).toHaveValue('https://example.com');
+});

--- a/test-e2e/address-bar.spec.js
+++ b/test-e2e/address-bar.spec.js
@@ -40,11 +40,40 @@ test('typing a bzz:// URL with a path preserves the path in the address bar', as
   await expect(input).toHaveValue(`bzz://${SAMPLE_BZZ_HASH}/about`);
 });
 
-test('typing a bare HTTPS domain auto-prefixes the scheme', async ({ window }) => {
+test('typing a bare HTTPS domain auto-prefixes the scheme and stays inside the harness', async ({
+  window,
+}) => {
   const input = window.locator('[data-test="address-input"]');
   await input.click();
   await input.fill('example.com');
   await input.press('Enter');
 
   await expect(input).toHaveValue('https://example.com');
+
+  // Prove the navigation actually went through the harness stub
+  // (`makeHttpStubHandler` in src/main/test-harness.js) rather than
+  // out to the public internet. The stub embeds the request URL in a
+  // <p data-test="harness-http-stub-url"> element, so the presence of
+  // that text inside the active webview is unambiguous evidence the
+  // request was intercepted at the protocol-handler layer and served
+  // in-process. Without this assertion the spec would still pass even
+  // if the harness regressed back to letting Chromium reach the
+  // network.
+  await expect
+    .poll(
+      () =>
+        window.evaluate(async () => {
+          const wv = document.querySelector('webview:not(.hidden)');
+          if (!wv || typeof wv.executeJavaScript !== 'function') return null;
+          try {
+            return await wv.executeJavaScript(
+              'document.querySelector(\'[data-test="harness-http-stub-url"]\')?.textContent || null'
+            );
+          } catch {
+            return null;
+          }
+        }),
+      { message: 'Waiting for harness http(s) stub to be served', timeout: 5_000 }
+    )
+    .toBe('https://example.com/');
 });

--- a/test-e2e/bookmarks.spec.js
+++ b/test-e2e/bookmarks.spec.js
@@ -1,0 +1,47 @@
+// Bookmarks bar — add via the IPC the address-bar star uses, and assert
+// the bar reflects the new entry. Removal goes through the same IPC.
+
+const { test, expect } = require('./fixtures');
+
+// Force the bookmarks bar to be visible on every page. Without this the
+// bar is only shown on the home page, which complicates assertions when
+// the active tab navigates away.
+test.use({ seedSettings: { showBookmarkBar: true } });
+
+test('adding a bookmark via IPC shows it in the bookmarks bar', async ({ window }) => {
+  const items = window.locator('[data-test="bookmarks-bar"] [data-test="bookmark-item"]');
+  const initialCount = await items.count();
+
+  await window.evaluate(() =>
+    window.electronAPI.addBookmark({
+      label: 'Test Bookmark',
+      target: 'https://example.com/freedom-e2e',
+    })
+  );
+
+  // The bookmarks bar reads from the IPC at init and after explicit
+  // user actions; there's no "bookmarks changed" broadcast for external
+  // mutations. Reloading the renderer forces a fresh load.
+  await window.reload();
+  await window.waitForSelector('[data-test="address-input"]');
+
+  await expect(items).toHaveCount(initialCount + 1);
+  await expect(
+    window.locator(
+      '[data-test="bookmarks-bar"] [data-test="bookmark-item"][data-hash="https://example.com/freedom-e2e"]'
+    )
+  ).toBeVisible();
+
+  // Cleanup also goes through the IPC contract.
+  await window.evaluate(() =>
+    window.electronAPI.removeBookmark('https://example.com/freedom-e2e')
+  );
+
+  await window.reload();
+  await window.waitForSelector('[data-test="address-input"]');
+  await expect(
+    window.locator(
+      '[data-test="bookmarks-bar"] [data-test="bookmark-item"][data-hash="https://example.com/freedom-e2e"]'
+    )
+  ).toHaveCount(0);
+});

--- a/test-e2e/error-page.spec.js
+++ b/test-e2e/error-page.spec.js
@@ -1,0 +1,40 @@
+// Error page — when the swarm probe returns `not_found`, the renderer
+// routes the active webview to `pages/error.html` with the original
+// URL preserved in the address bar. We assert both via the chrome and
+// the webview's URL (the error page itself is loaded from the host
+// pages/ directory so it's accessible to Playwright as a frame).
+
+const { test, expect, SAMPLE_BZZ_HASH } = require('./fixtures');
+
+test('a probe-not-found bzz:// navigation lands on the error page', async ({
+  window,
+  harness,
+}) => {
+  // Force the Swarm probe stub to time out for this hash so navigation
+  // routes to error.html instead of the (also-stubbed) bzz:// fixture.
+  await harness.setProbeFixture(SAMPLE_BZZ_HASH, { ok: false, reason: 'not_found' });
+
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(`bzz://${SAMPLE_BZZ_HASH}`);
+  await input.press('Enter');
+
+  // Address bar keeps the original URL so the user knows what failed.
+  // The renderer's error path canonicalises to bzz://<hash>/ (trailing
+  // slash); the success path strips it. Match either form.
+  await expect(input).toHaveValue(new RegExp(`^bzz://${SAMPLE_BZZ_HASH}/?$`));
+
+  // Active webview is the one whose container is visible. We poll its
+  // src until it reports the error.html path; navigation is async.
+  await expect
+    .poll(
+      async () => {
+        return window.evaluate(() => {
+          const wv = document.querySelector('webview.active, webview:not(.hidden)');
+          return wv?.getURL?.() || wv?.getAttribute?.('src') || '';
+        });
+      },
+      { timeout: 10_000, intervals: [200, 500, 1000] }
+    )
+    .toMatch(/pages\/error\.html\?error=swarm_content_not_found/);
+});

--- a/test-e2e/fixtures.js
+++ b/test-e2e/fixtures.js
@@ -1,0 +1,127 @@
+// Custom Playwright fixtures for the Freedom renderer E2E suite.
+//
+// `electronApp` launches the app from the repo root with FREEDOM_TEST_MODE=1
+// and a per-run temp `userData` dir, so each test gets clean settings,
+// bookmarks, and history. `window` is the first BrowserWindow page.
+// `harness` exposes ergonomic helpers backed by the main-process test
+// harness (see `src/main/test-harness.js`).
+
+const { test: base, expect, _electron: electron } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+// We want a stable settings shape across runs. The main-process settings
+// store loads JSON from `<userData>/settings.json` and merges over
+// DEFAULT_SETTINGS, so writing this file before app launch lets specs
+// pick known initial values without going through the saveSettings IPC
+// (which broadcasts events and would fight with the renderer's bootstrap).
+function seedSettings(userDataDir, overrides) {
+  if (!overrides) return;
+  fs.mkdirSync(userDataDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(userDataDir, 'settings.json'),
+    JSON.stringify(overrides, null, 2),
+    'utf-8'
+  );
+}
+
+const test = base.extend({
+  // Explicit per-test option: seed settings.json before launch.
+  // Useful when a spec needs to start from a non-default UI state
+  // (e.g., bookmarks bar visible, theme=light) without the racing
+  // problem above.
+  seedSettings: [null, { option: true }],
+
+  electronApp: async ({ seedSettings: settingsOverride }, use) => {
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'freedom-e2e-'));
+    seedSettings(userDataDir, settingsOverride);
+
+    const app = await electron.launch({
+      args: ['.'],
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        FREEDOM_TEST_MODE: '1',
+        FREEDOM_TEST_USER_DATA: userDataDir,
+        ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+        // Force a deterministic locale so menu accelerators don't drift
+        // by region (CmdOrCtrl resolves to Cmd on darwin regardless).
+        LANG: 'en_US.UTF-8',
+      },
+      timeout: 20_000,
+    });
+
+    await use(app);
+
+    try {
+      await app.close();
+    } catch {
+      // Window may already have been closed by the spec.
+    }
+    try {
+      fs.rmSync(userDataDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup — leftover dirs in /tmp are harmless.
+    }
+  },
+
+  window: async ({ electronApp }, use) => {
+    const win = await electronApp.firstWindow();
+    await win.waitForLoadState('domcontentloaded');
+    // Wait for chrome to mount before any spec interacts with it. The
+    // address bar is the last toolbar element initialized; presence here
+    // implies tab bar, bookmarks bar, and menus are all live.
+    await win.waitForSelector('[data-test="address-input"]', { state: 'visible' });
+    await use(win);
+  },
+
+  // High-level helpers backed by the main-process test harness. Each
+  // method round-trips through electronApp.evaluate() so it runs in the
+  // main process where the harness state lives.
+  harness: async ({ electronApp }, use) => {
+    const setContentFixture = async (url, fixture) => {
+      await electronApp.evaluate(({ ipcMain: _ipcMain }, { url: u, fixture: f }) => {
+        globalThis.__FREEDOM_TEST_HARNESS__.setContentFixture(u, f);
+      }, { url, fixture });
+    };
+
+    const setEnsFixture = async (name, result) => {
+      await electronApp.evaluate(({ ipcMain: _ipcMain }, { name: n, result: r }) => {
+        globalThis.__FREEDOM_TEST_HARNESS__.setEnsFixture(n, r);
+      }, { name, result });
+    };
+
+    const setProbeFixture = async (hash, outcome) => {
+      await electronApp.evaluate(({ ipcMain: _ipcMain }, { hash: h, outcome: o }) => {
+        globalThis.__FREEDOM_TEST_HARNESS__.setProbeFixture(h, o);
+      }, { hash, outcome });
+    };
+
+    const reset = async () => {
+      await electronApp.evaluate(() => {
+        globalThis.__FREEDOM_TEST_HARNESS__.resetFixtures();
+      });
+    };
+
+    const state = async () => {
+      return electronApp.evaluate(() => globalThis.__FREEDOM_TEST_HARNESS__.state());
+    };
+
+    await use({ setContentFixture, setEnsFixture, setProbeFixture, reset, state });
+  },
+});
+
+// Convenience: an arbitrary 64-char Swarm hex hash for fixture-driven
+// `bzz://` navigation. Specs should treat this as opaque.
+const SAMPLE_BZZ_HASH = 'a'.repeat(64);
+const SAMPLE_IPFS_CID = 'bafybeib' + 'a'.repeat(51);
+
+module.exports = {
+  test,
+  expect,
+  SAMPLE_BZZ_HASH,
+  SAMPLE_IPFS_CID,
+};

--- a/test-e2e/live-fixtures.js
+++ b/test-e2e/live-fixtures.js
@@ -1,0 +1,99 @@
+// Custom fixtures for the live-network E2E suite.
+//
+// Unlike `fixtures.js`, this launches the app WITHOUT FREEDOM_TEST_MODE,
+// so the actual Bee / IPFS managers start, ENS resolution hits the
+// live Universal Resolver, and the production bzz:// / ipfs:// protocol
+// handlers stream from the local gateway. We still pass
+// FREEDOM_TEST_USER_DATA so the test session doesn't write to the
+// user's real settings/bookmarks/history files.
+
+const { test: base, expect, _electron: electron } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+// Mirror bee-manager.js's binary-path resolution so we can detect a
+// missing binary up front and skip the suite gracefully (downloading
+// the Bee binary is a per-platform extra step the user opts into via
+// `npm run bee:download`).
+function resolveBeeBinaryPath() {
+  const platformMap = { darwin: 'mac', linux: 'linux', win32: 'win' };
+  const platform = platformMap[process.platform] || process.platform;
+  const arch = process.arch;
+  const binName = process.platform === 'win32' ? 'bee.exe' : 'bee';
+  return path.join(repoRoot, 'bee-bin', `${platform}-${arch}`, binName);
+}
+
+// Mirror ipfs-manager.js's binary-path resolution. Used by specs that
+// hard-require IPFS so they can fail with a clear message instead of
+// timing out on "Connected Peers" never updating.
+function resolveIpfsBinaryPath() {
+  const platformMap = { darwin: 'mac', linux: 'linux', win32: 'win' };
+  const platform = platformMap[process.platform] || process.platform;
+  const arch = process.arch;
+  const binName = process.platform === 'win32' ? 'ipfs.exe' : 'ipfs';
+  return path.join(repoRoot, 'ipfs-bin', `${platform}-${arch}`, binName);
+}
+
+const BEE_BINARY_PATH = resolveBeeBinaryPath();
+const HAS_BEE_BINARY = fs.existsSync(BEE_BINARY_PATH);
+
+const IPFS_BINARY_PATH = resolveIpfsBinaryPath();
+const HAS_IPFS_BINARY = fs.existsSync(IPFS_BINARY_PATH);
+
+const test = base.extend({
+  // Playwright derives fixture dependencies from the first parameter's
+  // destructure; this fixture has none, but the empty `{}` is required
+  // so Playwright recognises it as a fixture function rather than a
+  // plain factory.
+  // eslint-disable-next-line no-empty-pattern
+  electronApp: async ({}, use) => {
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'freedom-live-e2e-'));
+
+    const app = await electron.launch({
+      args: ['.'],
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        // Deliberately NOT setting FREEDOM_TEST_MODE — this suite needs
+        // the production code paths (actual Bee spawn, live ENS, real
+        // protocol handlers).
+        FREEDOM_TEST_USER_DATA: userDataDir,
+        ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+        LANG: 'en_US.UTF-8',
+      },
+      timeout: 60_000,
+    });
+
+    await use(app);
+
+    try {
+      await app.close();
+    } catch {
+      // Window may already be closed by the spec.
+    }
+    try {
+      fs.rmSync(userDataDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup; leftover dirs in /tmp are harmless.
+    }
+  },
+
+  window: async ({ electronApp }, use) => {
+    const win = await electronApp.firstWindow();
+    await win.waitForLoadState('domcontentloaded');
+    await win.waitForSelector('[data-test="address-input"]', { state: 'visible' });
+    await use(win);
+  },
+});
+
+module.exports = {
+  test,
+  expect,
+  HAS_BEE_BINARY,
+  BEE_BINARY_PATH,
+  HAS_IPFS_BINARY,
+  IPFS_BINARY_PATH,
+};

--- a/test-e2e/live-fixtures.js
+++ b/test-e2e/live-fixtures.js
@@ -50,7 +50,28 @@ const test = base.extend({
   // plain factory.
   // eslint-disable-next-line no-empty-pattern
   electronApp: async ({}, use) => {
-    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'freedom-live-e2e-'));
+    // One temp root per run, with four subdirs:
+    //   - userData/     → settings, bookmarks, history (FREEDOM_TEST_USER_DATA)
+    //   - bee-data/     → Bee's identity, swarm key, peerstore (FREEDOM_BEE_DATA)
+    //   - ipfs-data/    → Kubo's repo, identity, peerstore (FREEDOM_IPFS_DATA)
+    //   - identity/     → vault meta + node-identity files (FREEDOM_IDENTITY_DATA)
+    // All four overrides matter: in dev mode these directories default
+    // to `<repoRoot>/bee-data`, `<repoRoot>/ipfs-data`, and
+    // `<repoRoot>/identity-data` — pointing them at empty temp dirs is
+    // what keeps a live run from clobbering the developer's persistent
+    // state. The identity override is the most subtle of the three:
+    // without it `hasVault()` would still find the developer's local
+    // vault, set the node managers into injected-identity mode, and
+    // Bee/IPFS would hang waiting for keys the temp data dirs don't
+    // have.
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'freedom-live-e2e-'));
+    const userDataDir = path.join(tmpRoot, 'userData');
+    const beeDataDir = path.join(tmpRoot, 'bee-data');
+    const ipfsDataDir = path.join(tmpRoot, 'ipfs-data');
+    const identityDataDir = path.join(tmpRoot, 'identity');
+    for (const dir of [userDataDir, beeDataDir, ipfsDataDir, identityDataDir]) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
 
     const app = await electron.launch({
       args: ['.'],
@@ -61,6 +82,9 @@ const test = base.extend({
         // the production code paths (actual Bee spawn, live ENS, real
         // protocol handlers).
         FREEDOM_TEST_USER_DATA: userDataDir,
+        FREEDOM_BEE_DATA: beeDataDir,
+        FREEDOM_IPFS_DATA: ipfsDataDir,
+        FREEDOM_IDENTITY_DATA: identityDataDir,
         ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
         LANG: 'en_US.UTF-8',
       },
@@ -75,7 +99,7 @@ const test = base.extend({
       // Window may already be closed by the spec.
     }
     try {
-      fs.rmSync(userDataDir, { recursive: true, force: true });
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
     } catch {
       // Best-effort cleanup; leftover dirs in /tmp are harmless.
     }

--- a/test-e2e/live/eth-sites.spec.js
+++ b/test-e2e/live/eth-sites.spec.js
@@ -23,10 +23,13 @@ const {
 } = require('../live-fixtures');
 
 const PEER_TARGET = 20;
-// Cold-start observations: a freshly-spawned Bee in DHT client mode
-// usually crosses 20 peers in 30–120 s; IPFS (Kubo) typically does so
-// in 10–60 s. 7 min keeps headroom for slow home connections without
-// making the test feel infinite.
+// Each live run starts with a *fresh* Bee/IPFS data dir
+// (FREEDOM_BEE_DATA / FREEDOM_IPFS_DATA point at a per-run temp dir,
+// see live-fixtures.js), so peerstores are empty and gossip starts
+// from the hardcoded bootstrap nodes every time. Bee in DHT client
+// mode typically crosses 20 peers in 30–180 s on a warm bootstrap
+// network; IPFS (Kubo) usually in 10–60 s. 7 min keeps headroom for
+// slow home connections without making the test feel infinite.
 const PEER_TIMEOUT_MS = 7 * 60_000;
 const NAVIGATION_TIMEOUT_MS = 90_000;
 const PAGE_RENDER_TIMEOUT_MS = 60_000;
@@ -127,60 +130,70 @@ const waitForWebviewCondition = (window, snippet, message) =>
     })
     .toBeTruthy();
 
-test('cold-start: Bee + IPFS reach >20 peers, meinhard.eth & vitalik.eth render', async ({
-  window,
-}) => {
+// Binary preconditions are evaluated at describe-load (before any
+// fixture runs). The previous in-test `test.skip` / `expect` form let
+// Playwright launch Electron *first* and only then notice the missing
+// binary — meaning a CI box without Bee/IPFS would still spawn the
+// app, attempt to start the production node managers against a missing
+// binary, and only fail/skip after that side-effect. Now the binary
+// check happens before `electronApp` is ever requested.
+test.describe('live cold-start sites', () => {
   test.skip(
     !HAS_BEE_BINARY,
     `Live E2E needs the Bee binary at ${BEE_BINARY_PATH}. Run \`npm run bee:download\` to fetch it.`
   );
-  // IPFS is required (not skipped) per test design — failing here gives
-  // a much clearer signal than timing out on "Connected Peers" never
-  // updating below.
-  expect(
-    HAS_IPFS_BINARY,
-    `Live E2E requires the IPFS binary at ${IPFS_BINARY_PATH}. Run \`npm run ipfs:download\` to fetch it.`
-  ).toBe(true);
+  // IPFS is required (not skipped) per test design — throw at module
+  // load so the runner reports a clear setup error instead of letting
+  // the app launch and time out on "Connected Peers" never updating.
+  if (!HAS_IPFS_BINARY) {
+    throw new Error(
+      `Live E2E requires the IPFS binary at ${IPFS_BINARY_PATH}. Run \`npm run ipfs:download\` to fetch it.`
+    );
+  }
 
-  const beeMenuButton = window.locator('#bee-menu-button');
-  const beeDropdown = window.locator('#bee-menu-dropdown');
-  const beePeersCount = window.locator('#bee-peers-count');
-  const ipfsPeersCount = window.locator('#ipfs-peers-count');
-
-  // (1) Open the Nodes menu — kicks off bee/ipfs/radicle status
-  // polling in the renderer. Both peer counters live inside this
-  // single dropdown so we only need one open/close cycle.
-  await beeMenuButton.click();
-  await expect(beeDropdown).toHaveClass(/open/);
-
-  // (2) Wait for both networks to come up. Run sequentially: in
-  // practice IPFS gossips faster than Bee, so by the time Bee crosses
-  // 20 peers IPFS is usually already there and the second poll
-  // returns on its first sample.
-  await waitForPeers(beePeersCount, 'Swarm');
-  await waitForPeers(ipfsPeersCount, 'IPFS');
-
-  // (3) Close the menu before driving the address bar. Polling stops
-  // and the visible counters reset to 0 — that's expected.
-  await beeMenuButton.click();
-  await expect(beeDropdown).not.toHaveClass(/open/);
-
-  // (4) meinhard.eth — Swarm-hosted; address bar must end up on bzz://.
-  await navigateTo(window, 'meinhard.eth', 'bzz');
-  await waitForWebviewCondition(
+  test('cold-start: Bee + IPFS reach >20 peers, meinhard.eth & vitalik.eth render', async ({
     window,
-    PLAY_BUTTON_SNIFFER,
-    'Waiting for a play-button-shaped element on meinhard.eth'
-  );
+  }) => {
+    const beeMenuButton = window.locator('#bee-menu-button');
+    const beeDropdown = window.locator('#bee-menu-dropdown');
+    const beePeersCount = window.locator('#bee-peers-count');
+    const ipfsPeersCount = window.locator('#ipfs-peers-count');
 
-  // (5) vitalik.eth — IPFS-hosted blog; address bar must end up on
-  // ipfs://. The page is content-heavy so the H1 is a stable
-  // structural marker that the page actually rendered (vs an error
-  // page).
-  await navigateTo(window, 'vitalik.eth', 'ipfs');
-  await waitForWebviewCondition(
-    window,
-    VITALIK_H1_SNIFFER,
-    'Waiting for an <h1> mentioning "Vitalik" on vitalik.eth'
-  );
+    // (1) Open the Nodes menu — kicks off bee/ipfs/radicle status
+    // polling in the renderer. Both peer counters live inside this
+    // single dropdown so we only need one open/close cycle.
+    await beeMenuButton.click();
+    await expect(beeDropdown).toHaveClass(/open/);
+
+    // (2) Wait for both networks to come up. Run sequentially: in
+    // practice IPFS gossips faster than Bee, so by the time Bee crosses
+    // 20 peers IPFS is usually already there and the second poll
+    // returns on its first sample.
+    await waitForPeers(beePeersCount, 'Swarm');
+    await waitForPeers(ipfsPeersCount, 'IPFS');
+
+    // (3) Close the menu before driving the address bar. Polling stops
+    // and the visible counters reset to 0 — that's expected.
+    await beeMenuButton.click();
+    await expect(beeDropdown).not.toHaveClass(/open/);
+
+    // (4) meinhard.eth — Swarm-hosted; address bar must end up on bzz://.
+    await navigateTo(window, 'meinhard.eth', 'bzz');
+    await waitForWebviewCondition(
+      window,
+      PLAY_BUTTON_SNIFFER,
+      'Waiting for a play-button-shaped element on meinhard.eth'
+    );
+
+    // (5) vitalik.eth — IPFS-hosted blog; address bar must end up on
+    // ipfs://. The page is content-heavy so the H1 is a stable
+    // structural marker that the page actually rendered (vs an error
+    // page).
+    await navigateTo(window, 'vitalik.eth', 'ipfs');
+    await waitForWebviewCondition(
+      window,
+      VITALIK_H1_SNIFFER,
+      'Waiting for an <h1> mentioning "Vitalik" on vitalik.eth'
+    );
+  });
 });

--- a/test-e2e/live/eth-sites.spec.js
+++ b/test-e2e/live/eth-sites.spec.js
@@ -1,0 +1,186 @@
+// Real-network E2E: Swarm + IPFS cold-start → ENS resolution → page render.
+//
+// Steps:
+//   1. Open the Nodes menu, which starts the bee + ipfs peer-info polling
+//      loops.
+//   2. Wait for both Swarm and IPFS connected-peer counts to climb past
+//      PEER_TARGET. The menu MUST stay open for this — closing it stops
+//      the polling and resets the counters to 0
+//      (src/renderer/lib/bee-ui.js, src/renderer/lib/ipfs-ui.js).
+//   3. Close the menu so it doesn't sit over the address bar.
+//   4. Navigate to `meinhard.eth` (Swarm-hosted), assert a play-button-
+//      shaped element exists in the active <webview>.
+//   5. Navigate to `vitalik.eth` (IPFS-hosted blog), assert an <h1>
+//      mentioning "Vitalik" exists in the active <webview>.
+
+const {
+  test,
+  expect,
+  HAS_BEE_BINARY,
+  BEE_BINARY_PATH,
+  HAS_IPFS_BINARY,
+  IPFS_BINARY_PATH,
+} = require('../live-fixtures');
+
+const PEER_TARGET = 20;
+// Cold-start observations: a freshly-spawned Bee in DHT client mode
+// usually crosses 20 peers in 30–120 s; IPFS (Kubo) typically does so
+// in 10–60 s. 7 min keeps headroom for slow home connections without
+// making the test feel infinite.
+const PEER_TIMEOUT_MS = 7 * 60_000;
+const NAVIGATION_TIMEOUT_MS = 90_000;
+const PAGE_RENDER_TIMEOUT_MS = 60_000;
+
+const PLAY_BUTTON_SNIFFER = `
+  (() => {
+    const sel = [
+      'button[aria-label*="play" i]',
+      '[role="button"][aria-label*="play" i]',
+      'a[aria-label*="play" i]',
+      '.play-button',
+      '.play',
+      'button.play',
+      'video',
+      'audio',
+    ].join(', ');
+    if (document.querySelector(sel)) return true;
+    const els = document.querySelectorAll('button, a, [role="button"]');
+    for (const el of els) {
+      if (/\\bplay\\b/i.test(el.textContent || '')) return true;
+    }
+    return false;
+  })()
+`;
+
+const VITALIK_H1_SNIFFER = `
+  (() => {
+    const headings = document.querySelectorAll('h1');
+    for (const h of headings) {
+      if (/vitalik/i.test(h.textContent || '')) return true;
+    }
+    return false;
+  })()
+`;
+
+// Read the textContent of a peer-count <span> and parse it as an int.
+// Returns -1 for "--" / non-numeric placeholders so the polling
+// comparator never accidentally satisfies `> PEER_TARGET`.
+const readPeerCount = async (locator) => {
+  const raw = (await locator.textContent()) || '';
+  const n = parseInt(raw.trim(), 10);
+  return Number.isFinite(n) ? n : -1;
+};
+
+// Wait for a peer-count <span> to exceed PEER_TARGET. Polling cadence
+// is tuned to the renderer's underlying fetch loops (Bee: 500 ms,
+// IPFS: 1 s, see bee-ui.js / ipfs-ui.js) — coarser polls would add
+// dead air between the count crossing the threshold and Playwright
+// noticing.
+const waitForPeers = (locator, label) =>
+  expect
+    .poll(() => readPeerCount(locator), {
+      message: `Waiting for ${label} connected peers > ${PEER_TARGET}`,
+      timeout: PEER_TIMEOUT_MS,
+      intervals: [500],
+    })
+    .toBeGreaterThan(PEER_TARGET);
+
+// Drive the address bar the way a user would: focus, fill, Enter.
+// Returns once the address bar has normalised to `<scheme>://<ensName>`,
+// optionally with a trailing slash or path. The scheme assertion is
+// strict: it pins the expected transport (bzz vs ipfs vs ipns) so a
+// regression in ENS contenthash dispatch can't silently land us on the
+// wrong gateway.
+const navigateTo = async (window, ensName, expectedScheme) => {
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(ensName);
+  await input.press('Enter');
+
+  const escapedHost = ensName.replace(/\./g, '\\.');
+  await expect(input).toHaveValue(
+    new RegExp(`^${expectedScheme}://${escapedHost}(/.*)?$`),
+    { timeout: NAVIGATION_TIMEOUT_MS }
+  );
+};
+
+// Playwright's Electron API doesn't expose <webview> guests as Pages,
+// so we route through the host renderer and use webview.executeJavaScript()
+// — the same DevTools-Protocol primitive Electron exposes for guests.
+const evalInActiveWebview = (window, snippet) =>
+  window.evaluate(async (s) => {
+    const wv = document.querySelector('webview:not(.hidden)');
+    if (!wv || typeof wv.executeJavaScript !== 'function') return false;
+    try {
+      return await wv.executeJavaScript(s);
+    } catch {
+      return false;
+    }
+  }, snippet);
+
+const waitForWebviewCondition = (window, snippet, message) =>
+  expect
+    .poll(() => evalInActiveWebview(window, snippet), {
+      message,
+      timeout: PAGE_RENDER_TIMEOUT_MS,
+      intervals: [1_000, 2_000, 5_000],
+    })
+    .toBeTruthy();
+
+test('cold-start: Bee + IPFS reach >20 peers, meinhard.eth & vitalik.eth render', async ({
+  window,
+}) => {
+  test.skip(
+    !HAS_BEE_BINARY,
+    `Live E2E needs the Bee binary at ${BEE_BINARY_PATH}. Run \`npm run bee:download\` to fetch it.`
+  );
+  // IPFS is required (not skipped) per test design — failing here gives
+  // a much clearer signal than timing out on "Connected Peers" never
+  // updating below.
+  expect(
+    HAS_IPFS_BINARY,
+    `Live E2E requires the IPFS binary at ${IPFS_BINARY_PATH}. Run \`npm run ipfs:download\` to fetch it.`
+  ).toBe(true);
+
+  const beeMenuButton = window.locator('#bee-menu-button');
+  const beeDropdown = window.locator('#bee-menu-dropdown');
+  const beePeersCount = window.locator('#bee-peers-count');
+  const ipfsPeersCount = window.locator('#ipfs-peers-count');
+
+  // (1) Open the Nodes menu — kicks off bee/ipfs/radicle status
+  // polling in the renderer. Both peer counters live inside this
+  // single dropdown so we only need one open/close cycle.
+  await beeMenuButton.click();
+  await expect(beeDropdown).toHaveClass(/open/);
+
+  // (2) Wait for both networks to come up. Run sequentially: in
+  // practice IPFS gossips faster than Bee, so by the time Bee crosses
+  // 20 peers IPFS is usually already there and the second poll
+  // returns on its first sample.
+  await waitForPeers(beePeersCount, 'Swarm');
+  await waitForPeers(ipfsPeersCount, 'IPFS');
+
+  // (3) Close the menu before driving the address bar. Polling stops
+  // and the visible counters reset to 0 — that's expected.
+  await beeMenuButton.click();
+  await expect(beeDropdown).not.toHaveClass(/open/);
+
+  // (4) meinhard.eth — Swarm-hosted; address bar must end up on bzz://.
+  await navigateTo(window, 'meinhard.eth', 'bzz');
+  await waitForWebviewCondition(
+    window,
+    PLAY_BUTTON_SNIFFER,
+    'Waiting for a play-button-shaped element on meinhard.eth'
+  );
+
+  // (5) vitalik.eth — IPFS-hosted blog; address bar must end up on
+  // ipfs://. The page is content-heavy so the H1 is a stable
+  // structural marker that the page actually rendered (vs an error
+  // page).
+  await navigateTo(window, 'vitalik.eth', 'ipfs');
+  await waitForWebviewCondition(
+    window,
+    VITALIK_H1_SNIFFER,
+    'Waiting for an <h1> mentioning "Vitalik" on vitalik.eth'
+  );
+});

--- a/test-e2e/settings.spec.js
+++ b/test-e2e/settings.spec.js
@@ -1,0 +1,33 @@
+// Settings — verify that the saveSettings IPC + the renderer's
+// settings:updated subscription combine to flip theme classes on the
+// document. The on-disk settings page lives at freedom://settings and
+// is rendered inside a webview; we drive the same IPC it would call,
+// which exercises the same end-to-end pipeline without coupling the
+// spec to the page's internal markup.
+
+const { test, expect } = require('./fixtures');
+
+test('switching theme to "light" sets data-theme on <html>', async ({ window }) => {
+  // Default theme is "system"; on macOS dark-mode CI this would be dark
+  // (no data-theme attribute). Drive an explicit transition to "light".
+  await window.evaluate(() => window.electronAPI.saveSettings({ theme: 'light' }));
+
+  await expect(window.locator('html')).toHaveAttribute('data-theme', 'light');
+
+  await window.evaluate(() => window.electronAPI.saveSettings({ theme: 'dark' }));
+
+  // Dark mode removes the data-theme attribute (root selector applies
+  // by default). We assert that toHaveAttribute fails — the attribute
+  // is absent.
+  await expect(window.locator('html')).not.toHaveAttribute('data-theme', 'light');
+});
+
+test('saveSettings persists across renderer reload', async ({ window }) => {
+  await window.evaluate(() => window.electronAPI.saveSettings({ theme: 'light' }));
+  await expect(window.locator('html')).toHaveAttribute('data-theme', 'light');
+
+  await window.reload();
+  await window.waitForSelector('[data-test="address-input"]');
+
+  await expect(window.locator('html')).toHaveAttribute('data-theme', 'light');
+});

--- a/test-e2e/tabs.spec.js
+++ b/test-e2e/tabs.spec.js
@@ -1,0 +1,35 @@
+// Tab strip — open via the new-tab button, close via the per-tab close
+// affordance, count tabs from the renderer DOM directly.
+
+const { test, expect } = require('./fixtures');
+
+test('starts with one tab, can open more, can close them', async ({ window }) => {
+  const tabs = window.locator('[data-test="tab"]');
+  await expect(tabs).toHaveCount(1);
+
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(tabs).toHaveCount(2);
+
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(tabs).toHaveCount(3);
+
+  // Close the first tab via its close button. Its data-tab-id is "1"
+  // because tabs.js counts from one and never recycles ids.
+  await window.locator('[data-test="tab"][data-tab-id="1"] [data-test="tab-close"]').click();
+  await expect(tabs).toHaveCount(2);
+});
+
+test('clicking a tab activates it', async ({ window }) => {
+  const tabs = window.locator('[data-test="tab"]');
+  await expect(tabs).toHaveCount(1);
+
+  // Open a second tab; new tabs become active automatically.
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(tabs).toHaveCount(2);
+  await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).toHaveClass(/active/);
+
+  // Switch back to the first tab.
+  await window.locator('[data-test="tab"][data-tab-id="1"]').click();
+  await expect(window.locator('[data-test="tab"][data-tab-id="1"]')).toHaveClass(/active/);
+  await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).not.toHaveClass(/active/);
+});


### PR DESCRIPTION
## Summary

Implements [#62](https://github.com/solardev-xyz/freedom-browser/issues/62) — adds renderer-driven end-to-end testing for the browser with Playwright + Electron. Two suites under `test-e2e/`:

- **`harness`** (`npm run test:e2e`) — fixture-driven, fully stubbed, no network. Runs in ~20 s. Covers address-bar normalisation (Swarm hash auto-prefix, `bzz://` path preservation, https:// auto-prefix), tabs (open/close/activate), bookmarks (add via IPC, render across reload), settings (theme switching + persistence), and the error page (probe-not-found navigation).
- **`live`** (`npm run test:e2e:live`) — drives the actual app against live services. One spec (`test-e2e/live/eth-sites.spec.js`) cold-starts both Bee and IPFS, waits for >20 connected peers on each, then navigates to `meinhard.eth` (Swarm) and `vitalik.eth` (IPFS) and asserts the rendered pages.

Both suites are **manual only** — neither is wired into CI. Each launch uses a per-run temp directory with isolated subdirs for `userData`, `bee-data/`, `ipfs-data/`, and `identity/` so the developer's persistent dev state is never mutated.

## Implementation notes

- **`src/main/test-harness.js`** (new): activates only when `FREEDOM_TEST_MODE=1`. **Owns** `bzz:` / `ipfs:` / `ipns:` / `http:` / `https:` schemes via `session.protocol.handle()`, so any spec that triggers `webview.loadURL(...)` for a real-looking URL is satisfied in-process — no DNS, no TCP/TLS, no network egress. Overrides ENS / swarm-probe / bee-start / ipfs-start IPC channels with fixture-driven responses, and seeds `service-registry` with mock "running" statuses. Fixtures are settable from specs via a `globalThis.__FREEDOM_TEST_HARNESS__` shim.
- **`src/main/index.js`**: `TEST_MODE` gates real protocol handler registration, Bee/IPFS/Radicle startup, and the auto-updater. `FREEDOM_TEST_USER_DATA` is honoured independently of `TEST_MODE`, so the live suite can also opt into a clean userData without activating the harness.
- **Data-dir isolation env vars** added to the production node managers (`bee-manager.getBeeDataPath`, `ipfs-manager.getIpfsDataPath`, `identity-manager.getIdentityDataDir`): `FREEDOM_BEE_DATA`, `FREEDOM_IPFS_DATA`, `FREEDOM_IDENTITY_DATA`. Honoured in both dev and packaged modes; the live fixture sets all three to per-run temp paths so a live run doesn't clobber the developer's `<repoRoot>/bee-data`, `<repoRoot>/ipfs-data`, or `<repoRoot>/identity-data`. The identity override matters for an additional reason: without it, `hasVault()` would still find the developer's local vault, flip the node managers into injected-identity mode, and Bee/IPFS would hang waiting for keys the temp dirs don't have.
- **Renderer `data-test` attributes** added to tabs, bookmarks, address input, new-tab button, etc. — purely additive; specs target these instead of CSS classes for resilience.
- **`src/renderer/lib/autocomplete.js`** bug fix: cancel a pending debounce timer when Enter or Escape is pressed before the dropdown has rendered. Without this, a fast typist (or a Playwright `fill+Enter`) could race the 80 ms debounce and trigger a ghost suggestion render *after* navigation already started, leaving the dropdown stuck open over the page. Found while debugging the live suite.
- **`playwright.config.js`**: two projects routed by directory — `test-e2e/live/` is the `live` project, everything else under `test-e2e/` is the `harness` project. Sequential runs only (`workers: 1`) — Electron + scheme registration and Bee port detection don't tolerate parallel app instances.
- Adds `@playwright/test` as a dev dependency (previously approved by the requestor).
- README updated: new "End-to-end tests (Playwright + Electron)" subsection under Development → Testing, plus `test:e2e` / `test:e2e:live` rows in the NPM Scripts table.

## Review findings addressed

Three review iterations on this branch. Each finding from the review is summarised below with the commit that addressed it.

| # | Finding | Fix | Commit |
|---|---|---|---|
| 1 | Live binary checks ran *after* Electron had launched (test body destructured `window`, fixture launched the app, only then `test.skip(!HAS_BEE_BINARY)` evaluated) | Wrapped live spec in `test.describe(...)` so the bee skip and the (hard) ipfs check execute at describe-load, before `electronApp` is requested | `e8f6795` |
| 2 | Live mode mutated repo-root `bee-data/` / `ipfs-data/` (and silently inherited the developer's identity vault, hanging IPFS in injected-identity mode) | Added `FREEDOM_BEE_DATA` / `FREEDOM_IPFS_DATA` / `FREEDOM_IDENTITY_DATA` env-var overrides; live fixture creates a per-run temp root and points all three at it | `e8f6795` |
| 3 | Harness node IPC stubs returned `{success, testMode}` while renderer destructures `{status, error}`; `*_GET_STATUS` channels still fell through to the real managers | Stubs now return `{status, error: null}`; in-memory status is tracked and the corresponding `*_GET_STATUS` channels report it | `e8f6795` |
| 4 | Harness wasn't strictly "no network" — bare-domain spec triggered a real `webview.loadURL('https://example.com')`. First attempt used `webRequest.onBeforeRequest` redirect, which is a *late* intercept | Switched to `protocol.handle('http' / 'https', …)` for outright scheme ownership in test mode (Electron 30+ allows overriding built-in standard schemes); request never enters Chromium's network stack at all. Bare-domain spec strengthened with positive proof — it polls inside the active webview for a `<p data-test="harness-http-stub-url">` paragraph the harness emits, so it would fail loudly if the request ever escaped to the network | `42960e1` |

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 1273 unit tests passing (no regressions, autocomplete unit tests still green)
- [x] `npm run test:e2e` — 9 harness specs passing in ~20 s
- [x] `npm run test:e2e:live` — single live spec passing in ~21 s on a machine with bee + ipfs binaries already downloaded; Bee + IPFS both cross 20 peers cold-start (with truly fresh per-run data dirs), both navigations resolve and render
- [x] Verified `bzz:`/`ipfs:`/`ipns:` and other production code paths unchanged when `FREEDOM_TEST_MODE` is unset (default for `npm start`)
- [ ] Reviewer to confirm `npm run test:e2e` runs locally on macOS (Linux/Windows untested by me)
