### PR TITLE
build(devenv): add Nix devenv shell for reproducible dev environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ identity-data/
 research/
 playwright-report/
 test-results/
+
+# Devenv (https://devenv.sh) — local state & per-user overrides only.
+# devenv.nix, devenv.yaml, devenv.lock, and .envrc are committed.
+.devenv*
+devenv.local.nix
+devenv.local.yaml

--- a/README.md
+++ b/README.md
@@ -36,6 +36,37 @@ It ships with integrated Swarm, IPFS, and Radicle nodes, enabling direct peer-to
 
 ---
 
+## Development Environment (devenv)
+
+If you have [Nix](https://nixos.org) and [devenv.sh](https://devenv.sh) installed, you can skip the manual Node.js / build-toolchain setup and drop straight into an environment that matches CI (Node 20, npm, and the system dependencies needed for native modules, binary fetches, and headless E2E):
+
+```bash
+devenv shell        # enter the dev shell
+# or, with direnv installed:
+direnv allow        # auto-activate on cd
+```
+
+First-time setup (installs npm deps and downloads the Ant / IPFS / Radicle binaries):
+
+```bash
+devenv run setup
+```
+
+Useful commands (also runnable as plain `npm run …`):
+
+| Command                     | What it does                                                  |
+| --------------------------- | ------------------------------------------------------------- |
+| `devenv run start`          | Launch Freedom (`npm start`).                                 |
+| `devenv run test`           | Jest unit tests.                                              |
+| `devenv run lint`           | ESLint.                                                       |
+| `devenv run format`         | Prettier write.                                               |
+| `devenv run e2e`            | Playwright E2E (headless via `xvfb-run` on Linux).            |
+| `devenv run fetch-binaries` | Re-download Ant, the IPFS native addon, and Radicle binaries. |
+
+The `.envrc` only activates with [direnv](https://direnv.net) installed, so contributors not using devenv are unaffected — the manual Quick Start above remains the canonical path.
+
+---
+
 ## Architecture
 
 Freedom Browser is an Electron application. Protocol logic lives in the main process; the renderer is a modular UI layer that talks to it over IPC (channels defined in `src/shared/ipc-channels.js`). The main process manages node lifecycles (`ant-manager.js`, `ipfs-manager.js`, `radicle-manager.js`), URL rewriting (`request-rewriter.js`), and persistent data (settings, bookmarks, history). A central `service-registry.js` tracks node endpoints, modes, and status, and broadcasts state to all windows — both node managers and the request rewriter read from it.

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,133 @@
+# Devenv shell for Freedom Browser.
+#
+#   devenv shell       enter the dev shell
+#   direnv allow       OR auto-activate on cd (requires direnv + the .envrc)
+#
+# This pins the same toolchain CI uses (Node 20 + npm, see
+# .github/workflows/ci.yml and the node:20 / electronuserland/builder:20
+# Docker images used by `npm run dist:linux:*:docker`) and bundles the system
+# dependencies required to:
+#
+#   - build native modules (better-sqlite3, node-addon-api, freedom-ipfs-node
+#     prebuild fallbacks via node-gyp): python3, gnumake, gcc, pkg-config
+#   - run the binary fetch scripts: curl + jq (ant/radicle status helpers) and
+#     xz (fetch-radicle.js runs `tar -xJf`)
+#   - run the Playwright E2E suite headlessly on Linux: xvfb-run
+#
+# The .envrc is opt-in (only activates with direnv installed), so this file is
+# a no-op for contributors who don't use devenv/Nix. See https://devenv.sh for
+# the full option reference.
+
+{ pkgs, config, lib, ... }:
+
+{
+  # ---------------------------------------------------------------------------
+  # Languages
+  # ---------------------------------------------------------------------------
+  languages.javascript = {
+    enable = true;
+    # Match CI (Node 20). package.json engines is >=18; Electron 41 ships its
+    # own bundled Node for the main process, but the dev toolchain (jest,
+    # eslint, electron-builder, the fetch scripts) runs on this system Node.
+    package = pkgs.nodejs_20;
+    npm = {
+      enable = true;
+      # Do NOT auto-install on shell entry. The repo's postinstall hook
+      # (`electron-builder install-app-deps`) rebuilds native addons for
+      # Electron, which is slow and not always wanted. Run `devenv run setup`
+      # (or `npm install`) explicitly instead.
+      install.enable = false;
+    };
+  };
+
+  # ---------------------------------------------------------------------------
+  # Packages
+  # ---------------------------------------------------------------------------
+  packages =
+    with pkgs;
+    [
+      # Version control + the `git-remote-rad` helper shipped by radicle:download.
+      git
+      # Used by the ant:status / system-ant:status / radicle:status npm scripts
+      # and general node scripting.
+      curl
+      jq
+      # fetch-radicle.js runs `tar -xJf` — needs xz for .tar.xz extraction.
+      xz
+      # Native-module build toolchain (node-gyp). better-sqlite3 and
+      # freedom-ipfs-node ship prebuilds for the common targets; these are the
+      # fallback for when a prebuild is missing.
+      python3
+      gnumake
+      gcc
+      pkg-config
+    ]
+    ++ lib.optionals pkgs.stdenv.isLinux [
+      # Headless X server for `xvfb-run -a npm run test:e2e` (CI uses the same
+      # invocation on ubuntu-latest). macOS/Windows runners boot a real
+      # display, so this is Linux-only.
+      xvfb_run
+    ];
+
+  # ---------------------------------------------------------------------------
+  # Scripts — thin wrappers over the repo's npm scripts so contributors don't
+  # have to remember the exact incantations. Invoke with `devenv run <name>`.
+  # ---------------------------------------------------------------------------
+  scripts.fetch-binaries.exec = ''
+    echo "Downloading Ant (Swarm)…"
+    npm run ant:download
+    echo "Downloading IPFS native addon…"
+    npm run ipfs:download
+    echo "Downloading Radicle binaries (macOS/Linux only)…"
+    npm run radicle:download || echo "radicle:download skipped (unsupported on this platform)"
+  '';
+  scripts.fetch-binaries.description = "Download antd, the freedom-ipfs native addon, and Radicle binaries.";
+
+  scripts.setup.exec = ''
+    npm install
+    echo "Downloading Ant (Swarm)…"
+    npm run ant:download
+    echo "Downloading IPFS native addon…"
+    npm run ipfs:download
+    echo "Downloading Radicle binaries (macOS/Linux only)…"
+    npm run radicle:download || echo "radicle:download skipped (unsupported on this platform)"
+  '';
+  scripts.setup.description = "First-time setup: npm install + download all node binaries.";
+
+  scripts.start.exec = "npm start";
+  scripts.start.description = "Launch Freedom (electron .).";
+
+  scripts.test.exec = "npm test";
+  scripts.test.description = "Run the Jest unit test suite.";
+
+  scripts.lint.exec = "npm run lint";
+  scripts.lint.description = "Run ESLint.";
+
+  scripts.format.exec = "npm run format";
+  scripts.format.description = "Format the tree with Prettier.";
+
+  scripts.e2e.exec = ''
+    if command -v xvfb-run >/dev/null 2>&1; then
+      xvfb-run -a npm run test:e2e
+    else
+      npm run test:e2e
+    fi
+  '';
+  scripts.e2e.description = "Run Playwright E2E (headless via xvfb when available).";
+
+  # ---------------------------------------------------------------------------
+  # enterShell — printed every time the shell activates.
+  # ---------------------------------------------------------------------------
+  enterShell = ''
+    echo ""
+    echo "  ⬢ Freedom Browser — devenv"
+    echo "    node $(node --version)  •  npm $(npm --version)"
+    echo ""
+    echo "  First run:    devenv run setup"
+    echo "  Launch:       devenv run start   (or npm start)"
+    echo "  Tests:        devenv run test"
+    echo "  Lint/format:  devenv run lint | devenv run format"
+    echo "  E2E:          devenv run e2e"
+    echo ""
+  '';
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling


### PR DESCRIPTION
## What

Adds a [devenv.sh](https://devenv.sh) configuration so contributors with [Nix](https://nixos.org) installed can drop straight into a dev environment that matches CI — no manual Node 20 / python / gcc / xvfb setup.

## Why

The Quick Start currently asks contributors to install Node 18+, then separately obtain the build toolchain needed for native modules (`better-sqlite3`, `freedom-ipfs-node`), the helpers used by the status/fetch npm scripts (`curl`, `jq`, `xz` for `tar -xJf` in `fetch-radicle.js`), and `xvfb-run` for headless E2E on Linux. That's a lot of platform-specific yak-shaving, and it's easy to drift from what CI actually uses (Node 20, per `.github/workflows/ci.yml` and the `node:20` / `electronuserland/builder:20` Docker images). A pinned `devenv.nix` makes the environment reproducible and self-documenting.

## What's included

- **`devenv.nix`** — `languages.javascript` pinned to `nodejs_20` (matches CI); packages for the native-module toolchain (`python3`, `gnumake`, `gcc`, `pkg-config`), the fetch/status helpers (`curl`, `jq`, `xz`, `git`), and `xvfb_run` on Linux only; convenience scripts (`setup`, `start`, `test`, `lint`, `format`, `e2e`, `fetch-binaries`); an `enterShell` banner.
- **`devenv.yaml`** — `cachix/devenv-nixpkgs/rolling` input.
- **`.envrc`** — `use devenv` (direnv opt-in).
- **`.gitignore`** — ignores `.devenv*` and `devenv.local.*`; `devenv.nix`, `devenv.yaml`, `devenv.lock`, and `.envrc` stay tracked.
- **`README.md`** — a short "Development Environment (devenv)" section after Quick Start.

`devenv.lock` is intentionally not committed in this PR — it's generated on first `devenv shell` and should be committed in a follow-up by whoever first runs it (I can't generate it here without a full Nix eval of the rolling nixpkgs input).

## Scope / non-invasiveness

- **No npm dependency added or upgraded** (per `AGENTS.md` rule 9). devenv is an external, opt-in tool — nothing in `package.json` changes.
- **No behavior change for non-devenv contributors.** The `.envrc` only activates with [direnv](https://direnv.net) installed; `devenv.nix`/`devenv.yaml` are inert without the devenv CLI. The manual Quick Start remains canonical.
- No source files under `src/`, no IPC channels, no build config (`scripts/build.js`, `electron-builder` block) touched. ESLint/Jest run against unchanged code.
- Nix syntax validated locally with `nix-instantiate --parse devenv.nix`.

## Verification

- `nix-instantiate --parse devenv.nix` → clean.
- `git diff` confined to the 5 files listed above.

Couldn't run a full `devenv shell` here (no network access to fetch the rolling nixpkgs input from this sandbox), but the module follows the documented option shapes from [devenv.sh/languages/javascript](https://devenv.sh/languages/javascript/) and [devenv.sh/scripts](https://devenv.sh/scripts/).

## Notes for reviewers

- The `e2e` script uses runtime `command -v xvfb-run` detection rather than a Nix-level `stdenv.isLinux` branch, so it degrades gracefully if someone runs it outside the devenv shell on a Linux box without xvfb.
- If you'd prefer a different Node pin (e.g. `nodejs_22` to match Electron 41's bundled Node for the main process), happy to switch — I went with 20 to match CI exactly.
- Happy to drop the README section, the convenience scripts, or the `.envrc` if any feel out of scope; kept them since they make the env self-documenting.
