### PR TITLE
fix(main): restore address-bar clipboard on Windows and Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,12 @@ jobs:
           path: coverage/
           if-no-files-found: error
 
-  # Regression for issue #69 — address-bar Ctrl+C/V/X/A on non-macOS.
-  # Fails until edit-menu accelerators work with autoHideMenuBar.
+  # Issue #69 — address-bar clipboard: Win/Linux menu wiring + chrome context menu (all platforms).
   e2e-address-bar-clipboard:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,14 @@ jobs:
           else
             npm run test:e2e -- test-e2e/address-bar-clipboard.spec.js
           fi
+
+      - name: Upload Playwright traces and screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-address-bar-clipboard-${{ matrix.os }}-traces
+          path: |
+            test-results/
+            playwright-report/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,39 @@ jobs:
           name: coverage
           path: coverage/
           if-no-files-found: error
+
+  # Regression for issue #69 — address-bar Ctrl+C/V/X/A on non-macOS.
+  # Fails until edit-menu accelerators work with autoHideMenuBar.
+  e2e-address-bar-clipboard:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright system dependencies
+        if: runner.os == 'Linux'
+        run: npx playwright install-deps
+
+      - name: Run address-bar clipboard E2E
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            xvfb-run -a npm run test:e2e -- test-e2e/address-bar-clipboard.spec.js
+          else
+            npm run test:e2e -- test-e2e/address-bar-clipboard.spec.js
+          fi

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ The suite covers most of `src/main/` and `src/renderer/lib/` — see `src/**/*.t
 
 #### End-to-end tests (Playwright + Electron)
 
-Two Playwright projects live under `test-e2e/`. The harness suite is run manually via `npm run test:e2e`; **issue #69 regression** (`test-e2e/address-bar-clipboard.spec.js`) runs on GitHub Actions for `ubuntu-latest` and `windows-latest`. Configuration is in `playwright.config.js`.
+Two Playwright projects live under `test-e2e/`. The harness suite is run manually via `npm run test:e2e`; **issue #69 regression** (`test-e2e/address-bar-clipboard.spec.js`) runs on GitHub Actions for `ubuntu-latest`, `windows-latest`, and `macos-latest` (macOS runs the chrome context-menu specs only; Win/Linux menu wiring is skipped on Darwin). Configuration is in `playwright.config.js`.
 
 | Suite | Command | Files | What it does |
 | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ The suite covers most of `src/main/` and `src/renderer/lib/` — see `src/**/*.t
 
 #### End-to-end tests (Playwright + Electron)
 
-Two Playwright projects live under `test-e2e/`. **Both are run manually — neither is wired into CI.** Configuration is in `playwright.config.js`.
+Two Playwright projects live under `test-e2e/`. The harness suite is run manually via `npm run test:e2e`; **issue #69 regression** (`test-e2e/address-bar-clipboard.spec.js`) runs on GitHub Actions for `ubuntu-latest` and `windows-latest`. Configuration is in `playwright.config.js`.
 
 | Suite | Command | Files | What it does |
 | --- | --- | --- | --- |

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -39,6 +39,7 @@ module.exports = defineConfig({
       // headroom without hiding genuine hangs.
       timeout: 30_000,
       expect: { timeout: 7_500 },
+      retries: process.env.CI ? 2 : 0,
     },
     {
       name: 'live',

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -342,6 +342,10 @@ function registerBaseIpcHandlers(callbacks = {}) {
     return { success: false, error: 'No text provided' };
   });
 
+  ipcMain.handle('clipboard:read-text', () => {
+    return { success: true, text: clipboard.readText() };
+  });
+
   // Copy image to clipboard
   ipcMain.handle('clipboard:copy-image', async (_event, imageUrl) => {
     if (!imageUrl) {

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -342,7 +342,15 @@ function registerBaseIpcHandlers(callbacks = {}) {
     return { success: false, error: 'No text provided' };
   });
 
-  ipcMain.handle('clipboard:read-text', () => {
+  // Address-bar chrome context menu Paste fallback. Restricted to the
+  // trusted main renderer: webviews (which expose `hostWebContents`)
+  // could otherwise exfiltrate the user's clipboard without a paste
+  // gesture by invoking this IPC directly through the exposed
+  // electronAPI on a hostile page.
+  ipcMain.handle('clipboard:read-text', (event) => {
+    if (event?.sender?.hostWebContents) {
+      return { success: false, error: 'Untrusted sender' };
+    }
     return { success: true, text: clipboard.readText() };
   });
 

--- a/src/main/ipc-handlers.test.js
+++ b/src/main/ipc-handlers.test.js
@@ -333,6 +333,13 @@ describe('ipc-handlers', () => {
       error: 'No text provided',
     });
 
+    ctx.clipboard.readText = jest.fn(() => 'from-main');
+    await expect(ctx.ipcMain.invoke('clipboard:read-text')).resolves.toEqual({
+      success: true,
+      text: 'from-main',
+    });
+    expect(ctx.clipboard.readText).toHaveBeenCalled();
+
     await expect(ctx.ipcMain.handlers.get('clipboard:copy-image')({}, undefined)).resolves.toEqual({
       success: false,
       error: 'No image URL provided',

--- a/src/main/ipc-handlers.test.js
+++ b/src/main/ipc-handlers.test.js
@@ -340,6 +340,14 @@ describe('ipc-handlers', () => {
     });
     expect(ctx.clipboard.readText).toHaveBeenCalled();
 
+    // Webview senders (hostWebContents !== null) must not be able to
+    // siphon the user's clipboard without a paste gesture.
+    const webviewEvent = { sender: { hostWebContents: { id: 99 } } };
+    expect(ctx.ipcMain.handlers.get('clipboard:read-text')(webviewEvent)).toEqual({
+      success: false,
+      error: 'Untrusted sender',
+    });
+
     await expect(ctx.ipcMain.handlers.get('clipboard:copy-image')({}, undefined)).resolves.toEqual({
       success: false,
       error: 'No image URL provided',

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -26,7 +26,251 @@ function updateTabMenuItems() {
   if (closeTabMenuItem) closeTabMenuItem.enabled = hasWindows;
 }
 
-function buildEditMenuTemplate(isMac) {
+function buildAppMenuSubmenu(updateMenuItems) {
+  return [
+    { role: 'about' },
+    { type: 'separator' },
+    ...updateMenuItems,
+    { type: 'separator' },
+    { role: 'services' },
+    { type: 'separator' },
+    { role: 'hide' },
+    { role: 'hideOthers' },
+    { role: 'unhide' },
+    { type: 'separator' },
+    { role: 'quit' },
+  ];
+}
+
+function buildFileSubmenu(isMac) {
+  const submenu = [
+    {
+      id: 'new-tab',
+      label: 'New Tab',
+      accelerator: 'CmdOrCtrl+T',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('tab:new');
+        }
+      },
+    },
+    {
+      id: 'close-tab',
+      label: 'Close Tab',
+      accelerator: 'CmdOrCtrl+W',
+      click: () => {
+        const mainWindows = getMainWindows();
+        const focusedMainWindow = mainWindows.find((win) => win.isFocused());
+
+        if (focusedMainWindow) {
+          focusedMainWindow.webContents.send('tab:close');
+        }
+        // If no main window is focused (DevTools has focus), do nothing.
+        // User can close DevTools with the X button or Cmd+Option+I
+      },
+    },
+  ];
+
+  if (!isMac) {
+    submenu.push({
+      label: 'Close Tab',
+      accelerator: 'Ctrl+F4',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('tab:close');
+        }
+      },
+    });
+  }
+
+  submenu.push(
+    {
+      id: 'reopen-closed-tab',
+      label: 'Reopen Closed Tab',
+      accelerator: 'CmdOrCtrl+Shift+T',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('tab:reopen-closed');
+        }
+      },
+    },
+    { type: 'separator' },
+    {
+      label: 'New Window',
+      accelerator: 'CmdOrCtrl+N',
+      click: () => {
+        log.info('[menu] New Window clicked');
+        createMainWindow();
+      },
+    },
+    { type: 'separator' },
+    { role: 'close' }
+  );
+
+  if (!isMac) {
+    submenu.push({ type: 'separator' }, { role: 'quit' });
+  }
+
+  return submenu;
+}
+
+function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
+  const submenu = [
+    {
+      id: 'reload',
+      label: 'Reload This Page',
+      accelerator: 'CmdOrCtrl+R',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('page:reload');
+        }
+      },
+    },
+    {
+      label: 'Force Reload This Page',
+      accelerator: 'CmdOrCtrl+Shift+R',
+      visible: false,
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('page:hard-reload');
+        }
+      },
+    },
+    { type: 'separator' },
+    {
+      label: 'Focus Address Bar',
+      accelerator: 'CmdOrCtrl+L',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('menus:close');
+          win.webContents.send('focus:address-bar');
+        }
+      },
+    },
+    { type: 'separator' },
+    {
+      id: 'fullscreen',
+      label: fullScreen ? 'Exit Full Screen' : 'Enter Full Screen',
+      accelerator: 'F11',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.setFullScreen(!win.isFullScreen());
+        }
+      },
+    },
+    { type: 'separator' },
+    {
+      id: 'next-tab',
+      label: 'Next Tab',
+      accelerator: 'Ctrl+PageDown',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('tab:next');
+        }
+      },
+    },
+    {
+      id: 'prev-tab',
+      label: 'Previous Tab',
+      accelerator: 'Ctrl+PageUp',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('tab:prev');
+        }
+      },
+    },
+    {
+      id: 'move-tab-right',
+      label: 'Move Tab Right',
+      accelerator: 'Ctrl+Shift+PageDown',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('tab:move-right');
+        }
+      },
+    },
+    {
+      id: 'move-tab-left',
+      label: 'Move Tab Left',
+      accelerator: 'Ctrl+Shift+PageUp',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('tab:move-left');
+        }
+      },
+    },
+    { type: 'separator' },
+    {
+      id: 'toggle-bookmark-bar',
+      label: 'Always Show Bookmarks Bar',
+      type: 'checkbox',
+      checked: false,
+      accelerator: 'CmdOrCtrl+Shift+B',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('bookmarks:toggle-bar');
+        }
+      },
+    },
+    { type: 'separator' },
+    {
+      id: 'toggle-devtools',
+      label: 'Developer Tools',
+      accelerator: 'CmdOrCtrl+Alt+I',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('devtools:toggle');
+        }
+      },
+    },
+  ];
+
+  if (showAppDevtools) {
+    submenu.push({
+      id: 'toggle-app-devtools',
+      label: 'App Developer Tools',
+      accelerator: 'CmdOrCtrl+Shift+Alt+I',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.toggleDevTools();
+        }
+      },
+    });
+  }
+
+  return submenu;
+}
+
+function buildHistorySubmenu(isMac) {
+  return [
+    {
+      label: 'Show All History',
+      accelerator: isMac ? 'Cmd+Y' : 'Ctrl+H',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('tab:new-with-url', 'freedom://history');
+        }
+      },
+    },
+  ];
+}
+
+function buildEditMenuEntry(isMac) {
   if (isMac) {
     return { role: 'editMenu' };
   }
@@ -47,267 +291,50 @@ function buildEditMenuTemplate(isMac) {
   };
 }
 
+function buildSharedMenuEntries(ctx) {
+  const { isMac, isFullScreen: fullScreen, isPackaged } = ctx;
+
+  return [
+    { label: 'File', submenu: buildFileSubmenu(isMac) },
+    {
+      label: 'View',
+      submenu: buildViewSubmenu({
+        isFullScreen: fullScreen,
+        showAppDevtools: !isPackaged,
+      }),
+    },
+    { label: 'History', submenu: buildHistorySubmenu(isMac) },
+    buildEditMenuEntry(isMac),
+  ];
+}
+
+function buildDarwinMenuTemplate(ctx) {
+  return [
+    { role: 'appMenu', submenu: buildAppMenuSubmenu(ctx.updateMenuItems) },
+    ...buildSharedMenuEntries(ctx),
+    { role: 'windowMenu' },
+  ];
+}
+
+function buildWinLinuxMenuTemplate(ctx) {
+  return buildSharedMenuEntries(ctx);
+}
+
 function buildApplicationMenuTemplate({
   platform = process.platform,
   updateMenuItems,
-  isFullScreen = false,
+  isFullScreen: fullScreen = false,
   isPackaged = app.isPackaged,
 } = {}) {
-  const isMac = platform === 'darwin';
+  const ctx = {
+    platform,
+    updateMenuItems,
+    isMac: platform === 'darwin',
+    isFullScreen: fullScreen,
+    isPackaged,
+  };
 
-  const template = [
-    ...(isMac
-      ? [
-          {
-            role: 'appMenu',
-            submenu: [
-              { role: 'about' },
-              { type: 'separator' },
-              ...updateMenuItems,
-              { type: 'separator' },
-              { role: 'services' },
-              { type: 'separator' },
-              { role: 'hide' },
-              { role: 'hideOthers' },
-              { role: 'unhide' },
-              { type: 'separator' },
-              { role: 'quit' },
-            ],
-          },
-        ]
-      : []),
-    {
-      label: 'File',
-      submenu: [
-        {
-          id: 'new-tab',
-          label: 'New Tab',
-          accelerator: 'CmdOrCtrl+T',
-          click: () => {
-            const win = getTargetWindow();
-            if (win) {
-              win.webContents.send('tab:new');
-            }
-          },
-        },
-        {
-          id: 'close-tab',
-          label: 'Close Tab',
-          accelerator: 'CmdOrCtrl+W',
-          click: () => {
-            const mainWindows = getMainWindows();
-
-            // Find a main browser window that is focused
-            const focusedMainWindow = mainWindows.find((win) => win.isFocused());
-
-            if (focusedMainWindow) {
-              focusedMainWindow.webContents.send('tab:close');
-            }
-            // If no main window is focused (DevTools has focus), do nothing.
-            // User can close DevTools with the X button or Cmd+Option+I
-          },
-        },
-        ...(!isMac
-          ? [
-              {
-                label: 'Close Tab',
-                accelerator: 'Ctrl+F4',
-                click: () => {
-                  const win = getTargetWindow();
-                  if (win) {
-                    win.webContents.send('tab:close');
-                  }
-                },
-              },
-            ]
-          : []),
-        {
-          id: 'reopen-closed-tab',
-          label: 'Reopen Closed Tab',
-          accelerator: 'CmdOrCtrl+Shift+T',
-          click: () => {
-            const win = getTargetWindow();
-            if (win) {
-              win.webContents.send('tab:reopen-closed');
-            }
-          },
-        },
-        { type: 'separator' },
-        {
-          label: 'New Window',
-          accelerator: 'CmdOrCtrl+N',
-          click: () => {
-            log.info('[menu] New Window clicked');
-            createMainWindow();
-          },
-        },
-        { type: 'separator' },
-        { role: 'close' },
-        ...(!isMac
-          ? [
-              { type: 'separator' },
-              { role: 'quit' },
-            ]
-          : []),
-      ],
-    },
-    {
-      label: 'View',
-      submenu: [
-        {
-          id: 'reload',
-          label: 'Reload This Page',
-          accelerator: 'CmdOrCtrl+R',
-          click: () => {
-            const win = getTargetWindow();
-            if (win) {
-              win.webContents.send('page:reload');
-            }
-          },
-        },
-        {
-          label: 'Force Reload This Page',
-          accelerator: 'CmdOrCtrl+Shift+R',
-          visible: false,
-          click: () => {
-            const win = getTargetWindow();
-            if (win) {
-              win.webContents.send('page:hard-reload');
-            }
-          },
-        },
-        { type: 'separator' },
-        {
-          label: 'Focus Address Bar',
-          accelerator: 'CmdOrCtrl+L',
-          click: () => {
-            const win = getTargetWindow();
-            if (win) {
-              win.webContents.send('menus:close');
-              win.webContents.send('focus:address-bar');
-            }
-          },
-        },
-        { type: 'separator' },
-        {
-          id: 'fullscreen',
-          label: isFullScreen ? 'Exit Full Screen' : 'Enter Full Screen',
-          accelerator: 'F11',
-          click: () => {
-            const win = getTargetWindow();
-            if (win) {
-              win.setFullScreen(!win.isFullScreen());
-            }
-          },
-        },
-        { type: 'separator' },
-        {
-          id: 'next-tab',
-          label: 'Next Tab',
-          accelerator: 'Ctrl+PageDown',
-          click: () => {
-            const win = getTargetWindow();
-            if (win) {
-              win.webContents.send('tab:next');
-            }
-          },
-        },
-        {
-          id: 'prev-tab',
-          label: 'Previous Tab',
-          accelerator: 'Ctrl+PageUp',
-          click: () => {
-            const win = getTargetWindow();
-            if (win) {
-              win.webContents.send('tab:prev');
-            }
-          },
-        },
-        {
-          id: 'move-tab-right',
-          label: 'Move Tab Right',
-          accelerator: 'Ctrl+Shift+PageDown',
-          click: () => {
-            const win = getTargetWindow();
-            if (win) {
-              win.webContents.send('tab:move-right');
-            }
-          },
-        },
-        {
-          id: 'move-tab-left',
-          label: 'Move Tab Left',
-          accelerator: 'Ctrl+Shift+PageUp',
-          click: () => {
-            const win = getTargetWindow();
-            if (win) {
-              win.webContents.send('tab:move-left');
-            }
-          },
-        },
-        { type: 'separator' },
-        {
-          id: 'toggle-bookmark-bar',
-          label: 'Always Show Bookmarks Bar',
-          type: 'checkbox',
-          checked: false,
-          accelerator: 'CmdOrCtrl+Shift+B',
-          click: () => {
-            const win = getTargetWindow();
-            if (win) {
-              win.webContents.send('bookmarks:toggle-bar');
-            }
-          },
-        },
-        { type: 'separator' },
-        {
-          id: 'toggle-devtools',
-          label: 'Developer Tools',
-          accelerator: 'CmdOrCtrl+Alt+I',
-          click: () => {
-            const win = getTargetWindow();
-            if (win) {
-              win.webContents.send('devtools:toggle');
-            }
-          },
-        },
-        ...(!isPackaged
-          ? [
-              {
-                id: 'toggle-app-devtools',
-                label: 'App Developer Tools',
-                accelerator: 'CmdOrCtrl+Shift+Alt+I',
-                click: () => {
-                  const win = getTargetWindow();
-                  if (win) {
-                    win.webContents.toggleDevTools();
-                  }
-                },
-              },
-            ]
-          : []),
-      ],
-    },
-    {
-      label: 'History',
-      submenu: [
-        {
-          label: 'Show All History',
-          accelerator: isMac ? 'Cmd+Y' : 'Ctrl+H',
-          click: () => {
-            const win = getTargetWindow();
-            if (win) {
-              win.webContents.send('tab:new-with-url', 'freedom://history');
-            }
-          },
-        },
-      ],
-    },
-    buildEditMenuTemplate(isMac),
-    ...(isMac ? [{ role: 'windowMenu' }] : []),
-  ];
-
-  return template;
+  return ctx.isMac ? buildDarwinMenuTemplate(ctx) : buildWinLinuxMenuTemplate(ctx);
 }
 
 function setupApplicationMenu() {

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -296,6 +296,7 @@ function buildSharedMenuEntries(ctx) {
 
   return [
     { label: 'File', submenu: buildFileSubmenu(isMac) },
+    buildEditMenuEntry(isMac),
     {
       label: 'View',
       submenu: buildViewSubmenu({
@@ -304,7 +305,6 @@ function buildSharedMenuEntries(ctx) {
       }),
     },
     { label: 'History', submenu: buildHistorySubmenu(isMac) },
-    buildEditMenuEntry(isMac),
   ];
 }
 

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -26,48 +26,56 @@ function updateTabMenuItems() {
   if (closeTabMenuItem) closeTabMenuItem.enabled = hasWindows;
 }
 
-function setupApplicationMenu() {
-  const updateReady = isUpdateReady();
+function buildEditMenuTemplate(isMac) {
+  if (isMac) {
+    return { role: 'editMenu' };
+  }
 
-  const updateMenuItems = updateReady
-    ? [
-        {
-          label: 'Install Update and Restart...',
-          click: () => {
-            installUpdate();
-          },
-        },
-        {
-          label: 'Check for Updates...',
-          enabled: false,
-        },
-      ]
-    : [
-        {
-          label: 'Check for Updates...',
-          click: () => {
-            checkForUpdates();
-          },
-        },
-      ];
+  return {
+    label: 'Edit',
+    submenu: [
+      { role: 'undo' },
+      { role: 'redo' },
+      { type: 'separator' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { role: 'delete' },
+      { type: 'separator' },
+      { role: 'selectAll' },
+    ],
+  };
+}
+
+function buildApplicationMenuTemplate({
+  platform = process.platform,
+  updateMenuItems,
+  isFullScreen = false,
+  isPackaged = app.isPackaged,
+} = {}) {
+  const isMac = platform === 'darwin';
 
   const template = [
-    {
-      role: 'appMenu',
-      submenu: [
-        { role: 'about' },
-        { type: 'separator' },
-        ...updateMenuItems,
-        { type: 'separator' },
-        { role: 'services' },
-        { type: 'separator' },
-        { role: 'hide' },
-        { role: 'hideOthers' },
-        { role: 'unhide' },
-        { type: 'separator' },
-        { role: 'quit' },
-      ],
-    },
+    ...(isMac
+      ? [
+          {
+            role: 'appMenu',
+            submenu: [
+              { role: 'about' },
+              { type: 'separator' },
+              ...updateMenuItems,
+              { type: 'separator' },
+              { role: 'services' },
+              { type: 'separator' },
+              { role: 'hide' },
+              { role: 'hideOthers' },
+              { role: 'unhide' },
+              { type: 'separator' },
+              { role: 'quit' },
+            ],
+          },
+        ]
+      : []),
     {
       label: 'File',
       submenu: [
@@ -99,7 +107,7 @@ function setupApplicationMenu() {
             // User can close DevTools with the X button or Cmd+Option+I
           },
         },
-        ...(process.platform !== 'darwin'
+        ...(!isMac
           ? [
               {
                 label: 'Close Tab',
@@ -135,6 +143,12 @@ function setupApplicationMenu() {
         },
         { type: 'separator' },
         { role: 'close' },
+        ...(!isMac
+          ? [
+              { type: 'separator' },
+              { role: 'quit' },
+            ]
+          : []),
       ],
     },
     {
@@ -257,7 +271,7 @@ function setupApplicationMenu() {
             }
           },
         },
-        ...(!app.isPackaged
+        ...(!isPackaged
           ? [
               {
                 id: 'toggle-app-devtools',
@@ -279,7 +293,7 @@ function setupApplicationMenu() {
       submenu: [
         {
           label: 'Show All History',
-          accelerator: process.platform === 'darwin' ? 'Cmd+Y' : 'Ctrl+H',
+          accelerator: isMac ? 'Cmd+Y' : 'Ctrl+H',
           click: () => {
             const win = getTargetWindow();
             if (win) {
@@ -289,9 +303,43 @@ function setupApplicationMenu() {
         },
       ],
     },
-    { role: 'editMenu' },
-    { role: 'windowMenu' },
+    buildEditMenuTemplate(isMac),
+    ...(isMac ? [{ role: 'windowMenu' }] : []),
   ];
+
+  return template;
+}
+
+function setupApplicationMenu() {
+  const updateReady = isUpdateReady();
+
+  const updateMenuItems = updateReady
+    ? [
+        {
+          label: 'Install Update and Restart...',
+          click: () => {
+            installUpdate();
+          },
+        },
+        {
+          label: 'Check for Updates...',
+          enabled: false,
+        },
+      ]
+    : [
+        {
+          label: 'Check for Updates...',
+          click: () => {
+            checkForUpdates();
+          },
+        },
+      ];
+
+  const template = buildApplicationMenuTemplate({
+    updateMenuItems,
+    isFullScreen,
+    isPackaged: app.isPackaged,
+  });
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
 
@@ -361,6 +409,7 @@ function updateFullscreenMenuItem(newIsFullScreen) {
 }
 
 module.exports = {
+  buildApplicationMenuTemplate,
   setupApplicationMenu,
   updateTabMenuItems,
   updateFullscreenMenuItem,

--- a/src/main/menu.test.js
+++ b/src/main/menu.test.js
@@ -1,0 +1,78 @@
+const { loadMainModule } = require('../../test/helpers/main-process-test-utils');
+
+function loadMenuModule(platform) {
+  let capturedTemplate = null;
+  const menuInstance = {
+    on: jest.fn(),
+    getMenuItemById: jest.fn(),
+  };
+
+  const { mod } = loadMainModule(require.resolve('./menu'), {
+    electronOverrides: {
+      Menu: {
+        buildFromTemplate: jest.fn((template) => {
+          capturedTemplate = template;
+          return menuInstance;
+        }),
+        setApplicationMenu: jest.fn(),
+        getApplicationMenu: jest.fn(() => menuInstance),
+      },
+    },
+    extraMocks: {
+      [require.resolve('./windows/mainWindow')]: () => ({
+        isMainBrowserWindow: () => true,
+        getMainWindows: () => [],
+        createMainWindow: jest.fn(),
+      }),
+      [require.resolve('./updater')]: () => ({
+        checkForUpdates: jest.fn(),
+        isUpdateReady: () => false,
+        installUpdate: jest.fn(),
+      }),
+    },
+  });
+
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform });
+
+  try {
+    mod.setupApplicationMenu();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  }
+
+  return { capturedTemplate, mod };
+}
+
+function findTopLabel(template, label) {
+  return template.find((item) => item.label === label);
+}
+
+describe('menu', () => {
+  test('Windows template omits macOS-only appMenu and windowMenu', () => {
+    const { capturedTemplate } = loadMenuModule('win32');
+
+    expect(capturedTemplate.some((item) => item.role === 'appMenu')).toBe(false);
+    expect(capturedTemplate.some((item) => item.role === 'windowMenu')).toBe(false);
+    expect(findTopLabel(capturedTemplate, 'File')).toBeTruthy();
+    expect(findTopLabel(capturedTemplate, 'Edit')).toBeTruthy();
+  });
+
+  test('Linux template uses explicit Edit roles for clipboard accelerators', () => {
+    const { capturedTemplate } = loadMenuModule('linux');
+    const edit = findTopLabel(capturedTemplate, 'Edit');
+
+    expect(edit?.submenu?.map((item) => item.role)).toEqual(
+      expect.arrayContaining(['cut', 'copy', 'paste', 'selectAll'])
+    );
+  });
+
+  test('macOS template keeps appMenu and editMenu roles', () => {
+    const { capturedTemplate } = loadMenuModule('darwin');
+
+    expect(capturedTemplate.some((item) => item.role === 'appMenu')).toBe(true);
+    expect(capturedTemplate.some((item) => item.role === 'editMenu')).toBe(true);
+    expect(capturedTemplate.some((item) => item.role === 'windowMenu')).toBe(true);
+    expect(findTopLabel(capturedTemplate, 'Edit')).toBeFalsy();
+  });
+});

--- a/src/main/menu.test.js
+++ b/src/main/menu.test.js
@@ -65,6 +65,8 @@ describe('menu', () => {
     expect(edit?.submenu?.map((item) => item.role)).toEqual(
       expect.arrayContaining(['cut', 'copy', 'paste', 'selectAll'])
     );
+    expect(capturedTemplate.some((item) => item.role === 'appMenu')).toBe(false);
+    expect(capturedTemplate.some((item) => item.role === 'windowMenu')).toBe(false);
   });
 
   test('macOS template keeps appMenu and editMenu roles', () => {

--- a/src/main/menu.test.js
+++ b/src/main/menu.test.js
@@ -58,6 +58,20 @@ describe('menu', () => {
     expect(findTopLabel(capturedTemplate, 'Edit')).toBeTruthy();
   });
 
+  test('Windows and Linux place Edit immediately after File', () => {
+    for (const platform of ['win32', 'linux']) {
+      const { capturedTemplate } = loadMenuModule(platform);
+      const labels = capturedTemplate.map((item) => item.label ?? item.role);
+      const fileIndex = labels.indexOf('File');
+      const editIndex = labels.indexOf('Edit');
+      const viewIndex = labels.indexOf('View');
+
+      expect(fileIndex).toBeGreaterThanOrEqual(0);
+      expect(editIndex).toBe(fileIndex + 1);
+      expect(viewIndex).toBeGreaterThan(editIndex);
+    }
+  });
+
   test('Linux template uses explicit Edit roles for clipboard accelerators', () => {
     const { capturedTemplate } = loadMenuModule('linux');
     const edit = findTopLabel(capturedTemplate, 'Edit');
@@ -76,5 +90,17 @@ describe('menu', () => {
     expect(capturedTemplate.some((item) => item.role === 'editMenu')).toBe(true);
     expect(capturedTemplate.some((item) => item.role === 'windowMenu')).toBe(true);
     expect(findTopLabel(capturedTemplate, 'Edit')).toBeFalsy();
+  });
+
+  test('macOS places editMenu immediately after File', () => {
+    const { capturedTemplate } = loadMenuModule('darwin');
+    const labels = capturedTemplate.map((item) => item.label ?? item.role);
+    const fileIndex = labels.indexOf('File');
+    const editIndex = labels.indexOf('editMenu');
+    const viewIndex = labels.indexOf('View');
+
+    expect(fileIndex).toBeGreaterThanOrEqual(0);
+    expect(editIndex).toBe(fileIndex + 1);
+    expect(viewIndex).toBeGreaterThan(editIndex);
   });
 });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -63,6 +63,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   saveImage: (imageUrl) => ipcRenderer.invoke('context-menu:save-image', imageUrl),
   // Clipboard
   copyText: (text) => ipcRenderer.invoke('clipboard:copy-text', text),
+  readClipboardText: () => ipcRenderer.invoke('clipboard:read-text'),
   copyImageFromUrl: (imageUrl) => ipcRenderer.invoke('clipboard:copy-image', imageUrl),
   // Favicons
   getFavicon: (url) => ipcRenderer.invoke('favicon:get', url),

--- a/src/main/preload.test.js
+++ b/src/main/preload.test.js
@@ -138,6 +138,7 @@ describe('preload', () => {
       [exposures.electronAPI, 'getWebviewPreloadPath', [], IPC.GET_WEBVIEW_PRELOAD_PATH, []],
       [exposures.electronAPI, 'saveImage', ['https://example.com/image.png'], IPC.CONTEXT_MENU_SAVE_IMAGE, ['https://example.com/image.png']],
       [exposures.electronAPI, 'copyText', ['hello'], 'clipboard:copy-text', ['hello']],
+      [exposures.electronAPI, 'readClipboardText', [], 'clipboard:read-text', []],
       [exposures.electronAPI, 'copyImageFromUrl', ['https://example.com/image.png'], 'clipboard:copy-image', ['https://example.com/image.png']],
       [exposures.electronAPI, 'getFavicon', ['https://example.com'], IPC.FAVICON_GET, ['https://example.com']],
       [exposures.electronAPI, 'getCachedFavicon', ['https://example.com'], IPC.FAVICON_GET_CACHED, ['https://example.com']],

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -2348,6 +2348,15 @@
       </div>
     </dialog>
 
+    <!-- Chrome text-field context menu (address bar, etc.) -->
+    <div id="chrome-input-context-menu" class="context-menu hidden" data-test="chrome-input-context-menu">
+      <button class="context-menu-item" data-action="cut">Cut</button>
+      <button class="context-menu-item" data-action="copy">Copy</button>
+      <button class="context-menu-item" data-action="paste">Paste</button>
+      <div class="context-menu-separator"></div>
+      <button class="context-menu-item" data-action="select-all">Select All</button>
+    </div>
+
     <!-- Tab Context Menu -->
     <div id="tab-context-menu" class="context-menu hidden">
       <button class="context-menu-item" data-action="close">Close Tab</button>

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -50,6 +50,10 @@ import { initGithubBridgeUi, setOnOpenRadicleUrl } from './lib/github-bridge-ui.
 import { initMenuBackdrop } from './lib/menu-backdrop.js';
 import { initLinkStatus } from './lib/link-status.js';
 import { initPageContextMenu, hidePageContextMenu } from './lib/page-context-menu.js';
+import {
+  initChromeInputContextMenu,
+  hideChromeInputContextMenu,
+} from './lib/chrome-input-context-menu.js';
 import { pushDebug } from './lib/debug.js';
 import { initOnboarding } from './lib/onboarding.js';
 import { initSidebar } from './lib/sidebar.js';
@@ -117,6 +121,7 @@ const closeAllMenus = () => {
   hideTabContextMenu();
   hideBookmarkContextMenu();
   hidePageContextMenu();
+  hideChromeInputContextMenu();
 };
 
 // Close everything including autocomplete (used by backdrop)
@@ -222,6 +227,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   initTabs(); // Creates first tab and starts loading home page
   initAutocomplete(); // Address bar autocomplete
   initPageContextMenu(); // Page context menu for webviews
+  initChromeInputContextMenu({ onOpening: onAnyMenuOpening }); // Address bar edit menu
   initOnboarding();  // Identity onboarding wizard
   initSidebar();     // Identity & wallet sidebar
   initWalletUi();    // Wallet & identity display in sidebar

--- a/src/renderer/lib/chrome-input-context-menu.js
+++ b/src/renderer/lib/chrome-input-context-menu.js
@@ -1,0 +1,92 @@
+// Right-click edit menu for chrome <input> elements (address bar, etc.).
+import { showMenuBackdrop, hideMenuBackdrop } from './menu-backdrop.js';
+
+let contextMenu = null;
+let activeInput = null;
+
+export const hideChromeInputContextMenu = () => {
+  if (!contextMenu || contextMenu.classList.contains('hidden')) return;
+  contextMenu.classList.add('hidden');
+  activeInput = null;
+  hideMenuBackdrop();
+};
+
+function updateActionStates(input) {
+  if (!contextMenu || !input) return;
+  const hasSelection = input.selectionStart !== input.selectionEnd;
+  const hasText = input.value.length > 0;
+  const cut = contextMenu.querySelector('[data-action="cut"]');
+  const copy = contextMenu.querySelector('[data-action="copy"]');
+  const selectAll = contextMenu.querySelector('[data-action="select-all"]');
+  if (cut) cut.disabled = !hasSelection;
+  if (copy) copy.disabled = !hasSelection;
+  if (selectAll) selectAll.disabled = !hasText;
+}
+
+function showChromeInputContextMenu(input, clientX, clientY) {
+  if (!contextMenu || !input) return;
+
+  activeInput = input;
+  updateActionStates(input);
+  showMenuBackdrop();
+
+  contextMenu.style.left = `${clientX}px`;
+  contextMenu.style.top = `${clientY}px`;
+  contextMenu.classList.remove('hidden');
+
+  const rect = contextMenu.getBoundingClientRect();
+  if (rect.right > window.innerWidth) {
+    contextMenu.style.left = `${window.innerWidth - rect.width - 8}px`;
+  }
+  if (rect.bottom > window.innerHeight) {
+    contextMenu.style.top = `${window.innerHeight - rect.height - 8}px`;
+  }
+}
+
+function runEditAction(action, input) {
+  input.focus();
+  switch (action) {
+    case 'cut':
+      document.execCommand('cut');
+      break;
+    case 'copy':
+      document.execCommand('copy');
+      break;
+    case 'paste':
+      document.execCommand('paste');
+      break;
+    case 'select-all':
+      input.select();
+      break;
+    default:
+      return;
+  }
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+/**
+ * @param {{ onOpening?: () => void, inputs?: (HTMLInputElement|null)[] }} [options]
+ */
+export const initChromeInputContextMenu = (options = {}) => {
+  contextMenu = document.getElementById('chrome-input-context-menu');
+  if (!contextMenu) return;
+
+  const inputs =
+    options.inputs?.filter(Boolean) ??
+    [document.getElementById('address-input')].filter(Boolean);
+
+  for (const input of inputs) {
+    input.addEventListener('contextmenu', (event) => {
+      event.preventDefault();
+      options.onOpening?.();
+      showChromeInputContextMenu(input, event.clientX, event.clientY);
+    });
+  }
+
+  contextMenu.addEventListener('click', (event) => {
+    const action = event.target.closest?.('[data-action]')?.dataset?.action;
+    if (!action || !activeInput) return;
+    runEditAction(action, activeInput);
+    hideChromeInputContextMenu();
+  });
+};

--- a/src/renderer/lib/chrome-input-context-menu.js
+++ b/src/renderer/lib/chrome-input-context-menu.js
@@ -43,11 +43,11 @@ function updateActionStates(input, selection) {
   if (selectAll) selectAll.disabled = !hasText;
 }
 
-function showChromeInputContextMenu(input, clientX, clientY) {
+function showChromeInputContextMenu(input, clientX, clientY, selection) {
   if (!contextMenu || !input) return;
 
   activeInput = input;
-  savedSelection = captureSelection(input);
+  savedSelection = selection ?? captureSelection(input);
   updateActionStates(input, savedSelection);
   showMenuBackdrop();
 
@@ -66,10 +66,15 @@ function showChromeInputContextMenu(input, clientX, clientY) {
 
 async function writeClipboard(text) {
   if (!text) return;
+  const result = await electronAPI?.copyText?.(text);
+  if (result?.success) {
+    return;
+  }
+
   try {
     await navigator.clipboard.writeText(text);
   } catch {
-    await electronAPI?.copyText?.(text);
+    // Best-effort; menu actions still update the input when possible.
   }
 }
 
@@ -83,16 +88,19 @@ function selectAllInInput(input) {
 }
 
 async function readClipboard() {
+  const result = await electronAPI?.readClipboardText?.();
+  if (result?.success) {
+    return result.text ?? '';
+  }
+
   try {
     return await navigator.clipboard.readText();
   } catch {
-    const result = await electronAPI?.readClipboardText?.();
-    return result?.text ?? '';
+    return '';
   }
 }
 
-async function runEditAction(action, input) {
-  const selection = savedSelection ?? captureSelection(input);
+async function runEditAction(action, input, selection) {
   applySelection(input, selection);
 
   switch (action) {
@@ -136,20 +144,25 @@ export const initChromeInputContextMenu = (options = {}) => {
   contextMenu = document.getElementById('chrome-input-context-menu');
   if (!contextMenu) return;
 
-  // Keep focus and text selection on the input while the menu is used.
-  contextMenu.addEventListener('mousedown', (event) => {
-    event.preventDefault();
-  });
-
   const inputs =
     options.inputs?.filter(Boolean) ??
     [document.getElementById('address-input')].filter(Boolean);
 
   for (const input of inputs) {
+    let selectionAtPointerDown = null;
+
+    input.addEventListener('mousedown', (event) => {
+      if (event.button === 2) {
+        selectionAtPointerDown = captureSelection(input);
+      }
+    });
+
     input.addEventListener('contextmenu', (event) => {
       event.preventDefault();
       options.onOpening?.();
-      showChromeInputContextMenu(input, event.clientX, event.clientY);
+      const selection = selectionAtPointerDown ?? captureSelection(input);
+      selectionAtPointerDown = null;
+      showChromeInputContextMenu(input, event.clientX, event.clientY, selection);
     });
   }
 
@@ -161,11 +174,13 @@ export const initChromeInputContextMenu = (options = {}) => {
     const input = activeInput;
     if (!action || !input) return;
 
-    void runEditAction(action, input).finally(() => {
+    const selection = savedSelection ?? captureSelection(input);
+    hideChromeInputContextMenu();
+
+    void runEditAction(action, input, selection).then(() => {
       if (action === 'select-all') {
         selectAllInInput(input);
       }
-      hideChromeInputContextMenu();
     });
   });
 };

--- a/src/renderer/lib/chrome-input-context-menu.js
+++ b/src/renderer/lib/chrome-input-context-menu.js
@@ -6,6 +6,9 @@ const electronAPI = window.electronAPI;
 let contextMenu = null;
 let activeInput = null;
 let savedSelection = null;
+// Serializes async edit actions so a slow Paste cannot overlap a
+// follow-up Cut/Copy/Paste against a stale selection range.
+let actionInFlight = false;
 
 export const hideChromeInputContextMenu = () => {
   if (!contextMenu || contextMenu.classList.contains('hidden')) return;
@@ -65,16 +68,22 @@ function showChromeInputContextMenu(input, clientX, clientY, selection) {
 }
 
 async function writeClipboard(text) {
-  if (!text) return;
-  const result = await electronAPI?.copyText?.(text);
-  if (result?.success) {
-    return;
+  if (!text) return { success: false };
+
+  try {
+    const result = await electronAPI?.copyText?.(text);
+    if (result?.success) {
+      return { success: true };
+    }
+  } catch {
+    // Fall through to navigator clipboard.
   }
 
   try {
     await navigator.clipboard.writeText(text);
+    return { success: true };
   } catch {
-    // Best-effort; menu actions still update the input when possible.
+    return { success: false };
   }
 }
 
@@ -102,6 +111,7 @@ async function readClipboard() {
 
 async function runEditAction(action, input, selection) {
   applySelection(input, selection);
+  let mutated = false;
 
   switch (action) {
     case 'copy': {
@@ -110,10 +120,16 @@ async function runEditAction(action, input, selection) {
     }
     case 'cut': {
       const text = getSelectedText(input, selection);
-      await writeClipboard(text);
+      const { success } = await writeClipboard(text);
+      if (!success) {
+        // Restore the selection so the user can retry without data loss.
+        applySelection(input, selection);
+        break;
+      }
       input.value = input.value.slice(0, selection.start) + input.value.slice(selection.end);
       const caret = selection.start;
       input.setSelectionRange(caret, caret);
+      mutated = true;
       break;
     }
     case 'paste': {
@@ -122,6 +138,7 @@ async function runEditAction(action, input, selection) {
         input.value.slice(0, selection.start) + clipText + input.value.slice(selection.end);
       const caret = selection.start + clipText.length;
       input.setSelectionRange(caret, caret);
+      mutated = true;
       break;
     }
     case 'select-all': {
@@ -132,7 +149,7 @@ async function runEditAction(action, input, selection) {
       return;
   }
 
-  if (action !== 'select-all') {
+  if (mutated) {
     input.dispatchEvent(new Event('input', { bubbles: true }));
   }
 }
@@ -160,8 +177,19 @@ export const initChromeInputContextMenu = (options = {}) => {
     input.addEventListener('contextmenu', (event) => {
       event.preventDefault();
       options.onOpening?.();
-      const selection = selectionAtPointerDown ?? captureSelection(input);
+
+      // Some platforms collapse a prior range to the caret on right-click.
+      // Only resurrect the pre-contextmenu snapshot if it captured an
+      // actual non-collapsed selection; otherwise honor the live caret so
+      // Paste happens at the right-click position instead of jumping back
+      // to a stale earlier position.
+      const pointerSelection = selectionAtPointerDown;
       selectionAtPointerDown = null;
+      const liveSelection = captureSelection(input);
+      const snapshotHasRange =
+        pointerSelection && pointerSelection.start !== pointerSelection.end;
+      const selection = snapshotHasRange ? pointerSelection : liveSelection;
+
       showChromeInputContextMenu(input, event.clientX, event.clientY, selection);
     });
   }
@@ -169,6 +197,7 @@ export const initChromeInputContextMenu = (options = {}) => {
   contextMenu.addEventListener('click', (event) => {
     const item = event.target.closest?.('.context-menu-item');
     if (!item || item.disabled) return;
+    if (actionInFlight) return;
 
     const action = item.dataset.action;
     const input = activeInput;
@@ -177,10 +206,22 @@ export const initChromeInputContextMenu = (options = {}) => {
     const selection = savedSelection ?? captureSelection(input);
     hideChromeInputContextMenu();
 
-    void runEditAction(action, input, selection).then(() => {
-      if (action === 'select-all') {
-        selectAllInInput(input);
-      }
-    });
+    actionInFlight = true;
+    void runEditAction(action, input, selection)
+      .then(() => {
+        if (action === 'select-all') {
+          selectAllInInput(input);
+        }
+      })
+      .finally(() => {
+        actionInFlight = false;
+      });
   });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      hideChromeInputContextMenu();
+    }
+  });
+  window.addEventListener('blur', hideChromeInputContextMenu);
 };

--- a/src/renderer/lib/chrome-input-context-menu.js
+++ b/src/renderer/lib/chrome-input-context-menu.js
@@ -10,11 +10,25 @@ let savedSelection = null;
 // follow-up Cut/Copy/Paste against a stale selection range.
 let actionInFlight = false;
 
+// One-shot snapshot of the selection at right-mousedown, scoped to a
+// single mouse gesture. The snapshot is consumed by the next
+// contextmenu event on the same input and is otherwise cleared on
+// non-right mousedown, blur, Escape/menu hide, and on the post-gesture
+// document mouseup if no contextmenu followed.
+let pointerSelection = null;
+let pointerSelectionInput = null;
+
+const clearPointerSelection = () => {
+  pointerSelection = null;
+  pointerSelectionInput = null;
+};
+
 export const hideChromeInputContextMenu = () => {
   if (!contextMenu || contextMenu.classList.contains('hidden')) return;
   contextMenu.classList.add('hidden');
   activeInput = null;
   savedSelection = null;
+  clearPointerSelection();
   hideMenuBackdrop();
 };
 
@@ -166,23 +180,13 @@ export const initChromeInputContextMenu = (options = {}) => {
     [document.getElementById('address-input')].filter(Boolean);
 
   for (const input of inputs) {
-    // The pre-contextmenu selection snapshot is tied to a single mouse
-    // gesture. It must be cleared aggressively so a stale range never
-    // leaks into an unrelated keyboard / Ctrl-click context menu later.
-    let pointerSelection = null;
-    const clearPointerSelection = () => {
-      pointerSelection = null;
-    };
-
     input.addEventListener('mousedown', (event) => {
       if (event.button !== 2) {
         clearPointerSelection();
         return;
       }
-      pointerSelection = {
-        ...captureSelection(input),
-        capturedAt: event.timeStamp,
-      };
+      pointerSelection = captureSelection(input);
+      pointerSelectionInput = input;
     });
 
     input.addEventListener('blur', clearPointerSelection);
@@ -192,19 +196,12 @@ export const initChromeInputContextMenu = (options = {}) => {
       options.onOpening?.();
 
       const liveSelection = captureSelection(input);
-      const snapshot = pointerSelection;
+      // Only trust the snapshot when it belongs to this same input;
+      // it is one-shot and cleared regardless of which branch wins.
+      const snapshot = pointerSelectionInput === input ? pointerSelection : null;
       clearPointerSelection();
 
-      // Only trust the mousedown snapshot when it belongs to this same
-      // gesture. Browsers fire contextmenu within a few ms of the
-      // matching mouseup, so a much older snapshot (the user right-
-      // mousedown on the input but released outside, then later opened
-      // the menu via keyboard or Ctrl-click) must not be reused.
-      const FRESH_GESTURE_WINDOW_MS = 500;
-      const isSameGesture =
-        snapshot && event.timeStamp - snapshot.capturedAt < FRESH_GESTURE_WINDOW_MS;
-      const snapshotHasRange =
-        isSameGesture && snapshot.start !== snapshot.end;
+      const snapshotHasRange = snapshot && snapshot.start !== snapshot.end;
       const selection = snapshotHasRange
         ? { start: snapshot.start, end: snapshot.end }
         : liveSelection;
@@ -212,6 +209,16 @@ export const initChromeInputContextMenu = (options = {}) => {
       showChromeInputContextMenu(input, event.clientX, event.clientY, selection);
     });
   }
+
+  // Browsers fire contextmenu in the same input-handling cycle as the
+  // mouseup (Win/Linux) or after the mousedown (macOS). Deferring the
+  // clear past the current task lets a same-gesture contextmenu consume
+  // the snapshot first; an orphaned right-mousedown (mouseup outside
+  // the input, no contextmenu) gets cleared here so a later keyboard
+  // or Ctrl-click contextmenu cannot reuse it.
+  document.addEventListener('mouseup', () => {
+    setTimeout(clearPointerSelection, 0);
+  });
 
   contextMenu.addEventListener('click', (event) => {
     const item = event.target.closest?.('.context-menu-item');

--- a/src/renderer/lib/chrome-input-context-menu.js
+++ b/src/renderer/lib/chrome-input-context-menu.js
@@ -166,29 +166,48 @@ export const initChromeInputContextMenu = (options = {}) => {
     [document.getElementById('address-input')].filter(Boolean);
 
   for (const input of inputs) {
-    let selectionAtPointerDown = null;
+    // The pre-contextmenu selection snapshot is tied to a single mouse
+    // gesture. It must be cleared aggressively so a stale range never
+    // leaks into an unrelated keyboard / Ctrl-click context menu later.
+    let pointerSelection = null;
+    const clearPointerSelection = () => {
+      pointerSelection = null;
+    };
 
     input.addEventListener('mousedown', (event) => {
-      if (event.button === 2) {
-        selectionAtPointerDown = captureSelection(input);
+      if (event.button !== 2) {
+        clearPointerSelection();
+        return;
       }
+      pointerSelection = {
+        ...captureSelection(input),
+        capturedAt: event.timeStamp,
+      };
     });
+
+    input.addEventListener('blur', clearPointerSelection);
 
     input.addEventListener('contextmenu', (event) => {
       event.preventDefault();
       options.onOpening?.();
 
-      // Some platforms collapse a prior range to the caret on right-click.
-      // Only resurrect the pre-contextmenu snapshot if it captured an
-      // actual non-collapsed selection; otherwise honor the live caret so
-      // Paste happens at the right-click position instead of jumping back
-      // to a stale earlier position.
-      const pointerSelection = selectionAtPointerDown;
-      selectionAtPointerDown = null;
       const liveSelection = captureSelection(input);
+      const snapshot = pointerSelection;
+      clearPointerSelection();
+
+      // Only trust the mousedown snapshot when it belongs to this same
+      // gesture. Browsers fire contextmenu within a few ms of the
+      // matching mouseup, so a much older snapshot (the user right-
+      // mousedown on the input but released outside, then later opened
+      // the menu via keyboard or Ctrl-click) must not be reused.
+      const FRESH_GESTURE_WINDOW_MS = 500;
+      const isSameGesture =
+        snapshot && event.timeStamp - snapshot.capturedAt < FRESH_GESTURE_WINDOW_MS;
       const snapshotHasRange =
-        pointerSelection && pointerSelection.start !== pointerSelection.end;
-      const selection = snapshotHasRange ? pointerSelection : liveSelection;
+        isSameGesture && snapshot.start !== snapshot.end;
+      const selection = snapshotHasRange
+        ? { start: snapshot.start, end: snapshot.end }
+        : liveSelection;
 
       showChromeInputContextMenu(input, event.clientX, event.clientY, selection);
     });

--- a/src/renderer/lib/chrome-input-context-menu.js
+++ b/src/renderer/lib/chrome-input-context-menu.js
@@ -157,11 +157,10 @@ export const initChromeInputContextMenu = (options = {}) => {
     if (!action || !input) return;
 
     void runEditAction(action, input).finally(() => {
-      hideChromeInputContextMenu();
-      // Closing the menu can move focus on macOS and collapse the selection.
       if (action === 'select-all') {
         selectAllInInput(input);
       }
+      hideChromeInputContextMenu();
     });
   });
 };

--- a/src/renderer/lib/chrome-input-context-menu.js
+++ b/src/renderer/lib/chrome-input-context-menu.js
@@ -76,7 +76,10 @@ async function writeClipboard(text) {
 function selectAllInInput(input) {
   const end = input.value.length;
   input.focus();
-  input.setSelectionRange(0, end);
+  input.select();
+  if (input.selectionStart !== 0 || input.selectionEnd !== end) {
+    input.setSelectionRange(0, end);
+  }
 }
 
 async function readClipboard() {
@@ -121,7 +124,9 @@ async function runEditAction(action, input) {
       return;
   }
 
-  input.dispatchEvent(new Event('input', { bubbles: true }));
+  if (action !== 'select-all') {
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  }
 }
 
 /**

--- a/src/renderer/lib/chrome-input-context-menu.js
+++ b/src/renderer/lib/chrome-input-context-menu.js
@@ -1,19 +1,39 @@
 // Right-click edit menu for chrome <input> elements (address bar, etc.).
 import { showMenuBackdrop, hideMenuBackdrop } from './menu-backdrop.js';
 
+const electronAPI = window.electronAPI;
+
 let contextMenu = null;
 let activeInput = null;
+let savedSelection = null;
 
 export const hideChromeInputContextMenu = () => {
   if (!contextMenu || contextMenu.classList.contains('hidden')) return;
   contextMenu.classList.add('hidden');
   activeInput = null;
+  savedSelection = null;
   hideMenuBackdrop();
 };
 
-function updateActionStates(input) {
+function captureSelection(input) {
+  const start = input.selectionStart ?? 0;
+  const end = input.selectionEnd ?? 0;
+  return { start, end };
+}
+
+function getSelectedText(input, selection) {
+  const { start, end } = selection;
+  return input.value.slice(start, end);
+}
+
+function applySelection(input, selection) {
+  input.focus();
+  input.setSelectionRange(selection.start, selection.end);
+}
+
+function updateActionStates(input, selection) {
   if (!contextMenu || !input) return;
-  const hasSelection = input.selectionStart !== input.selectionEnd;
+  const hasSelection = selection.start !== selection.end;
   const hasText = input.value.length > 0;
   const cut = contextMenu.querySelector('[data-action="cut"]');
   const copy = contextMenu.querySelector('[data-action="copy"]');
@@ -27,7 +47,8 @@ function showChromeInputContextMenu(input, clientX, clientY) {
   if (!contextMenu || !input) return;
 
   activeInput = input;
-  updateActionStates(input);
+  savedSelection = captureSelection(input);
+  updateActionStates(input, savedSelection);
   showMenuBackdrop();
 
   contextMenu.style.left = `${clientX}px`;
@@ -43,24 +64,58 @@ function showChromeInputContextMenu(input, clientX, clientY) {
   }
 }
 
-function runEditAction(action, input) {
-  input.focus();
+async function writeClipboard(text) {
+  if (!text) return;
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    await electronAPI?.copyText?.(text);
+  }
+}
+
+async function readClipboard() {
+  try {
+    return await navigator.clipboard.readText();
+  } catch {
+    const result = await electronAPI?.readClipboardText?.();
+    return result?.text ?? '';
+  }
+}
+
+async function runEditAction(action, input) {
+  const selection = savedSelection ?? captureSelection(input);
+  applySelection(input, selection);
+
   switch (action) {
-    case 'cut':
-      document.execCommand('cut');
+    case 'copy': {
+      await writeClipboard(getSelectedText(input, selection));
       break;
-    case 'copy':
-      document.execCommand('copy');
+    }
+    case 'cut': {
+      const text = getSelectedText(input, selection);
+      await writeClipboard(text);
+      input.value = input.value.slice(0, selection.start) + input.value.slice(selection.end);
+      const caret = selection.start;
+      input.setSelectionRange(caret, caret);
       break;
-    case 'paste':
-      document.execCommand('paste');
+    }
+    case 'paste': {
+      const clipText = await readClipboard();
+      input.value =
+        input.value.slice(0, selection.start) + clipText + input.value.slice(selection.end);
+      const caret = selection.start + clipText.length;
+      input.setSelectionRange(caret, caret);
       break;
-    case 'select-all':
-      input.select();
+    }
+    case 'select-all': {
+      const end = input.value.length;
+      input.setSelectionRange(0, end);
       break;
+    }
     default:
       return;
   }
+
   input.dispatchEvent(new Event('input', { bubbles: true }));
 }
 
@@ -70,6 +125,11 @@ function runEditAction(action, input) {
 export const initChromeInputContextMenu = (options = {}) => {
   contextMenu = document.getElementById('chrome-input-context-menu');
   if (!contextMenu) return;
+
+  // Keep focus and text selection on the input while the menu is used.
+  contextMenu.addEventListener('mousedown', (event) => {
+    event.preventDefault();
+  });
 
   const inputs =
     options.inputs?.filter(Boolean) ??
@@ -84,9 +144,14 @@ export const initChromeInputContextMenu = (options = {}) => {
   }
 
   contextMenu.addEventListener('click', (event) => {
-    const action = event.target.closest?.('[data-action]')?.dataset?.action;
+    const item = event.target.closest?.('.context-menu-item');
+    if (!item || item.disabled) return;
+
+    const action = item.dataset.action;
     if (!action || !activeInput) return;
-    runEditAction(action, activeInput);
-    hideChromeInputContextMenu();
+
+    void runEditAction(action, activeInput).finally(() => {
+      hideChromeInputContextMenu();
+    });
   });
 };

--- a/src/renderer/lib/chrome-input-context-menu.js
+++ b/src/renderer/lib/chrome-input-context-menu.js
@@ -73,6 +73,12 @@ async function writeClipboard(text) {
   }
 }
 
+function selectAllInInput(input) {
+  const end = input.value.length;
+  input.focus();
+  input.setSelectionRange(0, end);
+}
+
 async function readClipboard() {
   try {
     return await navigator.clipboard.readText();
@@ -108,8 +114,7 @@ async function runEditAction(action, input) {
       break;
     }
     case 'select-all': {
-      const end = input.value.length;
-      input.setSelectionRange(0, end);
+      selectAllInInput(input);
       break;
     }
     default:
@@ -148,10 +153,15 @@ export const initChromeInputContextMenu = (options = {}) => {
     if (!item || item.disabled) return;
 
     const action = item.dataset.action;
-    if (!action || !activeInput) return;
+    const input = activeInput;
+    if (!action || !input) return;
 
-    void runEditAction(action, activeInput).finally(() => {
+    void runEditAction(action, input).finally(() => {
       hideChromeInputContextMenu();
+      // Closing the menu can move focus on macOS and collapse the selection.
+      if (action === 'select-all') {
+        selectAllInInput(input);
+      }
     });
   });
 };

--- a/src/renderer/lib/chrome-input-context-menu.test.js
+++ b/src/renderer/lib/chrome-input-context-menu.test.js
@@ -95,14 +95,19 @@ const loadModule = async ({ input, contextMenu, electronAPI } = {}) => {
   const addressInput = input ?? createInput();
   const menu = contextMenu ?? createContextMenu();
 
+  const documentHandlers = {};
   global.document = {
     getElementById: jest.fn((id) => {
       if (id === 'address-input') return addressInput;
       if (id === 'chrome-input-context-menu') return menu;
       return null;
     }),
+    addEventListener: jest.fn((event, handler) => {
+      documentHandlers[event] = handler;
+    }),
   };
 
+  const windowHandlers = {};
   global.window = {
     innerWidth: 800,
     innerHeight: 600,
@@ -113,6 +118,9 @@ const loadModule = async ({ input, contextMenu, electronAPI } = {}) => {
             copyText: jest.fn().mockResolvedValue({ success: true }),
             readClipboardText: jest.fn().mockResolvedValue({ success: true, text: 'pasted' }),
           }),
+    addEventListener: jest.fn((event, handler) => {
+      windowHandlers[event] = handler;
+    }),
   };
 
   global.navigator = {
@@ -129,11 +137,13 @@ const loadModule = async ({ input, contextMenu, electronAPI } = {}) => {
 
   const mod = await import('./chrome-input-context-menu.js');
   mod.initChromeInputContextMenu();
-  return { mod, input: addressInput, menu };
+  return { mod, input: addressInput, menu, documentHandlers, windowHandlers };
 };
 
-const openContextMenu = (input, { collapseSelectionOnOpen = false } = {}) => {
-  input.handlers.mousedown?.({ button: 2 });
+const openContextMenu = (input, { collapseSelectionOnOpen = false, skipMousedown = false } = {}) => {
+  if (!skipMousedown) {
+    input.handlers.mousedown?.({ button: 2 });
+  }
   if (collapseSelectionOnOpen) {
     const caret = input.value.length;
     input.setSelectionRange(caret, caret);
@@ -226,5 +236,133 @@ describe('chrome-input-context-menu', () => {
 
     expect(navigator.clipboard.readText).toHaveBeenCalled();
     expect(input.value).toBe('hello pastedworld');
+  });
+
+  test('paste uses live caret when right-click did not capture a range', async () => {
+    const input = createInput('abcdef');
+    // User clicks at caret position 3 with no selection; the right-click
+    // mousedown captures the live caret rather than a stale earlier range.
+    input.setSelectionRange(3, 3);
+    const { menu } = await loadModule({ input });
+
+    openContextMenu(input);
+    await clickMenu(menu, 'paste');
+
+    expect(input.value).toBe('abcpasteddef');
+    expect(input.selectionStart).toBe(3 + 'pasted'.length);
+    expect(input.selectionEnd).toBe(3 + 'pasted'.length);
+  });
+
+  test('paste honors live caret when contextmenu fires without prior mousedown', async () => {
+    const input = createInput('abcdef');
+    input.setSelectionRange(2, 2);
+    const { menu } = await loadModule({ input });
+
+    openContextMenu(input, { skipMousedown: true });
+    await clickMenu(menu, 'paste');
+
+    expect(input.value).toBe('abpastedcdef');
+  });
+
+  test('disabled menu items are ignored', async () => {
+    const input = createInput('');
+    input.setSelectionRange(0, 0);
+    const { menu } = await loadModule({ input });
+    openContextMenu(input);
+
+    expect(menu.items.cut.disabled).toBe(true);
+    expect(menu.items.copy.disabled).toBe(true);
+    expect(menu.items['select-all'].disabled).toBe(true);
+    expect(menu.items.paste.disabled).toBe(false);
+
+    await clickMenu(menu, 'copy');
+    expect(window.electronAPI.copyText).not.toHaveBeenCalled();
+  });
+
+  test('cut leaves text untouched when clipboard write fails', async () => {
+    const input = createInput('hello world');
+    const { menu } = await loadModule({
+      input,
+      electronAPI: {
+        copyText: jest.fn().mockResolvedValue({ success: false }),
+        readClipboardText: jest.fn().mockResolvedValue({ success: true, text: '' }),
+      },
+    });
+    navigator.clipboard.writeText.mockRejectedValueOnce(new Error('denied'));
+
+    openContextMenu(input);
+    await clickMenu(menu, 'cut');
+
+    expect(input.value).toBe('hello world');
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(5);
+    expect(input.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  test('select-all preserves the full selection without dispatching input', async () => {
+    const input = createInput('select-me');
+    input.setSelectionRange(0, 0);
+    const { menu } = await loadModule({ input });
+
+    openContextMenu(input);
+    await clickMenu(menu, 'select-all');
+
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe('select-me'.length);
+    // No synthetic input event - listeners must not reset the range.
+    expect(input.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  test('Escape hides the menu', async () => {
+    const { input, menu, documentHandlers } = await loadModule();
+    openContextMenu(input);
+    expect(menu.classList.contains('hidden')).toBe(false);
+
+    documentHandlers.keydown({ key: 'Escape' });
+    expect(menu.classList.contains('hidden')).toBe(true);
+  });
+
+  test('Window blur hides the menu', async () => {
+    const { input, menu, windowHandlers } = await loadModule();
+    openContextMenu(input);
+    expect(menu.classList.contains('hidden')).toBe(false);
+
+    windowHandlers.blur();
+    expect(menu.classList.contains('hidden')).toBe(true);
+  });
+
+  test('serializes overlapping actions so paste cannot race a follow-up cut', async () => {
+    const input = createInput('hello world');
+    let resolveRead;
+    const readClipboardText = jest.fn(
+      () => new Promise((resolve) => { resolveRead = resolve; })
+    );
+    const { menu } = await loadModule({
+      input,
+      electronAPI: {
+        copyText: jest.fn().mockResolvedValue({ success: true }),
+        readClipboardText,
+      },
+    });
+
+    input.setSelectionRange(5, 5);
+    openContextMenu(input);
+    // Start a slow paste; do not await yet.
+    menu.handlers.click({ target: menu.items.paste });
+
+    // Reopen and try to cut while paste is still pending.
+    openContextMenu(input);
+    menu.handlers.click({ target: menu.items.cut });
+    await flushMicrotasks();
+
+    // Cut must not have run against the stale range.
+    expect(window.electronAPI.copyText).not.toHaveBeenCalled();
+
+    // Let paste complete.
+    resolveRead({ success: true, text: 'X' });
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(input.value).toBe('helloX world');
   });
 });

--- a/src/renderer/lib/chrome-input-context-menu.test.js
+++ b/src/renderer/lib/chrome-input-context-menu.test.js
@@ -1,0 +1,211 @@
+const originalWindow = global.window;
+const originalDocument = global.document;
+const originalNavigator = global.navigator;
+
+const createClassList = (initialClasses = []) => {
+  const classes = new Set(initialClasses);
+  return {
+    add: jest.fn((className) => classes.add(className)),
+    remove: jest.fn((className) => classes.delete(className)),
+    contains: jest.fn((className) => classes.has(className)),
+  };
+};
+
+const createMenuItem = (action) => ({
+  dataset: { action },
+  disabled: false,
+  closest: jest.fn((selector) => (selector === '.context-menu-item' ? createMenuItem(action) : null)),
+});
+
+const createInput = (value = 'hello world') => {
+  let selectionStart = 0;
+  let selectionEnd = 5;
+  const handlers = {};
+
+  const input = {
+    value,
+    selectionStart,
+    selectionEnd,
+    focus: jest.fn(),
+    select: jest.fn(),
+    setSelectionRange: jest.fn((start, end) => {
+      selectionStart = start;
+      selectionEnd = end;
+      input.selectionStart = start;
+      input.selectionEnd = end;
+    }),
+    dispatchEvent: jest.fn(),
+    addEventListener: jest.fn((event, handler) => {
+      handlers[event] = handler;
+    }),
+    handlers,
+  };
+
+  Object.defineProperty(input, 'selectionStart', {
+    get: () => selectionStart,
+    set: (v) => {
+      selectionStart = v;
+    },
+  });
+  Object.defineProperty(input, 'selectionEnd', {
+    get: () => selectionEnd,
+    set: (v) => {
+      selectionEnd = v;
+    },
+  });
+
+  return input;
+};
+
+const createContextMenu = () => {
+  const handlers = {};
+  const items = {
+    cut: createMenuItem('cut'),
+    copy: createMenuItem('copy'),
+    paste: createMenuItem('paste'),
+    'select-all': createMenuItem('select-all'),
+  };
+
+  return {
+    handlers,
+    classList: createClassList(['hidden']),
+    style: {},
+    querySelector: jest.fn((selector) => items[selector.match(/data-action="([^"]+)"/)[1]]),
+    addEventListener: jest.fn((event, handler) => {
+      handlers[event] = handler;
+    }),
+    getBoundingClientRect: jest.fn(() => ({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 100,
+      width: 100,
+      height: 100,
+    })),
+    items,
+  };
+};
+
+const loadModule = async ({ input, contextMenu } = {}) => {
+  jest.resetModules();
+
+  const addressInput = input ?? createInput();
+  const menu = contextMenu ?? createContextMenu();
+
+  global.document = {
+    getElementById: jest.fn((id) => {
+      if (id === 'address-input') return addressInput;
+      if (id === 'chrome-input-context-menu') return menu;
+      return null;
+    }),
+  };
+
+  global.window = {
+    innerWidth: 800,
+    innerHeight: 600,
+    electronAPI: {
+      copyText: jest.fn().mockResolvedValue({ success: true }),
+      readClipboardText: jest.fn().mockResolvedValue({ success: true, text: 'pasted' }),
+    },
+  };
+
+  global.navigator = {
+    clipboard: {
+      writeText: jest.fn().mockResolvedValue(undefined),
+      readText: jest.fn().mockResolvedValue('pasted'),
+    },
+  };
+
+  jest.doMock('./menu-backdrop.js', () => ({
+    showMenuBackdrop: jest.fn(),
+    hideMenuBackdrop: jest.fn(),
+  }));
+
+  const mod = await import('./chrome-input-context-menu.js');
+  mod.initChromeInputContextMenu();
+  return { mod, input: addressInput, menu };
+};
+
+const openContextMenu = (input) => {
+  input.handlers.contextmenu({
+    preventDefault: jest.fn(),
+    clientX: 10,
+    clientY: 10,
+  });
+};
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const clickMenu = async (menu, action) => {
+  const item = menu.items[action];
+  item.closest.mockReturnValue(item);
+  menu.handlers.click({
+    target: item,
+  });
+  await flushMicrotasks();
+};
+
+describe('chrome-input-context-menu', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.navigator = originalNavigator;
+    jest.clearAllMocks();
+  });
+
+  test('copy writes saved selection via clipboard API', async () => {
+    const { input, menu } = await loadModule();
+    openContextMenu(input);
+    await clickMenu(menu, 'copy');
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello');
+    expect(input.value).toBe('hello world');
+  });
+
+  test('cut removes selected text and writes to clipboard', async () => {
+    const { input, menu } = await loadModule();
+    openContextMenu(input);
+    await clickMenu(menu, 'cut');
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello');
+    expect(input.value).toBe(' world');
+  });
+
+  test('paste inserts clipboard text at saved caret position', async () => {
+    const input = createInput('hello world');
+    input.setSelectionRange(6, 6);
+    const { menu } = await loadModule({ input });
+
+    openContextMenu(input);
+    await clickMenu(menu, 'paste');
+
+    expect(navigator.clipboard.readText).toHaveBeenCalled();
+    expect(input.value).toBe('hello pastedworld');
+  });
+
+  test('falls back to electron copyText when clipboard write fails', async () => {
+    const { input, menu } = await loadModule();
+    navigator.clipboard.writeText.mockRejectedValueOnce(new Error('denied'));
+
+    openContextMenu(input);
+    await clickMenu(menu, 'copy');
+
+    expect(window.electronAPI.copyText).toHaveBeenCalledWith('hello');
+  });
+
+  test('falls back to electron readClipboardText when clipboard read fails', async () => {
+    const input = createInput('hello world');
+    input.setSelectionRange(6, 6);
+    const { menu } = await loadModule({ input });
+    navigator.clipboard.readText.mockRejectedValueOnce(new Error('denied'));
+
+    openContextMenu(input);
+    await clickMenu(menu, 'paste');
+
+    expect(window.electronAPI.readClipboardText).toHaveBeenCalled();
+    expect(input.value).toBe('hello pastedworld');
+  });
+});

--- a/src/renderer/lib/chrome-input-context-menu.test.js
+++ b/src/renderer/lib/chrome-input-context-menu.test.js
@@ -103,7 +103,13 @@ const loadModule = async ({ input, contextMenu, electronAPI } = {}) => {
       return null;
     }),
     addEventListener: jest.fn((event, handler) => {
-      documentHandlers[event] = handler;
+      const existing = documentHandlers[event];
+      documentHandlers[event] = existing
+        ? (...args) => {
+            existing(...args);
+            handler(...args);
+          }
+        : handler;
     }),
   };
 
@@ -142,15 +148,10 @@ const loadModule = async ({ input, contextMenu, electronAPI } = {}) => {
 
 const openContextMenu = (
   input,
-  {
-    collapseSelectionOnOpen = false,
-    skipMousedown = false,
-    mousedownAt = 100,
-    contextmenuAt = 110,
-  } = {}
+  { collapseSelectionOnOpen = false, skipMousedown = false } = {}
 ) => {
   if (!skipMousedown) {
-    input.handlers.mousedown?.({ button: 2, timeStamp: mousedownAt });
+    input.handlers.mousedown?.({ button: 2 });
   }
   if (collapseSelectionOnOpen) {
     const caret = input.value.length;
@@ -160,7 +161,6 @@ const openContextMenu = (
     preventDefault: jest.fn(),
     clientX: 10,
     clientY: 10,
-    timeStamp: contextmenuAt,
   });
 };
 
@@ -273,27 +273,56 @@ describe('chrome-input-context-menu', () => {
     expect(input.value).toBe('abpastedcdef');
   });
 
-  test('stale mousedown snapshot does not survive a later keyboard contextmenu', async () => {
-    const input = createInput('abcdef');
-    input.setSelectionRange(0, 3);
-    const { menu } = await loadModule({ input });
+  test('orphaned right-mousedown is cleared by the post-gesture document mouseup', async () => {
+    jest.useFakeTimers();
+    try {
+      const input = createInput('abcdef');
+      input.setSelectionRange(0, 3);
+      const { menu, documentHandlers } = await loadModule({ input });
 
-    // Right-mousedown captures [0, 3] but no contextmenu follows (e.g.
-    // user released the button outside the input).
-    input.handlers.mousedown({ button: 2, timeStamp: 100 });
+      // User right-mousedown inside the input captures [0, 3].
+      input.handlers.mousedown({ button: 2 });
 
-    // Much later, the caret moves and the user opens the menu via the
-    // keyboard menu key (no mousedown precedes the contextmenu).
-    input.setSelectionRange(5, 5);
-    input.handlers.contextmenu({
-      preventDefault: jest.fn(),
-      clientX: 10,
-      clientY: 10,
-      timeStamp: 5_000,
-    });
+      // User released the right button outside the input: no contextmenu
+      // on our input, but the document still sees the mouseup, which
+      // schedules a deferred clear of the orphaned snapshot.
+      documentHandlers.mouseup();
+      jest.runAllTimers();
 
-    await clickMenu(menu, 'paste');
-    expect(input.value).toBe('abcdepastedf');
+      // Later, the caret moves and the menu opens via the keyboard menu
+      // key (no mousedown precedes the contextmenu).
+      input.setSelectionRange(5, 5);
+      openContextMenu(input, { skipMousedown: true });
+
+      await clickMenu(menu, 'paste');
+      expect(input.value).toBe('abcdepastedf');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('document mouseup defer does not pre-empt a same-gesture contextmenu', async () => {
+    jest.useFakeTimers();
+    try {
+      const input = createInput('abcdef');
+      input.setSelectionRange(0, 3);
+      const { menu, documentHandlers } = await loadModule({ input });
+
+      // Real-world gesture: right-mousedown, then mouseup, then contextmenu
+      // are dispatched in separate event tasks. The mouseup-scheduled
+      // clear must not run before the contextmenu consumes the snapshot.
+      input.handlers.mousedown({ button: 2 });
+      documentHandlers.mouseup();
+      // Browser collapses the selection before contextmenu fires.
+      input.setSelectionRange(input.value.length, input.value.length);
+      openContextMenu(input, { skipMousedown: true });
+      jest.runAllTimers();
+
+      await clickMenu(menu, 'copy');
+      expect(window.electronAPI.copyText).toHaveBeenCalledWith('abc');
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test('non-right mousedown clears the captured snapshot', async () => {
@@ -301,12 +330,12 @@ describe('chrome-input-context-menu', () => {
     input.setSelectionRange(0, 3);
     const { menu } = await loadModule({ input });
 
-    input.handlers.mousedown({ button: 2, timeStamp: 100 });
+    input.handlers.mousedown({ button: 2 });
     // A subsequent left click invalidates the prior right-mousedown snapshot.
-    input.handlers.mousedown({ button: 0, timeStamp: 110 });
+    input.handlers.mousedown({ button: 0 });
     input.setSelectionRange(4, 4);
 
-    openContextMenu(input, { skipMousedown: true, contextmenuAt: 120 });
+    openContextMenu(input, { skipMousedown: true });
     await clickMenu(menu, 'paste');
     expect(input.value).toBe('abcdpastedef');
   });
@@ -316,13 +345,32 @@ describe('chrome-input-context-menu', () => {
     input.setSelectionRange(0, 3);
     const { menu } = await loadModule({ input });
 
-    input.handlers.mousedown({ button: 2, timeStamp: 100 });
+    input.handlers.mousedown({ button: 2 });
     input.handlers.blur?.();
     input.setSelectionRange(2, 2);
 
-    openContextMenu(input, { skipMousedown: true, contextmenuAt: 200 });
+    openContextMenu(input, { skipMousedown: true });
     await clickMenu(menu, 'paste');
     expect(input.value).toBe('abpastedcdef');
+  });
+
+  test('long right-button hold still uses the captured selection', async () => {
+    // Reviewer regression: the previous 500ms freshness heuristic
+    // discarded valid right-click selections if the user held the
+    // button for more than half a second.
+    const input = createInput('abcdef');
+    input.setSelectionRange(0, 3);
+    const { menu } = await loadModule({ input });
+
+    input.handlers.mousedown({ button: 2 });
+    // Browser collapses the selection between mousedown and contextmenu
+    // on a slow gesture (held button or system pause); no document
+    // mouseup fires until the user releases the button.
+    input.setSelectionRange(input.value.length, input.value.length);
+    openContextMenu(input, { skipMousedown: true });
+
+    await clickMenu(menu, 'copy');
+    expect(window.electronAPI.copyText).toHaveBeenCalledWith('abc');
   });
 
   test('disabled menu items are ignored', async () => {

--- a/src/renderer/lib/chrome-input-context-menu.test.js
+++ b/src/renderer/lib/chrome-input-context-menu.test.js
@@ -27,7 +27,10 @@ const createInput = (value = 'hello world') => {
     selectionStart,
     selectionEnd,
     focus: jest.fn(),
-    select: jest.fn(),
+    select: jest.fn(function selectAll() {
+      const end = this.value.length;
+      this.setSelectionRange(0, end);
+    }),
     setSelectionRange: jest.fn((start, end) => {
       selectionStart = start;
       selectionEnd = end;

--- a/src/renderer/lib/chrome-input-context-menu.test.js
+++ b/src/renderer/lib/chrome-input-context-menu.test.js
@@ -89,7 +89,7 @@ const createContextMenu = () => {
   };
 };
 
-const loadModule = async ({ input, contextMenu } = {}) => {
+const loadModule = async ({ input, contextMenu, electronAPI } = {}) => {
   jest.resetModules();
 
   const addressInput = input ?? createInput();
@@ -106,10 +106,13 @@ const loadModule = async ({ input, contextMenu } = {}) => {
   global.window = {
     innerWidth: 800,
     innerHeight: 600,
-    electronAPI: {
-      copyText: jest.fn().mockResolvedValue({ success: true }),
-      readClipboardText: jest.fn().mockResolvedValue({ success: true, text: 'pasted' }),
-    },
+    electronAPI:
+      electronAPI === null
+        ? undefined
+        : (electronAPI ?? {
+            copyText: jest.fn().mockResolvedValue({ success: true }),
+            readClipboardText: jest.fn().mockResolvedValue({ success: true, text: 'pasted' }),
+          }),
   };
 
   global.navigator = {
@@ -129,7 +132,12 @@ const loadModule = async ({ input, contextMenu } = {}) => {
   return { mod, input: addressInput, menu };
 };
 
-const openContextMenu = (input) => {
+const openContextMenu = (input, { collapseSelectionOnOpen = false } = {}) => {
+  input.handlers.mousedown?.({ button: 2 });
+  if (collapseSelectionOnOpen) {
+    const caret = input.value.length;
+    input.setSelectionRange(caret, caret);
+  }
   input.handlers.contextmenu({
     preventDefault: jest.fn(),
     clientX: 10,
@@ -164,7 +172,7 @@ describe('chrome-input-context-menu', () => {
     openContextMenu(input);
     await clickMenu(menu, 'copy');
 
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello');
+    expect(window.electronAPI.copyText).toHaveBeenCalledWith('hello');
     expect(input.value).toBe('hello world');
   });
 
@@ -173,7 +181,7 @@ describe('chrome-input-context-menu', () => {
     openContextMenu(input);
     await clickMenu(menu, 'cut');
 
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello');
+    expect(window.electronAPI.copyText).toHaveBeenCalledWith('hello');
     expect(input.value).toBe(' world');
   });
 
@@ -185,30 +193,38 @@ describe('chrome-input-context-menu', () => {
     openContextMenu(input);
     await clickMenu(menu, 'paste');
 
-    expect(navigator.clipboard.readText).toHaveBeenCalled();
+    expect(window.electronAPI.readClipboardText).toHaveBeenCalled();
     expect(input.value).toBe('hello pastedworld');
   });
 
-  test('falls back to electron copyText when clipboard write fails', async () => {
-    const { input, menu } = await loadModule();
-    navigator.clipboard.writeText.mockRejectedValueOnce(new Error('denied'));
-
+  test('falls back to navigator clipboard write when electron copy is unavailable', async () => {
+    const { input, menu } = await loadModule({ electronAPI: null });
     openContextMenu(input);
     await clickMenu(menu, 'copy');
 
-    expect(window.electronAPI.copyText).toHaveBeenCalledWith('hello');
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello');
   });
 
-  test('falls back to electron readClipboardText when clipboard read fails', async () => {
+  test('copy uses selection captured on right mousedown when contextmenu collapses it', async () => {
+    const input = createInput('copy-via-menu-69');
+    input.setSelectionRange(0, input.value.length);
+    const { menu } = await loadModule({ input });
+
+    openContextMenu(input, { collapseSelectionOnOpen: true });
+    await clickMenu(menu, 'copy');
+
+    expect(window.electronAPI.copyText).toHaveBeenCalledWith('copy-via-menu-69');
+  });
+
+  test('falls back to navigator clipboard read when electron read is unavailable', async () => {
     const input = createInput('hello world');
     input.setSelectionRange(6, 6);
-    const { menu } = await loadModule({ input });
-    navigator.clipboard.readText.mockRejectedValueOnce(new Error('denied'));
+    const { menu } = await loadModule({ input, electronAPI: null });
 
     openContextMenu(input);
     await clickMenu(menu, 'paste');
 
-    expect(window.electronAPI.readClipboardText).toHaveBeenCalled();
+    expect(navigator.clipboard.readText).toHaveBeenCalled();
     expect(input.value).toBe('hello pastedworld');
   });
 });

--- a/src/renderer/lib/chrome-input-context-menu.test.js
+++ b/src/renderer/lib/chrome-input-context-menu.test.js
@@ -140,9 +140,17 @@ const loadModule = async ({ input, contextMenu, electronAPI } = {}) => {
   return { mod, input: addressInput, menu, documentHandlers, windowHandlers };
 };
 
-const openContextMenu = (input, { collapseSelectionOnOpen = false, skipMousedown = false } = {}) => {
+const openContextMenu = (
+  input,
+  {
+    collapseSelectionOnOpen = false,
+    skipMousedown = false,
+    mousedownAt = 100,
+    contextmenuAt = 110,
+  } = {}
+) => {
   if (!skipMousedown) {
-    input.handlers.mousedown?.({ button: 2 });
+    input.handlers.mousedown?.({ button: 2, timeStamp: mousedownAt });
   }
   if (collapseSelectionOnOpen) {
     const caret = input.value.length;
@@ -152,6 +160,7 @@ const openContextMenu = (input, { collapseSelectionOnOpen = false, skipMousedown
     preventDefault: jest.fn(),
     clientX: 10,
     clientY: 10,
+    timeStamp: contextmenuAt,
   });
 };
 
@@ -261,6 +270,58 @@ describe('chrome-input-context-menu', () => {
     openContextMenu(input, { skipMousedown: true });
     await clickMenu(menu, 'paste');
 
+    expect(input.value).toBe('abpastedcdef');
+  });
+
+  test('stale mousedown snapshot does not survive a later keyboard contextmenu', async () => {
+    const input = createInput('abcdef');
+    input.setSelectionRange(0, 3);
+    const { menu } = await loadModule({ input });
+
+    // Right-mousedown captures [0, 3] but no contextmenu follows (e.g.
+    // user released the button outside the input).
+    input.handlers.mousedown({ button: 2, timeStamp: 100 });
+
+    // Much later, the caret moves and the user opens the menu via the
+    // keyboard menu key (no mousedown precedes the contextmenu).
+    input.setSelectionRange(5, 5);
+    input.handlers.contextmenu({
+      preventDefault: jest.fn(),
+      clientX: 10,
+      clientY: 10,
+      timeStamp: 5_000,
+    });
+
+    await clickMenu(menu, 'paste');
+    expect(input.value).toBe('abcdepastedf');
+  });
+
+  test('non-right mousedown clears the captured snapshot', async () => {
+    const input = createInput('abcdef');
+    input.setSelectionRange(0, 3);
+    const { menu } = await loadModule({ input });
+
+    input.handlers.mousedown({ button: 2, timeStamp: 100 });
+    // A subsequent left click invalidates the prior right-mousedown snapshot.
+    input.handlers.mousedown({ button: 0, timeStamp: 110 });
+    input.setSelectionRange(4, 4);
+
+    openContextMenu(input, { skipMousedown: true, contextmenuAt: 120 });
+    await clickMenu(menu, 'paste');
+    expect(input.value).toBe('abcdpastedef');
+  });
+
+  test('input blur clears the captured snapshot', async () => {
+    const input = createInput('abcdef');
+    input.setSelectionRange(0, 3);
+    const { menu } = await loadModule({ input });
+
+    input.handlers.mousedown({ button: 2, timeStamp: 100 });
+    input.handlers.blur?.();
+    input.setSelectionRange(2, 2);
+
+    openContextMenu(input, { skipMousedown: true, contextmenuAt: 200 });
+    await clickMenu(menu, 'paste');
     expect(input.value).toBe('abpastedcdef');
   });
 

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -49,7 +49,8 @@ test.describe('address bar clipboard', () => {
 
   test('Edit menu exposes clipboard roles', async ({ electronApp }) => {
     const menu = await electronApp.evaluate(inspectApplicationMenu());
-    expect(menu.roles).toEqual(expect.arrayContaining(['cut', 'copy', 'paste', 'selectAll']));
+    const roles = menu.roles.map((role) => role.toLowerCase());
+    expect(roles).toEqual(expect.arrayContaining(['cut', 'copy', 'paste', 'selectall']));
   });
 
   test('right-click shows Cut/Copy/Paste/Select All on the address bar', async ({ window }) => {

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -35,16 +35,17 @@ test.describe('address bar clipboard', () => {
   test('application menu excludes macOS-only roles', async ({ electronApp }) => {
     const top = await getTopMenuLabels(electronApp);
     expect(top).not.toContain('appMenu');
-    expect(top[0]).toBe('File');
+    expect(top).not.toContain('windowMenu');
+    expect(top.some((entry) => entry === 'File' || entry === 'fileMenu')).toBe(true);
     expect(top).toContain('Edit');
   });
 
-  test('Edit menu registers Ctrl+C/V/X/A accelerators', async ({ electronApp }) => {
+  test('Edit menu registers standard copy/cut/paste/select-all accelerators', async ({ electronApp }) => {
     const accelerators = await getEditAccelerators(electronApp);
-    expect(accelerators.copy).toBe('Ctrl+C');
-    expect(accelerators.cut).toBe('Ctrl+X');
-    expect(accelerators.paste).toBe('Ctrl+V');
-    expect(accelerators.selectAll).toBe('Ctrl+A');
+    expect(accelerators.copy).toMatch(/Control\+C$/);
+    expect(accelerators.cut).toMatch(/Control\+X$/);
+    expect(accelerators.paste).toMatch(/Control\+V$/);
+    expect(accelerators.selectAll).toMatch(/Control\+A$/);
   });
 
   test('right-click shows Cut/Copy/Paste/Select All on the address bar', async ({ window }) => {

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -12,10 +12,17 @@ const modifier = process.env.E2E_CLIPBOARD_MODIFIER || (isDarwin ? 'Meta' : 'Con
 async function readApplicationMenu(electronApp) {
   let menu;
   await expect
-    .poll(async () => {
-      menu = await electronApp.evaluate(inspectApplicationMenu());
-      return menu.ready;
-    })
+    .poll(
+      async () => {
+        try {
+          menu = await electronApp.evaluate(inspectApplicationMenu());
+        } catch {
+          return false;
+        }
+        return menu.ready;
+      },
+      { timeout: 30_000 }
+    )
     .toBe(true);
   return menu;
 }

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -1,16 +1,82 @@
-// Address-bar clipboard shortcuts on Windows/Linux (issue #69).
+// Address-bar clipboard on Windows/Linux (issue #69).
 //
-// Standard Edit-menu accelerators (Ctrl+C/V/X/A) must work in chrome inputs
-// when the menu bar is hidden. macOS uses Cmd via appMenu and is covered
-// separately if needed.
+// Playwright keyboard events can satisfy native <input> editing without the
+// application Edit menu, so these specs assert menu wiring and the chrome
+// right-click menu that users rely on when accelerators are missing.
 
 const { test, expect } = require('./fixtures');
 
 const isDarwin = process.platform === 'darwin';
 const modifier = process.env.E2E_CLIPBOARD_MODIFIER || (isDarwin ? 'Meta' : 'Control');
 
+async function getEditAccelerators(electronApp) {
+  return electronApp.evaluate(() => {
+    const { Menu } = require('electron');
+    const edit = Menu.getApplicationMenu()?.items.find((item) => item.label === 'Edit');
+    if (!edit?.submenu) return {};
+    const pick = (role) => edit.submenu.items.find((item) => item.role === role)?.accelerator ?? null;
+    return {
+      cut: pick('cut'),
+      copy: pick('copy'),
+      paste: pick('paste'),
+      selectAll: pick('selectAll'),
+    };
+  });
+}
+
+async function getTopMenuLabels(electronApp) {
+  return electronApp.evaluate(() => {
+    const { Menu } = require('electron');
+    return Menu.getApplicationMenu()?.items.map((item) => item.role || item.label) ?? [];
+  });
+}
+
 test.describe('address bar clipboard', () => {
   test.skip(isDarwin, 'issue #69 is Windows/Linux only');
+
+  test('application menu excludes macOS-only roles', async ({ electronApp }) => {
+    const top = await getTopMenuLabels(electronApp);
+    expect(top).not.toContain('appMenu');
+    expect(top[0]).toBe('File');
+    expect(top).toContain('Edit');
+  });
+
+  test('Edit menu registers Ctrl+C/V/X/A accelerators', async ({ electronApp }) => {
+    const accelerators = await getEditAccelerators(electronApp);
+    expect(accelerators.copy).toBe('Ctrl+C');
+    expect(accelerators.cut).toBe('Ctrl+X');
+    expect(accelerators.paste).toBe('Ctrl+V');
+    expect(accelerators.selectAll).toBe('Ctrl+A');
+  });
+
+  test('right-click shows Cut/Copy/Paste/Select All on the address bar', async ({ window }) => {
+    const input = window.locator('[data-test="address-input"]');
+    const menu = window.locator('[data-test="chrome-input-context-menu"]');
+
+    await input.click();
+    await input.fill('context-menu-69');
+    await input.click({ button: 'right' });
+
+    await expect(menu).toBeVisible();
+    await expect(menu.getByRole('button', { name: 'Cut' })).toBeVisible();
+    await expect(menu.getByRole('button', { name: 'Copy' })).toBeVisible();
+    await expect(menu.getByRole('button', { name: 'Paste' })).toBeVisible();
+    await expect(menu.getByRole('button', { name: 'Select All' })).toBeVisible();
+  });
+
+  test('context menu Paste inserts clipboard text', async ({ window, electronApp }) => {
+    const input = window.locator('[data-test="address-input"]');
+    const menu = window.locator('[data-test="chrome-input-context-menu"]');
+    const sample = 'paste-via-menu-69';
+
+    await electronApp.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), sample);
+    await input.click();
+    await input.fill('');
+    await input.click({ button: 'right' });
+    await menu.getByRole('button', { name: 'Paste' }).click();
+
+    await expect(input).toHaveValue(sample);
+  });
 
   test('Ctrl shortcuts copy, cut, and paste in the address bar', async ({ window, electronApp }) => {
     const input = window.locator('[data-test="address-input"]');

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -9,6 +9,27 @@ const { test, expect } = require('./fixtures');
 const isDarwin = process.platform === 'darwin';
 const modifier = process.env.E2E_CLIPBOARD_MODIFIER || (isDarwin ? 'Meta' : 'Control');
 
+async function selectAllInInput(input) {
+  await input.evaluate((el) => {
+    el.focus();
+    el.select();
+    if (el.selectionStart !== 0 || el.selectionEnd !== el.value.length) {
+      el.setSelectionRange(0, el.value.length);
+    }
+  });
+}
+
+async function expectRendererClipboard(window, sample) {
+  await expect
+    .poll(() =>
+      window.evaluate(async () => {
+        const result = await window.electronAPI.readClipboardText();
+        return result?.text ?? '';
+      })
+    )
+    .toBe(sample);
+}
+
 async function readApplicationMenu(electronApp) {
   let menu;
   await expect
@@ -74,86 +95,94 @@ test.describe('address bar application menu (Windows/Linux)', () => {
 });
 
 test.describe('address bar chrome context menu', () => {
-  test('right-click shows Cut/Copy/Paste/Select All on the address bar', async ({ window }) => {
+  const dismissChromeInputMenu = async (window) => {
+    const menu = window.locator('[data-test="chrome-input-context-menu"]');
+    if (!(await menu.isVisible())) {
+      return;
+    }
+
+    await window.keyboard.press('Escape');
+
+    const backdrop = window.locator('#menu-backdrop');
+    if (await backdrop.isVisible()) {
+      await backdrop.click({ force: true });
+    }
+
+    try {
+      await expect(menu).toBeHidden({ timeout: 2_000 });
+    } catch {
+      await window.evaluate(() => {
+        document.getElementById('chrome-input-context-menu')?.classList.add('hidden');
+        document.getElementById('menu-backdrop')?.classList.add('hidden');
+      });
+      await expect(menu).toBeHidden();
+    }
+  };
+
+  test('chrome context menu cut, copy, paste, and select all', async ({ window, electronApp }) => {
+    test.setTimeout(60_000);
+
     const input = window.locator('[data-test="address-input"]');
     const menu = window.locator('[data-test="chrome-input-context-menu"]');
 
     await input.click();
     await input.fill('context-menu-69');
     await input.click({ button: 'right' });
-
     await expect(menu).toBeVisible();
     await expect(menu.getByRole('button', { name: 'Cut' })).toBeVisible();
     await expect(menu.getByRole('button', { name: 'Copy' })).toBeVisible();
     await expect(menu.getByRole('button', { name: 'Paste' })).toBeVisible();
     await expect(menu.getByRole('button', { name: 'Select All' })).toBeVisible();
-  });
+    await dismissChromeInputMenu(window);
 
-  test('context menu Copy writes selection to the clipboard', async ({ window, electronApp }) => {
-    const input = window.locator('[data-test="address-input"]');
-    const menu = window.locator('[data-test="chrome-input-context-menu"]');
-    const sample = 'copy-via-menu-69';
-
-    await input.click();
-    await input.fill(sample);
-    await input.press(`${modifier}+a`);
+    const copySample = 'copy-via-menu-69';
+    await input.fill(copySample);
+    await selectAllInInput(input);
     await input.click({ button: 'right' });
+    await expect(menu.getByRole('button', { name: 'Copy' })).toBeEnabled();
     await menu.getByRole('button', { name: 'Copy' }).click();
-
     await expect
       .poll(() => electronApp.evaluate(({ clipboard }) => clipboard.readText()))
-      .toBe(sample);
-  });
+      .toBe(copySample);
+    await dismissChromeInputMenu(window);
 
-  test('context menu Cut clears selection and copies to clipboard', async ({ window, electronApp }) => {
-    const input = window.locator('[data-test="address-input"]');
-    const menu = window.locator('[data-test="chrome-input-context-menu"]');
-    const sample = 'cut-via-menu-69';
-
-    await input.click();
-    await input.fill(sample);
-    await input.press(`${modifier}+a`);
+    const cutSample = 'cut-via-menu-69';
+    await input.fill(cutSample);
+    await selectAllInInput(input);
     await input.click({ button: 'right' });
+    await expect(menu.getByRole('button', { name: 'Cut' })).toBeEnabled();
     await menu.getByRole('button', { name: 'Cut' }).click();
-
     await expect(input).toHaveValue('');
     await expect
       .poll(() => electronApp.evaluate(({ clipboard }) => clipboard.readText()))
-      .toBe(sample);
-  });
+      .toBe(cutSample);
+    await dismissChromeInputMenu(window);
 
-  test('context menu Paste inserts clipboard text', async ({ window, electronApp }) => {
-    const input = window.locator('[data-test="address-input"]');
-    const menu = window.locator('[data-test="chrome-input-context-menu"]');
-    const sample = 'paste-via-menu-69';
-
-    await electronApp.evaluate(({ clipboard }, text) => clipboard.writeText(text), sample);
-    await expect
-      .poll(() => electronApp.evaluate(({ clipboard }) => clipboard.readText()))
-      .toBe(sample);
-
-    await input.click();
-    await input.fill('');
+    const pasteSample = 'paste-via-menu-69';
+    await electronApp.evaluate(({ clipboard }, text) => clipboard.writeText(text), pasteSample);
+    await expectRendererClipboard(window, pasteSample);
+    await input.evaluate((el) => {
+      el.value = '';
+      el.setSelectionRange(0, 0);
+    });
     await input.click({ button: 'right' });
+    await expect(menu.getByRole('button', { name: 'Paste' })).toBeEnabled();
     await menu.getByRole('button', { name: 'Paste' }).click();
+    await expect.poll(async () => input.inputValue(), { timeout: 15_000 }).toBe(pasteSample);
+    await dismissChromeInputMenu(window);
 
-    await expect.poll(async () => input.inputValue(), { timeout: 15_000 }).toBe(sample);
-  });
-
-  test('context menu Select All then Copy copies the full address', async ({ window, electronApp }) => {
-    const input = window.locator('[data-test="address-input"]');
-    const menu = window.locator('[data-test="chrome-input-context-menu"]');
-    const sample = 'select-all-via-menu-69';
-
-    await input.click();
-    await input.fill(sample);
+    const selectAllSample = 'select-all-via-menu-69';
+    await input.fill(selectAllSample);
     await input.click({ button: 'right' });
     await menu.getByRole('button', { name: 'Select All' }).click();
-    await input.press(`${modifier}+c`);
-
+    await dismissChromeInputMenu(window);
+    await input.click({ button: 'right' });
+    await expect(menu.getByRole('button', { name: 'Copy' })).toBeEnabled();
+    await menu.getByRole('button', { name: 'Copy' }).click();
     await expect
       .poll(() => electronApp.evaluate(({ clipboard }) => clipboard.readText()))
-      .toBe(sample);
+      .toBe(selectAllSample);
+    await dismissChromeInputMenu(window);
   });
 
   test(`${modifier} shortcuts copy, cut, and paste in the address bar`, async ({ window, electronApp }) => {

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -1,8 +1,8 @@
-// Address-bar clipboard on Windows/Linux (issue #69).
+// Address-bar clipboard (issue #69).
 //
-// Playwright keyboard events can satisfy native <input> editing without the
-// application Edit menu, so these specs assert menu wiring and the chrome
-// right-click menu that users rely on when accelerators are missing.
+// Win/Linux: application Edit menu must expose clipboard roles when the menu
+// bar is hidden. All platforms: chrome right-click menu must edit the address
+// bar (execCommand loses selection when the menu steals focus).
 
 const { test, expect } = require('./fixtures');
 
@@ -35,8 +35,8 @@ function inspectApplicationMenu() {
   };
 }
 
-test.describe('address bar clipboard', () => {
-  test.skip(isDarwin, 'issue #69 is Windows/Linux only');
+test.describe('address bar application menu (Windows/Linux)', () => {
+  test.skip(isDarwin, 'macOS uses native app/window/edit menu roles');
 
   test('application menu excludes macOS-only roles', async ({ electronApp }) => {
     const menu = await electronApp.evaluate(inspectApplicationMenu());
@@ -52,7 +52,9 @@ test.describe('address bar clipboard', () => {
     const roles = menu.roles.map((role) => role.toLowerCase());
     expect(roles).toEqual(expect.arrayContaining(['cut', 'copy', 'paste', 'selectall']));
   });
+});
 
+test.describe('address bar chrome context menu', () => {
   test('right-click shows Cut/Copy/Paste/Select All on the address bar', async ({ window }) => {
     const input = window.locator('[data-test="address-input"]');
     const menu = window.locator('[data-test="chrome-input-context-menu"]');
@@ -84,7 +86,59 @@ test.describe('address bar clipboard', () => {
       .toBe(sample);
   });
 
-  test('Ctrl shortcuts copy, cut, and paste in the address bar', async ({ window, electronApp }) => {
+  test('context menu Cut clears selection and copies to clipboard', async ({ window, electronApp }) => {
+    const input = window.locator('[data-test="address-input"]');
+    const menu = window.locator('[data-test="chrome-input-context-menu"]');
+    const sample = 'cut-via-menu-69';
+
+    await input.click();
+    await input.fill(sample);
+    await input.press(`${modifier}+a`);
+    await input.click({ button: 'right' });
+    await menu.getByRole('button', { name: 'Cut' }).click();
+
+    await expect(input).toHaveValue('');
+    await expect
+      .poll(() => electronApp.evaluate(({ clipboard }) => clipboard.readText()))
+      .toBe(sample);
+  });
+
+  test('context menu Paste inserts clipboard text', async ({ window, electronApp }) => {
+    const input = window.locator('[data-test="address-input"]');
+    const menu = window.locator('[data-test="chrome-input-context-menu"]');
+    const sample = 'paste-via-menu-69';
+
+    await electronApp.evaluate(({ clipboard }, text) => clipboard.writeText(text), sample);
+
+    await input.click();
+    await input.fill('');
+    await input.click({ button: 'right' });
+    await menu.getByRole('button', { name: 'Paste' }).click();
+
+    await expect(input).toHaveValue(sample);
+  });
+
+  test('context menu Select All selects the full address', async ({ window }) => {
+    const input = window.locator('[data-test="address-input"]');
+    const menu = window.locator('[data-test="chrome-input-context-menu"]');
+    const sample = 'select-all-via-menu-69';
+
+    await input.click();
+    await input.fill(sample);
+    await input.click({ button: 'right' });
+    await menu.getByRole('button', { name: 'Select All' }).click();
+
+    const selection = await input.evaluate((el) => ({
+      start: el.selectionStart,
+      end: el.selectionEnd,
+      length: el.value.length,
+    }));
+    expect(selection.start).toBe(0);
+    expect(selection.end).toBe(selection.length);
+    expect(selection.length).toBe(sample.length);
+  });
+
+  test(`${modifier} shortcuts copy, cut, and paste in the address bar`, async ({ window, electronApp }) => {
     const input = window.locator('[data-test="address-input"]');
     const sample = 'freedom-clipboard-69';
 

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -121,13 +121,16 @@ test.describe('address bar chrome context menu', () => {
     const sample = 'paste-via-menu-69';
 
     await electronApp.evaluate(({ clipboard }, text) => clipboard.writeText(text), sample);
+    await expect
+      .poll(() => electronApp.evaluate(({ clipboard }) => clipboard.readText()))
+      .toBe(sample);
 
     await input.click();
     await input.fill('');
     await input.click({ button: 'right' });
     await menu.getByRole('button', { name: 'Paste' }).click();
 
-    await expect.poll(async () => input.inputValue()).toBe(sample);
+    await expect.poll(async () => input.inputValue(), { timeout: 15_000 }).toBe(sample);
   });
 
   test('context menu Select All selects the full address', async ({ window }) => {

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -9,20 +9,6 @@ const { test, expect } = require('./fixtures');
 const isDarwin = process.platform === 'darwin';
 const modifier = process.env.E2E_CLIPBOARD_MODIFIER || (isDarwin ? 'Meta' : 'Control');
 
-async function getEditAccelerators(electronApp) {
-  return electronApp.evaluate(({ Menu }) => {
-    const edit = Menu.getApplicationMenu()?.items.find((item) => item.label === 'Edit');
-    if (!edit?.submenu) return {};
-    const pick = (role) => edit.submenu.items.find((item) => item.role === role)?.accelerator ?? null;
-    return {
-      cut: pick('cut'),
-      copy: pick('copy'),
-      paste: pick('paste'),
-      selectAll: pick('selectAll'),
-    };
-  });
-}
-
 async function getTopMenuLabels(electronApp) {
   return electronApp.evaluate(({ Menu }) => {
     return Menu.getApplicationMenu()?.items.map((item) => item.role || item.label) ?? [];
@@ -36,16 +22,19 @@ test.describe('address bar clipboard', () => {
     const top = await getTopMenuLabels(electronApp);
     expect(top).not.toContain('appMenu');
     expect(top).not.toContain('windowMenu');
-    expect(top.some((entry) => entry === 'File' || entry === 'fileMenu')).toBe(true);
+    expect(top.some((entry) => /file/i.test(String(entry)))).toBe(true);
     expect(top).toContain('Edit');
   });
 
-  test('Edit menu registers standard copy/cut/paste/select-all accelerators', async ({ electronApp }) => {
-    const accelerators = await getEditAccelerators(electronApp);
-    expect(accelerators.copy).toMatch(/Control\+C$/);
-    expect(accelerators.cut).toMatch(/Control\+X$/);
-    expect(accelerators.paste).toMatch(/Control\+V$/);
-    expect(accelerators.selectAll).toMatch(/Control\+A$/);
+  test('Edit menu exposes clipboard roles', async ({ electronApp }) => {
+    const roles = await electronApp.evaluate(({ Menu }) => {
+      const topItems = Menu.getApplicationMenu()?.items ?? [];
+      const editSubmenu =
+        topItems.find((item) => item.label === 'Edit')?.submenu ??
+        topItems.find((item) => item.submenu?.items?.some((entry) => entry.role === 'copy'))?.submenu;
+      return editSubmenu?.items.map((item) => item.role).filter(Boolean) ?? [];
+    });
+    expect(roles).toEqual(expect.arrayContaining(['cut', 'copy', 'paste', 'selectAll']));
   });
 
   test('right-click shows Cut/Copy/Paste/Select All on the address bar', async ({ window }) => {

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -151,7 +151,7 @@ test.describe('address bar chrome context menu', () => {
             end: el.selectionEnd,
             length: el.value.length,
           })),
-        { timeout: 15_000 }
+        { timeout: 30_000 }
       )
       .toEqual({ start: 0, end: sample.length, length: sample.length });
   });

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -115,7 +115,7 @@ test.describe('address bar chrome context menu', () => {
     await input.click({ button: 'right' });
     await menu.getByRole('button', { name: 'Paste' }).click();
 
-    await expect(input).toHaveValue(sample);
+    await expect.poll(async () => input.inputValue()).toBe(sample);
   });
 
   test('context menu Select All selects the full address', async ({ window }) => {
@@ -128,14 +128,15 @@ test.describe('address bar chrome context menu', () => {
     await input.click({ button: 'right' });
     await menu.getByRole('button', { name: 'Select All' }).click();
 
-    const selection = await input.evaluate((el) => ({
-      start: el.selectionStart,
-      end: el.selectionEnd,
-      length: el.value.length,
-    }));
-    expect(selection.start).toBe(0);
-    expect(selection.end).toBe(selection.length);
-    expect(selection.length).toBe(sample.length);
+    await expect
+      .poll(async () =>
+        input.evaluate((el) => ({
+          start: el.selectionStart,
+          end: el.selectionEnd,
+          length: el.value.length,
+        }))
+      )
+      .toEqual({ start: 0, end: sample.length, length: sample.length });
   });
 
   test(`${modifier} shortcuts copy, cut, and paste in the address bar`, async ({ window, electronApp }) => {

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -10,8 +10,7 @@ const isDarwin = process.platform === 'darwin';
 const modifier = process.env.E2E_CLIPBOARD_MODIFIER || (isDarwin ? 'Meta' : 'Control');
 
 async function getEditAccelerators(electronApp) {
-  return electronApp.evaluate(() => {
-    const { Menu } = require('electron');
+  return electronApp.evaluate(({ Menu }) => {
     const edit = Menu.getApplicationMenu()?.items.find((item) => item.label === 'Edit');
     if (!edit?.submenu) return {};
     const pick = (role) => edit.submenu.items.find((item) => item.role === role)?.accelerator ?? null;
@@ -25,8 +24,7 @@ async function getEditAccelerators(electronApp) {
 }
 
 async function getTopMenuLabels(electronApp) {
-  return electronApp.evaluate(() => {
-    const { Menu } = require('electron');
+  return electronApp.evaluate(({ Menu }) => {
     return Menu.getApplicationMenu()?.items.map((item) => item.role || item.label) ?? [];
   });
 }
@@ -64,18 +62,20 @@ test.describe('address bar clipboard', () => {
     await expect(menu.getByRole('button', { name: 'Select All' })).toBeVisible();
   });
 
-  test('context menu Paste inserts clipboard text', async ({ window, electronApp }) => {
+  test('context menu Copy writes selection to the clipboard', async ({ window, electronApp }) => {
     const input = window.locator('[data-test="address-input"]');
     const menu = window.locator('[data-test="chrome-input-context-menu"]');
-    const sample = 'paste-via-menu-69';
+    const sample = 'copy-via-menu-69';
 
-    await electronApp.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), sample);
     await input.click();
-    await input.fill('');
+    await input.fill(sample);
+    await input.press(`${modifier}+a`);
     await input.click({ button: 'right' });
-    await menu.getByRole('button', { name: 'Paste' }).click();
+    await menu.getByRole('button', { name: 'Copy' }).click();
 
-    await expect(input).toHaveValue(sample);
+    await expect
+      .poll(() => electronApp.evaluate(({ clipboard }) => clipboard.readText()))
+      .toBe(sample);
   });
 
   test('Ctrl shortcuts copy, cut, and paste in the address bar', async ({ window, electronApp }) => {

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -9,6 +9,17 @@ const { test, expect } = require('./fixtures');
 const isDarwin = process.platform === 'darwin';
 const modifier = process.env.E2E_CLIPBOARD_MODIFIER || (isDarwin ? 'Meta' : 'Control');
 
+async function readApplicationMenu(electronApp) {
+  let menu;
+  await expect
+    .poll(async () => {
+      menu = await electronApp.evaluate(inspectApplicationMenu());
+      return menu.ready;
+    })
+    .toBe(true);
+  return menu;
+}
+
 function inspectApplicationMenu() {
   return ({ Menu }) => {
     const menu = Menu.getApplicationMenu();
@@ -38,17 +49,18 @@ function inspectApplicationMenu() {
 test.describe('address bar application menu (Windows/Linux)', () => {
   test.skip(isDarwin, 'macOS uses native app/window/edit menu roles');
 
-  test('application menu excludes macOS-only roles', async ({ electronApp }) => {
-    const menu = await electronApp.evaluate(inspectApplicationMenu());
-    expect(menu.ready).toBe(true);
+  test('application menu excludes macOS-only roles', async ({ electronApp, window }) => {
+    await expect(window.locator('[data-test="address-input"]')).toBeVisible();
+    const menu = await readApplicationMenu(electronApp);
     expect(menu.hasAppMenu).toBe(false);
     expect(menu.hasWindowMenu).toBe(false);
     expect(menu.hasFileMenu).toBe(true);
     expect(menu.hasEditMenu).toBe(true);
   });
 
-  test('Edit menu exposes clipboard roles', async ({ electronApp }) => {
-    const menu = await electronApp.evaluate(inspectApplicationMenu());
+  test('Edit menu exposes clipboard roles', async ({ electronApp, window }) => {
+    await expect(window.locator('[data-test="address-input"]')).toBeVisible();
+    const menu = await readApplicationMenu(electronApp);
     const roles = menu.roles.map((role) => role.toLowerCase());
     expect(roles).toEqual(expect.arrayContaining(['cut', 'copy', 'paste', 'selectall']));
   });

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -129,12 +129,14 @@ test.describe('address bar chrome context menu', () => {
     await menu.getByRole('button', { name: 'Select All' }).click();
 
     await expect
-      .poll(async () =>
-        input.evaluate((el) => ({
-          start: el.selectionStart,
-          end: el.selectionEnd,
-          length: el.value.length,
-        }))
+      .poll(
+        async () =>
+          input.evaluate((el) => ({
+            start: el.selectionStart,
+            end: el.selectionEnd,
+            length: el.value.length,
+          })),
+        { timeout: 15_000 }
       )
       .toEqual({ start: 0, end: sample.length, length: sample.length });
   });

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -9,32 +9,47 @@ const { test, expect } = require('./fixtures');
 const isDarwin = process.platform === 'darwin';
 const modifier = process.env.E2E_CLIPBOARD_MODIFIER || (isDarwin ? 'Meta' : 'Control');
 
-async function getTopMenuLabels(electronApp) {
-  return electronApp.evaluate(({ Menu }) => {
-    return Menu.getApplicationMenu()?.items.map((item) => item.role || item.label) ?? [];
-  });
+function inspectApplicationMenu() {
+  return ({ Menu }) => {
+    const menu = Menu.getApplicationMenu();
+    if (!menu) {
+      return { ready: false };
+    }
+
+    const top = menu.items.map((item) => item.role || item.label);
+    const editSubmenu =
+      menu.items.find((item) => item.label === 'Edit')?.submenu ??
+      menu.items.find((item) => item.submenu?.items?.some((entry) => entry.role === 'copy'))
+        ?.submenu;
+    const roles = editSubmenu?.items.map((item) => item.role).filter(Boolean) ?? [];
+
+    return {
+      ready: true,
+      top,
+      hasAppMenu: top.includes('appMenu'),
+      hasWindowMenu: top.includes('windowMenu'),
+      hasFileMenu: top.some((entry) => /file/i.test(String(entry))),
+      hasEditMenu: Boolean(editSubmenu),
+      roles,
+    };
+  };
 }
 
 test.describe('address bar clipboard', () => {
   test.skip(isDarwin, 'issue #69 is Windows/Linux only');
 
   test('application menu excludes macOS-only roles', async ({ electronApp }) => {
-    const top = await getTopMenuLabels(electronApp);
-    expect(top).not.toContain('appMenu');
-    expect(top).not.toContain('windowMenu');
-    expect(top.some((entry) => /file/i.test(String(entry)))).toBe(true);
-    expect(top).toContain('Edit');
+    const menu = await electronApp.evaluate(inspectApplicationMenu());
+    expect(menu.ready).toBe(true);
+    expect(menu.hasAppMenu).toBe(false);
+    expect(menu.hasWindowMenu).toBe(false);
+    expect(menu.hasFileMenu).toBe(true);
+    expect(menu.hasEditMenu).toBe(true);
   });
 
   test('Edit menu exposes clipboard roles', async ({ electronApp }) => {
-    const roles = await electronApp.evaluate(({ Menu }) => {
-      const topItems = Menu.getApplicationMenu()?.items ?? [];
-      const editSubmenu =
-        topItems.find((item) => item.label === 'Edit')?.submenu ??
-        topItems.find((item) => item.submenu?.items?.some((entry) => entry.role === 'copy'))?.submenu;
-      return editSubmenu?.items.map((item) => item.role).filter(Boolean) ?? [];
-    });
-    expect(roles).toEqual(expect.arrayContaining(['cut', 'copy', 'paste', 'selectAll']));
+    const menu = await electronApp.evaluate(inspectApplicationMenu());
+    expect(menu.roles).toEqual(expect.arrayContaining(['cut', 'copy', 'paste', 'selectAll']));
   });
 
   test('right-click shows Cut/Copy/Paste/Select All on the address bar', async ({ window }) => {

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -140,7 +140,7 @@ test.describe('address bar chrome context menu', () => {
     await expect.poll(async () => input.inputValue(), { timeout: 15_000 }).toBe(sample);
   });
 
-  test('context menu Select All selects the full address', async ({ window }) => {
+  test('context menu Select All then Copy copies the full address', async ({ window, electronApp }) => {
     const input = window.locator('[data-test="address-input"]');
     const menu = window.locator('[data-test="chrome-input-context-menu"]');
     const sample = 'select-all-via-menu-69';
@@ -149,18 +149,11 @@ test.describe('address bar chrome context menu', () => {
     await input.fill(sample);
     await input.click({ button: 'right' });
     await menu.getByRole('button', { name: 'Select All' }).click();
+    await input.press(`${modifier}+c`);
 
     await expect
-      .poll(
-        async () =>
-          input.evaluate((el) => ({
-            start: el.selectionStart,
-            end: el.selectionEnd,
-            length: el.value.length,
-          })),
-        { timeout: 30_000 }
-      )
-      .toEqual({ start: 0, end: sample.length, length: sample.length });
+      .poll(() => electronApp.evaluate(({ clipboard }) => clipboard.readText()))
+      .toBe(sample);
   });
 
   test(`${modifier} shortcuts copy, cut, and paste in the address bar`, async ({ window, electronApp }) => {

--- a/test-e2e/address-bar-clipboard.spec.js
+++ b/test-e2e/address-bar-clipboard.spec.js
@@ -1,0 +1,41 @@
+// Address-bar clipboard shortcuts on Windows/Linux (issue #69).
+//
+// Standard Edit-menu accelerators (Ctrl+C/V/X/A) must work in chrome inputs
+// when the menu bar is hidden. macOS uses Cmd via appMenu and is covered
+// separately if needed.
+
+const { test, expect } = require('./fixtures');
+
+const isDarwin = process.platform === 'darwin';
+const modifier = process.env.E2E_CLIPBOARD_MODIFIER || (isDarwin ? 'Meta' : 'Control');
+
+test.describe('address bar clipboard', () => {
+  test.skip(isDarwin, 'issue #69 is Windows/Linux only');
+
+  test('Ctrl shortcuts copy, cut, and paste in the address bar', async ({ window, electronApp }) => {
+    const input = window.locator('[data-test="address-input"]');
+    const sample = 'freedom-clipboard-69';
+
+    await input.click();
+    await input.fill(sample);
+
+    await input.press(`${modifier}+a`);
+    await input.press(`${modifier}+c`);
+
+    const copied = await electronApp.evaluate(async ({ clipboard }) => clipboard.readText());
+    expect(copied).toBe(sample);
+
+    await input.fill('');
+    await expect(input).toHaveValue('');
+
+    await input.press(`${modifier}+v`);
+    await expect(input).toHaveValue(sample);
+
+    await input.press(`${modifier}+a`);
+    await input.press(`${modifier}+x`);
+    await expect(input).toHaveValue('');
+
+    const cut = await electronApp.evaluate(async ({ clipboard }) => clipboard.readText());
+    expect(cut).toBe(sample);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [#69](https://github.com/solardev-xyz/freedom-browser/issues/69) — address-bar copy/paste broken on Windows and Linux since v0.7.1 (shortcuts inert, no right-click edit menu). Also adds a chrome context menu on **all** platforms so the address bar stays editable when the custom menu steals focus.

### Application menu (Windows / Linux)

- Refactor `menu.js` into `buildDarwinMenuTemplate` / `buildWinLinuxMenuTemplate` helpers.
- Drop macOS-only `appMenu` and `windowMenu` on Win/Linux.
- Add an explicit **Edit** submenu with `cut`, `copy`, `paste`, and `selectAll` roles so `Ctrl+C/V/X/A` work with `autoHideMenuBar`.

### Chrome context menu (all platforms)

- Right-click **Cut / Copy / Paste / Select All** on `#address-input` (and extensible to other chrome inputs).
- **Capture selection on right `mousedown`** before the browser collapses it on `contextmenu` (fixes macOS CI and real “select all, then right-click” flows).
- **Clipboard via Electron IPC** (`clipboard:copy-text`, `clipboard:read-text`) with navigator API fallback — avoids hung `navigator.clipboard.readText()` in Electron and flaky paste.
- **Hide the menu before** running async edit actions; pass selection into the action explicitly.
- **No synthetic `input` event** after Select All (navigation/autocomplete listeners were resetting selection).
- Use `input.select()` + `setSelectionRange` for Select All; removed menu `mousedown` `preventDefault` that could block menu item `click` events.

### Tests & CI

- **E2E:** `test-e2e/address-bar-clipboard.spec.js` — Win/Linux application-menu checks (skipped on macOS) plus one **serial** chrome context-menu test (show, copy, cut, paste, select-all → copy) and a keyboard-shortcuts test.
- **Unit:** `chrome-input-context-menu.test.js`, updated `menu.test.js`, IPC/preload tests.
- **CI:** `e2e-address-bar-clipboard` matrix on `ubuntu-latest`, `windows-latest`, and `macos-latest` (Linux uses `xvfb-run`). Harness project retries twice in CI.

Closes #69.

## Test plan

- [x] `npm run lint`
- [x] `npm test` (menu, ipc-handlers, preload, chrome-input-context-menu)
- [x] `npm run test:e2e -- test-e2e/address-bar-clipboard.spec.js` (macOS host — 20/20 consecutive local runs after stabilization)
- [x] Linux UTM VM — full E2E pass
- [x] Windows UTM VM — full E2E pass
- [x] GitHub Actions — `test` + `e2e-address-bar-clipboard` on ubuntu, windows, and macOS ([run 26309231289](https://github.com/solardev-xyz/freedom-browser/actions/runs/26309231289))