### PR TITLE
feat(renderer): hover-link URL preview

### DIFF
--- a/src/main/webview-preload.js
+++ b/src/main/webview-preload.js
@@ -160,15 +160,19 @@ document.addEventListener('auxclick', handleDwebLinkActivation, true);
 // on zone transitions to keep IPC traffic minimal — for typical browsing
 // the channel is silent.
 //
-// Width must track the actual bar's `max-width: min(70vw, 640px)` from
-// link-status.css. A fixed width was too narrow on wide viewports, so a
-// link hovered between the band's right edge and the bar's right edge
-// would sit under the bar without triggering the flip.
+// Width must track the actual bar's `max-width: min(70%, 640px)` from
+// link-status.css. Both reference the webview content area — the CSS
+// `%` resolves against the bar's positioning ancestor `.content-page`,
+// and `window.innerWidth` here is the guest webview's viewport, which
+// is the same width as `.content-page`. Keeping these consistent
+// matters when the sidebar is open: a `vw`-based CSS width plus a
+// webview-relative zone width would diverge by the sidebar's 320 px
+// and leave a band where the bar covers the link the user is hovering.
 const LINK_STATUS_ZONE_BAND_PX = 28; // bottom band height (~bar height)
 const LINK_STATUS_ZONE_MAX_WIDTH_PX = 640;
-const LINK_STATUS_ZONE_VW_FRACTION = 0.7;
+const LINK_STATUS_ZONE_CONTENT_FRACTION = 0.7;
 const linkStatusZoneWidth = () =>
-  Math.min(LINK_STATUS_ZONE_MAX_WIDTH_PX, window.innerWidth * LINK_STATUS_ZONE_VW_FRACTION);
+  Math.min(LINK_STATUS_ZONE_MAX_WIDTH_PX, window.innerWidth * LINK_STATUS_ZONE_CONTENT_FRACTION);
 let linkStatusInZone = false;
 const sendLinkStatusZone = (inZone) => {
   if (linkStatusInZone === inZone) return;

--- a/src/main/webview-preload.js
+++ b/src/main/webview-preload.js
@@ -154,6 +154,32 @@ const handleDwebLinkActivation = (event) => {
 document.addEventListener('click', handleDwebLinkActivation, true);
 document.addEventListener('auxclick', handleDwebLinkActivation, true);
 
+// Notify the host renderer when the cursor enters/leaves the bottom-left
+// region of the viewport so the link-hover URL preview can flip to the
+// opposite corner (matches Chrome's status-bubble behaviour). Only emits
+// on zone transitions to keep IPC traffic minimal — for typical browsing
+// the channel is silent.
+const LINK_STATUS_ZONE_BAND_PX = 28;   // bottom band height (~bar height)
+const LINK_STATUS_ZONE_WIDTH_PX = 280; // left band width
+let linkStatusInZone = false;
+const sendLinkStatusZone = (inZone) => {
+  if (linkStatusInZone === inZone) return;
+  linkStatusInZone = inZone;
+  ipcRenderer.sendToHost('link-status:zone', { inLeftZone: inZone });
+};
+document.addEventListener(
+  'mousemove',
+  (event) => {
+    const inZone =
+      event.clientY > window.innerHeight - LINK_STATUS_ZONE_BAND_PX &&
+      event.clientX < LINK_STATUS_ZONE_WIDTH_PX;
+    sendLinkStatusZone(inZone);
+  },
+  { passive: true, capture: true }
+);
+document.addEventListener('mouseleave', () => sendLinkStatusZone(false));
+window.addEventListener('blur', () => sendLinkStatusZone(false));
+
 // Expose APIs to internal pages (guarded for safety)
 contextBridge.exposeInMainWorld('freedomAPI', {
   // History

--- a/src/main/webview-preload.js
+++ b/src/main/webview-preload.js
@@ -159,8 +159,16 @@ document.addEventListener('auxclick', handleDwebLinkActivation, true);
 // opposite corner (matches Chrome's status-bubble behaviour). Only emits
 // on zone transitions to keep IPC traffic minimal — for typical browsing
 // the channel is silent.
-const LINK_STATUS_ZONE_BAND_PX = 28;   // bottom band height (~bar height)
-const LINK_STATUS_ZONE_WIDTH_PX = 280; // left band width
+//
+// Width must track the actual bar's `max-width: min(70vw, 640px)` from
+// link-status.css. A fixed width was too narrow on wide viewports, so a
+// link hovered between the band's right edge and the bar's right edge
+// would sit under the bar without triggering the flip.
+const LINK_STATUS_ZONE_BAND_PX = 28; // bottom band height (~bar height)
+const LINK_STATUS_ZONE_MAX_WIDTH_PX = 640;
+const LINK_STATUS_ZONE_VW_FRACTION = 0.7;
+const linkStatusZoneWidth = () =>
+  Math.min(LINK_STATUS_ZONE_MAX_WIDTH_PX, window.innerWidth * LINK_STATUS_ZONE_VW_FRACTION);
 let linkStatusInZone = false;
 const sendLinkStatusZone = (inZone) => {
   if (linkStatusInZone === inZone) return;
@@ -172,7 +180,7 @@ document.addEventListener(
   (event) => {
     const inZone =
       event.clientY > window.innerHeight - LINK_STATUS_ZONE_BAND_PX &&
-      event.clientX < LINK_STATUS_ZONE_WIDTH_PX;
+      event.clientX < linkStatusZoneWidth();
     sendLinkStatusZone(inZone);
   },
   { passive: true, capture: true }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -684,8 +684,19 @@
     <nav class="bookmarks" aria-label="Bookmarks" id="bookmarks-bar" data-test="bookmarks-bar"></nav>
     <section class="app-body">
       <main class="content">
-        <div id="webview-container" class="webview-container">
-          <!-- Webviews inserted dynamically by tabs.js -->
+        <div class="content-page">
+          <div id="webview-container" class="webview-container">
+            <!-- Webviews inserted dynamically by tabs.js -->
+          </div>
+          <div
+            id="link-status"
+            class="link-status"
+            hidden
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            <span id="link-status-url" class="link-status-url"></span>
+          </div>
         </div>
       </main>
       <aside id="sidebar" class="sidebar collapsed">

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -688,13 +688,7 @@
           <div id="webview-container" class="webview-container">
             <!-- Webviews inserted dynamically by tabs.js -->
           </div>
-          <div
-            id="link-status"
-            class="link-status"
-            hidden
-            aria-live="polite"
-            aria-atomic="true"
-          >
+          <div id="link-status" class="link-status" hidden aria-hidden="true">
             <span id="link-status-url" class="link-status-url"></span>
           </div>
         </div>

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -48,6 +48,7 @@ import {
 } from './lib/autocomplete.js';
 import { initGithubBridgeUi, setOnOpenRadicleUrl } from './lib/github-bridge-ui.js';
 import { initMenuBackdrop } from './lib/menu-backdrop.js';
+import { initLinkStatus } from './lib/link-status.js';
 import { initPageContextMenu, hidePageContextMenu } from './lib/page-context-menu.js';
 import { pushDebug } from './lib/debug.js';
 import { initOnboarding } from './lib/onboarding.js';
@@ -217,6 +218,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   });
   initBookmarks();
   initNavigation(); // Sets up event handler with tabs module
+  initLinkStatus();
   initTabs(); // Creates first tab and starts loading home page
   initAutocomplete(); // Address bar autocomplete
   initPageContextMenu(); // Page context menu for webviews

--- a/src/renderer/lib/link-status.js
+++ b/src/renderer/lib/link-status.js
@@ -4,6 +4,7 @@ let linkStatusEl = null;
 let linkStatusUrlEl = null;
 let hideTimer = null;
 let showTimer = null;
+let currentSide = 'left';
 
 const SHOW_DELAY_MS = 150;
 const HIDE_DELAY_MS = 250;
@@ -23,6 +24,28 @@ const scheduleFrame = (callback) => {
 export const initLinkStatus = () => {
   linkStatusEl = document.getElementById('link-status');
   linkStatusUrlEl = document.getElementById('link-status-url');
+};
+
+const applySide = (side) => {
+  if (!linkStatusEl) return;
+  if (side === 'right') {
+    linkStatusEl.classList.add('link-status--right');
+  } else {
+    linkStatusEl.classList.remove('link-status--right');
+  }
+};
+
+/**
+ * Set which corner the preview anchors to. Called when the cursor enters
+ * or leaves the default bottom-left position so the bar gets out of the
+ * way of the link the user is hovering.
+ * @param {'left' | 'right'} side
+ */
+export const setLinkStatusSide = (side) => {
+  const next = side === 'right' ? 'right' : 'left';
+  if (next === currentSide) return;
+  currentSide = next;
+  applySide(currentSide);
 };
 
 export const clearLinkStatus = () => {
@@ -66,6 +89,7 @@ const revealLinkStatus = (url) => {
 
   linkStatusUrlEl.textContent = url;
   linkStatusEl.hidden = false;
+  applySide(currentSide);
 
   if (prefersReducedMotion()) {
     linkStatusEl.classList.add('visible');

--- a/src/renderer/lib/link-status.js
+++ b/src/renderer/lib/link-status.js
@@ -48,7 +48,13 @@ export const setLinkStatusSide = (side) => {
   applySide(currentSide);
 };
 
-export const clearLinkStatus = () => {
+/**
+ * Clear the link hover preview.
+ * @param {{ immediate?: boolean }} [options] When `immediate` is true, the
+ *   bar is hidden synchronously with no fade-out — used by tab switches
+ *   so the previous tab's URL never visibly trails into the new tab.
+ */
+export const clearLinkStatus = (options = {}) => {
   if (!linkStatusEl || !linkStatusUrlEl) return;
 
   if (showTimer) {
@@ -65,6 +71,12 @@ export const clearLinkStatus = () => {
     linkStatusUrlEl.textContent = '';
     linkStatusEl.hidden = true;
   };
+
+  if (options.immediate) {
+    linkStatusEl.classList.remove('visible');
+    finishHide();
+    return;
+  }
 
   if (!linkStatusEl.classList.contains('visible')) {
     finishHide();
@@ -111,18 +123,27 @@ export const showLinkStatus = (url) => {
     return;
   }
 
+  // A pending hide means the bar was visible moments ago and is mid-fade.
+  // Treat that as still visible so re-hovers within the fade window swap
+  // text instantly instead of restarting the show delay.
+  const wasFadingOut = hideTimer !== null;
   if (hideTimer) {
     clearTimeout(hideTimer);
     hideTimer = null;
   }
 
-  // Already visible: swap text in place, no fade.
-  if (linkStatusEl.classList.contains('visible')) {
+  // Already visible (or mid fade-out): swap text in place, no fade.
+  if (linkStatusEl.classList.contains('visible') || wasFadingOut) {
     if (showTimer) {
       clearTimeout(showTimer);
       showTimer = null;
     }
     linkStatusUrlEl.textContent = trimmed;
+    linkStatusEl.hidden = false;
+    applySide(currentSide);
+    if (!linkStatusEl.classList.contains('visible')) {
+      linkStatusEl.classList.add('visible');
+    }
     return;
   }
 

--- a/src/renderer/lib/link-status.js
+++ b/src/renderer/lib/link-status.js
@@ -4,10 +4,19 @@ let linkStatusEl = null;
 let linkStatusUrlEl = null;
 let hideTimer = null;
 let showTimer = null;
+let revealFrame = null;
 let currentSide = 'left';
 
 const SHOW_DELAY_MS = 150;
 const HIDE_DELAY_MS = 250;
+
+// Cap before assigning to textContent — `update-target-url` will happily
+// forward megabyte-scale `data:` / `javascript:` URLs from a hostile (or
+// merely sloppy) embedded iframe, which a single ellipsis-styled element
+// shouldn't have to chew on every hover. Chrome / Firefox truncate around
+// the same range; users can still see the full target via right-click +
+// "Copy link address" on the page itself.
+const MAX_URL_LENGTH = 2048;
 
 const prefersReducedMotion = () =>
   typeof window !== 'undefined' &&
@@ -15,10 +24,18 @@ const prefersReducedMotion = () =>
 
 const scheduleFrame = (callback) => {
   if (typeof globalThis.requestAnimationFrame === 'function') {
-    globalThis.requestAnimationFrame(callback);
-  } else {
-    callback();
+    return globalThis.requestAnimationFrame(callback);
   }
+  callback();
+  return null;
+};
+
+const cancelScheduledFrame = () => {
+  if (revealFrame == null) return;
+  if (typeof globalThis.cancelAnimationFrame === 'function') {
+    globalThis.cancelAnimationFrame(revealFrame);
+  }
+  revealFrame = null;
 };
 
 export const initLinkStatus = () => {
@@ -65,6 +82,10 @@ export const clearLinkStatus = (options = {}) => {
     clearTimeout(hideTimer);
     hideTimer = null;
   }
+  // A queued reveal frame would otherwise re-add `visible` after we hide,
+  // leaving the element with `hidden=true` + `.visible` and skipping the
+  // next show delay. Cancel it before touching the class.
+  cancelScheduledFrame();
 
   const finishHide = () => {
     if (!linkStatusEl || !linkStatusUrlEl) return;
@@ -109,19 +130,25 @@ const revealLinkStatus = (url) => {
   }
 
   linkStatusEl.classList.remove('visible');
-  scheduleFrame(() => {
+  cancelScheduledFrame();
+  revealFrame = scheduleFrame(() => {
+    revealFrame = null;
     linkStatusEl?.classList.add('visible');
   });
 };
 
+const truncateUrl = (url) =>
+  url.length > MAX_URL_LENGTH ? url.slice(0, MAX_URL_LENGTH) : url;
+
 export const showLinkStatus = (url) => {
   if (!linkStatusEl || !linkStatusUrlEl) return;
 
-  const trimmed = typeof url === 'string' ? url.trim() : '';
-  if (!trimmed) {
+  const raw = typeof url === 'string' ? url.trim() : '';
+  if (!raw) {
     clearLinkStatus();
     return;
   }
+  const trimmed = truncateUrl(raw);
 
   // A pending hide means the bar was visible moments ago and is mid-fade.
   // Treat that as still visible so re-hovers within the fade window swap
@@ -138,6 +165,7 @@ export const showLinkStatus = (url) => {
       clearTimeout(showTimer);
       showTimer = null;
     }
+    cancelScheduledFrame();
     linkStatusUrlEl.textContent = trimmed;
     linkStatusEl.hidden = false;
     applySide(currentSide);
@@ -155,21 +183,4 @@ export const showLinkStatus = (url) => {
     showTimer = null;
     revealLinkStatus(trimmed);
   }, SHOW_DELAY_MS);
-};
-
-/**
- * Handle webview `update-target-url` for the active tab.
- * @param {number} tabId
- * @param {string} url
- * @param {number|null} activeTabId
- */
-export const handleUpdateTargetUrl = (tabId, url, activeTabId) => {
-  if (tabId !== activeTabId) return;
-
-  const trimmed = typeof url === 'string' ? url.trim() : '';
-  if (!trimmed) {
-    clearLinkStatus();
-    return;
-  }
-  showLinkStatus(trimmed);
 };

--- a/src/renderer/lib/link-status.js
+++ b/src/renderer/lib/link-status.js
@@ -1,0 +1,130 @@
+// Chrome-style link hover URL preview at the bottom of the page area.
+
+let linkStatusEl = null;
+let linkStatusUrlEl = null;
+let hideTimer = null;
+let showTimer = null;
+
+const SHOW_DELAY_MS = 150;
+const HIDE_DELAY_MS = 250;
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
+
+const scheduleFrame = (callback) => {
+  if (typeof globalThis.requestAnimationFrame === 'function') {
+    globalThis.requestAnimationFrame(callback);
+  } else {
+    callback();
+  }
+};
+
+export const initLinkStatus = () => {
+  linkStatusEl = document.getElementById('link-status');
+  linkStatusUrlEl = document.getElementById('link-status-url');
+};
+
+export const clearLinkStatus = () => {
+  if (!linkStatusEl || !linkStatusUrlEl) return;
+
+  if (showTimer) {
+    clearTimeout(showTimer);
+    showTimer = null;
+  }
+  if (hideTimer) {
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+
+  const finishHide = () => {
+    if (!linkStatusEl || !linkStatusUrlEl) return;
+    linkStatusUrlEl.textContent = '';
+    linkStatusEl.hidden = true;
+  };
+
+  if (!linkStatusEl.classList.contains('visible')) {
+    finishHide();
+    return;
+  }
+
+  linkStatusEl.classList.remove('visible');
+
+  if (prefersReducedMotion()) {
+    finishHide();
+    return;
+  }
+
+  hideTimer = setTimeout(() => {
+    hideTimer = null;
+    finishHide();
+  }, HIDE_DELAY_MS);
+};
+
+const revealLinkStatus = (url) => {
+  if (!linkStatusEl || !linkStatusUrlEl) return;
+
+  linkStatusUrlEl.textContent = url;
+  linkStatusEl.hidden = false;
+
+  if (prefersReducedMotion()) {
+    linkStatusEl.classList.add('visible');
+    return;
+  }
+
+  linkStatusEl.classList.remove('visible');
+  scheduleFrame(() => {
+    linkStatusEl?.classList.add('visible');
+  });
+};
+
+export const showLinkStatus = (url) => {
+  if (!linkStatusEl || !linkStatusUrlEl) return;
+
+  const trimmed = typeof url === 'string' ? url.trim() : '';
+  if (!trimmed) {
+    clearLinkStatus();
+    return;
+  }
+
+  if (hideTimer) {
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+
+  // Already visible: swap text in place, no fade.
+  if (linkStatusEl.classList.contains('visible')) {
+    if (showTimer) {
+      clearTimeout(showTimer);
+      showTimer = null;
+    }
+    linkStatusUrlEl.textContent = trimmed;
+    return;
+  }
+
+  // Not yet visible: defer reveal so brief mouse passes don't flicker the bar.
+  if (showTimer) {
+    clearTimeout(showTimer);
+  }
+  showTimer = setTimeout(() => {
+    showTimer = null;
+    revealLinkStatus(trimmed);
+  }, SHOW_DELAY_MS);
+};
+
+/**
+ * Handle webview `update-target-url` for the active tab.
+ * @param {number} tabId
+ * @param {string} url
+ * @param {number|null} activeTabId
+ */
+export const handleUpdateTargetUrl = (tabId, url, activeTabId) => {
+  if (tabId !== activeTabId) return;
+
+  const trimmed = typeof url === 'string' ? url.trim() : '';
+  if (!trimmed) {
+    clearLinkStatus();
+    return;
+  }
+  showLinkStatus(trimmed);
+};

--- a/src/renderer/lib/link-status.test.js
+++ b/src/renderer/lib/link-status.test.js
@@ -1,0 +1,110 @@
+describe('link-status', () => {
+  const originalDocument = global.document;
+  const originalWindow = global.window;
+
+  const createElements = ({ visible = false } = {}) => {
+    const urlEl = { textContent: '' };
+    let isVisible = visible;
+    const linkStatus = {
+      hidden: true,
+      classList: {
+        contains: jest.fn((cls) => cls === 'visible' && isVisible),
+        add: jest.fn((cls) => {
+          if (cls === 'visible') isVisible = true;
+        }),
+        remove: jest.fn((cls) => {
+          if (cls === 'visible') isVisible = false;
+        }),
+      },
+    };
+    return { linkStatus, urlEl };
+  };
+
+  const loadModule = async (linkStatus, urlEl) => {
+    jest.resetModules();
+    jest.useFakeTimers();
+    global.document = {
+      getElementById: jest.fn((id) => {
+        if (id === 'link-status') return linkStatus;
+        if (id === 'link-status-url') return urlEl;
+        return null;
+      }),
+    };
+    global.window = {
+      matchMedia: jest.fn(() => ({ matches: false })),
+      requestAnimationFrame: (cb) => cb(),
+    };
+    return import('./link-status.js');
+  };
+
+  afterEach(() => {
+    jest.useRealTimers();
+    global.document = originalDocument;
+    global.window = originalWindow;
+  });
+
+  test('shows URL for active tab after delay and clears on empty target', async () => {
+    const { linkStatus, urlEl } = createElements();
+    const mod = await loadModule(linkStatus, urlEl);
+    mod.initLinkStatus();
+
+    mod.handleUpdateTargetUrl(1, 'https://example.com/path', 1);
+    expect(urlEl.textContent).toBe('');
+    expect(linkStatus.hidden).toBe(true);
+
+    jest.advanceTimersByTime(200);
+    expect(urlEl.textContent).toBe('https://example.com/path');
+    expect(linkStatus.hidden).toBe(false);
+    expect(linkStatus.classList.add).toHaveBeenCalledWith('visible');
+
+    mod.handleUpdateTargetUrl(1, '', 1);
+    jest.runAllTimers();
+    expect(urlEl.textContent).toBe('');
+    expect(linkStatus.hidden).toBe(true);
+  });
+
+  test('cancels pending show when hover ends before delay elapses', async () => {
+    const { linkStatus, urlEl } = createElements();
+    const mod = await loadModule(linkStatus, urlEl);
+    mod.initLinkStatus();
+
+    mod.handleUpdateTargetUrl(1, 'https://example.com/', 1);
+    mod.handleUpdateTargetUrl(1, '', 1);
+    jest.runAllTimers();
+    expect(urlEl.textContent).toBe('');
+    expect(linkStatus.hidden).toBe(true);
+    expect(linkStatus.classList.add).not.toHaveBeenCalledWith('visible');
+  });
+
+  test('ignores update-target-url from inactive tabs', async () => {
+    const { linkStatus, urlEl } = createElements();
+    const mod = await loadModule(linkStatus, urlEl);
+    mod.initLinkStatus();
+
+    mod.handleUpdateTargetUrl(2, 'https://other.example/', 1);
+    expect(urlEl.textContent).toBe('');
+    expect(linkStatus.hidden).toBe(true);
+  });
+
+  test('updates text in place when already visible', async () => {
+    const { linkStatus, urlEl } = createElements({ visible: true });
+    const mod = await loadModule(linkStatus, urlEl);
+    mod.initLinkStatus();
+
+    mod.showLinkStatus('https://a.example/');
+    linkStatus.classList.add.mockClear();
+    mod.showLinkStatus('https://b.example/');
+    expect(urlEl.textContent).toBe('https://b.example/');
+    expect(linkStatus.classList.add).not.toHaveBeenCalled();
+  });
+
+  test('handles missing DOM elements safely', async () => {
+    const mod = await loadModule(null, null);
+    expect(() => {
+      mod.initLinkStatus();
+      mod.showLinkStatus('https://example.com/');
+      mod.clearLinkStatus();
+      mod.handleUpdateTargetUrl(1, 'https://example.com/', 1);
+    }).not.toThrow();
+  });
+});

--- a/src/renderer/lib/link-status.test.js
+++ b/src/renderer/lib/link-status.test.js
@@ -1,175 +1,225 @@
+const { createDocument, createElement } = require('../../../test/helpers/fake-dom.js');
+
 describe('link-status', () => {
   const originalDocument = global.document;
   const originalWindow = global.window;
 
-  const createElements = ({ visible = false } = {}) => {
-    const urlEl = { textContent: '' };
-    let isVisible = visible;
-    const linkStatus = {
-      hidden: true,
-      classList: {
-        contains: jest.fn((cls) => cls === 'visible' && isVisible),
-        add: jest.fn((cls) => {
-          if (cls === 'visible') isVisible = true;
-        }),
-        remove: jest.fn((cls) => {
-          if (cls === 'visible') isVisible = false;
-        }),
-      },
-    };
-    return { linkStatus, urlEl };
+  const buildElements = () => {
+    const linkStatusEl = createElement('div');
+    linkStatusEl.hidden = true;
+    const linkStatusUrlEl = createElement('span');
+    return { linkStatusEl, linkStatusUrlEl };
   };
 
-  const loadModule = async (linkStatus, urlEl) => {
+  const loadModule = async ({ withDom = true, reduceMotion = false } = {}) => {
     jest.resetModules();
     jest.useFakeTimers();
-    global.document = {
-      getElementById: jest.fn((id) => {
-        if (id === 'link-status') return linkStatus;
-        if (id === 'link-status-url') return urlEl;
-        return null;
-      }),
-    };
+
+    let elements = null;
+    if (withDom) {
+      elements = buildElements();
+      global.document = createDocument({
+        elementsById: {
+          'link-status': elements.linkStatusEl,
+          'link-status-url': elements.linkStatusUrlEl,
+        },
+      });
+    } else {
+      global.document = createDocument({});
+    }
+
+    // rAF-aware shim: the real DOM applies opacity transitions via
+    // requestAnimationFrame, and link-status.js coordinates against that
+    // timing. Returning a handle (rather than firing synchronously) lets
+    // tests verify the cancellation behaviour from PR review #1.
+    // link-status.js looks up rAF on globalThis (matches browser semantics
+    // where globalThis === window). In Jest's Node environment globalThis
+    // is `global`, so install the shim there.
+    let nextFrame = 1;
+    const queuedFrames = new Map();
     global.window = {
-      matchMedia: jest.fn(() => ({ matches: false })),
-      requestAnimationFrame: (cb) => cb(),
+      matchMedia: jest.fn(() => ({ matches: reduceMotion })),
     };
-    return import('./link-status.js');
+    global.requestAnimationFrame = jest.fn((cb) => {
+      const handle = nextFrame++;
+      queuedFrames.set(handle, cb);
+      return handle;
+    });
+    global.cancelAnimationFrame = jest.fn((handle) => {
+      queuedFrames.delete(handle);
+    });
+    const flushFrames = () => {
+      const callbacks = Array.from(queuedFrames.values());
+      queuedFrames.clear();
+      callbacks.forEach((cb) => cb());
+    };
+
+    const mod = await import('./link-status.js');
+    return { mod, elements, flushFrames, queuedFrames };
   };
 
   afterEach(() => {
     jest.useRealTimers();
     global.document = originalDocument;
     global.window = originalWindow;
+    delete global.requestAnimationFrame;
+    delete global.cancelAnimationFrame;
   });
 
-  test('shows URL for active tab after delay and clears on empty target', async () => {
-    const { linkStatus, urlEl } = createElements();
-    const mod = await loadModule(linkStatus, urlEl);
+  test('shows URL after the show delay and clears on empty target', async () => {
+    const { mod, elements, flushFrames } = await loadModule();
     mod.initLinkStatus();
 
-    mod.handleUpdateTargetUrl(1, 'https://example.com/path', 1);
-    expect(urlEl.textContent).toBe('');
-    expect(linkStatus.hidden).toBe(true);
+    mod.showLinkStatus('https://example.com/path');
+    expect(elements.linkStatusUrlEl.textContent).toBe('');
+    expect(elements.linkStatusEl.hidden).toBe(true);
 
     jest.advanceTimersByTime(200);
-    expect(urlEl.textContent).toBe('https://example.com/path');
-    expect(linkStatus.hidden).toBe(false);
-    expect(linkStatus.classList.add).toHaveBeenCalledWith('visible');
+    flushFrames();
+    expect(elements.linkStatusUrlEl.textContent).toBe('https://example.com/path');
+    expect(elements.linkStatusEl.hidden).toBe(false);
+    expect(elements.linkStatusEl.classList.contains('visible')).toBe(true);
 
-    mod.handleUpdateTargetUrl(1, '', 1);
+    mod.showLinkStatus('');
     jest.runAllTimers();
-    expect(urlEl.textContent).toBe('');
-    expect(linkStatus.hidden).toBe(true);
+    expect(elements.linkStatusUrlEl.textContent).toBe('');
+    expect(elements.linkStatusEl.hidden).toBe(true);
   });
 
   test('cancels pending show when hover ends before delay elapses', async () => {
-    const { linkStatus, urlEl } = createElements();
-    const mod = await loadModule(linkStatus, urlEl);
+    const { mod, elements } = await loadModule();
     mod.initLinkStatus();
 
-    mod.handleUpdateTargetUrl(1, 'https://example.com/', 1);
-    mod.handleUpdateTargetUrl(1, '', 1);
+    mod.showLinkStatus('https://example.com/');
+    mod.showLinkStatus('');
     jest.runAllTimers();
-    expect(urlEl.textContent).toBe('');
-    expect(linkStatus.hidden).toBe(true);
-    expect(linkStatus.classList.add).not.toHaveBeenCalledWith('visible');
-  });
-
-  test('ignores update-target-url from inactive tabs', async () => {
-    const { linkStatus, urlEl } = createElements();
-    const mod = await loadModule(linkStatus, urlEl);
-    mod.initLinkStatus();
-
-    mod.handleUpdateTargetUrl(2, 'https://other.example/', 1);
-    expect(urlEl.textContent).toBe('');
-    expect(linkStatus.hidden).toBe(true);
+    expect(elements.linkStatusUrlEl.textContent).toBe('');
+    expect(elements.linkStatusEl.hidden).toBe(true);
+    expect(elements.linkStatusEl.classList.contains('visible')).toBe(false);
   });
 
   test('updates text in place when already visible', async () => {
-    const { linkStatus, urlEl } = createElements({ visible: true });
-    const mod = await loadModule(linkStatus, urlEl);
+    const { mod, elements, flushFrames } = await loadModule();
     mod.initLinkStatus();
 
     mod.showLinkStatus('https://a.example/');
-    linkStatus.classList.add.mockClear();
+    jest.advanceTimersByTime(200);
+    flushFrames();
+    expect(elements.linkStatusEl.classList.contains('visible')).toBe(true);
+
+    elements.linkStatusEl.classList.add.mockClear();
     mod.showLinkStatus('https://b.example/');
-    expect(urlEl.textContent).toBe('https://b.example/');
-    expect(linkStatus.classList.add).not.toHaveBeenCalled();
+    expect(elements.linkStatusUrlEl.textContent).toBe('https://b.example/');
+    expect(elements.linkStatusEl.classList.add).not.toHaveBeenCalledWith('visible');
   });
 
   test('handles missing DOM elements safely', async () => {
-    const mod = await loadModule(null, null);
+    const { mod } = await loadModule({ withDom: false });
     expect(() => {
       mod.initLinkStatus();
       mod.showLinkStatus('https://example.com/');
       mod.clearLinkStatus();
-      mod.handleUpdateTargetUrl(1, 'https://example.com/', 1);
+      mod.clearLinkStatus({ immediate: true });
       mod.setLinkStatusSide('right');
     }).not.toThrow();
   });
 
   test('setLinkStatusSide toggles the right-anchor class', async () => {
-    const { linkStatus, urlEl } = createElements();
-    const mod = await loadModule(linkStatus, urlEl);
+    const { mod, elements } = await loadModule();
     mod.initLinkStatus();
 
     mod.setLinkStatusSide('right');
-    expect(linkStatus.classList.add).toHaveBeenCalledWith('link-status--right');
+    expect(elements.linkStatusEl.classList.contains('link-status--right')).toBe(true);
 
-    linkStatus.classList.remove.mockClear();
     mod.setLinkStatusSide('left');
-    expect(linkStatus.classList.remove).toHaveBeenCalledWith('link-status--right');
+    expect(elements.linkStatusEl.classList.contains('link-status--right')).toBe(false);
   });
 
-  test('reveal applies current side', async () => {
-    const { linkStatus, urlEl } = createElements();
-    const mod = await loadModule(linkStatus, urlEl);
+  test('reveal applies the current side', async () => {
+    const { mod, elements, flushFrames } = await loadModule();
     mod.initLinkStatus();
 
     mod.setLinkStatusSide('right');
-    linkStatus.classList.add.mockClear();
-    mod.handleUpdateTargetUrl(1, 'https://example.com/', 1);
+    mod.showLinkStatus('https://example.com/');
     jest.advanceTimersByTime(200);
-    expect(linkStatus.classList.add).toHaveBeenCalledWith('link-status--right');
+    flushFrames();
+    expect(elements.linkStatusEl.classList.contains('link-status--right')).toBe(true);
   });
 
   test('clearLinkStatus({ immediate: true }) hides synchronously', async () => {
-    const { linkStatus, urlEl } = createElements();
-    const mod = await loadModule(linkStatus, urlEl);
+    const { mod, elements, flushFrames } = await loadModule();
     mod.initLinkStatus();
 
-    mod.handleUpdateTargetUrl(1, 'https://example.com/', 1);
+    mod.showLinkStatus('https://example.com/');
     jest.advanceTimersByTime(200);
-    expect(linkStatus.hidden).toBe(false);
-    expect(urlEl.textContent).toBe('https://example.com/');
+    flushFrames();
+    expect(elements.linkStatusEl.hidden).toBe(false);
 
     mod.clearLinkStatus({ immediate: true });
-    expect(urlEl.textContent).toBe('');
-    expect(linkStatus.hidden).toBe(true);
-    expect(linkStatus.classList.contains('visible')).toBe(false);
+    expect(elements.linkStatusUrlEl.textContent).toBe('');
+    expect(elements.linkStatusEl.hidden).toBe(true);
+    expect(elements.linkStatusEl.classList.contains('visible')).toBe(false);
+  });
+
+  test('immediate clear cancels a queued reveal frame', async () => {
+    // Regression: without cancelAnimationFrame, the rAF queued by
+    // revealLinkStatus would fire after switchTab's immediate clear and
+    // re-add `.visible` to a hidden bar — leaving stale state that
+    // skipped the next show delay. See PR review item #1.
+    const { mod, elements, queuedFrames, flushFrames } = await loadModule();
+    mod.initLinkStatus();
+
+    mod.showLinkStatus('https://example.com/');
+    jest.advanceTimersByTime(200);
+    expect(queuedFrames.size).toBe(1);
+    expect(elements.linkStatusEl.hidden).toBe(false);
+
+    mod.clearLinkStatus({ immediate: true });
+    expect(queuedFrames.size).toBe(0);
+
+    flushFrames();
+    expect(elements.linkStatusEl.classList.contains('visible')).toBe(false);
+    expect(elements.linkStatusEl.hidden).toBe(true);
   });
 
   test('re-hovering during fade-out swaps text instantly', async () => {
-    const { linkStatus, urlEl } = createElements();
-    const mod = await loadModule(linkStatus, urlEl);
+    const { mod, elements, flushFrames } = await loadModule();
     mod.initLinkStatus();
 
-    mod.handleUpdateTargetUrl(1, 'https://a.example/', 1);
+    mod.showLinkStatus('https://a.example/');
     jest.advanceTimersByTime(200);
-    expect(linkStatus.classList.contains('visible')).toBe(true);
+    flushFrames();
+    expect(elements.linkStatusEl.classList.contains('visible')).toBe(true);
 
-    // Empty url begins fade-out — visible class removed, text still mounted.
-    mod.handleUpdateTargetUrl(1, '', 1);
-    expect(linkStatus.classList.contains('visible')).toBe(false);
-    expect(linkStatus.hidden).toBe(false);
+    mod.showLinkStatus('');
+    expect(elements.linkStatusEl.classList.contains('visible')).toBe(false);
+    expect(elements.linkStatusEl.hidden).toBe(false);
 
-    // New hover before HIDE_DELAY_MS elapses must swap immediately, not
-    // schedule another show delay and not flicker the bar empty.
-    linkStatus.classList.add.mockClear();
-    mod.handleUpdateTargetUrl(1, 'https://b.example/', 1);
-    expect(urlEl.textContent).toBe('https://b.example/');
-    expect(linkStatus.hidden).toBe(false);
-    expect(linkStatus.classList.add).toHaveBeenCalledWith('visible');
+    mod.showLinkStatus('https://b.example/');
+    expect(elements.linkStatusUrlEl.textContent).toBe('https://b.example/');
+    expect(elements.linkStatusEl.hidden).toBe(false);
+    expect(elements.linkStatusEl.classList.contains('visible')).toBe(true);
+  });
+
+  test('truncates pathologically long URLs before assigning to textContent', async () => {
+    const { mod, elements, flushFrames } = await loadModule();
+    mod.initLinkStatus();
+
+    const longUrl = 'data:text/html,' + 'A'.repeat(10_000);
+    mod.showLinkStatus(longUrl);
+    jest.advanceTimersByTime(200);
+    flushFrames();
+    expect(elements.linkStatusUrlEl.textContent.length).toBe(2048);
+    expect(longUrl.startsWith(elements.linkStatusUrlEl.textContent)).toBe(true);
+  });
+
+  test('reduced motion path applies visible class without scheduling rAF', async () => {
+    const { mod, elements, queuedFrames } = await loadModule({ reduceMotion: true });
+    mod.initLinkStatus();
+
+    mod.showLinkStatus('https://example.com/');
+    jest.advanceTimersByTime(200);
+    expect(elements.linkStatusEl.classList.contains('visible')).toBe(true);
+    expect(queuedFrames.size).toBe(0);
   });
 });

--- a/src/renderer/lib/link-status.test.js
+++ b/src/renderer/lib/link-status.test.js
@@ -133,4 +133,43 @@ describe('link-status', () => {
     jest.advanceTimersByTime(200);
     expect(linkStatus.classList.add).toHaveBeenCalledWith('link-status--right');
   });
+
+  test('clearLinkStatus({ immediate: true }) hides synchronously', async () => {
+    const { linkStatus, urlEl } = createElements();
+    const mod = await loadModule(linkStatus, urlEl);
+    mod.initLinkStatus();
+
+    mod.handleUpdateTargetUrl(1, 'https://example.com/', 1);
+    jest.advanceTimersByTime(200);
+    expect(linkStatus.hidden).toBe(false);
+    expect(urlEl.textContent).toBe('https://example.com/');
+
+    mod.clearLinkStatus({ immediate: true });
+    expect(urlEl.textContent).toBe('');
+    expect(linkStatus.hidden).toBe(true);
+    expect(linkStatus.classList.contains('visible')).toBe(false);
+  });
+
+  test('re-hovering during fade-out swaps text instantly', async () => {
+    const { linkStatus, urlEl } = createElements();
+    const mod = await loadModule(linkStatus, urlEl);
+    mod.initLinkStatus();
+
+    mod.handleUpdateTargetUrl(1, 'https://a.example/', 1);
+    jest.advanceTimersByTime(200);
+    expect(linkStatus.classList.contains('visible')).toBe(true);
+
+    // Empty url begins fade-out — visible class removed, text still mounted.
+    mod.handleUpdateTargetUrl(1, '', 1);
+    expect(linkStatus.classList.contains('visible')).toBe(false);
+    expect(linkStatus.hidden).toBe(false);
+
+    // New hover before HIDE_DELAY_MS elapses must swap immediately, not
+    // schedule another show delay and not flicker the bar empty.
+    linkStatus.classList.add.mockClear();
+    mod.handleUpdateTargetUrl(1, 'https://b.example/', 1);
+    expect(urlEl.textContent).toBe('https://b.example/');
+    expect(linkStatus.hidden).toBe(false);
+    expect(linkStatus.classList.add).toHaveBeenCalledWith('visible');
+  });
 });

--- a/src/renderer/lib/link-status.test.js
+++ b/src/renderer/lib/link-status.test.js
@@ -105,6 +105,32 @@ describe('link-status', () => {
       mod.showLinkStatus('https://example.com/');
       mod.clearLinkStatus();
       mod.handleUpdateTargetUrl(1, 'https://example.com/', 1);
+      mod.setLinkStatusSide('right');
     }).not.toThrow();
+  });
+
+  test('setLinkStatusSide toggles the right-anchor class', async () => {
+    const { linkStatus, urlEl } = createElements();
+    const mod = await loadModule(linkStatus, urlEl);
+    mod.initLinkStatus();
+
+    mod.setLinkStatusSide('right');
+    expect(linkStatus.classList.add).toHaveBeenCalledWith('link-status--right');
+
+    linkStatus.classList.remove.mockClear();
+    mod.setLinkStatusSide('left');
+    expect(linkStatus.classList.remove).toHaveBeenCalledWith('link-status--right');
+  });
+
+  test('reveal applies current side', async () => {
+    const { linkStatus, urlEl } = createElements();
+    const mod = await loadModule(linkStatus, urlEl);
+    mod.initLinkStatus();
+
+    mod.setLinkStatusSide('right');
+    linkStatus.classList.add.mockClear();
+    mod.handleUpdateTargetUrl(1, 'https://example.com/', 1);
+    jest.advanceTimersByTime(200);
+    expect(linkStatus.classList.add).toHaveBeenCalledWith('link-status--right');
   });
 });

--- a/src/renderer/lib/tabs-ui.test.js
+++ b/src/renderer/lib/tabs-ui.test.js
@@ -137,6 +137,11 @@ const loadTabsModule = async (options = {}) => {
   const pageContextMenuMocks = {
     setupWebviewContextMenu: jest.fn(),
   };
+  const linkStatusMocks = {
+    clearLinkStatus: jest.fn(),
+    handleUpdateTargetUrl: jest.fn(),
+    setLinkStatusSide: jest.fn(),
+  };
 
   addressInput.focus = jest.fn();
   addressInput.select = jest.fn();
@@ -162,6 +167,7 @@ const loadTabsModule = async (options = {}) => {
   jest.doMock('./bookmarks-ui.js', () => bookmarksMocks);
   jest.doMock('./menu-backdrop.js', () => backdropMocks);
   jest.doMock('./page-context-menu.js', () => pageContextMenuMocks);
+  jest.doMock('./link-status.js', () => linkStatusMocks);
   jest.doMock('./page-urls.js', () => ({
     homeUrl: options.homeUrl || HOME_URL,
   }));
@@ -192,6 +198,7 @@ const loadTabsModule = async (options = {}) => {
     bookmarksMocks,
     backdropMocks,
     pageContextMenuMocks,
+    linkStatusMocks,
   };
 };
 
@@ -1012,5 +1019,79 @@ describe('tabs ui behavior', () => {
     expect(firstTab.webview.closeDevTools.mock.calls.length).toBe(devtoolsCloseBefore + 1);
     expect(debugMocks.pushDebug).toHaveBeenCalledWith('DevTools opened');
     expect(debugMocks.pushDebug).toHaveBeenCalledWith('DevTools closed');
+  });
+
+  test('forwards update-target-url and link-status:zone for the active tab only', async () => {
+    const { mod, linkStatusMocks } = await loadTabsModule();
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+    mod.switchTab(secondTab.id);
+
+    linkStatusMocks.handleUpdateTargetUrl.mockClear();
+    linkStatusMocks.setLinkStatusSide.mockClear();
+
+    // Active tab forwards both events with the active tab id.
+    secondTab.webview.dispatch('update-target-url', { url: 'https://hovered.example/' });
+    expect(linkStatusMocks.handleUpdateTargetUrl).toHaveBeenCalledWith(
+      secondTab.id,
+      'https://hovered.example/',
+      secondTab.id
+    );
+
+    secondTab.webview.dispatch('ipc-message', {
+      channel: 'link-status:zone',
+      args: [{ inLeftZone: true }],
+    });
+    expect(linkStatusMocks.setLinkStatusSide).toHaveBeenLastCalledWith('right');
+
+    secondTab.webview.dispatch('ipc-message', {
+      channel: 'link-status:zone',
+      args: [{ inLeftZone: false }],
+    });
+    expect(linkStatusMocks.setLinkStatusSide).toHaveBeenLastCalledWith('left');
+
+    // Background tab still calls handleUpdateTargetUrl (it gates internally
+    // by comparing tabId to activeTabId), but the zone signal is dropped
+    // entirely so a hover in a background webview can never move the bar
+    // shown for the active tab.
+    linkStatusMocks.handleUpdateTargetUrl.mockClear();
+    linkStatusMocks.setLinkStatusSide.mockClear();
+
+    firstTab.webview.dispatch('update-target-url', { url: 'https://background.example/' });
+    expect(linkStatusMocks.handleUpdateTargetUrl).toHaveBeenCalledWith(
+      firstTab.id,
+      'https://background.example/',
+      secondTab.id
+    );
+
+    firstTab.webview.dispatch('ipc-message', {
+      channel: 'link-status:zone',
+      args: [{ inLeftZone: true }],
+    });
+    expect(linkStatusMocks.setLinkStatusSide).not.toHaveBeenCalled();
+  });
+
+  test('switchTab clears the link status immediately and resets side', async () => {
+    const { mod, linkStatusMocks } = await loadTabsModule();
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+
+    linkStatusMocks.clearLinkStatus.mockClear();
+    linkStatusMocks.setLinkStatusSide.mockClear();
+
+    mod.switchTab(firstTab.id);
+    expect(linkStatusMocks.clearLinkStatus).toHaveBeenCalledWith({ immediate: true });
+    expect(linkStatusMocks.setLinkStatusSide).toHaveBeenCalledWith('left');
+
+    linkStatusMocks.clearLinkStatus.mockClear();
+    linkStatusMocks.setLinkStatusSide.mockClear();
+
+    mod.switchTab(secondTab.id);
+    expect(linkStatusMocks.clearLinkStatus).toHaveBeenCalledWith({ immediate: true });
+    expect(linkStatusMocks.setLinkStatusSide).toHaveBeenCalledWith('left');
   });
 });

--- a/src/renderer/lib/tabs-ui.test.js
+++ b/src/renderer/lib/tabs-ui.test.js
@@ -139,7 +139,7 @@ const loadTabsModule = async (options = {}) => {
   };
   const linkStatusMocks = {
     clearLinkStatus: jest.fn(),
-    handleUpdateTargetUrl: jest.fn(),
+    showLinkStatus: jest.fn(),
     setLinkStatusSide: jest.fn(),
   };
 
@@ -1029,16 +1029,17 @@ describe('tabs ui behavior', () => {
     const secondTab = mod.createTab('https://second.example');
     mod.switchTab(secondTab.id);
 
-    linkStatusMocks.handleUpdateTargetUrl.mockClear();
+    linkStatusMocks.showLinkStatus.mockClear();
+    linkStatusMocks.clearLinkStatus.mockClear();
     linkStatusMocks.setLinkStatusSide.mockClear();
 
-    // Active tab forwards both events with the active tab id.
+    // Active tab: non-empty url goes to showLinkStatus, empty triggers a
+    // (faded) clearLinkStatus.
     secondTab.webview.dispatch('update-target-url', { url: 'https://hovered.example/' });
-    expect(linkStatusMocks.handleUpdateTargetUrl).toHaveBeenCalledWith(
-      secondTab.id,
-      'https://hovered.example/',
-      secondTab.id
-    );
+    expect(linkStatusMocks.showLinkStatus).toHaveBeenCalledWith('https://hovered.example/');
+
+    secondTab.webview.dispatch('update-target-url', { url: '' });
+    expect(linkStatusMocks.clearLinkStatus).toHaveBeenLastCalledWith();
 
     secondTab.webview.dispatch('ipc-message', {
       channel: 'link-status:zone',
@@ -1052,19 +1053,15 @@ describe('tabs ui behavior', () => {
     });
     expect(linkStatusMocks.setLinkStatusSide).toHaveBeenLastCalledWith('left');
 
-    // Background tab still calls handleUpdateTargetUrl (it gates internally
-    // by comparing tabId to activeTabId), but the zone signal is dropped
-    // entirely so a hover in a background webview can never move the bar
-    // shown for the active tab.
-    linkStatusMocks.handleUpdateTargetUrl.mockClear();
+    // Background-tab events for both channels are dropped entirely so
+    // hovering links in a hidden tab can never move the active tab's bar.
+    linkStatusMocks.showLinkStatus.mockClear();
+    linkStatusMocks.clearLinkStatus.mockClear();
     linkStatusMocks.setLinkStatusSide.mockClear();
 
     firstTab.webview.dispatch('update-target-url', { url: 'https://background.example/' });
-    expect(linkStatusMocks.handleUpdateTargetUrl).toHaveBeenCalledWith(
-      firstTab.id,
-      'https://background.example/',
-      secondTab.id
-    );
+    expect(linkStatusMocks.showLinkStatus).not.toHaveBeenCalled();
+    expect(linkStatusMocks.clearLinkStatus).not.toHaveBeenCalled();
 
     firstTab.webview.dispatch('ipc-message', {
       channel: 'link-status:zone',

--- a/src/renderer/lib/tabs-ui.test.js
+++ b/src/renderer/lib/tabs-ui.test.js
@@ -1070,7 +1070,10 @@ describe('tabs ui behavior', () => {
     expect(linkStatusMocks.setLinkStatusSide).not.toHaveBeenCalled();
   });
 
-  test('switchTab clears the link status immediately and resets side', async () => {
+  test('switchTab clears the link status immediately and restores per-tab side', async () => {
+    // Per-tab side is restored from the tab's last-known cursor-zone
+    // state instead of being blindly reset to 'left'. With no prior
+    // zone events on either tab, the restored side is 'left' for both.
     const { mod, linkStatusMocks } = await loadTabsModule();
     await mod.initTabs();
 
@@ -1090,5 +1093,51 @@ describe('tabs ui behavior', () => {
     mod.switchTab(secondTab.id);
     expect(linkStatusMocks.clearLinkStatus).toHaveBeenCalledWith({ immediate: true });
     expect(linkStatusMocks.setLinkStatusSide).toHaveBeenCalledWith('left');
+  });
+
+  test('switchTab restores the active tab side from the per-tab zone state', async () => {
+    // Regression: the preload only emits link-status:zone events on
+    // transitions, and a hidden webview's `linkStatusInZone` freezes at
+    // whatever value it held when the tab was backgrounded. If the
+    // renderer reset `currentSide` to 'left' on every switch (the
+    // previous behavior), returning to a tab whose pointer is still in
+    // the bottom-left band would leave the bar on `left` until the
+    // pointer leaves and re-enters the zone — painting it over the
+    // link the user is hovering.
+    //
+    // The fix tracks per-tab zone state in tabs.js and restores it on
+    // activation so the bar's side matches the destination tab's
+    // current pointer position immediately.
+    const { mod, linkStatusMocks } = await loadTabsModule();
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+    mod.switchTab(firstTab.id);
+
+    // Pointer enters the bottom-left band on the first tab → bar flips
+    // to the right side and per-tab state remembers the zone hit.
+    firstTab.webview.dispatch('ipc-message', {
+      channel: 'link-status:zone',
+      args: [{ inLeftZone: true }],
+    });
+
+    linkStatusMocks.clearLinkStatus.mockClear();
+    linkStatusMocks.setLinkStatusSide.mockClear();
+
+    // Switch to a tab whose preload has never emitted — side restores to
+    // its default 'left'.
+    mod.switchTab(secondTab.id);
+    expect(linkStatusMocks.setLinkStatusSide).toHaveBeenLastCalledWith('left');
+
+    linkStatusMocks.clearLinkStatus.mockClear();
+    linkStatusMocks.setLinkStatusSide.mockClear();
+
+    // Switch back to the first tab — the per-tab state is replayed so
+    // the bar sits on the correct side without waiting for a new
+    // pointer transition inside the (still-in-zone) preload.
+    mod.switchTab(firstTab.id);
+    expect(linkStatusMocks.clearLinkStatus).toHaveBeenCalledWith({ immediate: true });
+    expect(linkStatusMocks.setLinkStatusSide).toHaveBeenLastCalledWith('right');
   });
 });

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -1121,7 +1121,7 @@ export const switchTab = (tabId, options = {}) => {
   const tab = tabState.tabs.find((t) => t.id === tabId);
   if (!tab) return;
 
-  clearLinkStatus();
+  clearLinkStatus({ immediate: true });
   setLinkStatusSide('left');
   tabState.activeTabId = tabId;
 

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -7,6 +7,7 @@ import { setupWebviewContextMenu } from './page-context-menu.js';
 import { homeUrl } from './page-urls.js';
 import { setupWebviewProvider, setActiveWebview } from './dapp-provider.js';
 import { setupSwarmProvider } from './swarm-provider.js';
+import { clearLinkStatus, handleUpdateTargetUrl } from './link-status.js';
 
 const electronAPI = window.electronAPI;
 
@@ -488,6 +489,9 @@ const createWebview = (tabId, initialUrl) => {
       if (tabId === tabState.activeTabId && onWebviewEvent) {
         onWebviewEvent('ipc-message', { tabId, channel: event.channel, args: event.args });
       }
+    },
+    'update-target-url': (event) => {
+      handleUpdateTargetUrl(tabId, event.url, tabState.activeTabId);
     },
   };
 
@@ -1102,6 +1106,7 @@ export const switchTab = (tabId, options = {}) => {
   const tab = tabState.tabs.find((t) => t.id === tabId);
   if (!tab) return;
 
+  clearLinkStatus();
   tabState.activeTabId = tabId;
 
   // Hide all webviews, show active one

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -7,7 +7,11 @@ import { setupWebviewContextMenu } from './page-context-menu.js';
 import { homeUrl } from './page-urls.js';
 import { setupWebviewProvider, setActiveWebview } from './dapp-provider.js';
 import { setupSwarmProvider } from './swarm-provider.js';
-import { clearLinkStatus, handleUpdateTargetUrl } from './link-status.js';
+import {
+  clearLinkStatus,
+  handleUpdateTargetUrl,
+  setLinkStatusSide,
+} from './link-status.js';
 
 const electronAPI = window.electronAPI;
 
@@ -482,6 +486,17 @@ const createWebview = (tabId, initialUrl) => {
       }
     },
     'ipc-message': (event) => {
+      // Link-hover preview cursor-zone updates from webview-preload — flip
+      // the bar to the opposite corner so it never covers the hovered link.
+      // Handled directly here (not via navigation.js) because it doesn't
+      // touch tab/navigation state.
+      if (event.channel === 'link-status:zone') {
+        if (tabId === tabState.activeTabId) {
+          const inLeftZone = event.args?.[0]?.inLeftZone === true;
+          setLinkStatusSide(inLeftZone ? 'right' : 'left');
+        }
+        return;
+      }
       // Messages from internal pages (e.g. ens-unverified interstitial
       // bubbling a "Continue once" signal). Route through the registered
       // onWebviewEvent handler so navigation.js can stay the sole owner
@@ -1107,6 +1122,7 @@ export const switchTab = (tabId, options = {}) => {
   if (!tab) return;
 
   clearLinkStatus();
+  setLinkStatusSide('left');
   tabState.activeTabId = tabId;
 
   // Hide all webviews, show active one

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -492,7 +492,19 @@ const createWebview = (tabId, initialUrl) => {
       // touch tab/navigation state.
       if (event.channel === 'link-status:zone') {
         if (tabId === tabState.activeTabId) {
+          const tab = tabState.tabs.find((t) => t.id === tabId);
           const inLeftZone = event.args?.[0]?.inLeftZone === true;
+          // Remember per-tab so switchTab can restore without waiting for
+          // the preload to re-emit. The preload only emits on zone
+          // transitions, and a hidden webview's `linkStatusInZone` freezes
+          // at whatever value it held when the tab was backgrounded — so
+          // without per-tab state, returning to a tab whose pointer is
+          // still in the bottom-left band would leave the bar on the
+          // default `left` side and paint it over the hovered link until
+          // the pointer leaves and re-enters the zone.
+          if (tab) {
+            tab.linkStatusInLeftZone = inLeftZone;
+          }
           setLinkStatusSide(inLeftZone ? 'right' : 'left');
         }
         return;
@@ -1132,11 +1144,16 @@ export const switchTab = (tabId, options = {}) => {
 
   // Reset the link-hover preview before swapping active tabs:
   // - immediate clear so the previous tab's URL never trails into the new tab
-  // - reset side because `currentSide` is module-level state shared across
-  //   tabs; the new tab's preload will re-arm the zone tracker on first
-  //   mousemove and update side accordingly.
+  // - restore side from the incoming tab's last-known cursor-zone state
+  //   rather than blindly resetting to `left`. The preload's zone tracker
+  //   only emits on transitions, and a hidden webview's `linkStatusInZone`
+  //   freezes at whatever value it held when the tab was backgrounded —
+  //   so the next zone IPC may never arrive until the pointer leaves and
+  //   re-enters the band. Without restoring per-tab state, returning to
+  //   a tab whose pointer is in the bottom-left band would leave the bar
+  //   on `left` and paint it over the hovered link.
   clearLinkStatus({ immediate: true });
-  setLinkStatusSide('left');
+  setLinkStatusSide(tab.linkStatusInLeftZone ? 'right' : 'left');
   tabState.activeTabId = tabId;
 
   // Hide all webviews, show active one

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -9,7 +9,7 @@ import { setupWebviewProvider, setActiveWebview } from './dapp-provider.js';
 import { setupSwarmProvider } from './swarm-provider.js';
 import {
   clearLinkStatus,
-  handleUpdateTargetUrl,
+  showLinkStatus,
   setLinkStatusSide,
 } from './link-status.js';
 
@@ -506,7 +506,16 @@ const createWebview = (tabId, initialUrl) => {
       }
     },
     'update-target-url': (event) => {
-      handleUpdateTargetUrl(tabId, event.url, tabState.activeTabId);
+      // Gate at the tab edge (same shape as `link-status:zone`) so the
+      // link-status module never sees background-tab hover events. Empty
+      // url → fade out; non-empty → start the show pipeline.
+      if (tabId !== tabState.activeTabId) return;
+      const url = typeof event.url === 'string' ? event.url : '';
+      if (url) {
+        showLinkStatus(url);
+      } else {
+        clearLinkStatus();
+      }
     },
   };
 
@@ -1121,6 +1130,11 @@ export const switchTab = (tabId, options = {}) => {
   const tab = tabState.tabs.find((t) => t.id === tabId);
   if (!tab) return;
 
+  // Reset the link-hover preview before swapping active tabs:
+  // - immediate clear so the previous tab's URL never trails into the new tab
+  // - reset side because `currentSide` is module-level state shared across
+  //   tabs; the new tab's preload will re-arm the zone tracker on first
+  //   mousemove and update side accordingly.
   clearLinkStatus({ immediate: true });
   setLinkStatusSide('left');
   tabState.activeTabId = tabId;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -12,5 +12,6 @@
 @import './styles/update-toast.css';
 @import './styles/github-bridge.css';
 @import './styles/sidebar.css';
+@import './styles/link-status.css';
 @import './styles/onboarding.css';
 @import './styles/light-theme.css';

--- a/src/renderer/styles/link-status.css
+++ b/src/renderer/styles/link-status.css
@@ -20,7 +20,17 @@
   right: auto;
   bottom: 0;
   z-index: 2;
-  max-width: min(70vw, 640px);
+  /* Anchor max-width to the positioning context (.content-page), not the
+   * window viewport. A `vw` here would resolve against the host window,
+   * but inside the guest <webview> the preload's zone-tracker uses
+   * `window.innerWidth` — which is the *webview's* width. With the
+   * sidebar open (320 px), those two reference widths differ, and the
+   * trigger zone would lag behind the visible bar — exactly the
+   * cover-the-link case the trigger zone exists to prevent. `%`
+   * resolves against `.content-page`, which equals the webview width,
+   * keeping the bar and the zone in lockstep regardless of sidebar
+   * state. */
+  max-width: min(70%, 640px);
   padding: 3px 8px 3px 12px;
   border-top: 1px solid var(--border);
   border-right: 1px solid var(--border);

--- a/src/renderer/styles/link-status.css
+++ b/src/renderer/styles/link-status.css
@@ -17,17 +17,31 @@
 .link-status {
   position: absolute;
   left: 0;
+  right: auto;
   bottom: 0;
   z-index: 2;
   max-width: min(70vw, 640px);
   padding: 3px 8px 3px 12px;
   border-top: 1px solid var(--border);
   border-right: 1px solid var(--border);
+  border-left: none;
   border-top-right-radius: 6px;
+  border-top-left-radius: 0;
   background: var(--bg);
   pointer-events: none;
   opacity: 0;
   transition: opacity 150ms ease-out;
+}
+
+.link-status.link-status--right {
+  left: auto;
+  right: 0;
+  padding-left: 8px;
+  padding-right: 12px;
+  border-right: none;
+  border-left: 1px solid var(--border);
+  border-top-right-radius: 0;
+  border-top-left-radius: 6px;
 }
 
 .link-status:not(.visible) {

--- a/src/renderer/styles/link-status.css
+++ b/src/renderer/styles/link-status.css
@@ -1,0 +1,69 @@
+/* Link hover URL preview (Chrome / Firefox style) */
+
+.content-page {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+
+.content-page .webview-container {
+  flex: 1;
+  min-height: 0;
+}
+
+.link-status {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  z-index: 2;
+  max-width: min(70vw, 640px);
+  padding: 3px 8px 3px 12px;
+  border-top: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  border-top-right-radius: 6px;
+  background: var(--bg);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 150ms ease-out;
+}
+
+.link-status:not(.visible) {
+  transition-duration: 200ms;
+  transition-timing-function: ease-in;
+}
+
+[data-theme='light'] .link-status {
+  background: var(--toolbar);
+}
+
+.link-status.visible {
+  opacity: 1;
+}
+
+.link-status[hidden] {
+  display: none !important;
+}
+
+.link-status-url {
+  display: block;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  direction: ltr;
+}
+
+[data-theme='light'] .link-status-url {
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .link-status {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary

<img width="403" height="83" alt="Screenshot 2026-05-19 at 00 01 40" src="https://github.com/user-attachments/assets/b98475cc-7a09-4c48-93b5-d89087513871" />

- Show the destination URL of a hovered link in a Chrome/Firefox-style overlay anchored to the bottom-left of the page area. Wires Electron's `update-target-url` per `<webview>` into a new renderer-only `link-status` module.
- Fade in (~150ms) on first hover after a 150ms grace delay, instant text swap when moving between links (including during the fade-out window), fade out (~200ms) on leave; gated to the active tab (both `update-target-url` and the cursor-zone signal drop at the `tabs.js` edge for background tabs) and cleared synchronously on tab switches; respects `prefers-reduced-motion` and is non-interactive (`pointer-events: none`, `aria-hidden="true"`).
- Avoid covering the link the user is hovering: a tiny zone tracker in `webview-preload.js` posts only on bottom-left zone transitions; the trigger zone width matches the bar's `min(70vw, 640px)` so it stays accurate on wide viewports. The bar mirrors to the bottom-right corner with rounded corner + border swapped to the opposite side.
- Defensively cap the displayed URL at 2048 chars before assigning to `textContent` so a hostile/sloppy embedded iframe cannot spam megabyte-scale `data:` / `javascript:` URLs through the chrome on every hover.
- Cancel any queued reveal `requestAnimationFrame` inside `clearLinkStatus` so an immediate clear (tab switch) cannot be re-flipped to `.visible` after the fact.

## Behavior summary

| Action | Behavior |
|---|---|
| Hover a link | Bar appears bottom-left after a 150 ms hover, fades in over ~150 ms |
| Move between links | Text swaps instantly, no fade, no flicker (including during fade-out) |
| Move off all links | Fades out over ~200 ms, fully cleared after 250 ms |
| Hover a link near bottom-left | Bar mirrors to bottom-right corner |
| Switch tabs while bar is visible | Bar clears synchronously; never trails over the new tab |
| Hover in a background tab | Ignored at the `tabs.js` edge — never affects the active tab's bar |
| `prefers-reduced-motion` | Show/clear with no animation, no rAF |
| Hostile huge URL | Truncated at 2048 chars before being painted |

## Test plan

- [ ] Hover an `https` link — URL appears bottom-left after a brief delay, fades in.
- [ ] Move between links rapidly (including during the fade-out window) — text swaps instantly, no flicker.
- [ ] Move cursor off all links — bar fades out.
- [ ] Hover a link near bottom-left, then near bottom-right of a wide window — bar flips on both sides; trigger zone tracks `min(70vw, 640px)`.
- [ ] Switch tabs while bar is visible — bar clears immediately; queued reveal rAF does not paint stale text on the new tab.
- [ ] Hovering links in a background tab does not affect the chrome.
- [ ] Long URLs are ellipsized; pathological data: URLs are truncated to 2048 chars before painting.
- [ ] Light + dark themes both legible.
- [ ] Screen reader does not announce hovered URLs (preview is `aria-hidden`).
- [ ] System `prefers-reduced-motion` — appears/clears without animation.
- [ ] `npm run lint` and `npm test` (link-status + tabs) pass.
