### PR TITLE
test(main): cover v0.8.0 upgrade data continuity

### DIFF
--- a/docs/freedom-ipfs-native-desktop.md
+++ b/docs/freedom-ipfs-native-desktop.md
@@ -69,6 +69,14 @@ The packaged app includes the `.node` addon via Electron Builder
   they are not part of this branch's runtime path.
 - Native node data is stored under `ipfs-data/freedom-ipfs/` in development (or
   the `freedom-ipfs/` child of `FREEDOM_IPFS_DATA` when that override is set).
+- **Upgrade behavior (Kubo → freedom-ipfs).** A pre-v0.8.0 install carries a
+  Kubo-shaped `ipfs-data/` repo (`config`, `blocks/`, pins). On upgrade this
+  repo is **not** migrated: the native node uses its own `ipfs-data/freedom-ipfs/`
+  subdirectory, so no Kubo identity (PeerID), blocks, or pins carry over —
+  native IPFS identity is ephemeral and content reloads from the network on
+  demand. The old Kubo repo is left orphaned on disk (its dedicated cleanup is
+  tracked in issue #101). The app starts cleanly with the old repo present;
+  this isolation is verified by `src/main/__tests__/integration/v08-upgrade.test.js`.
 - IPFS identity status is reported as ephemeral. Native `freedom-ipfs` does not
   consume or expose a durable vault-derived PeerID for read-only retrieval in
   this release.

--- a/src/main/__tests__/integration/v08-upgrade.test.js
+++ b/src/main/__tests__/integration/v08-upgrade.test.js
@@ -1,0 +1,324 @@
+/**
+ * End-to-end v0.8.0 upgrade-path integration test (issue #107).
+ *
+ * Takes a realistic v0.7.x on-disk layout — a flat, pre-profile packaged
+ * userData directory with a Bee-era Swarm node identity — and drives the
+ * startup migration sequence index.js performs for the structural v0.8.0
+ * changes:
+ *
+ *   1. initializeProfile()       — the pre-profile flat userData becomes the
+ *                                  default profile *in place* (no file move),
+ *                                  creating the catalog + profile.json
+ *   2. migrateBeeDataToAntData() — bee-data/ → ant-data/, Swarm identity +
+ *                                  postage stamps preserved (Bee → Ant swap)
+ *   3. loadSettings()            — beeNodeMode→antNodeMode key rename
+ *   4. network-registry load()   — legacy ENS settings → network-config.json
+ *   5. IPFS (Kubo → freedom-ipfs) — no Kubo repo carryover; native node uses
+ *                                  an isolated freedom-ipfs/ subdir
+ *
+ * The contract under test: an upgrading user keeps their bookmarks, history,
+ * identity vault, Swarm keystore + postage stamps (stamperstore), and
+ * permissions, the default profile + catalog are created in place, and no
+ * data is lost anywhere along the chain. Each step runs against the real
+ * filesystem; only Electron's `app`/logger are mocked.
+ *
+ * The separate "Freedom Browser" → "Freedom" userData rename
+ * (migrateUserData()) predates this repository and is a no-op for every
+ * version Freedom has shipped, so it is intentionally NOT part of this
+ * upgrade scenario.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {
+  createAppMock,
+  createTempUserDataDir,
+  removeTempUserDataDir,
+  loadMainModule,
+} = require('../../../../test/helpers/main-process-test-utils');
+
+const NOW = '2026-06-16T00:00:00.000Z';
+const BEE_PASSWORD = 'bee-era-keystore-password';
+const SWARM_KEYSTORE = '{"version":3,"address":"abc123"}';
+
+const silentLogger = () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() });
+
+// Loads a main-process module fresh against the real on-disk `userDataDir`.
+// Each call re-mocks Electron so the module sees `userDataDir` as userData
+// while operating on actual files, letting the migration chain hand state
+// from one step to the next exactly as it does at startup.
+function loadModule(relModulePath, userDataDir, { isPackaged = true } = {}) {
+  return loadMainModule(require.resolve(relModulePath), {
+    app: createAppMock({ isPackaged, userDataDir }),
+    extraMocks: {
+      [require.resolve('../../logger')]: () => silentLogger(),
+    },
+  });
+}
+
+// Writes a believable pre-upgrade v0.7.x flat userData tree: the user's
+// settings (with Bee-era keys + legacy ENS policy), bookmarks, history,
+// identity vault, the injected Swarm keystore + postage stamps, and the
+// Swarm/dApp permission stores — all directly under userData, with no
+// profile catalog yet (the pre-profile layout).
+function writeLegacyInstall(dir, overrides = {}) {
+  fs.mkdirSync(dir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(dir, 'settings.json'),
+    JSON.stringify({
+      theme: 'dark',
+      beeNodeMode: 'light',
+      startBeeAtLaunch: false,
+      enableEnsCustomRpc: true,
+      ensRpcUrl: 'https://my-eth-rpc.example',
+      ...overrides.settings,
+    })
+  );
+
+  fs.writeFileSync(
+    path.join(dir, 'user-bookmarks.json'),
+    JSON.stringify([{ url: 'bzz://feed', name: 'My Swarm Feed' }])
+  );
+  fs.writeFileSync(path.join(dir, 'history.sqlite'), 'SQLite format 3\u0000history-rows');
+
+  // The identity vault (the mnemonic that regenerates the Bee overlay wallet
+  // and Swarm feed publisher keys) lives at identity/identity-vault.json.
+  fs.mkdirSync(path.join(dir, 'identity'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'identity', 'identity-vault.json'),
+    JSON.stringify({ version: 1, encrypted: 'encrypted-seed-vault' })
+  );
+
+  fs.writeFileSync(
+    path.join(dir, 'swarm-permissions.json'),
+    JSON.stringify({ 'bzz://feed': 'granted' })
+  );
+  fs.writeFileSync(
+    path.join(dir, 'dapp-permissions.json'),
+    JSON.stringify({ 'https://app.example': { accounts: ['0xabc'] } })
+  );
+
+  // Bee-era node data: injected keystore + the config that decrypts it,
+  // postage stamps (kept), and dead LevelDB state (dropped on migration).
+  const beeData = path.join(dir, 'bee-data');
+  fs.mkdirSync(path.join(beeData, 'keys'), { recursive: true });
+  fs.writeFileSync(path.join(beeData, 'keys', 'swarm.key'), SWARM_KEYSTORE);
+  fs.writeFileSync(path.join(beeData, 'config.yaml'), `password: ${BEE_PASSWORD}\n`);
+  fs.mkdirSync(path.join(beeData, 'stamperstore'), { recursive: true });
+  fs.writeFileSync(path.join(beeData, 'stamperstore', 'batch'), 'postage-batch-data');
+  fs.mkdirSync(path.join(beeData, 'statestore'), { recursive: true });
+  fs.writeFileSync(path.join(beeData, 'statestore', 'CURRENT'), 'leveldb');
+}
+
+// Runs the index.js startup migration chain against the flat userData dir and
+// returns the resolved default profile.
+function runUpgrade(userDataDir) {
+  const resolver = loadModule('../../profile-resolver', userDataDir);
+  const profile = resolver.mod.initializeProfile(resolver.app, {
+    argv: ['electron', '.'],
+    env: {},
+    now: NOW,
+  });
+
+  const beeAnt = loadModule('../../migrate-user-data', userDataDir);
+  const beeMigrated = beeAnt.mod.migrateBeeDataToAntData();
+
+  return { profile, beeMigrated };
+}
+
+describe('v0.8.0 upgrade path (end-to-end, in place)', () => {
+  let userDataDir;
+
+  beforeEach(() => {
+    userDataDir = createTempUserDataDir('freedom-v08-upgrade-');
+    delete process.env.FREEDOM_ANT_DATA;
+  });
+
+  afterEach(() => {
+    removeTempUserDataDir(userDataDir);
+    delete process.env.FREEDOM_ANT_DATA;
+  });
+
+  test('adopts the flat userData as the default profile in place and preserves all user data', () => {
+    writeLegacyInstall(userDataDir);
+
+    const { profile, beeMigrated } = runUpgrade(userDataDir);
+
+    // 1. Default profile + catalog created *in place* (no file move): the
+    //    pre-profile flat userData becomes the default profile directory.
+    expect(profile.id).toBe('default');
+    expect(profile.userDataDir).toBe(userDataDir);
+    expect(profile.appRoot).toBe(userDataDir);
+    expect(fs.existsSync(path.join(userDataDir, 'profile-registry.json'))).toBe(true);
+    expect(fs.existsSync(path.join(userDataDir, 'profile.json'))).toBe(true);
+    const catalog = JSON.parse(
+      fs.readFileSync(path.join(userDataDir, 'profile-registry.json'), 'utf-8')
+    );
+    expect(catalog.profiles.map((p) => p.id)).toEqual(['default']);
+    expect(catalog.profiles[0].dir).toBe(userDataDir);
+
+    // 2. bee-data → ant-data: identity + postage stamps survive, dead
+    //    LevelDB state is dropped, and the old dir is gone.
+    expect(beeMigrated).toBe(true);
+    const antData = path.join(userDataDir, 'ant-data');
+    expect(fs.readFileSync(path.join(antData, 'keys', 'swarm.key'), 'utf-8')).toBe(
+      SWARM_KEYSTORE
+    );
+    expect(fs.readFileSync(path.join(antData, 'config.yaml'), 'utf-8')).toContain(BEE_PASSWORD);
+    expect(fs.readFileSync(path.join(antData, 'stamperstore', 'batch'), 'utf-8')).toBe(
+      'postage-batch-data'
+    );
+    expect(fs.existsSync(path.join(antData, 'statestore'))).toBe(false);
+    expect(fs.existsSync(path.join(userDataDir, 'bee-data'))).toBe(false);
+
+    // 3. Browser data is intact after the whole chain.
+    expect(fs.readFileSync(path.join(userDataDir, 'user-bookmarks.json'), 'utf-8')).toContain(
+      'My Swarm Feed'
+    );
+    expect(fs.readFileSync(path.join(userDataDir, 'history.sqlite'), 'utf-8')).toContain(
+      'history-rows'
+    );
+    expect(
+      fs.readFileSync(path.join(userDataDir, 'identity', 'identity-vault.json'), 'utf-8')
+    ).toContain('encrypted-seed-vault');
+    expect(fs.readFileSync(path.join(userDataDir, 'swarm-permissions.json'), 'utf-8')).toContain(
+      'granted'
+    );
+    expect(fs.readFileSync(path.join(userDataDir, 'dapp-permissions.json'), 'utf-8')).toContain(
+      '0xabc'
+    );
+  });
+
+  test('migrates Bee-era settings keys and legacy ENS policy on upgrade', () => {
+    writeLegacyInstall(userDataDir);
+    runUpgrade(userDataDir);
+
+    // Bee-named settings keys are rewritten to their ant-named replacements.
+    const settings = loadModule('../../settings-store', userDataDir);
+    const loaded = settings.mod.loadSettings();
+    expect(loaded.antNodeMode).toBe('light');
+    expect(loaded.startAntAtLaunch).toBe(false);
+    expect(loaded).not.toHaveProperty('beeNodeMode');
+    expect(loaded).not.toHaveProperty('startBeeAtLaunch');
+
+    const persisted = JSON.parse(
+      fs.readFileSync(path.join(userDataDir, 'settings.json'), 'utf-8')
+    );
+    expect(persisted.antNodeMode).toBe('light');
+    expect(persisted).not.toHaveProperty('beeNodeMode');
+
+    // The legacy ENS custom-RPC policy produces a network-config.json with the
+    // expected mainnet verification strategy + a migrated endpoint source.
+    const net = loadModule('../../networks/network-registry', userDataDir, {
+      isPackaged: false,
+    });
+    expect(net.mod.getNetwork(1).verification.primary).toBe('direct');
+    expect(fs.existsSync(path.join(userDataDir, 'network-config.json'))).toBe(true);
+    const networkConfig = JSON.parse(
+      fs.readFileSync(path.join(userDataDir, 'network-config.json'), 'utf-8')
+    );
+    expect(networkConfig.networks['1']).toEqual({ verification: { primary: 'direct' } });
+    expect(networkConfig.endpointSources['migrated-eth-custom']).toEqual({
+      role: 'rpc',
+      keyed: false,
+      coverage: { '1': 'https://my-eth-rpc.example' },
+    });
+  });
+
+  test('is idempotent: re-running the whole chain churns no data', () => {
+    writeLegacyInstall(userDataDir);
+    runUpgrade(userDataDir);
+
+    const registryBefore = fs.readFileSync(
+      path.join(userDataDir, 'profile-registry.json'),
+      'utf-8'
+    );
+    const keystoreBefore = fs.readFileSync(
+      path.join(userDataDir, 'ant-data', 'keys', 'swarm.key'),
+      'utf-8'
+    );
+
+    // Second launch: every migration must be a no-op.
+    const beeAnt = loadModule('../../migrate-user-data', userDataDir);
+    expect(beeAnt.mod.migrateBeeDataToAntData()).toBe(false);
+    expect(beeAnt.mod.isBeeDataMigrationPending()).toBe(false);
+
+    const resolver = loadModule('../../profile-resolver', userDataDir);
+    resolver.mod.initializeProfile(resolver.app, {
+      argv: ['electron', '.'],
+      env: {},
+      now: NOW,
+    });
+
+    expect(
+      fs.readFileSync(path.join(userDataDir, 'ant-data', 'keys', 'swarm.key'), 'utf-8')
+    ).toBe(keystoreBefore);
+    const registryAfter = JSON.parse(
+      fs.readFileSync(path.join(userDataDir, 'profile-registry.json'), 'utf-8')
+    );
+    expect(registryAfter.profiles.map((p) => p.id)).toEqual(['default']);
+    // The catalog still references exactly one in-place default profile.
+    expect(JSON.parse(registryBefore).profiles.length).toBe(1);
+  });
+
+  test('a named profile gets fresh, isolated data and never touches the default', () => {
+    writeLegacyInstall(userDataDir);
+    runUpgrade(userDataDir);
+
+    // Launching --profile=work after upgrade creates an isolated profile dir.
+    const resolver = loadModule('../../profile-resolver', userDataDir);
+    const work = resolver.mod.initializeProfile(resolver.app, {
+      argv: ['electron', '.', '--profile=work'],
+      env: {},
+      now: NOW,
+    });
+
+    expect(work.id).toBe('work');
+    expect(work.userDataDir).toBe(path.join(userDataDir, 'Profiles', 'work'));
+    // The named profile uses the next managed port slot, not the default's.
+    expect(work.metadata.nodes.bee.apiPort).toBe(11634);
+
+    // The named profile has none of the default profile's data.
+    expect(fs.existsSync(path.join(work.userDataDir, 'user-bookmarks.json'))).toBe(false);
+    expect(fs.existsSync(path.join(work.userDataDir, 'ant-data'))).toBe(false);
+    expect(fs.existsSync(path.join(work.userDataDir, 'identity'))).toBe(false);
+
+    // The default profile's data is untouched.
+    expect(fs.readFileSync(path.join(userDataDir, 'user-bookmarks.json'), 'utf-8')).toContain(
+      'My Swarm Feed'
+    );
+    expect(fs.existsSync(path.join(userDataDir, 'ant-data', 'keys', 'swarm.key'))).toBe(true);
+  });
+
+  test('starts cleanly on a Kubo-era ipfs-data tree without carrying over its repo', () => {
+    writeLegacyInstall(userDataDir);
+    // A v0.7.x install also had a Kubo IPFS repo. By design freedom-ipfs
+    // carries over NO Kubo repo/blocks/pins (see docs/freedom-ipfs-native-
+    // desktop.md): native IPFS identity is ephemeral and content reloads from
+    // the network. The Kubo data is left orphaned (cleanup tracked in #101).
+    const kuboData = path.join(userDataDir, 'ipfs-data');
+    fs.mkdirSync(path.join(kuboData, 'blocks'), { recursive: true });
+    fs.writeFileSync(
+      path.join(kuboData, 'config'),
+      JSON.stringify({ Identity: { PeerID: 'Qm-kubo' } })
+    );
+    fs.writeFileSync(path.join(kuboData, 'blocks', 'CIQ.data'), 'kubo-block');
+    fs.mkdirSync(path.join(kuboData, 'datastore'), { recursive: true });
+
+    runUpgrade(userDataDir);
+
+    const ipfs = loadModule('../../ipfs-manager', userDataDir, { isPackaged: false });
+    const nativeDataPath = ipfs.mod.getIpfsDataPath();
+
+    // The native node lives in its own freedom-ipfs/ subdir, isolated from the
+    // Kubo layout — no Kubo identity, blocks, or pins are consumed.
+    expect(nativeDataPath).toBe(path.join(userDataDir, 'ipfs-data', 'freedom-ipfs'));
+    expect(fs.existsSync(nativeDataPath)).toBe(true);
+    expect(fs.readdirSync(nativeDataPath)).toEqual([]);
+
+    // The orphaned Kubo repo is left in place (not migrated, not deleted).
+    expect(fs.existsSync(path.join(userDataDir, 'ipfs-data', 'config'))).toBe(true);
+    expect(fs.existsSync(path.join(userDataDir, 'ipfs-data', 'blocks', 'CIQ.data'))).toBe(true);
+  });
+});

--- a/src/main/identity/__tests__/integration/postage-publisher-continuity.test.js
+++ b/src/main/identity/__tests__/integration/postage-publisher-continuity.test.js
@@ -1,0 +1,257 @@
+/**
+ * Integration: postage-stamp owner + publisher identity continuity across the
+ * v0.8.0 upgrade (issue #107). Crypto-level, but binary-free (no antd) — so it
+ * runs in CI on macOS, Windows, and Linux on every push.
+ *
+ * Why this matters for upgraders' funds:
+ *
+ *  - A postage batch in `stamperstore` is owned by the node's Swarm overlay,
+ *    which is the Ethereum address of the injected Bee wallet (keys/swarm.key,
+ *    decrypted with the password in config.yaml). The chequebook funds sit on
+ *    that same address. If the bee-data → ant-data migration carried the
+ *    keystore and the password out of sync — or carried a different key — antd
+ *    would come up as a *different* overlay that does not own the migrated
+ *    stamps, silently abandoning the user's paid-for storage and funds.
+ *
+ *  - The identity vault (identity/identity-vault.json) holds the mnemonic that
+ *    regenerates BOTH the Bee wallet (overlay) and the per-origin Swarm feed
+ *    *publisher* keys. The bee-data → ant-data migration must leave it intact,
+ *    and the key it derives for the node must stay equal to the address baked
+ *    into the migrated keystore.
+ *
+ * The real-antd integration test (bee-to-ant-migration.test.js) proves antd
+ * *adopts* the migrated overlay, but it's skipped without the binary. These
+ * tests assert the same identity invariants from the keystore/vault crypto so
+ * the continuity contract has unconditional coverage.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { Wallet } = require('ethers');
+const { deriveAllKeys, derivePublisherKey } = require('../../derivation');
+const { createBeeKeystore, getBeeAddress } = require('../../formats');
+const { createBeeConfig } = require('../../injection');
+const vault = require('../../vault');
+const {
+  createAppMock,
+  loadMainModule,
+} = require('../../../../../test/helpers/main-process-test-utils');
+
+const TEST_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const KEYSTORE_PASSWORD = 'bee-era-keystore-password';
+const VAULT_PASSWORD = 'vault-password-1234';
+
+// Read the `password:` line out of a (migrated) Bee/Ant config.yaml — this is
+// the secret antd uses to decrypt keys/swarm.key on start.
+function readConfigPassword(antDataDir) {
+  const config = fs.readFileSync(path.join(antDataDir, 'config.yaml'), 'utf-8');
+  const match = config.match(/^password:\s*(.+)$/m);
+  return match ? match[1].trim() : null;
+}
+
+// Snapshot a directory tree to a { relPath: contentHex } map so byte-identical
+// carry-over of opaque LevelDB files (stamperstore) can be asserted.
+function snapshotDir(dir) {
+  const out = {};
+  const walk = (current, prefix) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const abs = path.join(current, entry.name);
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(abs, rel);
+      } else {
+        out[rel] = fs.readFileSync(abs).toString('hex');
+      }
+    }
+  };
+  walk(dir, '');
+  return out;
+}
+
+// A believable postage stamperstore: LevelDB-shaped files holding the batch
+// owner's purchased batches. The bytes are opaque to us; the test only cares
+// that they survive byte-for-byte.
+function writeStamperstore(beeDataDir) {
+  const store = path.join(beeDataDir, 'stamperstore');
+  fs.mkdirSync(store, { recursive: true });
+  fs.writeFileSync(path.join(store, 'CURRENT'), 'MANIFEST-000001\n');
+  fs.writeFileSync(path.join(store, '000003.ldb'), Buffer.from('postage-batch-0xdeadbeef', 'utf-8'));
+  fs.writeFileSync(path.join(store, 'LOG'), 'stamperstore opened\n');
+  return store;
+}
+
+function loadMigrationModule(userDataDir) {
+  return loadMainModule(require.resolve('../../../migrate-user-data'), {
+    app: createAppMock({ isPackaged: true, userDataDir }),
+    extraMocks: {
+      [require.resolve('../../../logger')]: () => ({
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      }),
+    },
+  }).mod;
+}
+
+describe('postage-stamp owner + publisher identity continuity (binary-free)', () => {
+  let keys;
+  let overlayOwner;
+  let keystoreJson;
+  let tmpDirs;
+
+  beforeAll(async () => {
+    keys = deriveAllKeys(TEST_MNEMONIC);
+    // The overlay/wallet that owns the postage stamps and chequebook.
+    overlayOwner = getBeeAddress(keys.beeWallet.privateKey);
+    expect(overlayOwner).toBe(keys.beeWallet.address);
+    // Encrypt the keystore once (scrypt is slow) and reuse it across tests.
+    keystoreJson = await createBeeKeystore(keys.beeWallet.privateKey, KEYSTORE_PASSWORD);
+  }, 60000);
+
+  beforeEach(() => {
+    tmpDirs = [];
+    delete process.env.FREEDOM_ANT_DATA;
+  });
+
+  afterEach(() => {
+    vault.lockVault();
+    for (const dir of tmpDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    delete process.env.FREEDOM_ANT_DATA;
+  });
+
+  function makeUserData() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'postage-continuity-'));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  function writeBeeData(userDataDir) {
+    const beeDataDir = path.join(userDataDir, 'bee-data');
+    fs.mkdirSync(path.join(beeDataDir, 'keys'), { recursive: true });
+    fs.writeFileSync(path.join(beeDataDir, 'keys', 'swarm.key'), keystoreJson);
+    createBeeConfig(beeDataDir, KEYSTORE_PASSWORD, 1633, 1634);
+    return beeDataDir;
+  }
+
+  test(
+    'the migrated keystore decrypts to the same overlay that owns the carried stamps',
+    async () => {
+      const userDataDir = makeUserData();
+      writeBeeData(userDataDir);
+      const stamperstore = writeStamperstore(path.join(userDataDir, 'bee-data'));
+      const stampsBefore = snapshotDir(stamperstore);
+
+      const mod = loadMigrationModule(userDataDir);
+      expect(mod.migrateBeeDataToAntData()).toBe(true);
+
+      const antDataDir = path.join(userDataDir, 'ant-data');
+
+      // The password that decrypts the keystore must have ridden along with it.
+      const carriedPassword = readConfigPassword(antDataDir);
+      expect(carriedPassword).toBe(KEYSTORE_PASSWORD);
+
+      // Decrypting the migrated keystore must recover the SAME overlay owner —
+      // proving the carried stamps (owned by that overlay) stay usable.
+      const migratedKeystore = fs.readFileSync(
+        path.join(antDataDir, 'keys', 'swarm.key'),
+        'utf-8'
+      );
+      const recovered = await Wallet.fromEncryptedJson(migratedKeystore, carriedPassword);
+      expect(recovered.address).toBe(overlayOwner);
+
+      // The stamperstore is carried byte-for-byte.
+      expect(snapshotDir(path.join(antDataDir, 'stamperstore'))).toEqual(stampsBefore);
+    },
+    60000
+  );
+
+  test(
+    'on the merge path the carried bee-era password wins over a throwaway one',
+    async () => {
+      const userDataDir = makeUserData();
+      writeBeeData(userDataDir);
+      writeStamperstore(path.join(userDataDir, 'bee-data'));
+
+      // antd already ran once on an empty ant-data and self-generated a
+      // throwaway identity with a DIFFERENT keystore password. The merge must
+      // leave the keystore and the password consistent — i.e. the carried
+      // bee-era password (which matches the carried keystore), not the
+      // throwaway one.
+      const antDataDir = path.join(userDataDir, 'ant-data');
+      fs.mkdirSync(antDataDir, { recursive: true });
+      fs.writeFileSync(path.join(antDataDir, 'identity.json'), '{"throwaway":true}');
+      fs.writeFileSync(path.join(antDataDir, 'signing.key'), 'throwaway-signing-key');
+      createBeeConfig(antDataDir, 'a-totally-different-password', 11633, 12633);
+
+      const mod = loadMigrationModule(userDataDir);
+      expect(mod.migrateBeeDataToAntData()).toBe(true);
+
+      const carriedPassword = readConfigPassword(antDataDir);
+      expect(carriedPassword).toBe(KEYSTORE_PASSWORD);
+
+      const migratedKeystore = fs.readFileSync(
+        path.join(antDataDir, 'keys', 'swarm.key'),
+        'utf-8'
+      );
+      // If the throwaway password had won, this decrypt would throw.
+      const recovered = await Wallet.fromEncryptedJson(migratedKeystore, carriedPassword);
+      expect(recovered.address).toBe(overlayOwner);
+
+      // The throwaway identity antd minted must be gone, so it can't win over
+      // the migrated keystore on the next start.
+      expect(fs.existsSync(path.join(antDataDir, 'identity.json'))).toBe(false);
+      expect(fs.existsSync(path.join(antDataDir, 'signing.key'))).toBe(false);
+    },
+    60000
+  );
+
+  test(
+    'the vault regenerates the same publisher keys and stays consistent with the migrated overlay',
+    async () => {
+      const userDataDir = makeUserData();
+
+      // A v0.7.x install: the vault lives under identity/, the injected node
+      // identity + stamps under bee-data/. The bee → ant migration only
+      // touches bee-data/; the vault stays in place.
+      const identityDir = path.join(userDataDir, 'identity');
+      await vault.importVault(identityDir, VAULT_PASSWORD, TEST_MNEMONIC);
+      writeBeeData(userDataDir);
+      writeStamperstore(path.join(userDataDir, 'bee-data'));
+
+      // Capture the publisher + overlay identities the vault regenerates today.
+      const publisher0Before = derivePublisherKey(TEST_MNEMONIC, 0).address;
+      const publisher1Before = derivePublisherKey(TEST_MNEMONIC, 1).address;
+
+      // Run the node-data migration exactly as startup does.
+      const beeAntMod = loadMigrationModule(userDataDir);
+      expect(beeAntMod.migrateBeeDataToAntData()).toBe(true);
+
+      // The vault is untouched and still unlocks to the same mnemonic.
+      expect(vault.vaultExists(identityDir)).toBe(true);
+      await vault.unlockVault(identityDir, VAULT_PASSWORD, 0);
+      const mnemonic = vault.getMnemonic();
+      expect(mnemonic).toBe(TEST_MNEMONIC);
+
+      // Feed-signing publisher keys regenerate identically after the upgrade.
+      expect(derivePublisherKey(mnemonic, 0).address).toBe(publisher0Before);
+      expect(derivePublisherKey(mnemonic, 1).address).toBe(publisher1Before);
+
+      // The vault-derived Bee wallet equals the address inside the migrated
+      // keystore — the node overlay and the vault identity stay in lockstep.
+      const vaultBeeWallet = deriveAllKeys(mnemonic).beeWallet.address;
+      const migratedKeystore = fs.readFileSync(
+        path.join(userDataDir, 'ant-data', 'keys', 'swarm.key'),
+        'utf-8'
+      );
+      const carriedPassword = readConfigPassword(path.join(userDataDir, 'ant-data'));
+      const recovered = await Wallet.fromEncryptedJson(migratedKeystore, carriedPassword);
+      expect(recovered.address).toBe(vaultBeeWallet);
+      expect(recovered.address).toBe(overlayOwner);
+    },
+    60000
+  );
+});

--- a/src/main/migrate-user-data.test.js
+++ b/src/main/migrate-user-data.test.js
@@ -308,4 +308,36 @@ describe('migrateBeeDataToAntData (bee → ant upgrade)', () => {
     // Bee-only state is never carried by the item list.
     expect(fs.existsSync(path.join(antData, 'statestore'))).toBe(false);
   });
+
+  test('moves the keystore LAST on the merge path so an interrupt is always retryable', () => {
+    writeBeeData(userDataDir, { extras: ['stamperstore'] });
+    // Force the merge path: ant-data already exists (antd self-initialized),
+    // so the whole-directory fast rename is skipped and items are carried
+    // one by one in BEE_CARRY_ITEMS order.
+    const antData = path.join(userDataDir, 'ant-data');
+    fs.mkdirSync(antData, { recursive: true });
+    fs.writeFileSync(path.join(antData, 'identity.json'), '{}');
+
+    const mod = loadMigrationModule(userDataDir);
+
+    const moveOrder = [];
+    const realRename = fs.renameSync.bind(fs);
+    const spy = jest.spyOn(fs, 'renameSync').mockImplementation((src, dest) => {
+      if (String(src).includes(`${path.sep}bee-data${path.sep}`)) {
+        moveOrder.push(path.basename(String(src)));
+      }
+      return realRename(src, dest);
+    });
+
+    expect(mod.migrateBeeDataToAntData()).toBe(true);
+    spy.mockRestore();
+
+    // keys/ is the commit point that clears isBeeDataMigrationPending(): it
+    // MUST move after config.yaml and stamperstore. If a refactor reordered
+    // BEE_CARRY_ITEMS so keys moved earlier, an interrupted carry could strand
+    // a keystore in ant-data whose password is still in bee-data, with no
+    // retry — silently abandoning a funded identity. This locks the ordering.
+    expect(moveOrder).toEqual(['config.yaml', 'stamperstore', 'keys']);
+    expect(moveOrder[moveOrder.length - 1]).toBe('keys');
+  });
 });


### PR DESCRIPTION
## Summary

Adds end-to-end and identity-level test coverage (plus docs) for the v0.7.x → v0.8.0 upgrade migration, so the migration cannot silently lose user data. No runtime/behavior changes — tests and documentation only. Refs #107.

- **`src/main/__tests__/integration/v08-upgrade.test.js`** — drives a realistic *flat* (pre-profile) `userData` fixture through the full startup migration: in-place default-profile adoption, `bee-data/` → `ant-data/` migration, settings + legacy ENS migration, Kubo-era `ipfs-data/` isolation, idempotency, and named-profile isolation.
- **`src/main/identity/__tests__/integration/postage-publisher-continuity.test.js`** — proves, without a live Ant node, that the migrated keystore decrypts to the same Swarm overlay (i.e. the postage-stamp owner is preserved) and that publisher identity stays consistent with the vault across the upgrade.
- **`src/main/migrate-user-data.test.js`** — locks the **keys-last** invariant on the merge path so an interrupted `bee → ant` carry is always retryable and never strands a funded keystore whose password still lives in `bee-data`.
- **`docs/freedom-ipfs-native-desktop.md`** — documents the Kubo → `freedom-ipfs` upgrade behavior (legacy repo left orphaned, ephemeral native identity) and references the covering test.

## Test plan

- [x] `npm run lint` clean
- [x] `npx jest` for all three affected suites — 23/23 passing
- [ ] CI green on the PR
- [ ] (Acceptance, separate) Windows verification of the bee→ant EPERM/interrupted paths