### PR TITLE
feat(main): add swarm_apiRequest passthrough to the Bee HTTP API

### DIFF
--- a/src/main/swarm/swarm-provider-ipc.js
+++ b/src/main/swarm/swarm-provider-ipc.js
@@ -49,7 +49,28 @@ const LIMITS = {
   maxFileCount: 100,
   maxPathBytes: 100,
   maxChunkPayloadBytes: 4096,
+  maxApiBodyBytes: 50 * 1024 * 1024, // 50 MB — swarm_apiRequest req/resp body cap
+  maxApiHeaders: 30,
+  maxApiHeaderLen: 8192,
 };
+
+// swarm_apiRequest: which Bee HTTP API endpoints a connected dApp may reach
+// through the passthrough. ALLOW-LIST by first path segment — anything not
+// listed is denied. Deliberately EXCLUDES node-wallet / chequebook / staking /
+// network-admin endpoints (they move funds or reconfigure the node and must
+// never be reachable from web content). Covers the data + postage + pss surface
+// a dApp legitimately needs (matches the bee-js client's usage).
+const ALLOWED_API_SEGMENTS = new Set([
+  'health', 'readiness', 'node', 'addresses',
+  'stamps', 'batches',
+  'bzz', 'bytes', 'chunks', 'soc', 'feeds',
+  'tags', 'pins', 'pss', 'stewardship', 'gsoc',
+]);
+const ALLOWED_API_METHODS = new Set(['GET', 'POST', 'PATCH', 'DELETE', 'HEAD']);
+// Request headers we never forward (the node/fetch owns these).
+const BLOCKED_API_HEADERS = new Set(['host', 'content-length', 'connection', 'origin', 'referer', 'cookie']);
+// Response content-types returned as utf8 text (else base64).
+const TEXTUAL_CONTENT_TYPE = /^(application\/(json|.*\+json|xml|javascript|x-www-form-urlencoded)|text\/)/i;
 
 const SPEC_VERSION = '1.0';
 const MAX_U64 = (1n << 64n) - 1n;
@@ -92,6 +113,7 @@ const KNOWN_METHODS = [
   'swarm_writeSingleOwnerChunk',
   'swarm_readSingleOwnerChunk',
   'swarm_getSigningIdentity',
+  'swarm_apiRequest',
 ];
 
 // Tag ownership: tagUid → origin. Session-scoped, not persisted.
@@ -354,6 +376,10 @@ async function executeSwarmMethod(method, params, origin) {
       const result = await handleGetSigningIdentity(normalizedOrigin);
       if (result.result) resetVaultAutoLockTimer();
       return result;
+    }
+
+    if (method === 'swarm_apiRequest') {
+      return handleApiRequest(params, normalizedOrigin);
     }
 
     return { error: ERRORS.INTERNAL_ERROR };
@@ -1464,6 +1490,123 @@ async function checkSwarmPreFlight() {
     log.error('[SwarmProvider] Pre-flight check failed:', err.message);
     return { ok: false, reason: 'node-stopped' };
   }
+}
+
+/**
+ * swarm_apiRequest — permission-gated passthrough to the local Bee HTTP API.
+ *
+ * Lets a connected dApp make an arbitrary Bee API call from the MAIN process
+ * (which isn't subject to browser CORS), so libraries that use plain `fetch`
+ * against the node work without exposing the node API to the open web. The
+ * `path` is allow-listed by first segment (data + postage + pss surface only);
+ * node-wallet / chequebook / staking / admin endpoints are never reachable.
+ *
+ * @param {{ method?: string, path?: string, headers?: object, body?: string,
+ *   bodyEncoding?: 'utf8'|'base64' }} params
+ * @returns {{ result?: { ok, status, statusText, headers, body, bodyEncoding },
+ *   error? }}
+ */
+async function handleApiRequest(params, _origin) {
+  if (!params || typeof params !== 'object') {
+    return invalidParams('params object is required');
+  }
+
+  const httpMethod = String(params.method || 'GET').toUpperCase();
+  if (!ALLOWED_API_METHODS.has(httpMethod)) {
+    return invalidParams(`Unsupported method: ${httpMethod}`, 'unsupported_method', { method: httpMethod });
+  }
+
+  const path = params.path;
+  if (typeof path !== 'string' || !path.startsWith('/')) {
+    return invalidParams('path must be a string starting with "/"', 'invalid_path');
+  }
+  if (path.length > 2048 || path.includes('..')) {
+    return invalidParams('path is malformed', 'invalid_path');
+  }
+  // First path segment (before the next "/" or query/fragment) gates access.
+  const segment = path.slice(1).split(/[/?#]/, 1)[0].toLowerCase();
+  if (!ALLOWED_API_SEGMENTS.has(segment)) {
+    return notAuthorized('endpoint_not_allowed');
+  }
+
+  // Request headers: forward a safe subset.
+  const headers = {};
+  if (params.headers != null) {
+    if (typeof params.headers !== 'object' || Array.isArray(params.headers)) {
+      return invalidParams('headers must be an object', 'invalid_headers');
+    }
+    const entries = Object.entries(params.headers);
+    if (entries.length > LIMITS.maxApiHeaders) {
+      return invalidParams('too many headers', 'too_many_headers');
+    }
+    for (const [k, v] of entries) {
+      const key = String(k).toLowerCase();
+      if (BLOCKED_API_HEADERS.has(key)) continue;
+      const value = String(v);
+      if (key.length > LIMITS.maxApiHeaderLen || value.length > LIMITS.maxApiHeaderLen) {
+        return invalidParams('header too large', 'header_too_large');
+      }
+      headers[key] = value;
+    }
+  }
+
+  // Request body: utf8 string or base64-encoded bytes.
+  let body;
+  if (params.body != null) {
+    if (typeof params.body !== 'string') {
+      return invalidParams('body must be a string', 'invalid_body');
+    }
+    try {
+      body = Buffer.from(params.body, params.bodyEncoding === 'base64' ? 'base64' : 'utf8');
+    } catch {
+      return invalidParams('body could not be decoded', 'invalid_body');
+    }
+    if (body.length > LIMITS.maxApiBodyBytes) {
+      return invalidParams('body exceeds size limit', 'body_too_large');
+    }
+  }
+
+  const beeUrl = getBeeApiUrl();
+  if (!beeUrl) {
+    return { error: ERRORS.NODE_UNAVAILABLE };
+  }
+
+  let res;
+  try {
+    res = await fetch(`${beeUrl}${path}`, {
+      method: httpMethod,
+      headers,
+      body: httpMethod === 'GET' || httpMethod === 'HEAD' ? undefined : body,
+    });
+  } catch (err) {
+    return { error: { ...ERRORS.NODE_UNAVAILABLE, message: `Bee request failed: ${err.message}` } };
+  }
+
+  let buf;
+  try {
+    buf = Buffer.from(await res.arrayBuffer());
+  } catch (err) {
+    return { error: { ...ERRORS.INTERNAL_ERROR, message: `Failed reading response: ${err.message}` } };
+  }
+  if (buf.length > LIMITS.maxApiBodyBytes) {
+    return invalidParams('response exceeds size limit', 'response_too_large');
+  }
+
+  const contentType = res.headers.get('content-type') || '';
+  const textual = TEXTUAL_CONTENT_TYPE.test(contentType);
+  const respHeaders = {};
+  res.headers.forEach((value, key) => { respHeaders[key] = value; });
+
+  return {
+    result: {
+      ok: res.ok,
+      status: res.status,
+      statusText: res.statusText,
+      headers: respHeaders,
+      body: textual ? buf.toString('utf8') : buf.toString('base64'),
+      bodyEncoding: textual ? 'utf8' : 'base64',
+    },
+  };
 }
 
 /**

--- a/src/main/swarm/swarm-provider-ipc.test.js
+++ b/src/main/swarm/swarm-provider-ipc.test.js
@@ -1897,4 +1897,87 @@ describe('swarm-provider-ipc', () => {
       expect(mockGetAllFeeds).toHaveBeenCalledWith('specific-origin.eth');
     });
   });
+
+  describe('swarm_apiRequest', () => {
+    function mockBeeResponse({ ok = true, status = 200, statusText = 'OK', contentType = 'application/json', body = '' } = {}) {
+      const buf = Buffer.from(body);
+      const headers = new Map([['content-type', contentType]]);
+      return {
+        ok,
+        status,
+        statusText,
+        headers: {
+          get: (k) => (headers.has(String(k).toLowerCase()) ? headers.get(String(k).toLowerCase()) : null),
+          forEach: (cb) => headers.forEach((v, k) => cb(v, k)),
+        },
+        arrayBuffer: async () => buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength),
+      };
+    }
+
+    test('requires a connected origin', async () => {
+      mockGetPermission.mockReturnValue(null);
+      const r = await invokeProvider('swarm_apiRequest', { method: 'GET', path: '/stamps' }, 'app.eth');
+      expect(r.result).toBeUndefined();
+      expect(r.error.code).toBe(4100);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('denies non-allow-listed endpoints (no fund/admin surface)', async () => {
+      mockGetPermission.mockReturnValue({ origin: 'app.eth' });
+      for (const path of ['/wallet', '/chequebook/cashout', '/stake', '/settlements']) {
+        const r = await invokeProvider('swarm_apiRequest', { method: 'GET', path }, 'app.eth');
+        expect(r.error.code).toBe(4100);
+        expect(r.error.data.reason).toBe('endpoint_not_allowed');
+      }
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('rejects unsupported HTTP methods and malformed paths', async () => {
+      mockGetPermission.mockReturnValue({ origin: 'app.eth' });
+      expect((await invokeProvider('swarm_apiRequest', { method: 'OPTIONS', path: '/stamps' }, 'app.eth')).error.code).toBe(-32602);
+      expect((await invokeProvider('swarm_apiRequest', { method: 'GET', path: 'stamps' }, 'app.eth')).error.code).toBe(-32602);
+      expect((await invokeProvider('swarm_apiRequest', { method: 'GET', path: '/bzz/../wallet' }, 'app.eth')).error.code).toBe(-32602);
+    });
+
+    test('proxies a GET to the node and returns a utf8 body', async () => {
+      mockGetPermission.mockReturnValue({ origin: 'app.eth' });
+      mockGetBeeApiUrl.mockReturnValue('http://127.0.0.1:1633');
+      global.fetch.mockResolvedValueOnce(mockBeeResponse({ body: '{"stamps":[]}' }));
+
+      const r = await invokeProvider('swarm_apiRequest', { method: 'GET', path: '/stamps' }, 'app.eth');
+
+      expect(global.fetch).toHaveBeenCalledWith('http://127.0.0.1:1633/stamps', expect.objectContaining({ method: 'GET' }));
+      expect(r.result).toMatchObject({ ok: true, status: 200, body: '{"stamps":[]}', bodyEncoding: 'utf8' });
+    });
+
+    test('returns base64 for binary responses', async () => {
+      mockGetPermission.mockReturnValue({ origin: 'app.eth' });
+      mockGetBeeApiUrl.mockReturnValue('http://127.0.0.1:1633');
+      global.fetch.mockResolvedValueOnce(mockBeeResponse({ contentType: 'application/octet-stream', body: 'PNGDATA' }));
+
+      const r = await invokeProvider('swarm_apiRequest', { method: 'GET', path: '/bzz/abc/img.png' }, 'app.eth');
+
+      expect(r.result.bodyEncoding).toBe('base64');
+      expect(Buffer.from(r.result.body, 'base64').toString()).toBe('PNGDATA');
+    });
+
+    test('forwards method + safe headers + body, strips blocked headers', async () => {
+      mockGetPermission.mockReturnValue({ origin: 'app.eth' });
+      mockGetBeeApiUrl.mockReturnValue('http://127.0.0.1:1633');
+      global.fetch.mockResolvedValueOnce(mockBeeResponse({ body: '{"reference":"abc"}' }));
+
+      await invokeProvider('swarm_apiRequest', {
+        method: 'POST',
+        path: '/bzz',
+        headers: { 'swarm-postage-batch-id': 'batch1', host: 'evil.example', 'content-type': 'application/json' },
+        body: 'hello',
+      }, 'app.eth');
+
+      const [, init] = global.fetch.mock.calls[0];
+      expect(init.method).toBe('POST');
+      expect(init.headers['swarm-postage-batch-id']).toBe('batch1');
+      expect(init.headers.host).toBeUndefined();
+      expect(Buffer.from(init.body).toString()).toBe('hello');
+    });
+  });
 });

--- a/src/main/webview-preload.js
+++ b/src/main/webview-preload.js
@@ -547,7 +547,8 @@ try {
               method === 'swarm_updateFeed' ||
               method === 'swarm_writeFeedEntry' ||
               method === 'swarm_writeSingleOwnerChunk' ||
-              method === 'swarm_getSigningIdentity';
+              method === 'swarm_getSigningIdentity' ||
+              method === 'swarm_apiRequest';
             const timeout = longRunning ? 300000 : 60000;
             setTimeout(() => {
               if (pendingRequests.has(id)) {
@@ -575,6 +576,7 @@ try {
         writeSingleOwnerChunk(params) { return this.request({ method: 'swarm_writeSingleOwnerChunk', params: params }); },
         readSingleOwnerChunk(params) { return this.request({ method: 'swarm_readSingleOwnerChunk', params: params }); },
         getSigningIdentity() { return this.request({ method: 'swarm_getSigningIdentity' }); },
+        apiRequest(params) { return this.request({ method: 'swarm_apiRequest', params: params }); },
 
         on(event, handler) { if (eventListeners[event]) eventListeners[event].push(handler); return this; },
         removeListener(event, handler) {


### PR DESCRIPTION
## Problem

dApps served by Freedom that talk to the local Bee node with plain `fetch` are blocked by browser CORS. A page at e.g. `https://<name>.eth.limo` doing `fetch('http://localhost:1633/stamps')` gets:

```
Access to fetch at 'http://localhost:1633/stamps' from origin '…' blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

The request **reaches the node and returns `200`** — the browser just won't let the page read the response. Bee's restrictive default CORS is correct (its API can move funds), but it leaves served dApps with no sanctioned path to the node. This is likely the same root cause behind #72 (Swarm OSM tiles don't load in Freedom though the node serves them fine elsewhere).

`window.swarm` already exists with a per-origin permission prompt + grant store, but only high-level methods (`swarm_publishData`, feeds, chunks) — nothing for arbitrary endpoints like `/stamps` or `/health`, and libraries use `fetch` anyway.

## Change

Add **`window.swarm.apiRequest({ method, path, headers, body })`** — a permission-gated passthrough to the Bee HTTP API. The renderer's existing default branch forwards it through the permission check to a new `swarm_apiRequest` handler in the main process, which performs the `fetch` (not subject to browser CORS) and returns `{ ok, status, statusText, headers, body, bodyEncoding }`.

Libraries can feature-detect `window.swarm.apiRequest` and route Bee calls through it, falling back to direct `fetch` in normal browsers.

## Security

- **Requires an established per-origin Swarm connection** — falls through to the same permission check as the other privileged methods (no new prompt path).
- **Path allow-list by first segment** — data + postage + pss surface only (`health`, `readiness`, `node`, `addresses`, `stamps`, `bzz`, `bytes`, `chunks`, `soc`, `feeds`, `tags`, `pins`, `pss`, `stewardship`, `gsoc`). **Node-wallet / chequebook / staking / settlements / network-admin endpoints are never reachable.**
- Blocks unsafe request headers (`host`, `cookie`, `origin`, …), caps header count/size and request/response body size (50 MB), rejects malformed paths (`..`).
- Returns text as `utf8`, binary as `base64`.

## Why this location

Extends the existing `src/main/swarm` provider, where the origin-trust + permission model already live (per the trust-model comment in `swarm-provider-ipc.js`). No new cross-layer dependency; the renderer's default branch already forwards unknown methods through the permission check, so **no renderer change** is required.

## Tests

- `src/main/swarm/swarm-provider-ipc.test.js`: 6 new cases (requires connection; denies non-allow-listed/fund endpoints; rejects bad method/path; proxies GET → utf8; binary → base64; forwards method/safe-headers/body + strips blocked headers). **Full suite 142/142 green; `eslint` clean on touched files.**

## Not covered here / follow-ups

- **Draft:** the main-process logic is unit-tested, but I haven't run the Electron GUI e2e for the consent → apiRequest round-trip — please validate interactively.
- Pairs with a small **dApp-side** change (e.g. in `@ffaerber/swarm-connect`) to detect `window.swarm.apiRequest` and use it; happy to open that too.
- Open to gating fund-spending stamp ops (`POST /stamps`) behind an extra approval if you'd prefer — currently allowed under the connection grant.

Closes #72 (likely).
