### PR TITLE
feat(ens): cryptographic ENS verification via Colibri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Freedom will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Cryptographic ENS verification via Colibri (`@corpus-core/colibri-stateless`) as the new default resolution path:
+  - Every `.eth` / `.box` lookup is verified locally against the Ethereum sync committee (or, with ZK consensus proof enabled, a recursive zk sync proof), rather than relying on M-of-K agreement between public RPCs
+  - Address-bar shield popover shows "Cryptographically verified via Colibri" and the prover host instead of the RPC quorum row
+  - CCIP-Read names (`.box` via 3DNS and offchain ENS resolvers in general) keep working — the partner prover proves the initial call, ethers fetches the gateway response, and the final `resolveCallback` is independently proven
+- `freedom://settings` → ENS Resolution: choose between Colibri (recommended), the public-RPC quorum, or a custom Ethereum RPC; "Fall back to public-RPC quorum if primary fails" controls whether prover errors silently retry via the legacy path
+
+### Changed
+
+- Default ENS resolution changed from public-RPC quorum to Colibri. Users running a custom RPC are migrated to the "Custom RPC" path (preserves the intent of keeping queries off public infrastructure); everyone else upgrades to Colibri. The migration is one-shot and idempotent
+
 ## [0.7.1] - 2026-05-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@adraffy/ens-normalize": "^1.10.1",
+        "@corpus-core/colibri-stateless": "^1.1.25",
         "@ensdomains/content-hash": "^3.0.0",
         "@ethersphere/bee-js": "^12.1.0",
         "@metamask/browser-passworder": "^6.0.0",
@@ -1805,6 +1806,12 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@corpus-core/colibri-stateless": {
+      "version": "1.1.25",
+      "resolved": "https://registry.npmjs.org/@corpus-core/colibri-stateless/-/colibri-stateless-1.1.25.tgz",
+      "integrity": "sha512-vsdf9kEyDT0+GhRotUg/9yZYSqnP91c8LaGINmtvtyz+1p+MoUmZKENhFZjJBgJAjLsfWGssWfRKVtmmsJLoTw==",
       "license": "MIT"
     },
     "node_modules/@develar/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
   },
   "dependencies": {
     "@adraffy/ens-normalize": "^1.10.1",
+    "@corpus-core/colibri-stateless": "^1.1.25",
     "@ensdomains/content-hash": "^3.0.0",
     "@ethersphere/bee-js": "^12.1.0",
     "@metamask/browser-passworder": "^6.0.0",

--- a/src/main/__tests__/integration/colibri-e2e.test.js
+++ b/src/main/__tests__/integration/colibri-e2e.test.js
@@ -1,0 +1,130 @@
+/**
+ * End-to-end battery for the Colibri-backed ENS resolution path.
+ *
+ * Gated by ENS_COLIBRI_E2E=1 — CI does not hit the partner prover by
+ * default. Run locally with:
+ *
+ *   NODE_OPTIONS=--experimental-vm-modules ENS_COLIBRI_E2E=1 \
+ *     npx jest src/main/__tests__/integration/colibri-e2e.test.js
+ *
+ * The Colibri CJS shim loads the emscripten glue via dynamic import, so
+ * Jest needs VM Modules enabled.
+ *
+ * Verifies the four scenarios the partner is on the hook for:
+ *   1. contenthash + addr on a well-known name (verified happy path)
+ *   2. NO_RESOLVER on an unregistered name (revert proven correctly)
+ *   3. .box via CCIP-Read (OffchainLookup round-trip + final proven call)
+ *   4. Repeated lookups don't leak / fall over (sanity for the warm path)
+ *
+ * No package mocks — the real @corpus-core/colibri-stateless WASM runs.
+ * Electron's app.getPath is mocked to a temp dir so the verifier state
+ * doesn't pollute the developer's userData folder.
+ */
+
+const E2E_ENABLED = process.env.ENS_COLIBRI_E2E === '1';
+const describeOrSkip = E2E_ENABLED ? describe : describe.skip;
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const mockTempUserData = fs.mkdtempSync(path.join(os.tmpdir(), 'colibri-e2e-'));
+
+jest.mock('electron', () => ({
+  app: { getPath: () => mockTempUserData },
+  ipcMain: { handle: jest.fn() },
+}));
+
+const mockLoadSettings = jest.fn();
+jest.mock('../../settings-store', () => ({
+  loadSettings: (...args) => mockLoadSettings(...args),
+  DEFAULT_ENS_PUBLIC_RPC_PROVIDERS: [],
+}));
+
+const TIMEOUT_MS = 60_000;
+
+// Loaded after mocks so the SUT's `require('../../settings-store')` resolves
+// to the mock. The Colibri package is NOT mocked — real WASM, real prover.
+const {
+  resolveEnsContent,
+  resolveEnsAddress,
+  clearEnsCachesForTest,
+} = require('../../ens-resolver');
+const { clearColibriClientForTest } = require('../../ens/colibri-resolver');
+
+beforeEach(() => {
+  mockLoadSettings.mockReturnValue({
+    enableEnsCustomRpc: false,
+    ensRpcUrl: '',
+    ensResolutionMethod: 'colibri',
+    ensFallbackToQuorum: false,           // surface Colibri errors loudly during e2e
+    ensColibriProverUrl: '',              // → DEFAULT_PROVER_URL (mainnet1.colibri-proof.tech)
+    ensColibriZkProof: true,
+    enableEnsQuorum: false,
+    ensQuorumK: 3,
+    ensQuorumM: 2,
+    ensQuorumTimeoutMs: 5000,
+    ensBlockAnchor: 'latest',
+    ensBlockAnchorTtlMs: 30000,
+    ensPublicRpcProviders: [],
+  });
+  clearEnsCachesForTest();
+});
+
+afterAll(() => {
+  clearColibriClientForTest();
+  try { fs.rmSync(mockTempUserData, { recursive: true, force: true }); }
+  catch { /* best-effort cleanup */ }
+});
+
+describeOrSkip('colibri e2e against mainnet1.colibri-proof.tech', () => {
+  test('resolves vitalik.eth contenthash with verified-via-colibri trust', async () => {
+    const result = await resolveEnsContent('vitalik.eth');
+    expect(result.type).toBe('ok');
+    expect(result.uri).toMatch(/^(ipfs|ipns|bzz):\/\//);
+    expect(result.trust).toMatchObject({
+      level: 'verified',
+      method: 'colibri',
+      prover: 'mainnet1.colibri-proof.tech',
+    });
+  }, TIMEOUT_MS);
+
+  test('resolves vitalik.eth addr to a non-zero address', async () => {
+    const result = await resolveEnsAddress('vitalik.eth');
+    expect(result.success).toBe(true);
+    expect(result.address).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    expect(result.address.toLowerCase()).not.toBe('0x' + '0'.repeat(40));
+    expect(result.trust.method).toBe('colibri');
+  }, TIMEOUT_MS);
+
+  test('unregistered name surfaces as NO_RESOLVER (verified revert)', async () => {
+    const result = await resolveEnsContent('this-name-definitely-does-not-exist-zzz-12345.eth');
+    expect(result.type).toBe('not_found');
+    expect(result.reason).toBe('NO_RESOLVER');
+    expect(result.trust.method).toBe('colibri');
+  }, TIMEOUT_MS);
+
+  test('.box CCIP-Read resolves through to a final proven eth_call', async () => {
+    // .box names are 3DNS-backed and require CCIP-Read. The Colibri prover
+    // surfaces the OffchainLookup revert; ethers fetches the gateway data
+    // and submits resolveCallback, which is independently proven.
+    // If this regresses, the integration loses .box support entirely.
+    const result = await resolveEnsContent('vitalik.box');
+    // Accept any non-error outcome — the point is "didn't throw on CCIP".
+    expect(['ok', 'not_found', 'unsupported']).toContain(result.type);
+    expect(result.trust.method).toBe('colibri');
+  }, TIMEOUT_MS);
+
+  test('repeated lookups warm the cache and stay healthy', async () => {
+    // First call is the real prover hit; rest are cache hits (15-min TTL).
+    // The point is to exercise the cache + singleton interaction and
+    // catch any unbounded-growth or stale-state regression in one shot.
+    const first = await resolveEnsContent('vitalik.eth');
+    expect(first.type).toBe('ok');
+    for (let i = 0; i < 5; i++) {
+      const r = await resolveEnsContent('vitalik.eth');
+      expect(r.type).toBe('ok');
+      expect(r.uri).toBe(first.uri);
+    }
+  }, TIMEOUT_MS);
+});

--- a/src/main/__tests__/integration/colibri-e2e.test.js
+++ b/src/main/__tests__/integration/colibri-e2e.test.js
@@ -48,6 +48,7 @@ const TIMEOUT_MS = 60_000;
 const {
   resolveEnsContent,
   resolveEnsAddress,
+  resolveEnsReverse,
   clearEnsCachesForTest,
 } = require('../../ens-resolver');
 const { clearColibriClientForTest } = require('../../ens/colibri-resolver');
@@ -95,6 +96,20 @@ describeOrSkip('colibri e2e against mainnet1.colibri-proof.tech', () => {
     expect(result.address).toMatch(/^0x[a-fA-F0-9]{40}$/);
     expect(result.address.toLowerCase()).not.toBe('0x' + '0'.repeat(40));
     expect(result.trust.method).toBe('colibri');
+  }, TIMEOUT_MS);
+
+  test('reverse-resolves vitalik.eth\'s known address back to vitalik.eth', async () => {
+    // Vitalik's known main address. The reverse record is well-known and
+    // forward-verifies. Catches a regression where the reverse path falls
+    // off the Colibri orchestrator branch.
+    const result = await resolveEnsReverse('0xd8da6bf26964af9d7eed9e03e53415d37aa96045');
+    expect(result.success).toBe(true);
+    expect(result.name).toBe('vitalik.eth');
+    expect(result.trust).toMatchObject({
+      level: 'verified',
+      method: 'colibri',
+      prover: 'mainnet1.colibri-proof.tech',
+    });
   }, TIMEOUT_MS);
 
   test('unregistered name surfaces as NO_RESOLVER (verified revert)', async () => {

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -409,6 +409,14 @@ const TTL_BY_LEVEL = {
 const DEFAULT_CACHE_TTL_MS = 15 * 60 * 1000;
 
 function ttlForResult(result) {
+  // UNVERIFIED outcomes describe a transient on-chain state (e.g. a
+  // reverse record that doesn't forward-verify) even when the underlying
+  // proof was cryptographically sound. Trust.level reads `verified` in
+  // that case — short-cache anyway so the user sees a fresh outcome
+  // when the on-chain state changes. Without this override the level
+  // table would pin the result for 15min.
+  if (result?.reason === 'UNVERIFIED') return TTL_BY_LEVEL.unverified;
+
   const level = result?.trust?.level;
   if (level && Object.prototype.hasOwnProperty.call(TTL_BY_LEVEL, level)) {
     return TTL_BY_LEVEL[level];
@@ -565,10 +573,17 @@ const UR_NOT_FOUND_SELECTORS = new Set([
 ]);
 const REVERSE_MISMATCH_SELECTOR = '0xef9c03ce'; // ReverseAddressMismatch(string,bytes)
 
-function urErrorSelector(err) {
+// ethers v6 stashes contract-revert data at either `.data` (newer wrappers)
+// or `.info.error.data` (the JSON-RPC error envelope). One reader, used by
+// every callsite that wants to inspect the revert payload.
+function getRevertData(err) {
   const data = err?.data || err?.info?.error?.data || '';
-  if (typeof data !== 'string' || data.length < 10) return null;
-  return data.slice(0, 10).toLowerCase();
+  return typeof data === 'string' && data.length >= 10 ? data : null;
+}
+
+function urErrorSelector(err) {
+  const data = getRevertData(err);
+  return data ? data.slice(0, 10).toLowerCase() : null;
 }
 
 function isResolverNotFoundError(err) {
@@ -593,9 +608,8 @@ function isReverseAddressMismatchError(err) {
 // Returns null if the data is missing or malformed — the warning UI then
 // falls back to a name-less "unverified reverse" message.
 function decodeReverseMismatchClaimedName(err) {
-  const data = err?.data || err?.info?.error?.data || '';
-  if (typeof data !== 'string' || data.length < 10) return null;
-  if (data.slice(0, 10).toLowerCase() !== REVERSE_MISMATCH_SELECTOR) return null;
+  const data = getRevertData(err);
+  if (!data || data.slice(0, 10).toLowerCase() !== REVERSE_MISMATCH_SELECTOR) return null;
   try {
     const [name] = ethers.AbiCoder.defaultAbiCoder().decode(
       ['string', 'bytes'],

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -587,6 +587,26 @@ function isReverseAddressMismatchError(err) {
   return urErrorSelector(err) === REVERSE_MISMATCH_SELECTOR;
 }
 
+// Decode the claimed primary name out of a ReverseAddressMismatch revert.
+// The UR's custom error is `ReverseAddressMismatch(string,bytes)`, so the
+// first ABI arg after the 4-byte selector is the claimed name string.
+// Returns null if the data is missing or malformed — the warning UI then
+// falls back to a name-less "unverified reverse" message.
+function decodeReverseMismatchClaimedName(err) {
+  const data = err?.data || err?.info?.error?.data || '';
+  if (typeof data !== 'string' || data.length < 10) return null;
+  if (data.slice(0, 10).toLowerCase() !== REVERSE_MISMATCH_SELECTOR) return null;
+  try {
+    const [name] = ethers.AbiCoder.defaultAbiCoder().decode(
+      ['string', 'bytes'],
+      '0x' + data.slice(10),
+    );
+    return name || null;
+  } catch {
+    return null;
+  }
+}
+
 // Call the Universal Resolver's resolve(name, data). `callData` is the raw
 // ABI-encoded call the resolver would have received directly (selector +
 // args). Returns the raw ABI-encoded response — the caller must decode
@@ -1569,6 +1589,7 @@ async function tryColibriReverse(normalizedAddress, settings) {
         success: false,
         address: normalizedAddress,
         reason: 'UNVERIFIED',
+        claimedName: decodeReverseMismatchClaimedName(err),
         error: `Reverse record for ${normalizedAddress} does not forward-verify`,
         trust,
       };
@@ -1615,6 +1636,7 @@ async function doResolveEnsReverse(normalizedAddress) {
         success: false,
         address: normalizedAddress,
         reason: 'UNVERIFIED',
+        claimedName: decodeReverseMismatchClaimedName(err),
         error: `Reverse record for ${normalizedAddress} does not forward-verify`,
       });
     }

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -821,6 +821,73 @@ function classifyNoAgreement({ results }) {
   return { kind: 'conflict' };
 }
 
+// Colibri primary path: a single cryptographically-verified eth_call against
+// the Universal Resolver via @corpus-core/colibri-stateless. The verifier
+// runs the EVM locally against proven storage, so a successful return is
+// already cross-checked against the Ethereum sync committee (or, with
+// zk_proof, a recursive zk sync proof). No anchor corroboration is needed —
+// Colibri pins to head − 1 by construction (sync committee signature for
+// block N lives in block N+1).
+//
+// Throws on proof-verification failure / network error / prover outage so
+// the orchestrator can fall through to the legacy quorum path when
+// ensFallbackToQuorum is enabled.
+async function tryColibriPath(name, callData, settings) {
+  // Lazy require avoids a load-time cycle: colibri-resolver imports
+  // universalResolverCall + hostOf from this module.
+  const { resolveViaColibri, DEFAULT_PROVER_URL } = require('./ens/colibri-resolver');
+  const proverUrl = (settings.ensColibriProverUrl || DEFAULT_PROVER_URL).trim();
+  const proverHost = hostOf(proverUrl);
+
+  let result;
+  try {
+    result = await resolveViaColibri(name, callData);
+  } catch (err) {
+    if (isResolverNotFoundError(err)) {
+      return {
+        outcome: 'not_found',
+        reason: 'NO_RESOLVER',
+        trust: buildColibriTrust(proverHost),
+        block: null,
+      };
+    }
+    if (err.code === 'CALL_EXCEPTION') {
+      // Verified revert with an unknown selector — same semantics as the
+      // quorum path's NO_CONTENTHASH bucket. Upstream maps that to
+      // RESOLUTION_ERROR for addr lookups and "no contenthash" for content.
+      return {
+        outcome: 'not_found',
+        reason: 'NO_CONTENTHASH',
+        error: err.message,
+        trust: buildColibriTrust(proverHost),
+        block: null,
+      };
+    }
+    throw err;
+  }
+
+  return {
+    outcome: 'data',
+    resolvedData: result.resolvedData,
+    resolverAddress: result.resolverAddress,
+    trust: buildColibriTrust(proverHost),
+    block: null,
+  };
+}
+
+function buildColibriTrust(proverHost) {
+  return {
+    level: 'verified',
+    method: 'colibri',
+    prover: proverHost,
+    block: null,
+    agreed: [proverHost],
+    dissented: [],
+    queried: [proverHost],
+    quorum: { k: 1, m: 1, achieved: true },
+  };
+}
+
 // Custom-RPC fast path: single leg against the user's own node, labelled
 // trust='user-configured'. On any failure, return null so the caller falls
 // back to the public quorum path (preserving existing graceful-degrade
@@ -907,6 +974,24 @@ async function resolveSingleSourceUnverified(url, name, callData, anchor, timeou
 // Throws when there are no providers or both waves all-errored.
 async function consensusResolve(normalizedName, callData, kind = 'content', options = {}) {
   const settings = loadSettings();
+
+  // Colibri primary: cryptographic verification via the sync committee
+  // (or zk sync proof). On verification failure or network/prover error
+  // we log loudly and fall through to the legacy quorum path below
+  // unless ensFallbackToQuorum is explicitly disabled. Loud-fallback is
+  // load-bearing: a silent fall-through would hide both prover health
+  // regressions and the (rare) "active attack" signal.
+  if (settings.ensResolutionMethod === 'colibri') {
+    try {
+      return await tryColibriPath(normalizedName, callData, settings);
+    } catch (err) {
+      if (settings.ensFallbackToQuorum === false) throw err;
+      log.warn(
+        `[ens] colibri-fallback name=${normalizedName} kind=${kind} ` +
+        `error=${err.message}`
+      );
+    }
+  }
 
   // Custom RPC: try first, fall back to public quorum on any failure so
   // users with a misbehaving own-node still resolve.

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -850,9 +850,8 @@ function classifyNoAgreement({ results }) {
 async function tryColibriPath(name, callData, settings) {
   // Lazy require avoids a load-time cycle: colibri-resolver imports
   // universalResolverCall + hostOf from this module.
-  const { resolveViaColibri, DEFAULT_PROVER_URL } = require('./ens/colibri-resolver');
-  const proverUrl = (settings.ensColibriProverUrl || DEFAULT_PROVER_URL).trim();
-  const proverHost = hostOf(proverUrl);
+  const { resolveViaColibri } = require('./ens/colibri-resolver');
+  const proverHost = colibriProverHost(settings);
 
   let result;
   try {
@@ -888,6 +887,14 @@ async function tryColibriPath(name, callData, settings) {
     trust: buildColibriTrust(proverHost),
     block: null,
   };
+}
+
+// Read the effective prover URL from settings and return its host.
+// Lazy-requires DEFAULT_PROVER_URL to dodge the load-time cycle between
+// this module and ./ens/colibri-resolver.
+function colibriProverHost(settings) {
+  const { DEFAULT_PROVER_URL } = require('./ens/colibri-resolver');
+  return hostOf((settings.ensColibriProverUrl || DEFAULT_PROVER_URL).trim());
 }
 
 function buildColibriTrust(proverHost) {
@@ -1546,9 +1553,8 @@ async function resolveEnsReverse(address) {
 // surfaces as UNVERIFIED — the proof was valid but the contract reverted,
 // which is the spoofed-reverse-record signal.
 async function tryColibriReverse(normalizedAddress, settings) {
-  const { resolveReverseViaColibri, DEFAULT_PROVER_URL } = require('./ens/colibri-resolver');
-  const proverHost = hostOf((settings.ensColibriProverUrl || DEFAULT_PROVER_URL).trim());
-  const trust = buildColibriTrust(proverHost);
+  const { resolveReverseViaColibri } = require('./ens/colibri-resolver');
+  const trust = buildColibriTrust(colibriProverHost(settings));
   const addrBytes = ethers.getBytes(normalizedAddress);
 
   let name;

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -611,6 +611,21 @@ async function universalResolverCall(provider, name, callData, overrides = {}) {
   return { resolvedData, resolverAddress };
 }
 
+// Reverse counterpart: call the UR's reverse(bytes, uint256). The UR
+// verifies the claimed primary name forward-resolves back to the input
+// address inside the contract — a successful return is already
+// trust-checked at the contract level. A spoofed reverse record surfaces
+// as `ReverseAddressMismatch` (selector 0xef9c03ce) on the err.data.
+// `addressBytes` is the 20-byte representation produced by `ethers.getBytes`.
+async function universalResolverReverse(provider, addressBytes, overrides = {}) {
+  const ur = new ethers.Contract(UNIVERSAL_RESOLVER_ADDRESS, UR_ABI, provider);
+  const [name] = await ur.reverse(addressBytes, ETH_COIN_TYPE, {
+    enableCcipRead: true,
+    ...overrides,
+  });
+  return { name };
+}
+
 // ---------------------------------------------------------------------------
 // Consensus resolution: hedged-quorum over K public RPCs at a shared pinned
 // block. Detects a lying RPC by requiring M byte-identical responses;
@@ -1525,7 +1540,57 @@ async function resolveEnsReverse(address) {
   return resolveWithCache(address, ensReverseCache, doResolveEnsReverse, 'reverse');
 }
 
+// Colibri reverse path: cryptographically-verified `ur.reverse`. Returns
+// the same result shape as the legacy path, plus a `trust` object so the
+// renderer can surface a "verified" indicator. ReverseAddressMismatch
+// surfaces as UNVERIFIED — the proof was valid but the contract reverted,
+// which is the spoofed-reverse-record signal.
+async function tryColibriReverse(normalizedAddress, settings) {
+  const { resolveReverseViaColibri, DEFAULT_PROVER_URL } = require('./ens/colibri-resolver');
+  const proverHost = hostOf((settings.ensColibriProverUrl || DEFAULT_PROVER_URL).trim());
+  const trust = buildColibriTrust(proverHost);
+  const addrBytes = ethers.getBytes(normalizedAddress);
+
+  let name;
+  try {
+    ({ name } = await resolveReverseViaColibri(addrBytes));
+  } catch (err) {
+    if (isResolverNotFoundError(err)) {
+      return { ...noReverseResult(normalizedAddress), trust };
+    }
+    if (isReverseAddressMismatchError(err)) {
+      return {
+        success: false,
+        address: normalizedAddress,
+        reason: 'UNVERIFIED',
+        error: `Reverse record for ${normalizedAddress} does not forward-verify`,
+        trust,
+      };
+    }
+    throw err;
+  }
+
+  if (!name) return { ...noReverseResult(normalizedAddress), trust };
+  return { success: true, address: normalizedAddress, name, trust };
+}
+
 async function doResolveEnsReverse(normalizedAddress) {
+  const settings = loadSettings();
+
+  if (settings.ensResolutionMethod === 'colibri') {
+    try {
+      return cacheReverseResult(
+        normalizedAddress,
+        await tryColibriReverse(normalizedAddress, settings)
+      );
+    } catch (err) {
+      if (settings.ensFallbackToQuorum === false) throw err;
+      log.warn(
+        `[ens] colibri-fallback reverse address=${normalizedAddress} error=${err.message}`
+      );
+    }
+  }
+
   const provider = await getWorkingProvider();
   const ur = new ethers.Contract(UNIVERSAL_RESOLVER_ADDRESS, UR_ABI, provider);
   const addrBytes = ethers.getBytes(normalizedAddress);
@@ -1717,6 +1782,7 @@ module.exports = {
   invalidateCachedProvider,
   invalidateEnsContent,
   universalResolverCall,
+  universalResolverReverse,
   isResolverNotFoundError,
   clearEnsCachesForTest,
   hostOf,

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -1634,4 +1634,5 @@ module.exports = {
   universalResolverCall,
   isResolverNotFoundError,
   clearEnsCachesForTest,
+  hostOf,
 };

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -48,8 +48,10 @@ jest.mock('./settings-store', () => ({
 // lazy-requires this; the lazy require sees the mocked module. Tests
 // flip behavior per case via mockResolveViaColibri.
 const mockResolveViaColibri = jest.fn();
+const mockResolveReverseViaColibri = jest.fn();
 jest.mock('./ens/colibri-resolver', () => ({
   resolveViaColibri: (...args) => mockResolveViaColibri(...args),
+  resolveReverseViaColibri: (...args) => mockResolveReverseViaColibri(...args),
   DEFAULT_PROVER_URL: 'https://test-prover.example',
 }));
 
@@ -1918,6 +1920,121 @@ describe('ens-resolver', () => {
 
       expect(mockResolveViaColibri).not.toHaveBeenCalled();
       expect(mockUrResolve).toHaveBeenCalled();
+    });
+  });
+
+  // Phase 2 A — same Colibri orchestrator branch, reverse direction.
+  // resolveEnsReverse goes through tryColibriReverse instead of consensusResolve.
+  describe('colibri orchestrator branch — reverse', () => {
+    const ADDR = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+
+    function withColibri(overrides = {}) {
+      mockLoadSettings.mockReturnValue({
+        ...mockLoadSettings(),
+        ensResolutionMethod: 'colibri',
+        ...overrides,
+      });
+    }
+
+    test('routes through Colibri and returns name + verified-via-colibri trust', async () => {
+      withColibri();
+      mockResolveReverseViaColibri.mockResolvedValue({ name: 'vitalik.eth' });
+
+      const result = await resolveEnsReverse(ADDR);
+
+      expect(mockResolveReverseViaColibri).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({
+        success: true,
+        address: ADDR,
+        name: 'vitalik.eth',
+        trust: { level: 'verified', method: 'colibri', prover: 'test-prover.example' },
+      });
+      expect(mockUrReverse).not.toHaveBeenCalled();
+    });
+
+    test('no primary set surfaces as NO_REVERSE with trust attached', async () => {
+      withColibri();
+      mockResolveReverseViaColibri.mockResolvedValue({ name: '' });
+
+      const result = await resolveEnsReverse(ADDR);
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('NO_REVERSE');
+      expect(result.trust.method).toBe('colibri');
+    });
+
+    test('ResolverNotFound surfaces as NO_REVERSE (no record at all)', async () => {
+      withColibri();
+      const err = Object.assign(new Error('ResolverNotFound(bytes)'), {
+        data: '0x77209fe8',
+      });
+      mockResolveReverseViaColibri.mockRejectedValue(err);
+
+      const result = await resolveEnsReverse(ADDR);
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('NO_REVERSE');
+      expect(result.trust.method).toBe('colibri');
+    });
+
+    test('ReverseAddressMismatch surfaces as UNVERIFIED (spoofed/stale record)', async () => {
+      withColibri();
+      const err = Object.assign(new Error('ReverseAddressMismatch'), {
+        data: '0xef9c03ce',
+      });
+      mockResolveReverseViaColibri.mockRejectedValue(err);
+
+      const result = await resolveEnsReverse(ADDR);
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('UNVERIFIED');
+      expect(result.trust.method).toBe('colibri');
+      // Critical: the trust object's level is still 'verified' — the proof
+      // was valid, the contract reverted. The 'reason' carries the spoofed-
+      // record signal, not the trust level.
+      expect(result.trust.level).toBe('verified');
+    });
+
+    test('non-revert error falls through to the legacy path by default', async () => {
+      withColibri();
+      mockResolveReverseViaColibri.mockRejectedValue(new Error('prover unreachable'));
+      mockUrReverse.mockResolvedValue(['legacy.eth']);
+
+      const result = await resolveEnsReverse(ADDR);
+
+      expect(result.success).toBe(true);
+      expect(result.name).toBe('legacy.eth');
+      // No trust field on the legacy path — additive design.
+      expect(result.trust).toBeUndefined();
+      expect(mockUrReverse).toHaveBeenCalled();
+    });
+
+    test('non-revert error rethrows when ensFallbackToQuorum is disabled', async () => {
+      withColibri({ ensFallbackToQuorum: false });
+      mockResolveReverseViaColibri.mockRejectedValue(new Error('prover unreachable'));
+
+      await expect(resolveEnsReverse(ADDR)).rejects.toThrow('prover unreachable');
+      expect(mockUrReverse).not.toHaveBeenCalled();
+    });
+
+    test('default ensResolutionMethod=quorum leaves the legacy reverse path untouched', async () => {
+      // Don't call withColibri — defaults to 'quorum'.
+      mockUrReverse.mockResolvedValue(['legacy.eth']);
+
+      const result = await resolveEnsReverse(ADDR);
+
+      expect(mockResolveReverseViaColibri).not.toHaveBeenCalled();
+      expect(mockUrReverse).toHaveBeenCalled();
+      expect(result.name).toBe('legacy.eth');
+    });
+
+    test('invalid address rejects before either path is hit', async () => {
+      withColibri();
+      const result = await resolveEnsReverse('0xnotanaddress');
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('INVALID_ADDRESS');
+      expect(mockResolveReverseViaColibri).not.toHaveBeenCalled();
+      expect(mockUrReverse).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -1989,6 +1989,37 @@ describe('ens-resolver', () => {
       expect(result.trust.level).toBe('verified');
     });
 
+    test('UNVERIFIED carries the decoded claimedName from revert data', async () => {
+      withColibri();
+      // ReverseAddressMismatch(string,bytes) — claimed name + address bytes.
+      // Building a real revert payload here so the decoder is exercised end-to-end.
+      const args = actualEthers.AbiCoder.defaultAbiCoder().encode(
+        ['string', 'bytes'],
+        ['spoofed.eth', '0xabcd'],
+      );
+      const err = Object.assign(new Error('ReverseAddressMismatch'), {
+        data: '0xef9c03ce' + args.slice(2),
+      });
+      mockResolveReverseViaColibri.mockRejectedValue(err);
+
+      const result = await resolveEnsReverse(ADDR);
+
+      expect(result.reason).toBe('UNVERIFIED');
+      expect(result.claimedName).toBe('spoofed.eth');
+    });
+
+    test('UNVERIFIED with no decodable revert data has claimedName=null', async () => {
+      withColibri();
+      const err = Object.assign(new Error('ReverseAddressMismatch'), {
+        data: '0xef9c03ce', // selector only, no args
+      });
+      mockResolveReverseViaColibri.mockRejectedValue(err);
+
+      const result = await resolveEnsReverse(ADDR);
+      expect(result.reason).toBe('UNVERIFIED');
+      expect(result.claimedName).toBeNull();
+    });
+
     test('non-revert error falls through to the legacy path by default', async () => {
       withColibri();
       mockResolveReverseViaColibri.mockRejectedValue(new Error('prover unreachable'));

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -23,6 +23,10 @@ const TEST_PROVIDERS = [
 const mockLoadSettings = jest.fn(() => ({
   enableEnsCustomRpc: false,
   ensRpcUrl: '',
+  ensResolutionMethod: 'quorum',
+  ensFallbackToQuorum: true,
+  ensColibriProverUrl: '',
+  ensColibriZkProof: true,
   enableEnsQuorum: true,
   ensQuorumK: 3,
   ensQuorumM: 2,
@@ -38,6 +42,15 @@ jest.mock('./settings-store', () => ({
     'https://default-b.example.com',
     'https://default-c.example.com',
   ],
+}));
+
+// Mocked Colibri resolver. The orchestrator branch in consensusResolve
+// lazy-requires this; the lazy require sees the mocked module. Tests
+// flip behavior per case via mockResolveViaColibri.
+const mockResolveViaColibri = jest.fn();
+jest.mock('./ens/colibri-resolver', () => ({
+  resolveViaColibri: (...args) => mockResolveViaColibri(...args),
+  DEFAULT_PROVER_URL: 'https://test-prover.example',
 }));
 
 // Mock ethers with controllable provider and resolver behavior.
@@ -160,6 +173,10 @@ beforeEach(() => {
   mockLoadSettings.mockReturnValue({
     enableEnsCustomRpc: false,
     ensRpcUrl: '',
+    ensResolutionMethod: 'quorum',
+    ensFallbackToQuorum: true,
+    ensColibriProverUrl: '',
+    ensColibriZkProof: true,
     enableEnsQuorum: true,
     ensQuorumK: 3,
     ensQuorumM: 2,
@@ -1789,6 +1806,118 @@ describe('ens-resolver', () => {
 
       expect(result.type).toBe('ok');
       expect(result.trust.level).toBe('verified');
+    });
+  });
+
+  // Orchestrator branch added in Step 3 — switches consensusResolve to
+  // the Colibri-backed verifier when ensResolutionMethod === 'colibri'.
+  // The colibri-resolver itself is unit-tested separately; here we cover
+  // the wiring: method routing, trust-shape, error → fallback handoff.
+  describe('colibri orchestrator branch', () => {
+    const IPFS_V0 = 'QmW81r84Aihiqqi2Jw6nM1LnpeMfRCenRxtjwHNkXVkZYa';
+
+    function withColibri(overrides = {}) {
+      mockLoadSettings.mockReturnValue({
+        ...mockLoadSettings(),
+        ensResolutionMethod: 'colibri',
+        ...overrides,
+      });
+    }
+
+    // resolveViaColibri returns { resolvedData, resolverAddress } (object),
+    // not the [bytes, address] tuple the contract mock returns. Adapt.
+    function colibriOk(innerHex) {
+      const [resolvedData, resolverAddress] = urReturnsBytes(innerHex);
+      return { resolvedData, resolverAddress };
+    }
+
+    test('routes through Colibri and returns verified trust with method=colibri', async () => {
+      withColibri();
+      mockResolveViaColibri.mockResolvedValue(colibriOk(ipfsContenthashFor(IPFS_V0)));
+
+      const result = await resolveEnsContent('vitalik.eth');
+
+      expect(mockResolveViaColibri).toHaveBeenCalledTimes(1);
+      expect(result.type).toBe('ok');
+      expect(result.uri).toBe(`ipfs://${IPFS_V0}`);
+      expect(result.trust).toMatchObject({
+        level: 'verified',
+        method: 'colibri',
+        prover: 'test-prover.example',
+        quorum: { k: 1, m: 1, achieved: true },
+      });
+      // No public-RPC quorum legs fired.
+      expect(mockUrResolve).not.toHaveBeenCalled();
+    });
+
+    test('uses the user-configured prover URL when set in settings', async () => {
+      withColibri({ ensColibriProverUrl: 'https://my.prover.example/abc' });
+      mockResolveViaColibri.mockResolvedValue(colibriOk(ipfsContenthashFor(IPFS_V0)));
+
+      const result = await resolveEnsContent('a.eth');
+      expect(result.trust.prover).toBe('my.prover.example');
+    });
+
+    test('ResolverNotFound surfaces as a verified NO_RESOLVER (name not registered)', async () => {
+      withColibri();
+      const err = Object.assign(new Error('ResolverNotFound(bytes)'), {
+        data: '0x77209fe8000000',
+      });
+      mockResolveViaColibri.mockRejectedValue(err);
+
+      const result = await resolveEnsContent('not-registered.eth');
+
+      expect(result.type).toBe('not_found');
+      expect(result.reason).toBe('NO_RESOLVER');
+      expect(result.trust.method).toBe('colibri');
+      expect(mockUrResolve).not.toHaveBeenCalled();
+    });
+
+    test('CALL_EXCEPTION (verified revert, unknown selector) buckets as NO_CONTENTHASH', async () => {
+      withColibri();
+      const err = Object.assign(new Error('reverted: custom resolver error'), {
+        code: 'CALL_EXCEPTION',
+        data: '0xdeadbeef',
+      });
+      mockResolveViaColibri.mockRejectedValue(err);
+
+      const result = await resolveEnsContent('empty-record.eth');
+
+      expect(result.type).toBe('not_found');
+      expect(result.trust.method).toBe('colibri');
+    });
+
+    test('non-revert error falls through to the quorum path by default', async () => {
+      withColibri();
+      mockResolveViaColibri.mockRejectedValue(new Error('proof verification failed'));
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
+
+      const result = await resolveEnsContent('proof-failure.eth');
+
+      expect(result.type).toBe('ok');
+      expect(result.uri).toBe(`ipfs://${IPFS_V0}`);
+      // Fell through to the public-RPC quorum — three legs queried.
+      expect(mockUrResolve).toHaveBeenCalled();
+      expect(result.trust.method).not.toBe('colibri');
+      expect(result.trust.quorum).toEqual({ k: 3, m: 2, achieved: true });
+    });
+
+    test('non-revert error rethrows when ensFallbackToQuorum is disabled', async () => {
+      withColibri({ ensFallbackToQuorum: false });
+      mockResolveViaColibri.mockRejectedValue(new Error('prover unreachable'));
+
+      await expect(resolveEnsContent('hard-fail.eth')).rejects.toThrow('prover unreachable');
+      expect(mockUrResolve).not.toHaveBeenCalled();
+    });
+
+    test('default ensResolutionMethod=quorum leaves the legacy path untouched (regression)', async () => {
+      // Don't call withColibri — defaults to 'quorum'.
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
+
+      await resolveEnsContent('legacy.eth');
+
+      expect(mockResolveViaColibri).not.toHaveBeenCalled();
+      expect(mockUrResolve).toHaveBeenCalled();
     });
   });
 });

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -1811,20 +1811,22 @@ describe('ens-resolver', () => {
     });
   });
 
-  // Orchestrator branch added in Step 3 — switches consensusResolve to
-  // the Colibri-backed verifier when ensResolutionMethod === 'colibri'.
-  // The colibri-resolver itself is unit-tested separately; here we cover
-  // the wiring: method routing, trust-shape, error → fallback handoff.
+  // Flip the mocked settings into Colibri-primary mode for the orchestrator
+  // tests below. Used by both the forward and reverse branch describes.
+  function withColibri(overrides = {}) {
+    mockLoadSettings.mockReturnValue({
+      ...mockLoadSettings(),
+      ensResolutionMethod: 'colibri',
+      ...overrides,
+    });
+  }
+
+  // Switches consensusResolve to the Colibri-backed verifier when
+  // ensResolutionMethod === 'colibri'. The colibri-resolver itself is
+  // unit-tested separately; here we cover the wiring: method routing,
+  // trust-shape, error → fallback handoff.
   describe('colibri orchestrator branch', () => {
     const IPFS_V0 = 'QmW81r84Aihiqqi2Jw6nM1LnpeMfRCenRxtjwHNkXVkZYa';
-
-    function withColibri(overrides = {}) {
-      mockLoadSettings.mockReturnValue({
-        ...mockLoadSettings(),
-        ensResolutionMethod: 'colibri',
-        ...overrides,
-      });
-    }
 
     // resolveViaColibri returns { resolvedData, resolverAddress } (object),
     // not the [bytes, address] tuple the contract mock returns. Adapt.
@@ -1923,18 +1925,10 @@ describe('ens-resolver', () => {
     });
   });
 
-  // Phase 2 A — same Colibri orchestrator branch, reverse direction.
-  // resolveEnsReverse goes through tryColibriReverse instead of consensusResolve.
+  // Same Colibri orchestrator branch, reverse direction. resolveEnsReverse
+  // goes through tryColibriReverse rather than consensusResolve.
   describe('colibri orchestrator branch — reverse', () => {
     const ADDR = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
-
-    function withColibri(overrides = {}) {
-      mockLoadSettings.mockReturnValue({
-        ...mockLoadSettings(),
-        ensResolutionMethod: 'colibri',
-        ...overrides,
-      });
-    }
 
     test('routes through Colibri and returns name + verified-via-colibri trust', async () => {
       withColibri();

--- a/src/main/ens/colibri-resolver.js
+++ b/src/main/ens/colibri-resolver.js
@@ -1,0 +1,104 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { app } = require('electron');
+const { ethers } = require('ethers');
+const Colibri = require('@corpus-core/colibri-stateless').default;
+const { Strategy } = require('@corpus-core/colibri-stateless');
+const log = require('../logger');
+const { loadSettings } = require('../settings-store');
+const { universalResolverCall, hostOf } = require('../ens-resolver');
+
+// privacy_mode 'basic' is a strict improvement (call params never sent
+// to the prover); pinning rather than exposing as a toggle keeps the
+// threat model legible.
+const PRIVACY_MODE = 'basic';
+const CHAIN_ID = 1;
+const DEFAULT_PROVER_URL = 'https://mainnet1.colibri-proof.tech';
+
+let cachedClient = null;
+let cachedClientKey = null;
+let cachedProvider = null;
+let inFlightBuild = null;
+
+// Disk-backed storage adapter for Colibri's verifier state (sync committee
+// pubkeys, current head witness, etc — keys like "states_1" / "sync_1_<slot>").
+// The bundled default writes these to process.cwd(), which means launching
+// the browser from a different directory loses the warm-cache state and
+// scatters files across the filesystem. Redirect to a stable per-app dir.
+function createDiskStorage() {
+  const dir = path.join(app.getPath('userData'), 'colibri');
+  fs.mkdirSync(dir, { recursive: true });
+  return {
+    get: (key) => {
+      try { return fs.readFileSync(path.join(dir, key)); }
+      catch { return null; }
+    },
+    set: (key, value) => { fs.writeFileSync(path.join(dir, key), value); },
+    del: (key) => {
+      try { fs.unlinkSync(path.join(dir, key)); }
+      catch (err) { if (err.code !== 'ENOENT') throw err; }
+    },
+  };
+}
+
+// Lazy singleton. Cache key is the tuple of settings that materially
+// affect proof state (prover URL + zk_proof flag); a runtime change to
+// either tears down the cached instance and rebuilds. WASM init is paid
+// on first use, not module load. `inFlightBuild` collapses concurrent
+// first-call lookups onto a single construction — without it, two cold
+// requests would both pass the cache check and double-init the WASM.
+async function getClient() {
+  const settings = loadSettings();
+  const proverUrl = (settings.ensColibriProverUrl || DEFAULT_PROVER_URL).trim();
+  const zkProof = settings.ensColibriZkProof !== false;
+  const key = `${proverUrl}|${zkProof}`;
+  if (cachedClient && cachedClientKey === key) return cachedClient;
+  if (inFlightBuild && inFlightBuild.key === key) return inFlightBuild.promise;
+
+  const promise = (async () => {
+    // Storage adapter is registered exactly once per process: on the very
+    // first construction. Later settings-change rebuilds reuse it — the
+    // adapter is keyless and the Colibri runtime expects a single global.
+    if (!cachedClient) {
+      await Colibri.register_storage(createDiskStorage());
+    }
+    const client = new Colibri({
+      chainId: CHAIN_ID,
+      prover: [proverUrl],
+      zk_proof: zkProof,
+      privacy_mode: PRIVACY_MODE,
+      proofStrategy: Strategy.VerifiedOnly,
+    });
+    cachedClient = client;
+    cachedClientKey = key;
+    cachedProvider = new ethers.BrowserProvider(client);
+    log.info(`[ens-colibri] client ready (prover=${hostOf(proverUrl)}, zk=${zkProof})`);
+    return client;
+  })();
+  inFlightBuild = { key, promise };
+  try { return await promise; }
+  finally { if (inFlightBuild && inFlightBuild.promise === promise) inFlightBuild = null; }
+}
+
+// Drop-in for what a single `consensusResolve` leg does today, but the
+// answer is cryptographically verified by Colibri rather than corroborated
+// across multiple public RPCs. No blockTag override — Colibri's verifier
+// pins to head − 1 by construction (sync committee signatures for block N
+// live in block N+1).
+async function resolveViaColibri(name, callData) {
+  await getClient();
+  return universalResolverCall(cachedProvider, name, callData);
+}
+
+function clearColibriClientForTest() {
+  cachedClient = null;
+  cachedClientKey = null;
+  cachedProvider = null;
+  inFlightBuild = null;
+}
+
+module.exports = {
+  resolveViaColibri,
+  clearColibriClientForTest,
+  DEFAULT_PROVER_URL,
+};

--- a/src/main/ens/colibri-resolver.js
+++ b/src/main/ens/colibri-resolver.js
@@ -6,7 +6,7 @@ const Colibri = require('@corpus-core/colibri-stateless').default;
 const { Strategy } = require('@corpus-core/colibri-stateless');
 const log = require('../logger');
 const { loadSettings } = require('../settings-store');
-const { universalResolverCall, hostOf } = require('../ens-resolver');
+const { universalResolverCall, universalResolverReverse, hostOf } = require('../ens-resolver');
 
 // privacy_mode 'basic' is a strict improvement (call params never sent
 // to the prover); pinning rather than exposing as a toggle keeps the
@@ -90,6 +90,15 @@ async function resolveViaColibri(name, callData) {
   return universalResolverCall(cachedProvider, name, callData);
 }
 
+// Reverse counterpart: cryptographically-verified `ur.reverse` for an
+// address. Returns { name } on a successful (forward-verified) lookup.
+// Throws on revert (UR's ResolverNotFound / ReverseAddressMismatch) or
+// network/verification failure — the orchestrator classifies.
+async function resolveReverseViaColibri(addressBytes) {
+  await getClient();
+  return universalResolverReverse(cachedProvider, addressBytes);
+}
+
 function clearColibriClientForTest() {
   cachedClient = null;
   cachedClientKey = null;
@@ -99,6 +108,7 @@ function clearColibriClientForTest() {
 
 module.exports = {
   resolveViaColibri,
+  resolveReverseViaColibri,
   clearColibriClientForTest,
   DEFAULT_PROVER_URL,
 };

--- a/src/main/ens/colibri-resolver.test.js
+++ b/src/main/ens/colibri-resolver.test.js
@@ -44,12 +44,19 @@ jest.mock('../settings-store', () => ({
 // Surgical: only stub the two symbols this module imports. Re-exporting the
 // whole ens-resolver here would pull every ENS dependency into the test.
 const mockUniversalResolverCall = jest.fn();
+const mockUniversalResolverReverse = jest.fn();
 jest.mock('../ens-resolver', () => ({
   universalResolverCall: (...args) => mockUniversalResolverCall(...args),
+  universalResolverReverse: (...args) => mockUniversalResolverReverse(...args),
   hostOf: (url) => { try { return new URL(url).host; } catch { return url; } },
 }));
 
-const { resolveViaColibri, clearColibriClientForTest, DEFAULT_PROVER_URL } = require('./colibri-resolver');
+const {
+  resolveViaColibri,
+  resolveReverseViaColibri,
+  clearColibriClientForTest,
+  DEFAULT_PROVER_URL,
+} = require('./colibri-resolver');
 
 const DEFAULTS = {
   ensColibriProverUrl: '',
@@ -65,6 +72,7 @@ beforeEach(() => {
     resolvedData: '0xdeadbeef',
     resolverAddress: '0x000000000000000000000000000000000000ffff',
   });
+  mockUniversalResolverReverse.mockResolvedValue({ name: 'vitalik.eth' });
 });
 
 describe('resolveViaColibri', () => {
@@ -169,6 +177,33 @@ describe('resolveViaColibri', () => {
     const err = new Error('proof verification failed');
     mockUniversalResolverCall.mockRejectedValue(err);
     await expect(resolveViaColibri('a.eth', '0x')).rejects.toBe(err);
+  });
+});
+
+describe('resolveReverseViaColibri', () => {
+  const ADDR_BYTES = new Uint8Array(20).fill(0xab);
+
+  test('delegates to universalResolverReverse via the cached BrowserProvider', async () => {
+    const result = await resolveReverseViaColibri(ADDR_BYTES);
+    expect(mockBrowserProvider).toHaveBeenCalledTimes(1);
+    expect(mockUniversalResolverReverse).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'browser-provider' }),
+      ADDR_BYTES,
+    );
+    expect(result).toEqual({ name: 'vitalik.eth' });
+  });
+
+  test('reuses the singleton + cached provider across forward and reverse calls', async () => {
+    await resolveViaColibri('vitalik.eth', '0x');
+    await resolveReverseViaColibri(ADDR_BYTES);
+    expect(mockColibriCtor).toHaveBeenCalledTimes(1);
+    expect(mockBrowserProvider).toHaveBeenCalledTimes(1);
+  });
+
+  test('propagates errors verbatim (caller classifies)', async () => {
+    const err = Object.assign(new Error('ReverseAddressMismatch'), { data: '0xef9c03ce' });
+    mockUniversalResolverReverse.mockRejectedValue(err);
+    await expect(resolveReverseViaColibri(ADDR_BYTES)).rejects.toBe(err);
   });
 });
 

--- a/src/main/ens/colibri-resolver.test.js
+++ b/src/main/ens/colibri-resolver.test.js
@@ -1,0 +1,223 @@
+const mockGetPath = jest.fn();
+jest.mock('electron', () => ({
+  app: { getPath: (...args) => mockGetPath(...args) },
+}));
+
+const mockMkdirSync = jest.fn();
+const mockReadFileSync = jest.fn();
+const mockWriteFileSync = jest.fn();
+const mockUnlinkSync = jest.fn();
+jest.mock('node:fs', () => ({
+  mkdirSync: (...args) => mockMkdirSync(...args),
+  readFileSync: (...args) => mockReadFileSync(...args),
+  writeFileSync: (...args) => mockWriteFileSync(...args),
+  unlinkSync: (...args) => mockUnlinkSync(...args),
+}));
+
+// Mock-prefixed names so Jest's "out-of-scope variable" guard permits them
+// in the factory (the factory runs before top-level `const` initializers).
+const mockColibriCtor = jest.fn();
+const mockRegisterStorage = jest.fn(() => Promise.resolve());
+jest.mock('@corpus-core/colibri-stateless', () => {
+  class FakeColibri {
+    constructor(config) { mockColibriCtor(config); this.config = config; }
+    static register_storage(storage) { return mockRegisterStorage(storage); }
+  }
+  return {
+    __esModule: true,
+    default: FakeColibri,
+    Strategy: { VerifiedOnly: Symbol('VerifiedOnly') },
+  };
+});
+const { Strategy } = require('@corpus-core/colibri-stateless');
+
+const mockBrowserProvider = jest.fn().mockImplementation((client) => ({ kind: 'browser-provider', client }));
+jest.mock('ethers', () => ({
+  ethers: { BrowserProvider: mockBrowserProvider },
+}));
+
+const mockLoadSettings = jest.fn();
+jest.mock('../settings-store', () => ({
+  loadSettings: (...args) => mockLoadSettings(...args),
+}));
+
+// Surgical: only stub the two symbols this module imports. Re-exporting the
+// whole ens-resolver here would pull every ENS dependency into the test.
+const mockUniversalResolverCall = jest.fn();
+jest.mock('../ens-resolver', () => ({
+  universalResolverCall: (...args) => mockUniversalResolverCall(...args),
+  hostOf: (url) => { try { return new URL(url).host; } catch { return url; } },
+}));
+
+const { resolveViaColibri, clearColibriClientForTest, DEFAULT_PROVER_URL } = require('./colibri-resolver');
+
+const DEFAULTS = {
+  ensColibriProverUrl: '',
+  ensColibriZkProof: true,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearColibriClientForTest();
+  mockGetPath.mockReturnValue('/tmp/freedom-test-userdata');
+  mockLoadSettings.mockReturnValue({ ...DEFAULTS });
+  mockUniversalResolverCall.mockResolvedValue({
+    resolvedData: '0xdeadbeef',
+    resolverAddress: '0x000000000000000000000000000000000000ffff',
+  });
+});
+
+describe('resolveViaColibri', () => {
+  test('constructs the client lazily with the partner-confirmed config', async () => {
+    expect(mockColibriCtor).not.toHaveBeenCalled();
+    await resolveViaColibri('vitalik.eth', '0xbc1c58d1...');
+    expect(mockColibriCtor).toHaveBeenCalledTimes(1);
+    expect(mockColibriCtor).toHaveBeenCalledWith({
+      chainId: 1,
+      prover: [DEFAULT_PROVER_URL],
+      zk_proof: true,
+      privacy_mode: 'basic',
+      proofStrategy: Strategy.VerifiedOnly,
+    });
+  });
+
+  test('registers disk storage exactly once and before the first client constructor', async () => {
+    await resolveViaColibri('a.eth', '0x');
+    await resolveViaColibri('b.eth', '0x');
+    expect(mockRegisterStorage).toHaveBeenCalledTimes(1);
+    expect(mockRegisterStorage.mock.invocationCallOrder[0])
+      .toBeLessThan(mockColibriCtor.mock.invocationCallOrder[0]);
+  });
+
+  test('does not re-register storage on a settings-driven rebuild', async () => {
+    await resolveViaColibri('a.eth', '0x');
+    mockLoadSettings.mockReturnValue({ ...DEFAULTS, ensColibriZkProof: false });
+    await resolveViaColibri('b.eth', '0x');
+    expect(mockRegisterStorage).toHaveBeenCalledTimes(1);
+    expect(mockColibriCtor).toHaveBeenCalledTimes(2);
+  });
+
+  test('reuses the singleton across calls when settings are unchanged', async () => {
+    await resolveViaColibri('one.eth', '0x');
+    await resolveViaColibri('two.eth', '0x');
+    expect(mockColibriCtor).toHaveBeenCalledTimes(1);
+    expect(mockBrowserProvider).toHaveBeenCalledTimes(1);
+  });
+
+  test('concurrent first calls collapse onto one construction', async () => {
+    const [a, b, c] = await Promise.all([
+      resolveViaColibri('a.eth', '0x'),
+      resolveViaColibri('b.eth', '0x'),
+      resolveViaColibri('c.eth', '0x'),
+    ]);
+    expect(mockColibriCtor).toHaveBeenCalledTimes(1);
+    expect(mockRegisterStorage).toHaveBeenCalledTimes(1);
+    expect(mockBrowserProvider).toHaveBeenCalledTimes(1);
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    expect(c).toBeDefined();
+  });
+
+  test('rebuilds the client when the prover URL changes', async () => {
+    await resolveViaColibri('one.eth', '0x');
+    mockLoadSettings.mockReturnValue({
+      ...DEFAULTS,
+      ensColibriProverUrl: 'https://other-prover.example',
+    });
+    await resolveViaColibri('two.eth', '0x');
+    expect(mockColibriCtor).toHaveBeenCalledTimes(2);
+    expect(mockColibriCtor.mock.calls[1][0].prover).toEqual(['https://other-prover.example']);
+    expect(mockBrowserProvider).toHaveBeenCalledTimes(2);
+  });
+
+  test('rebuilds the client when zk_proof toggles', async () => {
+    await resolveViaColibri('one.eth', '0x');
+    mockLoadSettings.mockReturnValue({ ...DEFAULTS, ensColibriZkProof: false });
+    await resolveViaColibri('two.eth', '0x');
+    expect(mockColibriCtor).toHaveBeenCalledTimes(2);
+    expect(mockColibriCtor.mock.calls[1][0].zk_proof).toBe(false);
+  });
+
+  test('respects a custom prover URL from settings', async () => {
+    mockLoadSettings.mockReturnValue({
+      ...DEFAULTS,
+      ensColibriProverUrl: 'https://custom.example/keyXYZ',
+    });
+    await resolveViaColibri('a.eth', '0x');
+    expect(mockColibriCtor.mock.calls[0][0].prover).toEqual(['https://custom.example/keyXYZ']);
+  });
+
+  test('passes name + callData through to universalResolverCall via the cached BrowserProvider', async () => {
+    await resolveViaColibri('vitalik.eth', '0xbc1c58d1deadbeef');
+    expect(mockUniversalResolverCall).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'browser-provider' }),
+      'vitalik.eth',
+      '0xbc1c58d1deadbeef',
+    );
+  });
+
+  test('returns the universalResolverCall payload verbatim', async () => {
+    const payload = {
+      resolvedData: '0xfeedface',
+      resolverAddress: '0x000000000000000000000000000000000000beef',
+    };
+    mockUniversalResolverCall.mockResolvedValue(payload);
+    await expect(resolveViaColibri('a.eth', '0x')).resolves.toEqual(payload);
+  });
+
+  test('propagates errors from universalResolverCall (e.g. verification failure)', async () => {
+    const err = new Error('proof verification failed');
+    mockUniversalResolverCall.mockRejectedValue(err);
+    await expect(resolveViaColibri('a.eth', '0x')).rejects.toBe(err);
+  });
+});
+
+describe('disk storage adapter', () => {
+  // Captured from the register_storage call after triggering construction.
+  // No public export — the integration assertion (passed to register_storage)
+  // is more valuable than unit-testing the adapter in isolation.
+  async function captureStorage() {
+    await resolveViaColibri('a.eth', '0x');
+    return mockRegisterStorage.mock.calls[0][0];
+  }
+
+  test('creates the colibri subdirectory under app userData on first use', async () => {
+    await captureStorage();
+    expect(mockGetPath).toHaveBeenCalledWith('userData');
+    expect(mockMkdirSync).toHaveBeenCalledWith(
+      '/tmp/freedom-test-userdata/colibri',
+      { recursive: true },
+    );
+  });
+
+  test('get/set/del route through fs against the colibri subdirectory', async () => {
+    const storage = await captureStorage();
+    mockReadFileSync.mockReturnValue(Buffer.from([1, 2, 3]));
+    expect(storage.get('states_1')).toEqual(Buffer.from([1, 2, 3]));
+    expect(mockReadFileSync).toHaveBeenCalledWith('/tmp/freedom-test-userdata/colibri/states_1');
+
+    storage.set('sync_1_42', new Uint8Array([9, 9]));
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      '/tmp/freedom-test-userdata/colibri/sync_1_42',
+      new Uint8Array([9, 9]),
+    );
+
+    storage.del('states_1');
+    expect(mockUnlinkSync).toHaveBeenCalledWith('/tmp/freedom-test-userdata/colibri/states_1');
+  });
+
+  test('get returns null when the underlying file is missing (warm-cache miss)', async () => {
+    const storage = await captureStorage();
+    mockReadFileSync.mockImplementation(() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); });
+    expect(storage.get('missing')).toBeNull();
+  });
+
+  test('del absorbs ENOENT but rethrows other errors (e.g. permission)', async () => {
+    const storage = await captureStorage();
+    mockUnlinkSync.mockImplementation(() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); });
+    expect(() => storage.del('already-gone')).not.toThrow();
+
+    mockUnlinkSync.mockImplementation(() => { throw Object.assign(new Error('EACCES'), { code: 'EACCES' }); });
+    expect(() => storage.del('locked')).toThrow(/EACCES/);
+  });
+});

--- a/src/main/settings-store.js
+++ b/src/main/settings-store.js
@@ -45,6 +45,21 @@ const DEFAULT_SETTINGS = {
   showBookmarkBar: false,
   enableEnsCustomRpc: false,
   ensRpcUrl: '',
+  // ENS resolution method selector. 'quorum' is the legacy public-RPC
+  // cross-checking path (see below); 'colibri' routes through the
+  // @corpus-core/colibri-stateless verifier for cryptographic proof
+  // rather than heuristic agreement; 'custom-rpc' uses ensRpcUrl as
+  // a single trusted source. Hidden until the settings UI lands —
+  // default keeps the pre-Colibri behaviour intact.
+  ensResolutionMethod: 'quorum',
+  // When 'colibri' is the primary and the prover errors / fails to
+  // verify, fall through to the quorum path instead of surfacing the
+  // failure. Loud-fallback is enforced via a structured log line.
+  ensFallbackToQuorum: true,
+  // Empty → ens/colibri-resolver falls back to its bundled DEFAULT_PROVER_URL.
+  ensColibriProverUrl: '',
+  // ZK consensus proof on the Colibri bootstrap; partner-recommended on.
+  ensColibriZkProof: true,
   // ENS public-RPC quorum resolution (active when enableEnsCustomRpc=false).
   // Detects RPC lying by requiring ensQuorumM of K parallel providers to
   // return byte-identical data at a pinned block. See docs/ens-resolution.md.

--- a/src/main/settings-store.js
+++ b/src/main/settings-store.js
@@ -45,13 +45,14 @@ const DEFAULT_SETTINGS = {
   showBookmarkBar: false,
   enableEnsCustomRpc: false,
   ensRpcUrl: '',
-  // ENS resolution method selector. 'quorum' is the legacy public-RPC
-  // cross-checking path (see below); 'colibri' routes through the
-  // @corpus-core/colibri-stateless verifier for cryptographic proof
-  // rather than heuristic agreement; 'custom-rpc' uses ensRpcUrl as
-  // a single trusted source. Hidden until the settings UI lands —
-  // default keeps the pre-Colibri behaviour intact.
-  ensResolutionMethod: 'quorum',
+  // ENS resolution method selector. 'colibri' routes through the
+  // @corpus-core/colibri-stateless verifier for cryptographic proof;
+  // 'quorum' is the legacy public-RPC cross-checking path (see below);
+  // 'custom-rpc' uses ensRpcUrl as a single trusted source. Default is
+  // 'colibri' on fresh installs. Existing installs without this key are
+  // migrated in loadSettings (custom-RPC users preserved, everyone else
+  // upgraded to colibri).
+  ensResolutionMethod: 'colibri',
   // When 'colibri' is the primary and the prover errors / fails to
   // verify, fall through to the quorum path instead of surfacing the
   // failure. Loud-fallback is enforced via a structured log line.
@@ -101,7 +102,20 @@ function loadSettings() {
     const filePath = getSettingsPath();
     if (fs.existsSync(filePath)) {
       const data = fs.readFileSync(filePath, 'utf-8');
-      cachedSettings = { ...DEFAULT_SETTINGS, ...JSON.parse(data) };
+      const parsed = JSON.parse(data);
+      // One-shot migration for installs that predate the ensResolutionMethod
+      // key. Custom-RPC users explicitly pointed at their own node, almost
+      // certainly to keep queries off public infrastructure — preserve that
+      // intent. Everyone else (the vast majority, who never picked quorum
+      // explicitly) auto-upgrades to the cryptographically-verified Colibri
+      // path. Idempotent: subsequent loads see the key on disk (after the
+      // next save) or recompute the same answer if the file is unchanged.
+      if (!Object.prototype.hasOwnProperty.call(parsed, 'ensResolutionMethod')) {
+        parsed.ensResolutionMethod = parsed.enableEnsCustomRpc === true
+          ? 'custom-rpc'
+          : 'colibri';
+      }
+      cachedSettings = { ...DEFAULT_SETTINGS, ...parsed };
     } else {
       cachedSettings = { ...DEFAULT_SETTINGS };
     }

--- a/src/main/settings-store.test.js
+++ b/src/main/settings-store.test.js
@@ -75,6 +75,43 @@ describe('settings-store', () => {
     expect(nativeTheme.themeSource).toBe('dark');
   });
 
+  test('migration: pre-Colibri installs without ensResolutionMethod default to colibri', () => {
+    fs.writeFileSync(
+      path.join(userDataDir, 'settings.json'),
+      // Realistic pre-Colibri file: no resolution method, no custom RPC.
+      JSON.stringify({ theme: 'dark', enableEnsCustomRpc: false, ensQuorumK: 3 }),
+      'utf-8'
+    );
+
+    const { mod } = loadSettingsStore({ userDataDir });
+    expect(mod.loadSettings().ensResolutionMethod).toBe('colibri');
+  });
+
+  test('migration: existing custom-RPC users are preserved as custom-rpc', () => {
+    fs.writeFileSync(
+      path.join(userDataDir, 'settings.json'),
+      JSON.stringify({ enableEnsCustomRpc: true, ensRpcUrl: 'http://localhost:8545' }),
+      'utf-8'
+    );
+
+    const { mod } = loadSettingsStore({ userDataDir });
+    const loaded = mod.loadSettings();
+    expect(loaded.ensResolutionMethod).toBe('custom-rpc');
+    expect(loaded.ensRpcUrl).toBe('http://localhost:8545');
+  });
+
+  test('migration: an explicit ensResolutionMethod on disk is respected', () => {
+    fs.writeFileSync(
+      path.join(userDataDir, 'settings.json'),
+      // Already-migrated file: ensResolutionMethod is present. Don't recompute.
+      JSON.stringify({ ensResolutionMethod: 'quorum', enableEnsCustomRpc: false }),
+      'utf-8'
+    );
+
+    const { mod } = loadSettingsStore({ userDataDir });
+    expect(mod.loadSettings().ensResolutionMethod).toBe('quorum');
+  });
+
   test('falls back to defaults when the settings file is invalid', () => {
     fs.writeFileSync(path.join(userDataDir, 'settings.json'), '{not-valid-json', 'utf-8');
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1372,7 +1372,6 @@
                 <div class="send-field">
                   <label class="send-label">Recipient</label>
                   <input type="text" class="send-input" id="send-recipient" placeholder="Address or ENS name" autocomplete="off" spellcheck="false">
-                  <div class="send-resolved-address hidden" id="send-resolved-address"></div>
                   <div class="send-field-error hidden" id="send-recipient-error"></div>
                 </div>
 

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -22,10 +22,12 @@ export const resolveTrustBadge = ({ value = '', ensTrustByName = new Map() } = {
 };
 
 // One-sentence status shown at the top of the trust popover, below the ENS
-// name. Keyed on trust level. Lookup misses (unknown level) yield `null`
-// from `buildTrustRows({...}).status` and the caller decides how to handle.
+// name. Keyed on trust level (and, for verified, on the resolution method).
+// Lookup misses (unknown level) yield `null` from `buildTrustRows({...}).status`
+// and the caller decides how to handle.
 const TRUST_STATUS_SENTENCE = {
   verified: 'ENS resolution verified',
+  'verified-colibri': 'Cryptographically verified via Colibri',
   'user-configured': 'Resolved with your configured RPC',
   unverified: 'ENS resolution not verified',
   conflict: 'Verification failed: RPCs disagree',
@@ -54,6 +56,37 @@ const TRUST_HASH_LABEL = {
 // already produces `'bzz'` directly.
 const protoToScheme = (proto) => (proto === 'swarm' ? 'bzz' : proto);
 
+// Network + hash content rows are the same across every resolution method —
+// they describe the resolved URI, not how we verified it. Extracted so the
+// Colibri branch (which skips the per-method trust rows above) and the
+// legacy branch share the rendering shape.
+const buildContentRows = ({ uri = '', proto = '' } = {}) => {
+  const uriMatch = uri.match(/^([a-z][a-z0-9+.-]*):\/\/(.+)$/i);
+  const scheme = uriMatch
+    ? uriMatch[1].toLowerCase()
+    : protoToScheme((proto || '').toLowerCase());
+  const body = uriMatch ? uriMatch[2] : '';
+
+  const networkName = scheme
+    ? TRUST_NETWORK_NAME[scheme] || scheme.toUpperCase()
+    : '';
+  const hashLabel = TRUST_HASH_LABEL[scheme] || 'Content Hash';
+
+  const contentRows = [];
+  if (networkName) {
+    contentRows.push({ label: 'Network', display: networkName, copy: '' });
+  }
+  if (body) {
+    contentRows.push({
+      label: hashLabel,
+      display: body,
+      copy: body,
+      autoFit: body,
+    });
+  }
+  return contentRows;
+};
+
 // Pure helper that turns a `(trust, level, uri, proto)` tuple into the
 // data the popover renders: a status sentence and two ordered arrays of
 // row descriptors for the trust and content sections. Each row is
@@ -67,7 +100,10 @@ export const buildTrustRows = ({
   uri = '',
   proto = '',
 } = {}) => {
-  const status = TRUST_STATUS_SENTENCE[level] || null;
+  const method = trust.method;
+  const isColibri = level === 'verified' && method === 'colibri';
+  const statusKey = isColibri ? 'verified-colibri' : level;
+  const status = TRUST_STATUS_SENTENCE[statusKey] || null;
 
   const agreed = Array.isArray(trust.agreed) ? trust.agreed : [];
   const queried = Array.isArray(trust.queried) ? trust.queried : [];
@@ -75,6 +111,22 @@ export const buildTrustRows = ({
   const blockNumber = trust.block?.number;
 
   const trustRows = [];
+
+  // Colibri results carry single-source agreed/queried (the prover host) by
+  // design — the cryptographic verification *replaces* the M-of-K heuristic,
+  // it doesn't run alongside it. Surface the prover + method instead of the
+  // degenerate quorum row.
+  if (isColibri) {
+    if (trust.prover) {
+      trustRows.push({
+        label: 'Verified by',
+        display: trust.prover,
+        copy: trust.prover,
+        autoFit: trust.prover,
+      });
+    }
+    return { status, trustRows, contentRows: buildContentRows({ uri, proto }) };
+  }
 
   // Quorum summary is meaningful only when more than one RPC was queried;
   // otherwise "1 of 1" is degenerate and just adds noise on the
@@ -133,34 +185,7 @@ export const buildTrustRows = ({
     trustRows.push({ label: 'Block', display: num, copy: num });
   }
 
-  // Parse the resolved URI to split scheme from body. The copy value
-  // for the hash row is the body alone (matching what's shown), not
-  // the full `scheme://body` URI.
-  const uriMatch = uri.match(/^([a-z][a-z0-9+.-]*):\/\/(.+)$/i);
-  const scheme = uriMatch
-    ? uriMatch[1].toLowerCase()
-    : protoToScheme((proto || '').toLowerCase());
-  const body = uriMatch ? uriMatch[2] : '';
-
-  const networkName = scheme
-    ? TRUST_NETWORK_NAME[scheme] || scheme.toUpperCase()
-    : '';
-  const hashLabel = TRUST_HASH_LABEL[scheme] || 'Content Hash';
-
-  const contentRows = [];
-  if (networkName) {
-    contentRows.push({ label: 'Network', display: networkName, copy: '' });
-  }
-  if (body) {
-    contentRows.push({
-      label: hashLabel,
-      display: body,
-      copy: body,
-      autoFit: body,
-    });
-  }
-
-  return { status, trustRows, contentRows };
+  return { status, trustRows, contentRows: buildContentRows({ uri, proto }) };
 };
 
 export const resolveProtocolIconType = ({

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -34,6 +34,15 @@ export const TRUST_STATUS_SENTENCE = {
   conflict: 'Verification failed: RPCs disagree',
 };
 
+// Long-form warning for a recipient whose reverse record exists but
+// doesn't forward-verify back to the address. The claimed name is NOT
+// rendered as visible text anywhere — only as tooltip text on a warning
+// glyph — so a phisher can't lean on its visual plausibility.
+export const describeUnverifiedReverse = (claimedName) =>
+  claimedName
+    ? `This address claims to be "${claimedName}", but the name doesn't forward-resolve back to it. Treat the name as untrusted — could be a stale record or a spoofing attempt.`
+    : `This address has a primary ENS name set, but it doesn't forward-verify back. Treat the claim as untrusted.`;
+
 // Friendly names for the network row, keyed by the URI's protocol scheme
 // (the `bzz` / `ipfs` / `ipns` prefix from the resolved contenthash URI).
 // Anything not in the table is shown uppercased.

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -24,8 +24,9 @@ export const resolveTrustBadge = ({ value = '', ensTrustByName = new Map() } = {
 // One-sentence status shown at the top of the trust popover, below the ENS
 // name. Keyed on trust level (and, for verified, on the resolution method).
 // Lookup misses (unknown level) yield `null` from `buildTrustRows({...}).status`
-// and the caller decides how to handle.
-const TRUST_STATUS_SENTENCE = {
+// and the caller decides how to handle. Exported because the wallet review
+// surface reuses these as tooltip copy — keep the vocabulary in one place.
+export const TRUST_STATUS_SENTENCE = {
   verified: 'ENS resolution verified',
   'verified-colibri': 'Cryptographically verified via Colibri',
   'user-configured': 'Resolved with your configured RPC',

--- a/src/renderer/lib/navigation-utils.test.js
+++ b/src/renderer/lib/navigation-utils.test.js
@@ -384,6 +384,55 @@ describe('navigation-utils', () => {
       ]);
     });
 
+    test('colibri-verified: shows method-specific status and a single Verified-by row', async () => {
+      const { buildTrustRows } = await loadNavigationUtils();
+
+      const result = buildTrustRows({
+        level: 'verified',
+        trust: {
+          method: 'colibri',
+          prover: 'mainnet1.colibri-proof.tech',
+          agreed: ['mainnet1.colibri-proof.tech'],
+          queried: ['mainnet1.colibri-proof.tech'],
+        },
+        uri: 'ipfs://QmPSYsfe8CVrBMrbh3q8qjzQYnAmDX8H4xkERzvFBaYkMS',
+      });
+
+      expect(result.status).toBe('Cryptographically verified via Colibri');
+      // No RPC Quorum / per-RPC rows — the prover is not a quorum member.
+      expect(result.trustRows).toEqual([
+        {
+          label: 'Verified by',
+          display: 'mainnet1.colibri-proof.tech',
+          copy: 'mainnet1.colibri-proof.tech',
+          autoFit: 'mainnet1.colibri-proof.tech',
+        },
+      ]);
+      // Content rows are independent of the verification method.
+      expect(result.contentRows).toEqual([
+        { label: 'Network', display: 'IPFS', copy: '' },
+        {
+          label: 'CID',
+          display: 'QmPSYsfe8CVrBMrbh3q8qjzQYnAmDX8H4xkERzvFBaYkMS',
+          copy: 'QmPSYsfe8CVrBMrbh3q8qjzQYnAmDX8H4xkERzvFBaYkMS',
+          autoFit: 'QmPSYsfe8CVrBMrbh3q8qjzQYnAmDX8H4xkERzvFBaYkMS',
+        },
+      ]);
+    });
+
+    test('colibri-verified without prover field: still uses Colibri status, omits the row', async () => {
+      const { buildTrustRows } = await loadNavigationUtils();
+
+      const result = buildTrustRows({
+        level: 'verified',
+        trust: { method: 'colibri' },
+        uri: 'bzz://abc123',
+      });
+
+      expect(result.status).toBe('Cryptographically verified via Colibri');
+      expect(result.trustRows).toEqual([]);
+    });
+
     test('returns null status for an unknown trust level', async () => {
       const { buildTrustRows } = await loadNavigationUtils();
 

--- a/src/renderer/lib/wallet/send.js
+++ b/src/renderer/lib/wallet/send.js
@@ -7,7 +7,7 @@
 import { walletState, registerScreenHider } from './wallet-state.js';
 import { escapeHtml } from './wallet-utils.js';
 import { refreshBalances, getTokensWithBalance, getChainsWithBalance, sortTokens } from './balance-display.js';
-import { TRUST_STATUS_SENTENCE } from '../navigation-utils.js';
+import { TRUST_STATUS_SENTENCE, describeUnverifiedReverse } from '../navigation-utils.js';
 import { createTab } from '../tabs.js';
 
 // DOM references
@@ -1003,20 +1003,16 @@ function renderRecipientReview(container, address, resolution) {
 // tooltip on the warning glyph, so a phisher can't slip a misleading
 // name onto the review screen.
 function renderRecipientUnverified(container, address, claimedName) {
-  const addressSpan = document.createElement('span');
-  addressSpan.className = 'send-review-recipient-address-bare';
-  addressSpan.textContent = address;
-
   const warn = document.createElement('span');
   warn.className = 'send-review-warning';
   warn.textContent = '⚠';
-  const detail = claimedName
-    ? `This address claims to be "${claimedName}", but the name doesn't forward-resolve back to it. Treat the name as untrusted — could be a stale record or a spoofing attempt.`
-    : `This address has a primary ENS name set, but it doesn't forward-verify back. Treat the claim as untrusted.`;
+  const detail = describeUnverifiedReverse(claimedName);
   warn.title = detail;
   warn.setAttribute('aria-label', detail);
 
-  container.replaceChildren(addressSpan, warn);
+  // Address inherits monospace + 11px from the parent .send-review-address
+  // class on #send-review-to — no per-span styling needed for the bare case.
+  container.replaceChildren(document.createTextNode(address), warn);
 }
 
 // Verified checkmark for the recipient cell when trust is verifiable.

--- a/src/renderer/lib/wallet/send.js
+++ b/src/renderer/lib/wallet/send.js
@@ -66,6 +66,10 @@ let sendTxState = {
   recipient: '',
   // Set only when `recipient` was resolved from ENS; review view shows both.
   recipientName: null,
+  // Trust metadata for `recipientName`. Carries the same shape the ENS
+  // resolver returns: { level, method?, prover?, agreed?, queried?, ... }.
+  // Null when the name came from an unverifiable source (or no name resolved).
+  recipientTrust: null,
   amount: '',
   gasLimit: null,
   maxFeePerGas: null,
@@ -164,6 +168,7 @@ function setupSendScreen() {
       // Edits invalidate any previously-resolved ENS address.
       hideResolvedAddress();
       sendTxState.recipientName = null;
+      sendTxState.recipientTrust = null;
     });
   }
 
@@ -259,6 +264,7 @@ function resetSendState() {
     selectedToken: null,
     recipient: '',
     recipientName: null,
+    recipientTrust: null,
     amount: '',
     gasLimit: null,
     maxFeePerGas: null,
@@ -802,7 +808,10 @@ async function handleSendContinue() {
       if (!resolved) return; // error already surfaced on the recipient field
       sendTxState.recipient = resolved.address;
       sendTxState.recipientName = resolved.name;
-      showResolvedAddress(resolved.address);
+      sendTxState.recipientTrust = resolved.trust;
+      // No `showResolvedAddress(...)` here — the address is about to be
+      // shown on the review screen, so painting it under the input field
+      // for a sub-second only flashes a transitional state at the user.
     } else {
       sendTxState.recipient = recipientClass.value;
       hideResolvedAddress();
@@ -815,9 +824,10 @@ async function handleSendContinue() {
     }
 
     if (sendContinueBtn) sendContinueBtn.textContent = 'Loading...';
-    const [, reverseName] = await Promise.all([estimateTransactionGas(), reverseLookup]);
-    if (reverseName && !sendTxState.recipientName) {
-      sendTxState.recipientName = reverseName;
+    const [, reverseResult] = await Promise.all([estimateTransactionGas(), reverseLookup]);
+    if (reverseResult && !sendTxState.recipientName) {
+      sendTxState.recipientName = reverseResult.name;
+      sendTxState.recipientTrust = reverseResult.trust;
     }
     populateSendReview();
     await configureSendUnlockUI();
@@ -833,15 +843,17 @@ async function handleSendContinue() {
   }
 }
 
-// Ask main for the primary ENS name set for an address and return it
-// only if it forward-verifies. Never throws — returns null on any
-// failure or unavailability so the send flow isn't blocked.
+// Ask main for the primary ENS name set for an address. Returns
+// { name, trust } when one is set and forward-verifies, or null
+// otherwise. Never throws — the review flow isn't blocked by a
+// reverse-lookup failure.
 async function lookupPrimaryNameForAddress(address) {
   const api = window.electronAPI;
   if (!api?.resolveEnsReverse) return null;
   try {
     const result = await api.resolveEnsReverse(address);
-    return result?.success && result.name ? result.name : null;
+    if (!result?.success || !result.name) return null;
+    return { name: result.name, trust: result.trust || null };
   } catch {
     return null;
   }
@@ -871,7 +883,11 @@ async function resolveRecipientEns(name) {
     return null;
   }
 
-  return { name: result.name || name, address: result.address };
+  return {
+    name: result.name || name,
+    address: result.address,
+    trust: result.trust || null,
+  };
 }
 
 function showResolvedAddress(address) {
@@ -948,9 +964,9 @@ function populateSendReview() {
 
   if (sendReviewTo) {
     if (sendTxState.recipientName) {
-      sendReviewTo.textContent = `${sendTxState.recipientName} (${sendTxState.recipient})`;
+      renderRecipientReview(sendReviewTo, sendTxState.recipientName, sendTxState.recipient, sendTxState.recipientTrust);
     } else {
-      sendReviewTo.textContent = sendTxState.recipient;
+      sendReviewTo.replaceChildren(document.createTextNode(sendTxState.recipient));
     }
   }
 
@@ -977,6 +993,56 @@ function populateSendReview() {
       sendReviewTotal.textContent = `${sendTxState.amount} ${token?.symbol || ''}`;
     }
   }
+}
+
+// Build the recipient cell on the review screen. Renders the resolved
+// ENS name in normal type, a verification badge when the trust object
+// reports verified/user-configured, then the address in monospace
+// parentheses. Falls back to plain text on null trust — no badge.
+function renderRecipientReview(container, name, address, trust) {
+  const nameSpan = document.createElement('span');
+  nameSpan.className = 'send-review-name';
+  nameSpan.textContent = name;
+  const children = [nameSpan];
+
+  const badge = buildRecipientVerifiedBadge(trust);
+  if (badge) children.push(document.createTextNode(' '), badge);
+
+  const addressSpan = document.createElement('span');
+  addressSpan.className = 'send-review-recipient-address';
+  addressSpan.textContent = ` (${address})`;
+  children.push(addressSpan);
+
+  container.replaceChildren(...children);
+}
+
+// Returns a styled checkmark span describing the trust outcome, or null
+// when there's nothing trustworthy to assert (conflict / unverified /
+// missing trust info). Tooltip + aria-label vocabulary matches the
+// address-bar trust shield popover so the surfaces feel consistent.
+function buildRecipientVerifiedBadge(trust) {
+  if (!trust) return null;
+  if (trust.level !== 'verified' && trust.level !== 'user-configured') return null;
+
+  let title;
+  if (trust.method === 'colibri') {
+    title = trust.prover
+      ? `Cryptographically verified via Colibri (${trust.prover})`
+      : 'Cryptographically verified via Colibri';
+  } else if (trust.level === 'user-configured') {
+    title = 'Resolved via your configured RPC';
+  } else if (Array.isArray(trust.agreed) && Array.isArray(trust.queried) && trust.queried.length > 1) {
+    title = `Cross-checked across ${trust.agreed.length} of ${trust.queried.length} public RPCs`;
+  } else {
+    title = 'Verified';
+  }
+
+  const badge = document.createElement('span');
+  badge.className = 'send-review-verified';
+  badge.textContent = '✓';
+  badge.title = title;
+  badge.setAttribute('aria-label', title);
+  return badge;
 }
 
 async function configureSendUnlockUI() {

--- a/src/renderer/lib/wallet/send.js
+++ b/src/renderer/lib/wallet/send.js
@@ -827,17 +827,23 @@ async function handleSendContinue() {
   }
 }
 
-// Ask main for the primary ENS name set for an address. Returns
-// { name, trust } when one is set and forward-verifies, or null
-// otherwise. Never throws — the review flow isn't blocked by a
-// reverse-lookup failure.
+// Ask main for the primary ENS name set for an address. Returns one of:
+//   { name, trust }                          forward-verified primary name
+//   { warning: 'unverified', claimedName }   primary claim doesn't forward-verify
+//   null                                     no reverse record / hard error
+// Never throws — the review flow isn't blocked by a reverse-lookup failure.
 async function lookupPrimaryNameForAddress(address) {
   const api = window.electronAPI;
   if (!api?.resolveEnsReverse) return null;
   try {
     const result = await api.resolveEnsReverse(address);
-    if (!result?.success || !result.name) return null;
-    return { name: result.name, trust: result.trust || null };
+    if (result?.success && result.name) {
+      return { name: result.name, trust: result.trust || null };
+    }
+    if (result?.reason === 'UNVERIFIED') {
+      return { warning: 'unverified', claimedName: result.claimedName || null };
+    }
+    return null;
   } catch {
     return null;
   }
@@ -968,7 +974,13 @@ function populateSendReview() {
   }
 }
 
-function renderRecipientReview(container, address, { name, trust }) {
+function renderRecipientReview(container, address, resolution) {
+  if (resolution.warning === 'unverified') {
+    renderRecipientUnverified(container, address, resolution.claimedName);
+    return;
+  }
+
+  const { name, trust } = resolution;
   const nameSpan = document.createElement('span');
   nameSpan.className = 'send-review-name';
   nameSpan.textContent = name;
@@ -983,6 +995,28 @@ function renderRecipientReview(container, address, { name, trust }) {
   children.push(addressSpan);
 
   container.replaceChildren(...children);
+}
+
+// Render path for the rare case where the recipient address has a primary
+// ENS name set, but that name doesn't forward-resolve back to the address.
+// The claim is untrusted, so we don't display it as text — only as a
+// tooltip on the warning glyph, so a phisher can't slip a misleading
+// name onto the review screen.
+function renderRecipientUnverified(container, address, claimedName) {
+  const addressSpan = document.createElement('span');
+  addressSpan.className = 'send-review-recipient-address-bare';
+  addressSpan.textContent = address;
+
+  const warn = document.createElement('span');
+  warn.className = 'send-review-warning';
+  warn.textContent = '⚠';
+  const detail = claimedName
+    ? `This address claims to be "${claimedName}", but the name doesn't forward-resolve back to it. Treat the name as untrusted — could be a stale record or a spoofing attempt.`
+    : `This address has a primary ENS name set, but it doesn't forward-verify back. Treat the claim as untrusted.`;
+  warn.title = detail;
+  warn.setAttribute('aria-label', detail);
+
+  container.replaceChildren(addressSpan, warn);
 }
 
 // Verified checkmark for the recipient cell when trust is verifiable.

--- a/src/renderer/lib/wallet/send.js
+++ b/src/renderer/lib/wallet/send.js
@@ -7,6 +7,7 @@
 import { walletState, registerScreenHider } from './wallet-state.js';
 import { escapeHtml } from './wallet-utils.js';
 import { refreshBalances, getTokensWithBalance, getChainsWithBalance, sortTokens } from './balance-display.js';
+import { TRUST_STATUS_SENTENCE } from '../navigation-utils.js';
 import { createTab } from '../tabs.js';
 
 // DOM references
@@ -18,7 +19,6 @@ let sendPendingView;
 let sendSuccessView;
 let sendErrorView;
 let sendRecipientInput;
-let sendResolvedAddress;
 let sendRecipientError;
 // Send chain selector
 let sendChainSelector;
@@ -64,12 +64,10 @@ let sendRetryBtn;
 let sendTxState = {
   selectedToken: null,
   recipient: '',
-  // Set only when `recipient` was resolved from ENS; review view shows both.
-  recipientName: null,
-  // Trust metadata for `recipientName`. Carries the same shape the ENS
-  // resolver returns: { level, method?, prover?, agreed?, queried?, ... }.
-  // Null when the name came from an unverifiable source (or no name resolved).
-  recipientTrust: null,
+  // { name, trust } when `recipient` was resolved from ENS (or a reverse
+  // lookup of a raw address succeeded), null otherwise. Bundled so that
+  // clearing one half can't leak a stale other half.
+  recipientResolution: null,
   amount: '',
   gasLimit: null,
   maxFeePerGas: null,
@@ -88,7 +86,6 @@ export function initSend() {
   sendSuccessView = document.getElementById('send-success-view');
   sendErrorView = document.getElementById('send-error-view');
   sendRecipientInput = document.getElementById('send-recipient');
-  sendResolvedAddress = document.getElementById('send-resolved-address');
   sendRecipientError = document.getElementById('send-recipient-error');
   sendChainSelector = document.getElementById('send-chain-selector');
   sendChainBtn = document.getElementById('send-chain-btn');
@@ -166,9 +163,7 @@ function setupSendScreen() {
     sendRecipientInput.addEventListener('input', () => {
       clearSendError('recipient');
       // Edits invalidate any previously-resolved ENS address.
-      hideResolvedAddress();
-      sendTxState.recipientName = null;
-      sendTxState.recipientTrust = null;
+      sendTxState.recipientResolution = null;
     });
   }
 
@@ -263,8 +258,7 @@ function resetSendState() {
   sendTxState = {
     selectedToken: null,
     recipient: '',
-    recipientName: null,
-    recipientTrust: null,
+    recipientResolution: null,
     amount: '',
     gasLimit: null,
     maxFeePerGas: null,
@@ -277,8 +271,6 @@ function resetSendState() {
   if (sendRecipientInput) sendRecipientInput.value = '';
   if (sendAmountInput) sendAmountInput.value = '';
   if (sendPasswordInput) sendPasswordInput.value = '';
-
-  if (sendResolvedAddress) sendResolvedAddress.textContent = '';
 
   closeSendChainDropdown();
   closeSendAssetDropdown();
@@ -293,8 +285,6 @@ function resetSendState() {
   clearSendError('general');
   clearSendError('review');
   clearSendError('unlock');
-
-  sendResolvedAddress?.classList.add('hidden');
 
   if (sendContinueBtn) {
     sendContinueBtn.disabled = false;
@@ -807,14 +797,9 @@ async function handleSendContinue() {
       const resolved = await resolveRecipientEns(recipientClass.value);
       if (!resolved) return; // error already surfaced on the recipient field
       sendTxState.recipient = resolved.address;
-      sendTxState.recipientName = resolved.name;
-      sendTxState.recipientTrust = resolved.trust;
-      // No `showResolvedAddress(...)` here — the address is about to be
-      // shown on the review screen, so painting it under the input field
-      // for a sub-second only flashes a transitional state at the user.
+      sendTxState.recipientResolution = { name: resolved.name, trust: resolved.trust };
     } else {
       sendTxState.recipient = recipientClass.value;
-      hideResolvedAddress();
       // Best-effort reverse lookup so the review screen can show the
       // recipient's primary ENS name alongside the address when one is
       // verifiably set. Fire in parallel with gas estimation so it
@@ -825,9 +810,8 @@ async function handleSendContinue() {
 
     if (sendContinueBtn) sendContinueBtn.textContent = 'Loading...';
     const [, reverseResult] = await Promise.all([estimateTransactionGas(), reverseLookup]);
-    if (reverseResult && !sendTxState.recipientName) {
-      sendTxState.recipientName = reverseResult.name;
-      sendTxState.recipientTrust = reverseResult.trust;
+    if (reverseResult && !sendTxState.recipientResolution) {
+      sendTxState.recipientResolution = reverseResult;
     }
     populateSendReview();
     await configureSendUnlockUI();
@@ -890,17 +874,6 @@ async function resolveRecipientEns(name) {
   };
 }
 
-function showResolvedAddress(address) {
-  if (!sendResolvedAddress) return;
-  sendResolvedAddress.textContent = address;
-  sendResolvedAddress.classList.remove('hidden');
-}
-
-function hideResolvedAddress() {
-  if (!sendResolvedAddress) return;
-  sendResolvedAddress.textContent = '';
-  sendResolvedAddress.classList.add('hidden');
-}
 
 async function estimateTransactionGas() {
   const token = sendTxState.selectedToken;
@@ -963,10 +936,10 @@ function populateSendReview() {
   const chain = walletState.registeredChains[sendTxState.chainId];
 
   if (sendReviewTo) {
-    if (sendTxState.recipientName) {
-      renderRecipientReview(sendReviewTo, sendTxState.recipientName, sendTxState.recipient, sendTxState.recipientTrust);
+    if (sendTxState.recipientResolution) {
+      renderRecipientReview(sendReviewTo, sendTxState.recipient, sendTxState.recipientResolution);
     } else {
-      sendReviewTo.replaceChildren(document.createTextNode(sendTxState.recipient));
+      sendReviewTo.textContent = sendTxState.recipient;
     }
   }
 
@@ -995,18 +968,14 @@ function populateSendReview() {
   }
 }
 
-// Build the recipient cell on the review screen. Renders the resolved
-// ENS name in normal type, a verification badge when the trust object
-// reports verified/user-configured, then the address in monospace
-// parentheses. Falls back to plain text on null trust — no badge.
-function renderRecipientReview(container, name, address, trust) {
+function renderRecipientReview(container, address, { name, trust }) {
   const nameSpan = document.createElement('span');
   nameSpan.className = 'send-review-name';
   nameSpan.textContent = name;
   const children = [nameSpan];
 
   const badge = buildRecipientVerifiedBadge(trust);
-  if (badge) children.push(document.createTextNode(' '), badge);
+  if (badge) children.push(badge);
 
   const addressSpan = document.createElement('span');
   addressSpan.className = 'send-review-recipient-address';
@@ -1016,26 +985,19 @@ function renderRecipientReview(container, name, address, trust) {
   container.replaceChildren(...children);
 }
 
-// Returns a styled checkmark span describing the trust outcome, or null
-// when there's nothing trustworthy to assert (conflict / unverified /
-// missing trust info). Tooltip + aria-label vocabulary matches the
-// address-bar trust shield popover so the surfaces feel consistent.
+// Verified checkmark for the recipient cell when trust is verifiable.
+// Tooltip copy is sourced from the address-bar popover's status table
+// (TRUST_STATUS_SENTENCE) so the two surfaces can't drift; for Colibri
+// the prover host is appended as the one inline detail this surface adds.
 function buildRecipientVerifiedBadge(trust) {
   if (!trust) return null;
   if (trust.level !== 'verified' && trust.level !== 'user-configured') return null;
 
-  let title;
-  if (trust.method === 'colibri') {
-    title = trust.prover
-      ? `Cryptographically verified via Colibri (${trust.prover})`
-      : 'Cryptographically verified via Colibri';
-  } else if (trust.level === 'user-configured') {
-    title = 'Resolved via your configured RPC';
-  } else if (Array.isArray(trust.agreed) && Array.isArray(trust.queried) && trust.queried.length > 1) {
-    title = `Cross-checked across ${trust.agreed.length} of ${trust.queried.length} public RPCs`;
-  } else {
-    title = 'Verified';
-  }
+  const isColibri = trust.level === 'verified' && trust.method === 'colibri';
+  const key = isColibri ? 'verified-colibri' : trust.level;
+  let title = TRUST_STATUS_SENTENCE[key];
+  if (!title) return null;
+  if (isColibri && trust.prover) title += ` (${trust.prover})`;
 
   const badge = document.createElement('span');
   badge.className = 'send-review-verified';

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -441,7 +441,7 @@
               <polygon points="12 2 4 12 12 16 20 12 12 2"></polygon>
               <polygon points="4 14 12 22 20 14 12 18 4 14"></polygon>
             </svg>
-            Ethereum RPC
+            ENS Resolution
           </button>
           <button type="button" class="nav-item" data-target="experimental" id="nav-experimental">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -512,23 +512,120 @@
           </div>
         </section>
 
-        <!-- Ethereum RPC -->
+        <!-- ENS Resolution -->
         <section class="section" id="ethereum">
-          <h2 class="section-title">Ethereum RPC</h2>
+          <h2 class="section-title">Resolution method</h2>
+          <p class="row-help" style="margin-bottom: 16px">
+            How Freedom resolves <code>.eth</code> and <code>.box</code> names to the content they
+            point at. Colibri verifies each answer cryptographically against the Ethereum sync
+            committee; the public-RPC quorum cross-checks several RPC providers; custom RPC
+            trusts a node you run yourself.
+          </p>
           <div class="card">
             <div class="row">
               <div class="row-body">
-                <p class="row-label">Use a custom RPC endpoint</p>
-                <p class="row-help">Freedom uses a default public endpoint when this is off.</p>
+                <p class="row-label">
+                  <label style="cursor: pointer; font-weight: normal">
+                    <input type="radio" name="ens-resolution-method" value="colibri" id="ens-method-colibri" />
+                    Colibri (cryptographic verification)
+                    <span style="color: var(--text-muted); font-size: 12px; margin-left: 6px">Recommended</span>
+                  </label>
+                </p>
+                <p class="row-help" style="padding-left: 22px">
+                  Each answer is verified against the Ethereum sync committee via a partner-hosted
+                  prover. Stronger than RPC cross-checking. Adds a single trust dependency on the
+                  prover; fall back to the public-RPC quorum if it fails.
+                </p>
+              </div>
+            </div>
+            <div class="row">
+              <div class="row-body">
+                <p class="row-label">
+                  <label style="cursor: pointer; font-weight: normal">
+                    <input type="radio" name="ens-resolution-method" value="quorum" id="ens-method-quorum" />
+                    Public-RPC quorum
+                  </label>
+                </p>
+                <p class="row-help" style="padding-left: 22px">
+                  Ask several public Ethereum RPCs in parallel and only trust answers where they
+                  agree. The previous Freedom default.
+                </p>
+              </div>
+            </div>
+            <div class="row">
+              <div class="row-body">
+                <p class="row-label">
+                  <label style="cursor: pointer; font-weight: normal">
+                    <input type="radio" name="ens-resolution-method" value="custom-rpc" id="ens-method-custom-rpc" />
+                    Custom Ethereum RPC
+                  </label>
+                </p>
+                <p class="row-help" style="padding-left: 22px">
+                  Resolve via a single Ethereum node you run yourself. No cross-checking, no
+                  prover dependency — you trust your own node.
+                </p>
+              </div>
+            </div>
+            <div class="row">
+              <div class="row-body">
+                <p class="row-label">Fall back to public-RPC quorum if primary fails</p>
+                <p class="row-help">
+                  When the primary method errors or can't verify, retry via the public-RPC quorum
+                  rather than surfacing the failure. The fallback is announced in DevTools so
+                  primary-method health regressions stay visible.
+                </p>
               </div>
               <div class="row-control">
                 <label class="toggle">
-                  <input type="checkbox" id="enable-ens-custom-rpc" />
+                  <input type="checkbox" id="ens-fallback-to-quorum" />
                   <span class="slider"></span>
                 </label>
               </div>
             </div>
-            <div class="rpc-block" id="ens-rpc-field">
+          </div>
+
+          <!-- Colibri configuration — visible when method=colibri -->
+          <h2 class="section-title" style="margin-top: 32px" id="ens-colibri-header">Colibri</h2>
+          <div class="card" id="ens-colibri-card">
+            <div class="row">
+              <div class="row-body">
+                <p class="row-label">Prover URL</p>
+                <p class="row-help">
+                  Partner-hosted Colibri prover. The default is operated by corpus.core; you can
+                  point at any compatible prover endpoint.
+                </p>
+              </div>
+              <div class="row-control" style="flex: 1; max-width: 320px">
+                <input
+                  type="text"
+                  id="ens-colibri-prover-url"
+                  class="rpc-input"
+                  placeholder="https://mainnet1.colibri-proof.tech"
+                  spellcheck="false"
+                />
+              </div>
+            </div>
+            <div class="row">
+              <div class="row-body">
+                <p class="row-label">Use ZK consensus proof</p>
+                <p class="row-help">
+                  Bootstraps the sync committee via a recursive zero-knowledge proof instead of
+                  classical light-client updates. Smaller bootstrap, partner-recommended on.
+                </p>
+              </div>
+              <div class="row-control">
+                <label class="toggle">
+                  <input type="checkbox" id="ens-colibri-zk-proof" />
+                  <span class="slider"></span>
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <!-- Custom Ethereum RPC — visible when method=custom-rpc -->
+          <h2 class="section-title" style="margin-top: 32px" id="ens-custom-rpc-header">Custom Ethereum RPC</h2>
+          <div class="card" id="ens-custom-rpc-card">
+            <div class="rpc-block" id="ens-rpc-field" style="border-top: none">
               <div class="rpc-row">
                 <input
                   type="text"
@@ -544,11 +641,12 @@
             </div>
           </div>
 
-          <!-- Cross-RPC verification — only active when no custom RPC is set -->
-          <h2 class="section-title" style="margin-top: 32px">Cross-RPC verification</h2>
+          <!-- Public-RPC quorum — primary or fallback depending on method choice above -->
+          <h2 class="section-title" style="margin-top: 32px">Public-RPC quorum</h2>
           <p class="row-help" style="margin-bottom: 16px">
-            When using public RPCs, Freedom asks multiple servers and only trusts answers where
-            several agree. A single malicious RPC cannot silently redirect an ENS name.
+            Used as the primary path when "Public-RPC quorum" is selected above, and as the
+            fallback for the other methods. Freedom asks multiple servers and only trusts answers
+            where several agree.
           </p>
           <div class="card">
             <div class="row">
@@ -735,7 +833,18 @@
         themeMode: $('theme-mode'),
         startBee: $('start-bee-at-launch'),
         startIpfs: $('start-ipfs-at-launch'),
-        enableEnsCustomRpc: $('enable-ens-custom-rpc'),
+        ensMethodRadios: [
+          $('ens-method-colibri'),
+          $('ens-method-quorum'),
+          $('ens-method-custom-rpc'),
+        ],
+        ensFallbackToQuorum: $('ens-fallback-to-quorum'),
+        ensColibriHeader: $('ens-colibri-header'),
+        ensColibriCard: $('ens-colibri-card'),
+        ensColibriProverUrl: $('ens-colibri-prover-url'),
+        ensColibriZkProof: $('ens-colibri-zk-proof'),
+        ensCustomRpcHeader: $('ens-custom-rpc-header'),
+        ensCustomRpcCard: $('ens-custom-rpc-card'),
         ensRpcField: $('ens-rpc-field'),
         ensRpcUrl: $('ens-rpc-url'),
         ensRpcTest: $('ens-rpc-test'),
@@ -833,8 +942,22 @@
         }
       };
 
-      const setEnsRpcBlockVisible = (visible) => {
-        fields.ensRpcField.classList.toggle('hidden', !visible);
+      const getSelectedEnsMethod = () => {
+        const checked = fields.ensMethodRadios.find((r) => r?.checked);
+        return checked?.value || 'colibri';
+      };
+
+      // Drive per-method visibility of the Colibri / Custom-RPC subsections.
+      // The public-RPC quorum block is always visible since it's either the
+      // primary path or the fallback for the other methods.
+      const applyEnsMethodVisibility = () => {
+        const method = getSelectedEnsMethod();
+        const showColibri = method === 'colibri';
+        const showCustomRpc = method === 'custom-rpc';
+        fields.ensColibriHeader.classList.toggle('hidden', !showColibri);
+        fields.ensColibriCard.classList.toggle('hidden', !showColibri);
+        fields.ensCustomRpcHeader.classList.toggle('hidden', !showCustomRpc);
+        fields.ensCustomRpcCard.classList.toggle('hidden', !showCustomRpc);
       };
 
       const setEnsRpcStatus = (text, type) => {
@@ -883,25 +1006,35 @@
           .map((input) => (input.value || '').trim())
           .filter((url) => url.length > 0);
 
-      const currentFormState = () => ({
-        theme: fields.themeMode.value || 'system',
-        startBeeAtLaunch: fields.startBee.checked,
-        startIpfsAtLaunch: fields.startIpfs.checked,
-        enableRadicleIntegration: isWindows ? false : fields.enableRadicle.checked,
-        startRadicleAtLaunch: isWindows ? false : fields.startRadicle.checked,
-        enableIdentityWallet: fields.enableIdentity.checked,
-        autoUpdate: fields.autoUpdate.checked,
-        enableEnsCustomRpc: fields.enableEnsCustomRpc.checked,
-        ensRpcUrl: (fields.ensRpcUrl.value || '').trim(),
-        blockUnverifiedEns: fields.blockUnverifiedEns.checked,
-        enableEnsQuorum: fields.enableEnsQuorum.checked,
-        ensQuorumK: Number(fields.ensQuorumK.value) || 3,
-        ensQuorumM: Number(fields.ensQuorumM.value) || 2,
-        ensQuorumTimeoutMs: Number(fields.ensQuorumTimeout.value) || 5000,
-        ensBlockAnchor: fields.ensBlockAnchor.value || 'latest',
-        ensBlockAnchorTtlMs: Number(fields.ensAnchorTtl.value) || 30000,
-        ensPublicRpcProviders: collectProviderUrls(),
-      });
+      const currentFormState = () => {
+        const method = getSelectedEnsMethod();
+        return {
+          theme: fields.themeMode.value || 'system',
+          startBeeAtLaunch: fields.startBee.checked,
+          startIpfsAtLaunch: fields.startIpfs.checked,
+          enableRadicleIntegration: isWindows ? false : fields.enableRadicle.checked,
+          startRadicleAtLaunch: isWindows ? false : fields.startRadicle.checked,
+          enableIdentityWallet: fields.enableIdentity.checked,
+          autoUpdate: fields.autoUpdate.checked,
+          ensResolutionMethod: method,
+          ensFallbackToQuorum: fields.ensFallbackToQuorum.checked,
+          ensColibriProverUrl: (fields.ensColibriProverUrl.value || '').trim(),
+          ensColibriZkProof: fields.ensColibriZkProof.checked,
+          // Keep enableEnsCustomRpc in sync with the radio so any legacy
+          // consumer reading the old flag (and the persisted JSON shape)
+          // stays correct without a separate migration pass.
+          enableEnsCustomRpc: method === 'custom-rpc',
+          ensRpcUrl: (fields.ensRpcUrl.value || '').trim(),
+          blockUnverifiedEns: fields.blockUnverifiedEns.checked,
+          enableEnsQuorum: fields.enableEnsQuorum.checked,
+          ensQuorumK: Number(fields.ensQuorumK.value) || 3,
+          ensQuorumM: Number(fields.ensQuorumM.value) || 2,
+          ensQuorumTimeoutMs: Number(fields.ensQuorumTimeout.value) || 5000,
+          ensBlockAnchor: fields.ensBlockAnchor.value || 'latest',
+          ensBlockAnchorTtlMs: Number(fields.ensAnchorTtl.value) || 30000,
+          ensPublicRpcProviders: collectProviderUrls(),
+        };
+      };
 
       const applyFormState = (settings) => {
         if (!settings) return;
@@ -912,7 +1045,19 @@
         fields.startRadicle.checked = settings.startRadicleAtLaunch === true;
         fields.enableIdentity.checked = settings.enableIdentityWallet === true;
         fields.autoUpdate.checked = settings.autoUpdate !== false;
-        fields.enableEnsCustomRpc.checked = settings.enableEnsCustomRpc === true;
+        // Read the new method key; legacy installs that haven't been migrated
+        // yet are mapped here as a safety net (loadSettings on the main side
+        // should have already done this — duplicate logic is cheap and keeps
+        // the form correct even if the value-resolution order changes).
+        const method =
+          settings.ensResolutionMethod ||
+          (settings.enableEnsCustomRpc === true ? 'custom-rpc' : 'colibri');
+        for (const radio of fields.ensMethodRadios) {
+          radio.checked = radio.value === method;
+        }
+        fields.ensFallbackToQuorum.checked = settings.ensFallbackToQuorum !== false;
+        fields.ensColibriProverUrl.value = settings.ensColibriProverUrl || '';
+        fields.ensColibriZkProof.checked = settings.ensColibriZkProof !== false;
         fields.ensRpcUrl.value = settings.ensRpcUrl || '';
         fields.blockUnverifiedEns.checked = settings.blockUnverifiedEns !== false;
         fields.enableEnsQuorum.checked = settings.enableEnsQuorum !== false;
@@ -926,7 +1071,7 @@
             ? settings.ensPublicRpcProviders
             : ENS_DEFAULT_PROVIDERS
         );
-        setEnsRpcBlockVisible(fields.enableEnsCustomRpc.checked);
+        applyEnsMethodVisibility();
         setFieldEnabled(fields.enableRadicle, fields.startRadicleRow, fields.startRadicle);
         setEnsRpcStatus('', '');
         setProviderStatus('', '');
@@ -1099,14 +1244,19 @@
       fields.enableIdentity.addEventListener('change', save);
       fields.autoUpdate.addEventListener('change', save);
 
-      fields.enableEnsCustomRpc.addEventListener('change', () => {
-        setEnsRpcBlockVisible(fields.enableEnsCustomRpc.checked);
-        save();
-      });
+      for (const radio of fields.ensMethodRadios) {
+        radio.addEventListener('change', () => {
+          applyEnsMethodVisibility();
+          save();
+        });
+      }
+      fields.ensFallbackToQuorum.addEventListener('change', save);
+      fields.ensColibriZkProof.addEventListener('change', save);
 
-      // Persist on blur only — autosaving mid-typing would briefly persist
-      // partial URLs (e.g. http://localh) that the ENS resolver picks up on
-      // the next lookup.
+      // Persist text fields on blur only — autosaving mid-typing would
+      // briefly persist partial URLs (e.g. http://localh) that the ENS
+      // resolver picks up on the next lookup.
+      fields.ensColibriProverUrl.addEventListener('blur', save);
       fields.ensRpcUrl.addEventListener('input', () => setEnsRpcStatus('', ''));
       fields.ensRpcUrl.addEventListener('blur', save);
 

--- a/src/renderer/styles/autocomplete.css
+++ b/src/renderer/styles/autocomplete.css
@@ -101,7 +101,7 @@
   color: #000;
 }
 .autocomplete-protocol-badge.protocol-https {
-  background: #6b9e7a;
+  background: var(--secure-fg);
   color: #000;
 }
 .autocomplete-protocol-badge.protocol-http {

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -4338,6 +4338,27 @@
   word-break: break-all;
 }
 
+/* When the recipient was ENS-resolved we render the name in normal type
+   followed by the address in parens-monospace, with an optional
+   verified-via-Colibri (or quorum/user-RPC) checkmark between them.
+   Parent .send-review-address sets a monospace baseline; the name span
+   opts out, the address span re-asserts. */
+.send-review-name {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 13px;
+}
+.send-review-recipient-address {
+  font-family: 'SF Mono', 'Menlo', 'Monaco', monospace;
+  font-size: 11px;
+  color: var(--muted);
+}
+.send-review-verified {
+  /* Same green as the address-bar trust shield's verified state. */
+  color: #6b9e7a;
+  font-size: 13px;
+  cursor: help;
+}
+
 .send-review-amount {
   font-weight: 600;
   font-size: 15px;

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -4253,15 +4253,6 @@
   margin-top: 6px;
 }
 
-/* Resolved address display */
-.send-resolved-address {
-  font-size: 12px;
-  color: var(--accent);
-  margin-top: 6px;
-  font-family: 'SF Mono', 'Menlo', 'Monaco', monospace;
-  word-break: break-all;
-}
-
 /* Field errors */
 .send-field-error {
   font-size: 12px;
@@ -4353,9 +4344,9 @@
   color: var(--muted);
 }
 .send-review-verified {
-  /* Same green as the address-bar trust shield's verified state. */
-  color: #6b9e7a;
+  color: var(--secure-fg);
   font-size: 13px;
+  margin: 0 4px;
   cursor: help;
 }
 

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -4350,15 +4350,6 @@
   cursor: help;
 }
 
-/* Bare-address rendering used when no name resolved OR the reverse
-   record was UNVERIFIED. Picks up the monospace baseline from the
-   parent .send-review-address container, but exists as a span so the
-   adjacent warning glyph can sit inline on the same line. */
-.send-review-recipient-address-bare {
-  font-family: 'SF Mono', 'Menlo', 'Monaco', monospace;
-  font-size: 11px;
-}
-
 .send-review-warning {
   color: var(--warning-fg);
   font-size: 13px;

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -4350,6 +4350,22 @@
   cursor: help;
 }
 
+/* Bare-address rendering used when no name resolved OR the reverse
+   record was UNVERIFIED. Picks up the monospace baseline from the
+   parent .send-review-address container, but exists as a span so the
+   adjacent warning glyph can sit inline on the same line. */
+.send-review-recipient-address-bare {
+  font-family: 'SF Mono', 'Menlo', 'Monaco', monospace;
+  font-size: 11px;
+}
+
+.send-review-warning {
+  color: var(--warning-fg);
+  font-size: 13px;
+  margin-left: 4px;
+  cursor: help;
+}
+
 .send-review-amount {
   font-weight: 600;
   font-size: 15px;

--- a/src/renderer/styles/toolbar.css
+++ b/src/renderer/styles/toolbar.css
@@ -167,7 +167,7 @@
   color: var(--secure-fg);
 }
 .trust-shield[data-trust='unverified'] .icon-unverified {
-  color: #d29922;
+  color: var(--warning-fg);
 }
 .trust-shield[data-trust='conflict'] .icon-conflict {
   color: #cf222e;

--- a/src/renderer/styles/toolbar.css
+++ b/src/renderer/styles/toolbar.css
@@ -161,10 +161,10 @@
 
 /* Verified / user-configured strokes match the HTTPS globe colour. */
 .trust-shield[data-trust='verified'] .icon-verified {
-  color: #6b9e7a;
+  color: var(--secure-fg);
 }
 .trust-shield[data-trust='user-configured'] .icon-user-configured {
-  color: #6b9e7a;
+  color: var(--secure-fg);
 }
 .trust-shield[data-trust='unverified'] .icon-unverified {
   color: #d29922;
@@ -371,7 +371,7 @@
 /* HTTPS secure - subtle green */
 .protocol-icon[data-protocol='https'] .icon-http {
   display: block;
-  stroke: #6b9e7a;
+  stroke: var(--secure-fg);
 }
 
 .address-input {

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -13,6 +13,9 @@
      verified/user-configured states, autocomplete row verified badge,
      wallet review verified checkmark. One token, all surfaces. */
   --secure-fg: #6b9e7a;
+  /* "Be careful" amber — address-bar trust shield's unverified state,
+     wallet review warning glyph (e.g. spoofed/stale ENS reverse claim). */
+  --warning-fg: #d29922;
 }
 
 /* Light theme */

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -9,6 +9,10 @@
   --modal-bg: #1a1a1a;
   --menu-bg: #1a1a1a;
   --danger: #f28b82;
+  /* "This is safe" green — HTTPS globe, address-bar trust shield's
+     verified/user-configured states, autocomplete row verified badge,
+     wallet review verified checkmark. One token, all surfaces. */
+  --secure-fg: #6b9e7a;
 }
 
 /* Light theme */


### PR DESCRIPTION
## Summary

- ENS resolution defaults to **cryptographic verification** via `@corpus-core/colibri-stateless` instead of the public-RPC quorum. Each `eth_call` against the Universal Resolver is independently verified against the Ethereum sync committee (zk-proven sync bootstrap by default), rather than trusting M-of-K agreement between public RPCs. Covers forward (`contenthash` + `addr`) **and** reverse lookups — the wallet's recipient-name display now carries the same guarantee as the address-bar shield.
- Existing public-RPC quorum stays in the codebase as the fallback path and as a selectable primary method. Custom-RPC users (the only group that actively chose their resolution path) are preserved on `'custom-rpc'`; everyone else auto-migrates to Colibri on first launch.
- New settings UI section, redesigned address-bar trust popover wording, and a verified ✓ next to the recipient name on the wallet review screen — plus a warning glyph when an address claims a primary ENS name that doesn't forward-verify back.

## Architecture

`tryColibriPath` / `tryColibriReverse` sit at the top of the existing `consensusResolve` / `doResolveEnsReverse` flows. On Colibri throw (proof failure, network, prover outage) and `ensFallbackToQuorum=true` (default), control falls through to the legacy quorum path with a loud structured log line — silent fallback would hide both prover-health regressions and the "active attack" signal. CCIP-Read (`.box` via 3DNS, ENSv2-style offchain resolvers) works as-is: the prover proves the initial `eth_call`, ethers' `enableCcipRead` handles the gateway round-trip, the final `resolveCallback` is independently proven.

## What changed under the hood

- New module `src/main/ens/colibri-resolver.js`: lazy WASM-init singleton, in-flight-build promise to collapse cold-start races, disk storage redirected to `app.getPath('userData')/colibri`.
- `consensusResolve` and `doResolveEnsReverse` gain a Colibri orchestrator branch with structured fallback logging.
- Migration in `loadSettings`: `enableEnsCustomRpc=true` → `ensResolutionMethod='custom-rpc'`; everyone else → `'colibri'`. Idempotent.
- Trust shield popover differentiates `verified-colibri` from quorum-verified; wallet review surfaces the same vocabulary via a shared `TRUST_STATUS_SENTENCE` table.
- `--secure-fg` / `--warning-fg` CSS variables promote the hardcoded greens and ambers used across the trust UI.
- `freedom://settings` ENS Resolution section: radio for method, fallback toggle, conditional Colibri / Custom-RPC subsections.
- CHANGELOG `[Unreleased]` entry.

## Test plan

- [x] Full unit suite green (1334 tests).
- [x] Live e2e against `mainnet1.colibri-proof.tech` (6 tests, gated by `ENS_COLIBRI_E2E=1`): `vitalik.eth` contenthash + addr, an unregistered name (`NO_RESOLVER`), a `.box` name (CCIP-Read round-trip + final proven `resolveCallback`), `0xd8da…96045` → `vitalik.eth` reverse, 5× cache-warm sanity.
- [x] Packaged macOS arm64 build: WASM loads cleanly from inside `app.asar`. Verified via log line `[ens-colibri] client ready (prover=mainnet1.colibri-proof.tech, zk=true)`. No `asarUnpack` entry needed.
- [x] Manual smoke: `freedom://settings` ENS Resolution section renders; method switch works; trust popover surfaces Colibri/quorum distinction; wallet send to ENS name shows the verified ✓ with hover tooltip.
- [ ] Linux + Windows packaged-build verification (high confidence based on macOS result + platform-neutral WASM, but worth running before tagging release).
- [ ] UNVERIFIED reverse warning visual smoke — run the DevTools snippet in the `feat(ens): warn on UNVERIFIED reverse-record claims` commit message and confirm `⚠` renders with the spoofed-claim tooltip.

## Out of scope / future work

- `prover_mode: 'local'` (uses your own beacon API + execution RPC, no remote prover, no zk_proof) — investigated; deferred. Practical audience is users running their own node infrastructure; otherwise it trades one third party for another without much privacy win.
- Multi-prover quorum on Colibri itself — deferred until there's a second independent prover endpoint to point at (partner's roadmap).
- Partner deliverables still pending: production API key for `mainnet1.colibri-proof.tech`, written retention/privacy policy, SLA target. Settings UI has a placeholder for the privacy link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)