### PR TITLE
fix(renderer): re-resolve ENS pages on reload to refresh trust badge

### DIFF
--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -194,16 +194,15 @@ const setLoading = (isLoading, tabId = null) => {
 // switchback after a background-tab view-source dispatch picks up the
 // right state.
 //
-// `commit` marks this call as the actual navigation commit point — the
-// site we're about to (or just did) hand to `webview.loadURL`. When set,
-// we also write the value into `navState.committedDisplayUrl`, which is
-// what reload reads. For the active tab `did-navigate` will overwrite
-// this shortly after, so the early write is harmless (but consistent).
-// For *background* tabs `tabs.js` does not forward `did-navigate` to the
-// renderer's navigation handler, so without this early write a background
-// ENS load would never populate `committedDisplayUrl` — the user could
-// switch back, hit reload, and fall through to `webview.reload()` instead
-// of re-resolving under today's verification method.
+// This helper deliberately never writes `committedDisplayUrl`. That
+// field is the post-commit page identity used by reload and by provider
+// permission keying; writing it before `webview.loadURL` actually
+// commits would let the destination origin briefly stand in for the
+// still-loaded previous page (most starkly: `bzz://name.eth` is set
+// here before the Bee warm-probe even completes). The committed write
+// belongs in tabs.js' per-webview `did-navigate` handler, which fires
+// for both active and background tabs once Chromium has actually
+// committed the navigation.
 //
 // The active-tab branch is gated on a value-change check so repeated
 // no-op calls (every dispatch + every did-navigate on the hot path) don't
@@ -212,13 +211,8 @@ const setLoading = (isLoading, tabId = null) => {
 const setAddressDisplayForTab = (
   displayValue,
   tabId,
-  { isViewingSourceForTab = false, commit = false } = {}
+  { isViewingSourceForTab = false } = {}
 ) => {
-  const targetTab =
-    tabId !== null && tabId !== undefined ? getTabById(tabId) : getActiveTab();
-  if (commit && targetTab?.navigationState) {
-    targetTab.navigationState.committedDisplayUrl = displayValue;
-  }
   if (isActiveTab(tabId) || tabId === null) {
     if (addressInput.value !== displayValue) {
       addressInput.value = displayValue;
@@ -226,6 +220,8 @@ const setAddressDisplayForTab = (
     }
     return;
   }
+  const targetTab =
+    tabId !== null && tabId !== undefined ? getTabById(tabId) : null;
   if (!targetTab) return;
   if (targetTab.navigationState) {
     targetTab.navigationState.addressBarSnapshot = displayValue;
@@ -971,7 +967,6 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
           if (transportDisplay) {
             setAddressDisplayForTab(`view-source:${transportDisplay}`, capturedTabId, {
               isViewingSourceForTab: true,
-              commit: true,
             });
           }
 
@@ -1013,7 +1008,6 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
     });
     setAddressDisplayForTab(viewSourceNavigation.addressValue, targetTabId, {
       isViewingSourceForTab: true,
-      commit: true,
     });
     webview.loadURL(viewSourceNavigation.loadUrl);
     return;
@@ -1236,7 +1230,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
     const radicleTarget = formatRadicleUrl(value, state.radicleBase);
     if (radicleTarget) {
       const radicleDisplayValue = displayOverride || radicleTarget.displayValue;
-      setAddressDisplayForTab(radicleDisplayValue, targetTabId, { commit: true });
+      setAddressDisplayForTab(radicleDisplayValue, targetTabId);
       pushDebug(`[AddressBar] Loading Radicle target, set to: ${radicleDisplayValue}`);
       navState.pendingTitleForUrl = radicleTarget.targetUrl;
       navState.pendingNavigationUrl = radicleTarget.targetUrl;
@@ -1282,7 +1276,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
       }
     }
     const displayValue = displayOverride || target.displayValue;
-    setAddressDisplayForTab(displayValue, targetTabId, { commit: true });
+    setAddressDisplayForTab(displayValue, targetTabId);
     navState.pendingTitleForUrl = expectedNavUrl;
     navState.pendingNavigationUrl = expectedNavUrl;
     navState.hasNavigatedDuringCurrentLoad = false;
@@ -1349,7 +1343,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
   // Try HTTP/HTTPS URLs
   if (value.startsWith('http://') || value.startsWith('https://')) {
     const httpDisplayValue = displayOverride || value;
-    setAddressDisplayForTab(httpDisplayValue, targetTabId, { commit: true });
+    setAddressDisplayForTab(httpDisplayValue, targetTabId);
     pushDebug(`[AddressBar] Loading HTTP(S) target: ${value}`);
     navState.pendingTitleForUrl = value;
     navState.pendingNavigationUrl = value;
@@ -1552,7 +1546,6 @@ const handleNavigationEvent = (event) => {
       updateGithubBridgeIcon();
       updateProtocolIcon();
       navState.addressBarSnapshot = addressInput.value;
-      navState.committedDisplayUrl = addressInput.value;
       return;
     }
 
@@ -1576,7 +1569,6 @@ const handleNavigationEvent = (event) => {
       // from an ENS page leaves the prior page's trust shield stuck on.
       updateProtocolIcon();
       navState.addressBarSnapshot = addressInput.value;
-      navState.committedDisplayUrl = addressInput.value;
       return;
     }
 
@@ -1594,7 +1586,6 @@ const handleNavigationEvent = (event) => {
       updateGithubBridgeIcon();
       updateProtocolIcon();
       navState.addressBarSnapshot = addressInput.value;
-      navState.committedDisplayUrl = addressInput.value;
       return;
     }
 
@@ -1664,14 +1655,14 @@ const handleNavigationEvent = (event) => {
   updateGithubBridgeIcon();
   updateProtocolIcon();
 
-  // Snapshot the committed display URL for provider origin derivation.
-  // This ensures getDisplayUrlForWebview() reads the post-navigation identity,
-  // not a stale or user-edited address bar value. Also write
-  // `committedDisplayUrl`, the dedicated commit-only field that reload reads
-  // — `addressBarSnapshot` gets overwritten by focusin/tab-switched and so
-  // must not be used for reload's "what page are we currently on" check.
+  // Snapshot the live address bar so the `tab-switched` handler and any
+  // focusin-style draft restoration can paint the foreground value back
+  // when the user comes back to this tab. The dedicated commit-only
+  // `committedDisplayUrl` (used by reload and provider permission keying)
+  // is written by tabs.js' per-webview did-navigate handler — that's the
+  // single source of truth for "what page are we actually on", and it
+  // covers background tabs too.
   navState.addressBarSnapshot = addressInput.value;
-  navState.committedDisplayUrl = addressInput.value;
 };
 
 // Update bookmark bar visibility for a URL change

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -194,11 +194,31 @@ const setLoading = (isLoading, tabId = null) => {
 // switchback after a background-tab view-source dispatch picks up the
 // right state.
 //
+// `commit` marks this call as the actual navigation commit point — the
+// site we're about to (or just did) hand to `webview.loadURL`. When set,
+// we also write the value into `navState.committedDisplayUrl`, which is
+// what reload reads. For the active tab `did-navigate` will overwrite
+// this shortly after, so the early write is harmless (but consistent).
+// For *background* tabs `tabs.js` does not forward `did-navigate` to the
+// renderer's navigation handler, so without this early write a background
+// ENS load would never populate `committedDisplayUrl` — the user could
+// switch back, hit reload, and fall through to `webview.reload()` instead
+// of re-resolving under today's verification method.
+//
 // The active-tab branch is gated on a value-change check so repeated
 // no-op calls (every dispatch + every did-navigate on the hot path) don't
 // re-run `updateProtocolIcon`, which walks `state.ensTrustByName` and
 // invokes the trust-badge resolver on every call.
-const setAddressDisplayForTab = (displayValue, tabId, { isViewingSourceForTab = false } = {}) => {
+const setAddressDisplayForTab = (
+  displayValue,
+  tabId,
+  { isViewingSourceForTab = false, commit = false } = {}
+) => {
+  const targetTab =
+    tabId !== null && tabId !== undefined ? getTabById(tabId) : getActiveTab();
+  if (commit && targetTab?.navigationState) {
+    targetTab.navigationState.committedDisplayUrl = displayValue;
+  }
   if (isActiveTab(tabId) || tabId === null) {
     if (addressInput.value !== displayValue) {
       addressInput.value = displayValue;
@@ -206,13 +226,12 @@ const setAddressDisplayForTab = (displayValue, tabId, { isViewingSourceForTab = 
     }
     return;
   }
-  const tab = getTabById(tabId);
-  if (!tab) return;
-  if (tab.navigationState) {
-    tab.navigationState.addressBarSnapshot = displayValue;
+  if (!targetTab) return;
+  if (targetTab.navigationState) {
+    targetTab.navigationState.addressBarSnapshot = displayValue;
   }
   if (isViewingSourceForTab) {
-    tab.isViewingSource = true;
+    targetTab.isViewingSource = true;
   }
 };
 
@@ -952,6 +971,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
           if (transportDisplay) {
             setAddressDisplayForTab(`view-source:${transportDisplay}`, capturedTabId, {
               isViewingSourceForTab: true,
+              commit: true,
             });
           }
 
@@ -993,6 +1013,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
     });
     setAddressDisplayForTab(viewSourceNavigation.addressValue, targetTabId, {
       isViewingSourceForTab: true,
+      commit: true,
     });
     webview.loadURL(viewSourceNavigation.loadUrl);
     return;
@@ -1215,7 +1236,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
     const radicleTarget = formatRadicleUrl(value, state.radicleBase);
     if (radicleTarget) {
       const radicleDisplayValue = displayOverride || radicleTarget.displayValue;
-      setAddressDisplayForTab(radicleDisplayValue, targetTabId);
+      setAddressDisplayForTab(radicleDisplayValue, targetTabId, { commit: true });
       pushDebug(`[AddressBar] Loading Radicle target, set to: ${radicleDisplayValue}`);
       navState.pendingTitleForUrl = radicleTarget.targetUrl;
       navState.pendingNavigationUrl = radicleTarget.targetUrl;
@@ -1261,7 +1282,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
       }
     }
     const displayValue = displayOverride || target.displayValue;
-    setAddressDisplayForTab(displayValue, targetTabId);
+    setAddressDisplayForTab(displayValue, targetTabId, { commit: true });
     navState.pendingTitleForUrl = expectedNavUrl;
     navState.pendingNavigationUrl = expectedNavUrl;
     navState.hasNavigatedDuringCurrentLoad = false;
@@ -1328,7 +1349,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
   // Try HTTP/HTTPS URLs
   if (value.startsWith('http://') || value.startsWith('https://')) {
     const httpDisplayValue = displayOverride || value;
-    setAddressDisplayForTab(httpDisplayValue, targetTabId);
+    setAddressDisplayForTab(httpDisplayValue, targetTabId, { commit: true });
     pushDebug(`[AddressBar] Loading HTTP(S) target: ${value}`);
     navState.pendingTitleForUrl = value;
     navState.pendingNavigationUrl = value;

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -1414,6 +1414,38 @@ const retryErrorPageOrReload = (webview, hard) => {
     }
   }
 
+  // ENS pages: reload re-resolves under the currently-configured verification
+  // method so the trust badge reflects today's settings, not whatever was in
+  // effect at first load. The webview's URL holds the resolved transport URL
+  // with the resolved hash/CID (or the ENS-host form like
+  // `bzz://name.eth/...`); re-running `webview.reload()` would just refetch
+  // the same content hash and never re-enter the ENS resolution path. The
+  // address bar always carries the ENS-form display
+  // (`bzz://name.eth/...`, `ipfs://name.eth/...`, `ipns://name.eth/...`,
+  // bare `name.eth`) thanks to `setAddressDisplayForTab`, so `parseEnsInput`
+  // matches and `loadTarget` runs the full resolution path, overwriting
+  // `state.ensTrustByName.get(name)` when the new resolution settles.
+  //
+  // Hard-reload (Cmd/Ctrl+Shift+R) bypasses Chromium's HTTP cache; the ENS
+  // analogue is to also bypass the main-process `ensResultCache` (15-min TTL)
+  // so a hard reload performed shortly after the previous resolution actually
+  // re-resolves rather than returning the cached result. We do this by
+  // calling the already-exported `invalidateEnsContent(name)` IPC before
+  // dispatching to `loadTarget`.
+  const addressValue = (addressInput?.value || '').trim();
+  const ensInput = parseEnsInput(addressValue);
+  if (ensInput) {
+    if (hard && electronAPI?.invalidateEnsContent) {
+      pushDebug(`Hard reload: invalidating ENS contenthash cache for ${ensInput.name}`);
+      electronAPI.invalidateEnsContent(ensInput.name).catch((err) => {
+        pushDebug(`[ENS] invalidateEnsContent failed: ${err?.message || err}`);
+      });
+    }
+    pushDebug(`${hard ? 'Hard reload' : 'Reload'} re-resolving ENS: ${addressValue}`);
+    loadTarget(addressValue);
+    return;
+  }
+
   if (hard) {
     webview.reloadIgnoringCache();
     pushDebug('Hard reload triggered');

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -1397,11 +1397,32 @@ export const loadHomePage = () => {
   pushDebug('Loading home page');
 };
 
+// Hard-reload (Cmd/Ctrl+Shift+R) bypasses Chromium's HTTP cache; the ENS
+// analogue is to also bypass the main-process `ensResultCache` (15-min TTL)
+// so a hard reload performed shortly after the previous resolution actually
+// re-resolves rather than returning the cached result. Fire-and-forget IPC —
+// the subsequent `loadTarget` call kicks off a fresh `resolveEns` that misses
+// the now-empty cache.
+const invalidateEnsContentForHardReload = (ensName) => {
+  if (!ensName || !electronAPI?.invalidateEnsContent) return;
+  pushDebug(`Hard reload: invalidating ENS contenthash cache for ${ensName}`);
+  electronAPI.invalidateEnsContent(ensName).catch((err) => {
+    pushDebug(`[ENS] invalidateEnsContent failed: ${err?.message || err}`);
+  });
+};
+
 // Shared error-page retry logic used by both reload variants and the reload button
 const retryErrorPageOrReload = (webview, hard) => {
   const current = webview.getURL();
   const originalUrl = getOriginalUrlFromErrorPage(current, errorUrlBase);
   if (originalUrl) {
+    // Hard reload of an ENS error page also bypasses `ensResultCache` so the
+    // recovery resolution actually re-runs under today's verification method
+    // rather than returning the cached contenthash from the failed attempt.
+    if (hard) {
+      const errorEns = parseEnsInput(originalUrl);
+      if (errorEns) invalidateEnsContentForHardReload(errorEns.name);
+    }
     pushDebug(`Retrying original URL from error page: ${originalUrl}`);
     loadTarget(originalUrl);
     return;
@@ -1419,30 +1440,23 @@ const retryErrorPageOrReload = (webview, hard) => {
   // effect at first load. The webview's URL holds the resolved transport URL
   // with the resolved hash/CID (or the ENS-host form like
   // `bzz://name.eth/...`); re-running `webview.reload()` would just refetch
-  // the same content hash and never re-enter the ENS resolution path. The
-  // address bar always carries the ENS-form display
-  // (`bzz://name.eth/...`, `ipfs://name.eth/...`, `ipns://name.eth/...`,
-  // bare `name.eth`) thanks to `setAddressDisplayForTab`, so `parseEnsInput`
-  // matches and `loadTarget` runs the full resolution path, overwriting
-  // `state.ensTrustByName.get(name)` when the new resolution settles.
+  // the same content hash and never re-enter the ENS resolution path.
   //
-  // Hard-reload (Cmd/Ctrl+Shift+R) bypasses Chromium's HTTP cache; the ENS
-  // analogue is to also bypass the main-process `ensResultCache` (15-min TTL)
-  // so a hard reload performed shortly after the previous resolution actually
-  // re-resolves rather than returning the cached result. We do this by
-  // calling the already-exported `invalidateEnsContent(name)` IPC before
-  // dispatching to `loadTarget`.
-  const addressValue = (addressInput?.value || '').trim();
-  const ensInput = parseEnsInput(addressValue);
+  // We key the decision on the active tab's *committed* display identity
+  // (`navState.addressBarSnapshot`, set on every `did-navigate`) rather than
+  // `addressInput.value`. The latter reflects whatever the user is currently
+  // typing — if they have an unsubmitted `vitalik.eth` over a committed
+  // `https://example.com` page and hit reload, we want to reload the current
+  // page, not navigate to the typed-but-unsubmitted ENS value. The Form
+  // `submit` handler already covers the "actually navigate to typed input"
+  // path; reload is the "do whatever you do, again" affordance.
+  const navState = getNavState();
+  const committedDisplay = (navState.addressBarSnapshot || '').trim();
+  const ensInput = committedDisplay ? parseEnsInput(committedDisplay) : null;
   if (ensInput) {
-    if (hard && electronAPI?.invalidateEnsContent) {
-      pushDebug(`Hard reload: invalidating ENS contenthash cache for ${ensInput.name}`);
-      electronAPI.invalidateEnsContent(ensInput.name).catch((err) => {
-        pushDebug(`[ENS] invalidateEnsContent failed: ${err?.message || err}`);
-      });
-    }
-    pushDebug(`${hard ? 'Hard reload' : 'Reload'} re-resolving ENS: ${addressValue}`);
-    loadTarget(addressValue);
+    if (hard) invalidateEnsContentForHardReload(ensInput.name);
+    pushDebug(`${hard ? 'Hard reload' : 'Reload'} re-resolving ENS: ${committedDisplay}`);
+    loadTarget(committedDisplay);
     return;
   }
 

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -1442,16 +1442,17 @@ const retryErrorPageOrReload = (webview, hard) => {
   // `bzz://name.eth/...`); re-running `webview.reload()` would just refetch
   // the same content hash and never re-enter the ENS resolution path.
   //
-  // We key the decision on the active tab's *committed* display identity
-  // (`navState.addressBarSnapshot`, set on every `did-navigate`) rather than
-  // `addressInput.value`. The latter reflects whatever the user is currently
-  // typing — if they have an unsubmitted `vitalik.eth` over a committed
-  // `https://example.com` page and hit reload, we want to reload the current
-  // page, not navigate to the typed-but-unsubmitted ENS value. The Form
-  // `submit` handler already covers the "actually navigate to typed input"
-  // path; reload is the "do whatever you do, again" affordance.
+  // We key the decision on the active tab's `committedDisplayUrl`, which is
+  // written *only* by did-navigate handlers and so represents the last
+  // user-facing display URL that actually committed. We deliberately do NOT
+  // use `addressInput.value` (reflects in-progress user typing) or
+  // `navState.addressBarSnapshot` (gets overwritten by `focusin` and
+  // `tab-switched` and so can carry an unsubmitted draft — e.g. typing
+  // `vitalik.eth` over an `https://example.com` page, switching tabs, and
+  // switching back). Submitting the typed value is the form `submit`
+  // handler's job; reload is the "do whatever you do, again" affordance.
   const navState = getNavState();
-  const committedDisplay = (navState.addressBarSnapshot || '').trim();
+  const committedDisplay = (navState.committedDisplayUrl || '').trim();
   const ensInput = committedDisplay ? parseEnsInput(committedDisplay) : null;
   if (ensInput) {
     if (hard) invalidateEnsContentForHardReload(ensInput.name);
@@ -1530,6 +1531,7 @@ const handleNavigationEvent = (event) => {
       updateGithubBridgeIcon();
       updateProtocolIcon();
       navState.addressBarSnapshot = addressInput.value;
+      navState.committedDisplayUrl = addressInput.value;
       return;
     }
 
@@ -1553,6 +1555,7 @@ const handleNavigationEvent = (event) => {
       // from an ENS page leaves the prior page's trust shield stuck on.
       updateProtocolIcon();
       navState.addressBarSnapshot = addressInput.value;
+      navState.committedDisplayUrl = addressInput.value;
       return;
     }
 
@@ -1570,6 +1573,7 @@ const handleNavigationEvent = (event) => {
       updateGithubBridgeIcon();
       updateProtocolIcon();
       navState.addressBarSnapshot = addressInput.value;
+      navState.committedDisplayUrl = addressInput.value;
       return;
     }
 
@@ -1641,8 +1645,12 @@ const handleNavigationEvent = (event) => {
 
   // Snapshot the committed display URL for provider origin derivation.
   // This ensures getDisplayUrlForWebview() reads the post-navigation identity,
-  // not a stale or user-edited address bar value.
+  // not a stale or user-edited address bar value. Also write
+  // `committedDisplayUrl`, the dedicated commit-only field that reload reads
+  // — `addressBarSnapshot` gets overwritten by focusin/tab-switched and so
+  // must not be used for reload's "what page are we currently on" check.
   navState.addressBarSnapshot = addressInput.value;
+  navState.committedDisplayUrl = addressInput.value;
 };
 
 // Update bookmark bar visibility for a URL change

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -1679,13 +1679,18 @@ describe('navigation', () => {
       });
     };
 
-    // Mirror the production did-navigate commit shape: the handler writes
-    // the user-facing display URL into the address input AND into both
-    // `addressBarSnapshot` (transient draft/restoration state) and
-    // `committedDisplayUrl` (commit-only, the field reload reads). The
-    // split matters because `addressBarSnapshot` is overwritten on focusin
-    // and tab-switched, so it can carry unsubmitted user input — only
-    // `committedDisplayUrl` stays a stable identity.
+    // Mirror the production post-commit shape across the two handlers
+    // that write to it:
+    //   - `addressInput.value` and `navState.addressBarSnapshot` are
+    //     written by navigation.js' did-navigate handler (foreground UI
+    //     and draft-restoration snapshot).
+    //   - `navState.committedDisplayUrl` is written by tabs.js'
+    //     per-webview did-navigate handler — for both active and
+    //     background tabs — so reload and provider permission keying
+    //     read the actual committed page identity rather than a draft
+    //     in addressBarSnapshot or an in-flight destination URL.
+    // The helper sets all three so reload tests start from a fully
+    // committed state regardless of which handler owns each field.
     const commitDisplay = (ctx, value) => {
       ctx.elements.addressInput.value = value;
       ctx.activeRef.tab.navigationState.addressBarSnapshot = value;
@@ -1882,17 +1887,26 @@ describe('navigation', () => {
     });
 
     test('reload after a background ENS navigation commits in another tab re-resolves on switch-back', async () => {
-      // Regression for the background-commit gap: tabs.js only forwards
-      // did-navigate to navigation.js's webviewEventHandler for the active
-      // tab, so an ENS load that finishes while its tab is in the
-      // background never wrote `committedDisplayUrl` through the regular
-      // did-navigate path. Pre-fix, that left committedDisplayUrl empty —
-      // switching back and hitting reload fell through to webview.reload()
-      // instead of re-running ENS resolution under today's verification
-      // method. The fix marks the commit points (commitDwebNavigationPrefix,
-      // HTTP, Radicle, view-source) with `{ commit: true }` so
-      // setAddressDisplayForTab writes committedDisplayUrl on the *target*
-      // tab regardless of active state.
+      // Regression for the background-commit gap: a slow ENS load that
+      // finishes while its tab is in the background must still populate
+      // `committedDisplayUrl` so a later reload re-runs ENS resolution
+      // under today's verification method.
+      //
+      // The committed write itself lives in tabs.js' per-webview
+      // did-navigate handler (which fires for active and background
+      // tabs). This test stubs that write so navigation.js' setup-and-
+      // reload flow can be exercised end-to-end against the resulting
+      // post-commit state — see tabs.test.js for the test that pins the
+      // tabs.js handler itself.
+      //
+      // Crucially, navigation.js must NOT be writing `committedDisplayUrl`
+      // before navigation actually commits. Doing so would let
+      // `getDisplayUrlForWebview()` (which feeds Swarm provider permission
+      // keys) briefly point at the destination origin while the previous
+      // page is still loaded. The pre-commit `setAddressDisplayForTab`
+      // call in the dweb dispatch path must therefore leave
+      // `committedDisplayUrl` untouched until the simulated did-navigate
+      // fires below.
       const tabA = createTab(1, 'https://a.example', { title: 'Tab A' });
       const tabB = createTab(2, 'about:blank', { title: 'Tab B' });
       const ctx = await loadNavigationModule({
@@ -1934,11 +1948,13 @@ describe('navigation', () => {
       });
       await flushMicrotasks();
 
-      // Step 3: resolveEns settles in the background, which triggers the
-      // recursive loadTarget that ultimately commits the IPFS dispatch on
-      // Tab A — setAddressDisplayForTab is called with `{ commit: true }`
-      // and writes both addressBarSnapshot AND committedDisplayUrl on Tab A
-      // even though Tab A is not active.
+      // Step 3: resolveEns settles in the background and the recursive
+      // loadTarget commits the IPFS dispatch on Tab A. Pre-fix this also
+      // wrote `committedDisplayUrl`, but that was wrong — Chromium hasn't
+      // committed yet (and for bzz the Bee warm-probe hasn't even run).
+      // Today the dispatch only stashes the display value into the
+      // background tab's `addressBarSnapshot` for switchback restoration,
+      // and `committedDisplayUrl` stays empty until did-navigate fires.
       resolveResolver({
         type: 'ok',
         name: 'vitalik.eth',
@@ -1950,12 +1966,21 @@ describe('navigation', () => {
 
       // Tab B's foreground address bar must not have been clobbered.
       expect(ctx.elements.addressInput.value).toBe('about:blank');
-      // Tab A picked up the resolved display in BOTH fields — the snapshot
-      // (existing behaviour) and committedDisplayUrl (new commit-only field).
+      // Tab A picked up the resolved display in addressBarSnapshot for
+      // tab-switched restoration, but `committedDisplayUrl` stays empty
+      // — it's only written by tabs.js' did-navigate handler.
       expect(tabA.navigationState.addressBarSnapshot).toBe('ipfs://vitalik.eth');
-      expect(tabA.navigationState.committedDisplayUrl).toBe('ipfs://vitalik.eth');
+      expect(tabA.navigationState.committedDisplayUrl).toBe('');
 
-      // Step 4: switch back to Tab A. The tab-switched handler restores
+      // Step 4: simulate the per-webview did-navigate that tabs.js fires
+      // for Tab A once Chromium commits the navigation. tabs.js writes
+      // `webview.getURL()` into `committedDisplayUrl` regardless of
+      // whether the tab is active. We mirror that here so the post-
+      // commit state matches production for the reload exercise below.
+      tabA.webview.getURL.mockReturnValue('ipfs://vitalik.eth');
+      tabA.navigationState.committedDisplayUrl = 'ipfs://vitalik.eth';
+
+      // Step 5: switch back to Tab A. The tab-switched handler restores
       // addressInput.value from the snapshot.
       ctx.navigationUtilsMocks.deriveSwitchedTabDisplay.mockReturnValueOnce(
         'ipfs://vitalik.eth'
@@ -1969,7 +1994,7 @@ describe('navigation', () => {
       await flushMicrotasks();
       expect(ctx.elements.addressInput.value).toBe('ipfs://vitalik.eth');
 
-      // Step 5: hit reload. Now that committedDisplayUrl is populated, the
+      // Step 6: hit reload. Now that committedDisplayUrl is populated, the
       // ENS branch fires instead of webview.reload().
       ctx.electronAPI.resolveEns.mockReset();
       ctx.electronAPI.resolveEns.mockResolvedValue({

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -299,6 +299,7 @@ const loadNavigationModule = async (options = {}) => {
       electronHandlers.toggleBookmarkBar = handler;
     }),
     resolveEns: jest.fn(),
+    invalidateEnsContent: jest.fn().mockResolvedValue(true),
   };
 
   const addressInput = createElement('input');
@@ -1648,6 +1649,165 @@ describe('navigation', () => {
 
       expect(ctx.elements.trustPopover.hidden).toBe(true);
       expect(ctx.elements.trustShield.getAttribute('aria-expanded')).toBe('false');
+    });
+  });
+
+  describe('ENS reload re-resolution', () => {
+    // Issue #82: reload on an ENS page used to call webview.reload() against
+    // the resolved transport URL (carrying the actual content hash), which
+    // never re-entered the ENS resolution path. After flipping the ENS
+    // verification method in settings, the trust badge stayed stuck on the
+    // previous method until the user re-typed the name. These tests pin the
+    // fix: reload now detects ENS-form address-bar values and routes them
+    // through loadTarget so the resolution + trust badge refresh under the
+    // currently-configured method.
+    const installEnsParser = (ctx) => {
+      ctx.pageUrlsMocks.parseEnsInput.mockImplementation((value) => {
+        const prefixMatch = value.match(/^(ens|bzz|ipfs|ipns):\/\//i);
+        const assertedTransport = prefixMatch
+          ? prefixMatch[1].toLowerCase() === 'ens'
+            ? null
+            : prefixMatch[1].toLowerCase()
+          : null;
+        const m = value.match(/^(?:(?:ens|bzz|ipfs|ipns):\/\/)?([^?/]+)(.*)?$/i);
+        if (!m) return null;
+        const name = m[1].toLowerCase();
+        return name.endsWith('.eth') || name.endsWith('.box')
+          ? { name, suffix: m[2] || '', assertedTransport }
+          : null;
+      });
+    };
+
+    test('soft reload of an ENS page re-resolves and updates trust', async () => {
+      const ctx = await loadNavigationModule();
+      installEnsParser(ctx);
+      await ctx.mod.initNavigation();
+
+      const oldTrust = {
+        level: 'verified',
+        method: 'colibri',
+        queried: ['a', 'b'],
+        agreed: ['a', 'b'],
+      };
+      const newTrust = {
+        level: 'verified',
+        method: 'public-rpc-quorum',
+        queried: ['a', 'b', 'c'],
+        agreed: ['a', 'b', 'c'],
+      };
+      ctx.state.ensTrustByName.set('vitalik.eth', oldTrust);
+      ctx.elements.addressInput.value = 'bzz://vitalik.eth/';
+      ctx.activeRef.tab.webview.getURL.mockReturnValue(
+        `bzz://${'a'.repeat(64)}/`
+      );
+      ctx.electronAPI.resolveEns.mockResolvedValue({
+        type: 'ok',
+        name: 'vitalik.eth',
+        protocol: 'bzz',
+        uri: `bzz://${'a'.repeat(64)}`,
+        decoded: 'a'.repeat(64),
+        trust: newTrust,
+      });
+
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: false });
+      await flushMicrotasks();
+
+      expect(ctx.electronAPI.resolveEns).toHaveBeenCalledWith('vitalik.eth');
+      expect(ctx.activeRef.tab.webview.reload).not.toHaveBeenCalled();
+      expect(ctx.activeRef.tab.webview.reloadIgnoringCache).not.toHaveBeenCalled();
+      expect(ctx.electronAPI.invalidateEnsContent).not.toHaveBeenCalled();
+      expect(ctx.state.ensTrustByName.get('vitalik.eth')).toEqual(newTrust);
+    });
+
+    test('hard reload of an ENS page invalidates the contenthash cache and re-resolves', async () => {
+      const ctx = await loadNavigationModule();
+      installEnsParser(ctx);
+      await ctx.mod.initNavigation();
+
+      ctx.elements.addressInput.value = 'ipfs://vitalik.eth/about';
+      ctx.activeRef.tab.webview.getURL.mockReturnValue('ipfs://bafyfake/about');
+      ctx.electronAPI.resolveEns.mockResolvedValue({
+        type: 'ok',
+        name: 'vitalik.eth',
+        protocol: 'ipfs',
+        uri: 'ipfs://bafyfake',
+        trust: { level: 'verified', queried: ['a'], agreed: ['a'] },
+      });
+
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: true });
+      await flushMicrotasks();
+
+      expect(ctx.electronAPI.invalidateEnsContent).toHaveBeenCalledWith('vitalik.eth');
+      expect(ctx.electronAPI.resolveEns).toHaveBeenCalledWith('vitalik.eth');
+      expect(ctx.activeRef.tab.webview.reload).not.toHaveBeenCalled();
+      expect(ctx.activeRef.tab.webview.reloadIgnoringCache).not.toHaveBeenCalled();
+    });
+
+    test('reload of a non-ENS page falls through to webview.reload()', async () => {
+      const ctx = await loadNavigationModule();
+      installEnsParser(ctx);
+      await ctx.mod.initNavigation();
+
+      ctx.elements.addressInput.value = 'https://example.com/';
+      ctx.activeRef.tab.webview.getURL.mockReturnValue('https://example.com/');
+
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: false });
+      await flushMicrotasks();
+
+      expect(ctx.activeRef.tab.webview.reload).toHaveBeenCalled();
+      expect(ctx.activeRef.tab.webview.reloadIgnoringCache).not.toHaveBeenCalled();
+      expect(ctx.electronAPI.resolveEns).not.toHaveBeenCalled();
+      expect(ctx.electronAPI.invalidateEnsContent).not.toHaveBeenCalled();
+    });
+
+    test('hard reload of a non-ENS page falls through to reloadIgnoringCache()', async () => {
+      const ctx = await loadNavigationModule();
+      installEnsParser(ctx);
+      await ctx.mod.initNavigation();
+
+      ctx.elements.addressInput.value = 'https://example.com/';
+      ctx.activeRef.tab.webview.getURL.mockReturnValue('https://example.com/');
+
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: true });
+      await flushMicrotasks();
+
+      expect(ctx.activeRef.tab.webview.reloadIgnoringCache).toHaveBeenCalled();
+      expect(ctx.activeRef.tab.webview.reload).not.toHaveBeenCalled();
+      expect(ctx.electronAPI.resolveEns).not.toHaveBeenCalled();
+      expect(ctx.electronAPI.invalidateEnsContent).not.toHaveBeenCalled();
+    });
+
+    test('reload from an ENS error page recovers via the original-URL branch', async () => {
+      // Regression guard for the existing branch order: the
+      // getOriginalUrlFromErrorPage recovery path runs before the ENS
+      // re-resolve check, so an error page recovered from an ENS load
+      // re-runs the original URL through loadTarget (which itself re-enters
+      // the ENS resolution path). The new ENS branch must not short-circuit
+      // this — without the early return, an error-page reload would skip
+      // the recovery path and re-resolve a possibly-stale address-bar value.
+      const ctx = await loadNavigationModule();
+      installEnsParser(ctx);
+      await ctx.mod.initNavigation();
+
+      ctx.elements.addressInput.value = 'bzz://vitalik.eth/';
+      ctx.activeRef.tab.webview.getURL.mockReturnValue(
+        'file:///app/pages/error.html?url=bzz%3A%2F%2Fvitalik.eth%2F'
+      );
+      ctx.electronAPI.resolveEns.mockResolvedValue({
+        type: 'ok',
+        name: 'vitalik.eth',
+        protocol: 'bzz',
+        uri: `bzz://${'a'.repeat(64)}`,
+        decoded: 'a'.repeat(64),
+        trust: { level: 'verified', queried: ['a'], agreed: ['a'] },
+      });
+
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: false });
+      await flushMicrotasks();
+
+      expect(ctx.electronAPI.resolveEns).toHaveBeenCalledWith('vitalik.eth');
+      expect(ctx.activeRef.tab.webview.reload).not.toHaveBeenCalled();
+      expect(ctx.electronAPI.invalidateEnsContent).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -1678,6 +1678,16 @@ describe('navigation', () => {
       });
     };
 
+    // Mirror the production commit shape: on every did-navigate the
+    // renderer writes the user-facing display URL into both the address
+    // input and `navState.addressBarSnapshot`. Reload reads the snapshot
+    // (the *committed* display identity), not `addressInput.value`, so an
+    // unsubmitted draft in the address bar can't hijack reload.
+    const commitDisplay = (ctx, value) => {
+      ctx.elements.addressInput.value = value;
+      ctx.activeRef.tab.navigationState.addressBarSnapshot = value;
+    };
+
     test('soft reload of an ENS page re-resolves and updates trust', async () => {
       const ctx = await loadNavigationModule();
       installEnsParser(ctx);
@@ -1696,7 +1706,7 @@ describe('navigation', () => {
         agreed: ['a', 'b', 'c'],
       };
       ctx.state.ensTrustByName.set('vitalik.eth', oldTrust);
-      ctx.elements.addressInput.value = 'bzz://vitalik.eth/';
+      commitDisplay(ctx, 'bzz://vitalik.eth/');
       ctx.activeRef.tab.webview.getURL.mockReturnValue(
         `bzz://${'a'.repeat(64)}/`
       );
@@ -1724,7 +1734,7 @@ describe('navigation', () => {
       installEnsParser(ctx);
       await ctx.mod.initNavigation();
 
-      ctx.elements.addressInput.value = 'ipfs://vitalik.eth/about';
+      commitDisplay(ctx, 'ipfs://vitalik.eth/about');
       ctx.activeRef.tab.webview.getURL.mockReturnValue('ipfs://bafyfake/about');
       ctx.electronAPI.resolveEns.mockResolvedValue({
         type: 'ok',
@@ -1748,7 +1758,7 @@ describe('navigation', () => {
       installEnsParser(ctx);
       await ctx.mod.initNavigation();
 
-      ctx.elements.addressInput.value = 'https://example.com/';
+      commitDisplay(ctx, 'https://example.com/');
       ctx.activeRef.tab.webview.getURL.mockReturnValue('https://example.com/');
 
       ctx.elements.reloadBtn.dispatch('click', { shiftKey: false });
@@ -1765,7 +1775,7 @@ describe('navigation', () => {
       installEnsParser(ctx);
       await ctx.mod.initNavigation();
 
-      ctx.elements.addressInput.value = 'https://example.com/';
+      commitDisplay(ctx, 'https://example.com/');
       ctx.activeRef.tab.webview.getURL.mockReturnValue('https://example.com/');
 
       ctx.elements.reloadBtn.dispatch('click', { shiftKey: true });
@@ -1784,12 +1794,12 @@ describe('navigation', () => {
       // re-runs the original URL through loadTarget (which itself re-enters
       // the ENS resolution path). The new ENS branch must not short-circuit
       // this — without the early return, an error-page reload would skip
-      // the recovery path and re-resolve a possibly-stale address-bar value.
+      // the recovery path and re-resolve a possibly-stale display value.
       const ctx = await loadNavigationModule();
       installEnsParser(ctx);
       await ctx.mod.initNavigation();
 
-      ctx.elements.addressInput.value = 'bzz://vitalik.eth/';
+      commitDisplay(ctx, 'bzz://vitalik.eth/');
       ctx.activeRef.tab.webview.getURL.mockReturnValue(
         'file:///app/pages/error.html?url=bzz%3A%2F%2Fvitalik.eth%2F'
       );
@@ -1807,6 +1817,63 @@ describe('navigation', () => {
 
       expect(ctx.electronAPI.resolveEns).toHaveBeenCalledWith('vitalik.eth');
       expect(ctx.activeRef.tab.webview.reload).not.toHaveBeenCalled();
+      expect(ctx.electronAPI.invalidateEnsContent).not.toHaveBeenCalled();
+    });
+
+    test('hard reload from an ENS error page invalidates the contenthash cache and re-resolves', async () => {
+      // Hard reload must bypass `ensResultCache` even on the recovery
+      // branch — without this, a hard reload from an ENS error page would
+      // re-run loadTarget but resolveEns would return the stale cached
+      // contenthash from the failed attempt.
+      const ctx = await loadNavigationModule();
+      installEnsParser(ctx);
+      await ctx.mod.initNavigation();
+
+      commitDisplay(ctx, 'bzz://vitalik.eth/');
+      ctx.activeRef.tab.webview.getURL.mockReturnValue(
+        'file:///app/pages/error.html?url=bzz%3A%2F%2Fvitalik.eth%2F'
+      );
+      ctx.electronAPI.resolveEns.mockResolvedValue({
+        type: 'ok',
+        name: 'vitalik.eth',
+        protocol: 'bzz',
+        uri: `bzz://${'a'.repeat(64)}`,
+        decoded: 'a'.repeat(64),
+        trust: { level: 'verified', queried: ['a'], agreed: ['a'] },
+      });
+
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: true });
+      await flushMicrotasks();
+
+      expect(ctx.electronAPI.invalidateEnsContent).toHaveBeenCalledWith('vitalik.eth');
+      expect(ctx.electronAPI.resolveEns).toHaveBeenCalledWith('vitalik.eth');
+      expect(ctx.activeRef.tab.webview.reload).not.toHaveBeenCalled();
+      expect(ctx.activeRef.tab.webview.reloadIgnoringCache).not.toHaveBeenCalled();
+    });
+
+    test('reload with unsubmitted ENS-looking text in the address bar reloads the current non-ENS page', async () => {
+      // Reload reads the *committed* display identity from
+      // `navState.addressBarSnapshot`, not `addressInput.value`. If the
+      // user has typed `vitalik.eth` over an `https://example.com` page
+      // but hasn't submitted it, hitting reload should reload the current
+      // page — submitting the typed value is the form-submit handler's job.
+      const ctx = await loadNavigationModule();
+      installEnsParser(ctx);
+      await ctx.mod.initNavigation();
+
+      commitDisplay(ctx, 'https://example.com/');
+      // Now simulate the user typing into the address bar without
+      // submitting: addressInput.value is dirty, but the snapshot still
+      // reflects the committed page.
+      ctx.elements.addressInput.value = 'vitalik.eth';
+      ctx.activeRef.tab.webview.getURL.mockReturnValue('https://example.com/');
+
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: false });
+      await flushMicrotasks();
+
+      expect(ctx.activeRef.tab.webview.reload).toHaveBeenCalled();
+      expect(ctx.activeRef.tab.webview.reloadIgnoringCache).not.toHaveBeenCalled();
+      expect(ctx.electronAPI.resolveEns).not.toHaveBeenCalled();
       expect(ctx.electronAPI.invalidateEnsContent).not.toHaveBeenCalled();
     });
   });

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -1881,6 +1881,112 @@ describe('navigation', () => {
       expect(ctx.electronAPI.invalidateEnsContent).not.toHaveBeenCalled();
     });
 
+    test('reload after a background ENS navigation commits in another tab re-resolves on switch-back', async () => {
+      // Regression for the background-commit gap: tabs.js only forwards
+      // did-navigate to navigation.js's webviewEventHandler for the active
+      // tab, so an ENS load that finishes while its tab is in the
+      // background never wrote `committedDisplayUrl` through the regular
+      // did-navigate path. Pre-fix, that left committedDisplayUrl empty —
+      // switching back and hitting reload fell through to webview.reload()
+      // instead of re-running ENS resolution under today's verification
+      // method. The fix marks the commit points (commitDwebNavigationPrefix,
+      // HTTP, Radicle, view-source) with `{ commit: true }` so
+      // setAddressDisplayForTab writes committedDisplayUrl on the *target*
+      // tab regardless of active state.
+      const tabA = createTab(1, 'https://a.example', { title: 'Tab A' });
+      const tabB = createTab(2, 'about:blank', { title: 'Tab B' });
+      const ctx = await loadNavigationModule({
+        firstTab: tabA,
+        tabs: [tabA, tabB],
+        activeTab: tabA,
+      });
+      installEnsParser(ctx);
+      ctx.tabsRef.list = [tabA, tabB];
+      ctx.activeRef.tab = tabA;
+      await ctx.mod.initNavigation();
+
+      // Step 1: kick off ENS navigation in Tab A with a deferred resolveEns.
+      let resolveResolver;
+      ctx.electronAPI.resolveEns.mockReturnValue(
+        new Promise((resolve) => {
+          resolveResolver = resolve;
+        })
+      );
+      ctx.mod.loadTarget('vitalik.eth', null, tabA.webview);
+      await flushMicrotasks();
+      expect(ctx.elements.addressInput.value).toBe('vitalik.eth');
+
+      // Step 2: user switches to Tab B before resolveEns settles. We seed
+      // previousActiveTabId via the prior tab-switched dispatch so a real
+      // switch flow is exercised, and clear the foreground address input
+      // to mimic Tab B's own URL taking over.
+      ctx.tabsMocks.webviewEventHandler('tab-switched', {
+        tabId: tabA.id,
+        tab: tabA,
+        isNewTab: false,
+      });
+      ctx.activeRef.tab = tabB;
+      ctx.elements.addressInput.value = 'about:blank';
+      ctx.tabsMocks.webviewEventHandler('tab-switched', {
+        tabId: tabB.id,
+        tab: tabB,
+        isNewTab: false,
+      });
+      await flushMicrotasks();
+
+      // Step 3: resolveEns settles in the background, which triggers the
+      // recursive loadTarget that ultimately commits the IPFS dispatch on
+      // Tab A — setAddressDisplayForTab is called with `{ commit: true }`
+      // and writes both addressBarSnapshot AND committedDisplayUrl on Tab A
+      // even though Tab A is not active.
+      resolveResolver({
+        type: 'ok',
+        name: 'vitalik.eth',
+        protocol: 'ipfs',
+        uri: 'ipfs://QmVitalik',
+        trust: { level: 'verified', queried: ['a', 'b'], agreed: ['a', 'b'] },
+      });
+      await flushMicrotasks();
+
+      // Tab B's foreground address bar must not have been clobbered.
+      expect(ctx.elements.addressInput.value).toBe('about:blank');
+      // Tab A picked up the resolved display in BOTH fields — the snapshot
+      // (existing behaviour) and committedDisplayUrl (new commit-only field).
+      expect(tabA.navigationState.addressBarSnapshot).toBe('ipfs://vitalik.eth');
+      expect(tabA.navigationState.committedDisplayUrl).toBe('ipfs://vitalik.eth');
+
+      // Step 4: switch back to Tab A. The tab-switched handler restores
+      // addressInput.value from the snapshot.
+      ctx.navigationUtilsMocks.deriveSwitchedTabDisplay.mockReturnValueOnce(
+        'ipfs://vitalik.eth'
+      );
+      ctx.activeRef.tab = tabA;
+      ctx.tabsMocks.webviewEventHandler('tab-switched', {
+        tabId: tabA.id,
+        tab: tabA,
+        isNewTab: false,
+      });
+      await flushMicrotasks();
+      expect(ctx.elements.addressInput.value).toBe('ipfs://vitalik.eth');
+
+      // Step 5: hit reload. Now that committedDisplayUrl is populated, the
+      // ENS branch fires instead of webview.reload().
+      ctx.electronAPI.resolveEns.mockReset();
+      ctx.electronAPI.resolveEns.mockResolvedValue({
+        type: 'ok',
+        name: 'vitalik.eth',
+        protocol: 'ipfs',
+        uri: 'ipfs://QmVitalik',
+        trust: { level: 'verified', queried: ['a', 'b', 'c'], agreed: ['a', 'b', 'c'] },
+      });
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: false });
+      await flushMicrotasks();
+
+      expect(ctx.electronAPI.resolveEns).toHaveBeenCalledWith('vitalik.eth');
+      expect(tabA.webview.reload).not.toHaveBeenCalled();
+      expect(tabA.webview.reloadIgnoringCache).not.toHaveBeenCalled();
+    });
+
     test('reload after typing ENS draft, switching tabs, and switching back reloads the current non-ENS page', async () => {
       // Regression for the addressBarSnapshot-vs-committedDisplayUrl split:
       //   1. Open https://example.com (commits).

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -44,6 +44,7 @@ const createTab = (id, url, overrides = {}) => {
     currentBzzBase: null,
     currentRadBase: null,
     addressBarSnapshot: '',
+    committedDisplayUrl: '',
     cachedWebContentsId: null,
     resolvingWebContentsId: null,
     ...overrides.navigationState,
@@ -1678,14 +1679,17 @@ describe('navigation', () => {
       });
     };
 
-    // Mirror the production commit shape: on every did-navigate the
-    // renderer writes the user-facing display URL into both the address
-    // input and `navState.addressBarSnapshot`. Reload reads the snapshot
-    // (the *committed* display identity), not `addressInput.value`, so an
-    // unsubmitted draft in the address bar can't hijack reload.
+    // Mirror the production did-navigate commit shape: the handler writes
+    // the user-facing display URL into the address input AND into both
+    // `addressBarSnapshot` (transient draft/restoration state) and
+    // `committedDisplayUrl` (commit-only, the field reload reads). The
+    // split matters because `addressBarSnapshot` is overwritten on focusin
+    // and tab-switched, so it can carry unsubmitted user input — only
+    // `committedDisplayUrl` stays a stable identity.
     const commitDisplay = (ctx, value) => {
       ctx.elements.addressInput.value = value;
       ctx.activeRef.tab.navigationState.addressBarSnapshot = value;
+      ctx.activeRef.tab.navigationState.committedDisplayUrl = value;
     };
 
     test('soft reload of an ENS page re-resolves and updates trust', async () => {
@@ -1852,19 +1856,19 @@ describe('navigation', () => {
     });
 
     test('reload with unsubmitted ENS-looking text in the address bar reloads the current non-ENS page', async () => {
-      // Reload reads the *committed* display identity from
-      // `navState.addressBarSnapshot`, not `addressInput.value`. If the
-      // user has typed `vitalik.eth` over an `https://example.com` page
-      // but hasn't submitted it, hitting reload should reload the current
-      // page — submitting the typed value is the form-submit handler's job.
+      // Reload reads `committedDisplayUrl`, not `addressInput.value`. If
+      // the user has typed `vitalik.eth` over an `https://example.com`
+      // page but hasn't submitted it, hitting reload should reload the
+      // current page — submitting the typed value is the form-submit
+      // handler's job.
       const ctx = await loadNavigationModule();
       installEnsParser(ctx);
       await ctx.mod.initNavigation();
 
       commitDisplay(ctx, 'https://example.com/');
       // Now simulate the user typing into the address bar without
-      // submitting: addressInput.value is dirty, but the snapshot still
-      // reflects the committed page.
+      // submitting: addressInput.value is dirty, but committedDisplayUrl
+      // still reflects the committed page.
       ctx.elements.addressInput.value = 'vitalik.eth';
       ctx.activeRef.tab.webview.getURL.mockReturnValue('https://example.com/');
 
@@ -1873,6 +1877,86 @@ describe('navigation', () => {
 
       expect(ctx.activeRef.tab.webview.reload).toHaveBeenCalled();
       expect(ctx.activeRef.tab.webview.reloadIgnoringCache).not.toHaveBeenCalled();
+      expect(ctx.electronAPI.resolveEns).not.toHaveBeenCalled();
+      expect(ctx.electronAPI.invalidateEnsContent).not.toHaveBeenCalled();
+    });
+
+    test('reload after typing ENS draft, switching tabs, and switching back reloads the current non-ENS page', async () => {
+      // Regression for the addressBarSnapshot-vs-committedDisplayUrl split:
+      //   1. Open https://example.com (commits).
+      //   2. Type `vitalik.eth` into the address bar (no submit).
+      //   3. Switch to another tab — tab-switched writes the live
+      //      addressInput.value (the draft) into the previous tab's
+      //      addressBarSnapshot.
+      //   4. Switch back — addressInput.value is restored from the snapshot
+      //      (still the draft).
+      //   5. Hit reload.
+      // Pre-fix, reload read addressBarSnapshot and re-resolved
+      // `vitalik.eth` — wrong, the user never submitted it. Post-fix,
+      // reload reads committedDisplayUrl (which only commits write to)
+      // and reloads `https://example.com`.
+      const tabA = createTab(1, 'https://example.com', { title: 'Tab A' });
+      const tabB = createTab(2, 'https://other.example', { title: 'Tab B' });
+      const ctx = await loadNavigationModule({
+        firstTab: tabA,
+        tabs: [tabA, tabB],
+        activeTab: tabA,
+      });
+      installEnsParser(ctx);
+      ctx.tabsRef.list = [tabA, tabB];
+      ctx.activeRef.tab = tabA;
+      await ctx.mod.initNavigation();
+
+      commitDisplay(ctx, 'https://example.com/');
+      tabA.webview.getURL.mockReturnValue('https://example.com/');
+
+      // Seed `previousActiveTabId` so the next tab-switched actually fires
+      // the address-bar-save branch (the first switch records the previous
+      // id and skips the save). Mirrors the existing tab-switching test.
+      ctx.tabsMocks.webviewEventHandler('tab-switched', {
+        tabId: tabA.id,
+        tab: tabA,
+        isNewTab: false,
+      });
+
+      // Step 2: user types an unsubmitted draft into the address bar.
+      ctx.elements.addressInput.value = 'vitalik.eth';
+
+      // Step 3: switch to tab B. The handler writes the live (draft)
+      // addressInput.value into Tab A's addressBarSnapshot.
+      ctx.activeRef.tab = tabB;
+      ctx.tabsMocks.webviewEventHandler('tab-switched', {
+        tabId: tabB.id,
+        tab: tabB,
+        isNewTab: false,
+      });
+      await flushMicrotasks();
+
+      expect(tabA.navigationState.addressBarSnapshot).toBe('vitalik.eth');
+      // Crucially, the draft did NOT leak into committedDisplayUrl.
+      expect(tabA.navigationState.committedDisplayUrl).toBe('https://example.com/');
+
+      // Step 4: switch back to tab A.
+      ctx.navigationUtilsMocks.deriveSwitchedTabDisplay.mockReturnValueOnce('vitalik.eth');
+      ctx.activeRef.tab = tabA;
+      ctx.tabsMocks.webviewEventHandler('tab-switched', {
+        tabId: tabA.id,
+        tab: tabA,
+        isNewTab: false,
+      });
+      await flushMicrotasks();
+
+      // Address input restored to the draft — but committedDisplayUrl
+      // remains the genuinely-committed URL.
+      expect(ctx.elements.addressInput.value).toBe('vitalik.eth');
+      expect(tabA.navigationState.committedDisplayUrl).toBe('https://example.com/');
+
+      // Step 5: hit reload.
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: false });
+      await flushMicrotasks();
+
+      expect(tabA.webview.reload).toHaveBeenCalled();
+      expect(tabA.webview.reloadIgnoringCache).not.toHaveBeenCalled();
       expect(ctx.electronAPI.resolveEns).not.toHaveBeenCalled();
       expect(ctx.electronAPI.invalidateEnsContent).not.toHaveBeenCalled();
     });

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -58,8 +58,11 @@ export const state = {
   // bar value on focusin and tab-switched. Do not key reload or other
   // commit-sensitive decisions on this field; use `committedDisplayUrl`.
   addressBarSnapshot: '',
-  // Display URL of the last committed navigation. Written only by
-  // did-navigate handlers, so it stays stable when the user is mid-typing.
+  // URL of the last committed navigation (`webview.getURL()` at
+  // did-navigate time). Written only by tabs.js' per-webview did-navigate
+  // handler, so it stays stable when the user is mid-typing or while a
+  // navigation is still in flight. Used by reload and by
+  // `getDisplayUrlForWebview` for provider permission keying.
   committedDisplayUrl: '',
 
   // Webview

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -54,7 +54,13 @@ export const state = {
   ensProtocols: new Map(), // Maps ENS name -> resolved protocol (swarm/ipfs/ipns)
   ensTrustByName: new Map(), // Maps ENS name -> trust object from last resolution
   ensUriByName: new Map(), // Maps ENS name -> full resolved content URI (bzz://HASH, ipfs://CID, ipns://NAME)
+  // Transient draft/restoration state — overwritten with the live address
+  // bar value on focusin and tab-switched. Do not key reload or other
+  // commit-sensitive decisions on this field; use `committedDisplayUrl`.
   addressBarSnapshot: '',
+  // Display URL of the last committed navigation. Written only by
+  // did-navigate handlers, so it stays stable when the user is mid-typing.
+  committedDisplayUrl: '',
 
   // Webview
   cachedWebContentsId: null,

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -206,22 +206,21 @@ export const isActiveTab = (tabId) =>
 
 /**
  * Get the committed display URL for a specific webview.
- * Reads from the tab's `committedDisplayUrl` — the last display URL
- * written by a `did-navigate` handler. Never reads the live address bar
- * input, and deliberately does not read `addressBarSnapshot`, which is
+ * Reads from the tab's `committedDisplayUrl` — the last URL committed
+ * by a `did-navigate` event for this tab's webview. Never falls back
+ * to the live address bar input or to `addressBarSnapshot`, which is
  * transient draft/restoration state (overwritten on `focusin` and on
- * `tab-switched`, so it can carry an unsubmitted typed-but-not-yet-loaded
- * value).
+ * `tab-switched`, so it can carry unsubmitted typed-but-not-yet-loaded
+ * values).
  *
  * This is critical for provider permission checks — if a page fires a
  * request while the user is typing in the address bar (or has switched
  * away from a tab whose snapshot now carries a draft), we must derive
  * the origin from the committed navigation identity, not partial input.
  *
- * Falls back to `addressBarSnapshot` only for legacy/partially-initialised
- * tab state that predates the `committedDisplayUrl` field — new tabs always
- * start with `committedDisplayUrl: ''` and have it populated on the first
- * `did-navigate`.
+ * Returns the empty string for tabs that haven't yet committed a
+ * navigation. New tabs initialize `committedDisplayUrl: ''` and the
+ * value is populated on the first `did-navigate`.
  *
  * @param {HTMLElement} webview - The webview element
  * @returns {string} The committed display URL for this webview's tab
@@ -229,11 +228,7 @@ export const isActiveTab = (tabId) =>
 export const getDisplayUrlForWebview = (webview) => {
   const tab = tabState.tabs.find((t) => t.webview === webview);
   if (!tab) return '';
-  return (
-    tab.navigationState?.committedDisplayUrl
-    || tab.navigationState?.addressBarSnapshot
-    || ''
-  );
+  return tab.navigationState?.committedDisplayUrl || '';
 };
 
 // Create default navigation state for a tab
@@ -250,10 +245,16 @@ const createNavigationState = () => ({
   // names). Reload and other commit-keyed decisions must NOT key on it; use
   // `committedDisplayUrl` instead.
   addressBarSnapshot: '',
-  // `committedDisplayUrl` is the user-facing display URL of the last
-  // committed navigation. It's written only by did-navigate handlers, never
-  // by focusin/tab-switched/setAddressDisplayForTab, so it stays a stable
-  // identity for the active page even when the user is mid-typing.
+  // `committedDisplayUrl` is the URL Chromium committed for this tab's
+  // last navigation (`webview.getURL()` at did-navigate time, including
+  // any view-source: prefix). It's written only by tabs.js' per-webview
+  // did-navigate handler — never by focusin, tab-switched, or
+  // setAddressDisplayForTab — so it stays a stable identity for the
+  // active page even while the user is mid-typing or while a slow
+  // navigation is in flight. Reload reads this to decide whether the
+  // current page is ENS-backed, and `getDisplayUrlForWebview` returns
+  // it so provider permission keys never see unsubmitted drafts or
+  // pending destinations.
   committedDisplayUrl: '',
   cachedWebContentsId: null,
   resolvingWebContentsId: null,
@@ -411,6 +412,18 @@ const createWebview = (tabId, initialUrl) => {
         tab.hasCertError = false; // Reset cert error on new navigation
         // Track view-source state directly on tab for reliable detection in page-title-updated
         tab.isViewingSource = webviewUrl.startsWith('view-source:');
+        // Commit the post-navigation page identity for both active and
+        // background tabs. This is the single source of truth for reload
+        // ("what page are we actually on?") and for provider permission
+        // keying (Swarm/dapp prompts), which must never see destination
+        // URLs of in-flight navigations or unsubmitted address-bar drafts.
+        // about:blank is skipped because Chromium fires did-navigate
+        // through about:blank during "open in new window" before the real
+        // loadURL runs; clobbering the previous commit there would lose
+        // the actual page identity.
+        if (tab.navigationState && event.url && event.url !== 'about:blank') {
+          tab.navigationState.committedDisplayUrl = webviewUrl;
+        }
         // Clear any stale favicon from the previous page when navigating to
         // an internal page — page-favicon-updated will paint one back in if
         // the page declares a <link rel="icon">.

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -231,7 +231,17 @@ const createNavigationState = () => ({
   hasNavigatedDuringCurrentLoad: false,
   isWebviewLoading: false,
   currentBzzBase: null,
+  // `addressBarSnapshot` is transient draft/restoration state — it's
+  // overwritten with `addressInput.value` on focusin and on tab-switched, so
+  // it can hold unsubmitted user input (e.g. typed-but-not-submitted ENS
+  // names). Reload and other commit-keyed decisions must NOT key on it; use
+  // `committedDisplayUrl` instead.
   addressBarSnapshot: '',
+  // `committedDisplayUrl` is the user-facing display URL of the last
+  // committed navigation. It's written only by did-navigate handlers, never
+  // by focusin/tab-switched/setAddressDisplayForTab, so it stays a stable
+  // identity for the active page even when the user is mid-typing.
+  committedDisplayUrl: '',
   cachedWebContentsId: null,
   resolvingWebContentsId: null,
   pendingSwarmProbeId: null,

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -206,13 +206,22 @@ export const isActiveTab = (tabId) =>
 
 /**
  * Get the committed display URL for a specific webview.
- * Always reads from the tab's addressBarSnapshot — the last display URL
- * committed by a navigation event or tab switch. Never reads the live
- * address bar input, which could contain user edits in progress.
+ * Reads from the tab's `committedDisplayUrl` — the last display URL
+ * written by a `did-navigate` handler. Never reads the live address bar
+ * input, and deliberately does not read `addressBarSnapshot`, which is
+ * transient draft/restoration state (overwritten on `focusin` and on
+ * `tab-switched`, so it can carry an unsubmitted typed-but-not-yet-loaded
+ * value).
  *
  * This is critical for provider permission checks — if a page fires a
- * request while the user is typing in the address bar, we must derive
+ * request while the user is typing in the address bar (or has switched
+ * away from a tab whose snapshot now carries a draft), we must derive
  * the origin from the committed navigation identity, not partial input.
+ *
+ * Falls back to `addressBarSnapshot` only for legacy/partially-initialised
+ * tab state that predates the `committedDisplayUrl` field — new tabs always
+ * start with `committedDisplayUrl: ''` and have it populated on the first
+ * `did-navigate`.
  *
  * @param {HTMLElement} webview - The webview element
  * @returns {string} The committed display URL for this webview's tab
@@ -220,7 +229,11 @@ export const isActiveTab = (tabId) =>
 export const getDisplayUrlForWebview = (webview) => {
   const tab = tabState.tabs.find((t) => t.webview === webview);
   if (!tab) return '';
-  return tab.navigationState?.addressBarSnapshot || '';
+  return (
+    tab.navigationState?.committedDisplayUrl
+    || tab.navigationState?.addressBarSnapshot
+    || ''
+  );
 };
 
 // Create default navigation state for a tab

--- a/src/renderer/lib/tabs.test.js
+++ b/src/renderer/lib/tabs.test.js
@@ -90,6 +90,7 @@ describe('Tab Navigation State Isolation', () => {
       expect(tab.navigationState).toHaveProperty('isWebviewLoading');
       expect(tab.navigationState).toHaveProperty('currentBzzBase');
       expect(tab.navigationState).toHaveProperty('addressBarSnapshot');
+      expect(tab.navigationState).toHaveProperty('committedDisplayUrl');
       expect(tab.navigationState).toHaveProperty('cachedWebContentsId');
     });
   });
@@ -136,6 +137,46 @@ describe('Tab Navigation State Isolation', () => {
       // Switch back to tab1 - state should be preserved
       switchTab(tab1.id);
       expect(getActiveTab().navigationState.currentPageUrl).toBe('http://tab1.com');
+    });
+  });
+
+  describe('getDisplayUrlForWebview', () => {
+    // Provider permission checks (swarm-provider.js etc.) call this helper
+    // to derive the page origin for keying prompts and storing decisions.
+    // It must return the *committed* display identity, never the user's
+    // unsubmitted address-bar draft — otherwise a Swarm site could fire a
+    // request while the user is mid-typing and have its permission prompt
+    // keyed on the typed-but-not-loaded URL instead of the actual page.
+    test('returns committedDisplayUrl, ignoring an unsubmitted draft in addressBarSnapshot', async () => {
+      const { createTab, getDisplayUrlForWebview } = await import('./tabs.js');
+
+      const tab = createTab('https://example.com/');
+      // Mirror the production did-navigate commit shape: committedDisplayUrl
+      // is the source of truth for the active page identity.
+      tab.navigationState.committedDisplayUrl = 'https://example.com/';
+      // addressBarSnapshot can carry an unsubmitted draft (focusin /
+      // tab-switched both write the live address-bar value into it). It
+      // must NOT be the value getDisplayUrlForWebview returns.
+      tab.navigationState.addressBarSnapshot = 'vitalik.eth';
+
+      expect(getDisplayUrlForWebview(tab.webview)).toBe('https://example.com/');
+    });
+
+    test('falls back to addressBarSnapshot when committedDisplayUrl is empty (legacy state)', async () => {
+      const { createTab, getDisplayUrlForWebview } = await import('./tabs.js');
+
+      const tab = createTab('https://example.com/');
+      tab.navigationState.committedDisplayUrl = '';
+      tab.navigationState.addressBarSnapshot = 'https://legacy.example/';
+
+      expect(getDisplayUrlForWebview(tab.webview)).toBe('https://legacy.example/');
+    });
+
+    test('returns empty string when the webview is not tracked', async () => {
+      const { getDisplayUrlForWebview } = await import('./tabs.js');
+
+      const orphan = createMockWebview(999);
+      expect(getDisplayUrlForWebview(orphan)).toBe('');
     });
   });
 

--- a/src/renderer/lib/tabs.test.js
+++ b/src/renderer/lib/tabs.test.js
@@ -162,14 +162,20 @@ describe('Tab Navigation State Isolation', () => {
       expect(getDisplayUrlForWebview(tab.webview)).toBe('https://example.com/');
     });
 
-    test('falls back to addressBarSnapshot when committedDisplayUrl is empty (legacy state)', async () => {
+    test('returns empty string when committedDisplayUrl is empty (no fallback to addressBarSnapshot)', async () => {
+      // `addressBarSnapshot` is overwritten with the live address-bar
+      // value on focusin and tab-switched, so it can carry an
+      // unsubmitted draft. Falling back to it would leak that draft
+      // into provider permission keying — instead, an unset
+      // `committedDisplayUrl` must surface as the empty string so
+      // callers explicitly handle the "no committed page yet" case.
       const { createTab, getDisplayUrlForWebview } = await import('./tabs.js');
 
       const tab = createTab('https://example.com/');
       tab.navigationState.committedDisplayUrl = '';
-      tab.navigationState.addressBarSnapshot = 'https://legacy.example/';
+      tab.navigationState.addressBarSnapshot = 'vitalik.eth';
 
-      expect(getDisplayUrlForWebview(tab.webview)).toBe('https://legacy.example/');
+      expect(getDisplayUrlForWebview(tab.webview)).toBe('');
     });
 
     test('returns empty string when the webview is not tracked', async () => {
@@ -177,6 +183,75 @@ describe('Tab Navigation State Isolation', () => {
 
       const orphan = createMockWebview(999);
       expect(getDisplayUrlForWebview(orphan)).toBe('');
+    });
+  });
+
+  describe('did-navigate populates committedDisplayUrl', () => {
+    // The committed display identity is the source of truth for reload
+    // ("what page are we actually on?") and for provider permission
+    // keying. It must be written on the per-webview `did-navigate`
+    // event (which fires after Chromium actually commits the
+    // navigation) for every tab — not pre-commit by the dispatch path,
+    // and not gated on the tab being active. Otherwise either:
+    //   - a pre-commit write lets the destination origin briefly stand
+    //     in for the still-loaded previous page, or
+    //   - a background ENS load that finishes while its tab is
+    //     inactive never populates the committed identity, so a later
+    //     reload falls through to webview.reload() instead of
+    //     re-resolving under today's verification method.
+    test('writes committedDisplayUrl for the active tab on did-navigate', async () => {
+      const { createTab } = await import('./tabs.js');
+
+      const tab = createTab('https://example.com/');
+      tab.webview.getURL.mockReturnValue('https://example.com/page');
+      tab.webview._eventHandlers['did-navigate']({ url: 'https://example.com/page' });
+
+      expect(tab.navigationState.committedDisplayUrl).toBe('https://example.com/page');
+    });
+
+    test('writes committedDisplayUrl for a background tab on did-navigate', async () => {
+      const { createTab, switchTab } = await import('./tabs.js');
+
+      const tabA = createTab('https://a.example/');
+      const tabB = createTab('https://b.example/');
+      // Foreground tabB so tabA is the background tab whose did-navigate
+      // we exercise.
+      switchTab(tabB.id);
+
+      tabA.webview.getURL.mockReturnValue('ipfs://vitalik.eth');
+      tabA.webview._eventHandlers['did-navigate']({ url: 'ipfs://vitalik.eth' });
+
+      expect(tabA.navigationState.committedDisplayUrl).toBe('ipfs://vitalik.eth');
+    });
+
+    test('preserves committedDisplayUrl when did-navigate fires for about:blank', async () => {
+      // about:blank navigations happen during "open in new window" before
+      // the real loadURL runs. Letting them clobber `committedDisplayUrl`
+      // would lose the actual page identity for the brief window between
+      // the about:blank commit and the real navigation committing.
+      const { createTab } = await import('./tabs.js');
+
+      const tab = createTab('https://example.com/');
+      tab.navigationState.committedDisplayUrl = 'https://example.com/';
+      tab.webview.getURL.mockReturnValue('about:blank');
+      tab.webview._eventHandlers['did-navigate']({ url: 'about:blank' });
+
+      expect(tab.navigationState.committedDisplayUrl).toBe('https://example.com/');
+    });
+
+    test('captures view-source: prefix from webview.getURL() on did-navigate', async () => {
+      // `webview.getURL()` is the canonical source for the committed
+      // URL because event.url omits the view-source: prefix. Reload
+      // checks downstream depend on the prefix being preserved here.
+      const { createTab } = await import('./tabs.js');
+
+      const tab = createTab('https://example.com/');
+      tab.webview.getURL.mockReturnValue('view-source:https://example.com/');
+      tab.webview._eventHandlers['did-navigate']({ url: 'https://example.com/' });
+
+      expect(tab.navigationState.committedDisplayUrl).toBe(
+        'view-source:https://example.com/'
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #82 — reload on an ENS page used to call `webview.reload()` against the resolved transport URL (carrying the actual content hash), which never re-entered the ENS resolution path. After flipping the ENS verification method at `freedom://settings/ens`, the trust badge stayed stuck on the previous method until the user re-typed the name into the address bar.

`retryErrorPageOrReload` now keys the decision on the active tab's **committed display URL** — a new dedicated `navigationState.committedDisplayUrl` field written *only* by navigation commit points. When that identity is ENS-form (`bzz://name.eth/...`, `ipfs://name.eth/...`, `ipns://name.eth/...`, bare `name.eth`), reload routes through `loadTarget`, which re-runs `resolveEns` under the currently-configured method and overwrites `state.ensTrustByName` with the fresh trust object.

- **Soft reload** (`Cmd/Ctrl+R`) of a committed ENS page re-runs the full ENS resolution path. The main process's `refreshDownstream` already clears `ensResultCache` on settings flips, so a fresh `resolveEns` call really does re-verify under the new method.
- **Hard reload** (`Cmd/Ctrl+Shift+R`) additionally calls the already-exported `electronAPI.invalidateEnsContent(name)` IPC to bypass the 15-min `ensResultCache` TTL — the simpler design option **(b)** from the issue, no new parameter threading required.
- **Dirty / draft address bar is preserved.** Reading `committedDisplayUrl` rather than the live input or the draft snapshot means an unsubmitted `vitalik.eth` typed over an `https://example.com` page reloads the current page; submitting the typed value remains the form `submit` handler's job.
- **Error-page recovery branch runs first.** `getOriginalUrlFromErrorPage` → `loadTarget(originalUrl)` is unchanged. For hard reload from an ENS error page, the recovery branch *also* invalidates the contenthash cache before re-resolving.
- **Background-tab ENS commits are covered.** `tabs.js` only forwards `did-navigate` to the renderer navigation handler for the active tab, so an ENS load that resolves while its tab is in the background never went through the foreground commit path. The fix marks the actual commit points (shared dweb prefix, HTTP, Radicle, view-source) with `{ commit: true }` so `setAddressDisplayForTab` writes `committedDisplayUrl` on the *target* tab regardless of active state — switching back and reloading now triggers a fresh ENS resolution.
- **Both `.eth` and `.box`** are handled uniformly through `parseEnsInput`; no special-casing.

A small `invalidateEnsContentForHardReload(name)` helper is shared between the error-recovery and committed-page branches.

### Why a new field instead of reusing `addressBarSnapshot`?

`addressBarSnapshot` is overloaded: it's overwritten on `focusin` and `tab-switched` to support address-bar draft restoration and Escape-to-restore. That means it can carry *unsubmitted* user input. Concretely, this flow used to break reload:

1. Open `https://example.com` (commits).
2. Type `vitalik.eth` in the address bar without submitting.
3. Switch to another tab — `tab-switched` writes the live (draft) `addressInput.value` into the previous tab's `addressBarSnapshot`.
4. Switch back — `addressInput.value` is restored from the snapshot (still the draft).
5. Hit reload — pre-fix, reload would re-resolve and navigate to the typed-but-unsubmitted `vitalik.eth`.

Splitting the state into two fields fixes this cleanly:

- `addressBarSnapshot` keeps its draft/restoration semantics — still written by `focusin` and `tab-switched`, still consumed by Escape-to-restore and tab-switching display derivation.
- `committedDisplayUrl` is written *only* by navigation commit points (the `did-navigate` handlers and, for background tabs, the `commit: true` calls in `loadTarget`'s commit branches), so it stays a stable identity for the active page even when the user is mid-typing.

Defaults added to `src/renderer/lib/tabs.js` `createNavigationState()` and to `src/renderer/lib/state.js`.

### Background-tab ENS commit gap

`tabs.js`'s per-webview `did-navigate` listener only forwards events to `navigation.js`'s `webviewEventHandler` for the **active** tab. An ENS load that resolved and committed while its tab was backgrounded would therefore never run the renderer-side `did-navigate` path that writes `committedDisplayUrl`. Pre-fix:

1. Start loading `vitalik.eth` in Tab A.
2. Switch to Tab B before `resolveEns` settles / `webview.loadURL` fires.
3. Tab A finishes loading in the background.
4. Switch back to Tab A.
5. Change the ENS verification method.
6. Hit reload — `committedDisplayUrl` is empty, the ENS branch doesn't fire, and reload falls through to `webview.reload()`.

Fix: `setAddressDisplayForTab(displayValue, tabId, opts)` now accepts `{ commit: true }`. When set, it writes `committedDisplayUrl` on the target tab's `navigationState` regardless of active state. Marked at the actual navigation commit points: `commitDwebNavigationPrefix` (shared by IPFS and Swarm/bzz), the HTTP/HTTPS branch, the Radicle branch, and the view-source ENS-post-resolve and default branches. Pre-resolution placeholder calls (the in-flight ENS placeholder at the top of the ENS path, the view-source ENS placeholder) keep the default `commit: false` — they're tentative and not a commit. For the active tab `did-navigate` overwrites `committedDisplayUrl` shortly after, so the early write is harmless and idempotent.

### Provider permission checks no longer key on draft URLs

`getDisplayUrlForWebview()` (consumed by `swarm-provider.js` → renderer, plus the main-process `swarm-provider-ipc` for permission keys/prompts) used to read `addressBarSnapshot`. After the field split that's a draft value. A Swarm site firing a request while the user was mid-typing — or after a tab-switched draft was outstanding — would have had its permission prompt keyed on the typed-but-not-loaded URL instead of the actual page origin.

The helper now returns `committedDisplayUrl` and falls back to `addressBarSnapshot` only as a defensive guard for legacy / partially-initialised tab state that predates the new field. Docstring updated to spell out the contract.

## Test plan

`src/renderer/lib/navigation.test.js` — nine regression tests under a new `ENS reload re-resolution` describe block:

- [x] Soft reload of a committed ENS page calls `electronAPI.resolveEns(name)` and updates `state.ensTrustByName`, without calling `webview.reload()` or `invalidateEnsContent`.
- [x] Hard reload of a committed ENS page calls `invalidateEnsContent(name)` *and* `resolveEns`, without calling `webview.reload()` or `webview.reloadIgnoringCache()`.
- [x] Soft reload of a non-ENS `https://` page falls through to `webview.reload()` and never touches `resolveEns`.
- [x] Hard reload of a non-ENS page falls through to `webview.reloadIgnoringCache()`.
- [x] Reload from an ENS error page still uses the `getOriginalUrlFromErrorPage` recovery path.
- [x] Hard reload from an ENS error page invalidates the contenthash cache and re-resolves.
- [x] Reload with unsubmitted ENS-looking text in the address bar reloads the current non-ENS page.
- [x] Reload after typing ENS draft → switching tabs → switching back reloads the current non-ENS page (asserts the `addressBarSnapshot` ↔ `committedDisplayUrl` split actually holds end-to-end through the tab-switch handler).
- [x] **New (review):** Reload after a background ENS navigation commits in another tab re-resolves on switch-back. End-to-end: kick off ENS resolution targeting Tab A with a deferred `resolveEns`; switch to Tab B; resolve ENS; assert `tabA.navigationState.committedDisplayUrl` is populated even though Tab A was backgrounded; switch back; click reload; assert `resolveEns` is called and `webview.reload()` is not.

A shared `commitDisplay(ctx, value)` helper in the test file mirrors the production `did-navigate` shape by writing the value into `addressInput.value`, `navigationState.addressBarSnapshot`, *and* `navigationState.committedDisplayUrl`.

`src/renderer/lib/tabs.test.js` — three new tests for `getDisplayUrlForWebview()`:

- [x] Returns `committedDisplayUrl`, ignoring an unsubmitted draft in `addressBarSnapshot`.
- [x] Falls back to `addressBarSnapshot` when `committedDisplayUrl` is empty (legacy state).
- [x] Returns `''` for an untracked webview.

Plus the existing per-tab navigation-state property test extended to assert `committedDisplayUrl` is present on every new tab.

Local verification:

- [x] `npm test -- src/renderer/lib/navigation.test.js src/renderer/lib/tabs.test.js` — 60/60 pass.
- [x] `npm test` — 1483 pass; one pre-existing `bee.test.js` integration failure on `main` that requires a live Bee node, unrelated to this PR.
- [x] `npm run lint` — clean.

## Manual smoke test

1. Navigate to `bzz://vitalik.eth/`. Confirm the trust shield is visible and the popover reports the current method.
2. Open `freedom://settings/ens` and switch **Verification method** from _Colibri_ to _Public-RPC quorum_ (or vice versa).
3. Return to the ENS tab and hit reload (or `Cmd/Ctrl+R`).
4. **Expected:** the trust shield popover now reports the new method (or surfaces a verification failure if quorum disagrees on the contenthash). Hard reload (`Cmd/Ctrl+Shift+R`) does the same and additionally bypasses the 15-min ENS contenthash cache.
5. **Dirty-address-bar guard:** on an `https://example.com` page, click into the address bar and type `vitalik.eth` *without submitting*, then click reload. The page should reload `example.com`, not navigate to `vitalik.eth`.
6. **Tab-switch guard:** repeat (5) but instead of clicking reload immediately, switch to a different tab, switch back to the `example.com` tab (the address bar will still display the unsubmitted `vitalik.eth`), and *then* click reload. The page should still reload `example.com`.
7. **Background-commit guard:** in Tab A type `vitalik.eth` and submit; *immediately* `Cmd/Ctrl+T` to a new tab so Tab A's resolution commits while it's backgrounded. Wait a moment, switch to `freedom://settings/ens` and flip the verification method, then switch back to Tab A and hit reload. The trust shield popover should reflect the new method.
