### PR TITLE
build(ant): bump pinned antd release to v0.5.28

### DIFF
--- a/scripts/fetch-ant.js
+++ b/scripts/fetch-ant.js
@@ -15,7 +15,7 @@ const ANT_REPO = process.env.ANT_REPO || 'solardev-xyz/ant';
 // could ship a different Ant than CI validated. Override via ANT_RELEASE_TAG
 // for local testing of newer releases; set it to `latest` to resolve the
 // repo's most recent published release.
-const PINNED_RELEASE_TAG = 'v0.5.27';
+const PINNED_RELEASE_TAG = 'v0.5.28';
 // In-repo trust root for the pinned release: the sha256 of its SHA256SUMS
 // asset, recorded at pin time (trust-on-first-use by the author). The release
 // downloads its SHA256SUMS from the same GitHub release as the binaries, so
@@ -24,7 +24,7 @@ const PINNED_RELEASE_TAG = 'v0.5.27';
 // that tampering detectable. Update alongside PINNED_RELEASE_TAG on every
 // deliberate bump: `shasum -a 256` the freshly downloaded SHA256SUMS.
 const PINNED_SHA256SUMS_DIGEST =
-  '9fe3a33ea2081946610970fd5f078e25392cceccced098dfee89cf246bbe23b0';
+  '487d0d98599627a317cae0e9664a270b09231718d1f86b5ea470e8a15b848faa';
 const ANT_RELEASE_TAG = process.env.ANT_RELEASE_TAG || PINNED_RELEASE_TAG;
 
 function fetchReleaseOnce() {


### PR DESCRIPTION
## Summary

- Bump the pinned Ant (`antd`) release in `scripts/fetch-ant.js` from `v0.5.27` to `v0.5.28` (latest upstream release on `solardev-xyz/ant`).
- Update `PINNED_SHA256SUMS_DIGEST` to the sha256 of the `v0.5.28` `SHA256SUMS` asset (`487d0d98...848faa`), the in-repo trust root that makes a later swap of the release assets detectable.

## Test plan

- [x] `npm run ant:download` downloads and checksum-verifies all targets against the new pinned digest, and verifies `SHA256SUMS` against the in-repo pinned digest
- [x] `./ant-bin/mac-arm64/antd --version` reports `antd 0.5.28`
- [x] `npm run lint` passes
- [x] `npm run check-binaries` passes
- [x] `bee-to-ant-migration` real-binary integration test stays green (guards the antd-never-self-creates-`keys/swarm.key` invariant)