### PR TITLE
feat: linux titlebar tabs settings

### DIFF
--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -1,6 +1,10 @@
 const crypto = require('crypto');
 const fs = require('fs');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
 const log = require('./logger');
+
+const execFileAsync = promisify(execFile);
 const { ipcMain, app, dialog, clipboard, nativeImage, webContents } = require('electron');
 const { URL } = require('url');
 const path = require('path');
@@ -576,6 +580,27 @@ function registerBaseIpcHandlers(callbacks = {}) {
 
   ipcMain.handle(IPC.WINDOW_GET_PLATFORM, () => {
     return process.platform;
+  });
+
+  // Which window-manager buttons the desktop expects (GNOME defaults to
+  // close-only). Returns null off-GNOME/non-Linux so the caller shows all three.
+  ipcMain.handle(IPC.WINDOW_GET_BUTTON_LAYOUT, async () => {
+    if (process.platform !== 'linux') return null;
+    try {
+      const { stdout } = await execFileAsync(
+        'gsettings',
+        ['get', 'org.gnome.desktop.wm.preferences', 'button-layout'],
+        { timeout: 2000 }
+      );
+      const tokens = stdout.replace(/['"\n]/g, '').replace(':', ',').split(',');
+      return {
+        minimize: tokens.includes('minimize'),
+        maximize: tokens.includes('maximize'),
+        close: tokens.includes('close'),
+      };
+    } catch {
+      return null;
+    }
   });
 
   ipcMain.on(IPC.APP_RELAUNCH, () => {

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -578,6 +578,11 @@ function registerBaseIpcHandlers(callbacks = {}) {
     return process.platform;
   });
 
+  ipcMain.on(IPC.APP_RELAUNCH, () => {
+    app.relaunch();
+    app.quit();
+  });
+
   ipcMain.on(IPC.WINDOW_TOGGLE_FULLSCREEN, (event) => {
     const win = event.sender.getOwnerBrowserWindow();
     if (win) {

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -37,6 +37,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   openUrlInNewWindow: (url) => ipcRenderer.send('window:new-with-url', url),
   showAbout: () => ipcRenderer.send('app:show-about'),
   getPlatform: () => ipcRenderer.invoke('window:get-platform'),
+  getWindowButtonLayout: () => ipcRenderer.invoke('window:get-button-layout'),
   getActiveProfile: () => ipcRenderer.invoke('profile:get-active'),
   listProfiles: () => ipcRenderer.invoke('profile:list'),
   createProfile: (input) => ipcRenderer.invoke('profile:create', input),

--- a/src/main/settings-store.js
+++ b/src/main/settings-store.js
@@ -44,6 +44,8 @@ const DEFAULT_SETTINGS = {
   blockUnverifiedEns: true,
   sidebarOpen: false,
   sidebarWidth: 320,
+  // Linux only: render the tab strip as the window titlebar (frameless window).
+  tabsInTitlebar: true,
 };
 
 let cachedSettings = null;

--- a/src/main/webview-preload.js
+++ b/src/main/webview-preload.js
@@ -233,6 +233,7 @@ contextBridge.exposeInMainWorld('freedomAPI', {
   saveSettings: guardInternal('saveSettings', (settings) =>
     ipcRenderer.invoke('settings:save', settings)
   ),
+  relaunchApp: guardInternal('relaunchApp', () => ipcRenderer.send('app:relaunch')),
 
   // Platform / environment info needed by settings page
   getPlatform: guardInternal('getPlatform', () => ipcRenderer.invoke('window:get-platform')),

--- a/src/main/windows/mainWindow.js
+++ b/src/main/windows/mainWindow.js
@@ -2,6 +2,7 @@ const log = require('../logger');
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
 const fs = require('fs');
+const { loadSettings } = require('../settings-store');
 
 let currentWindowTitle = 'Freedom';
 
@@ -26,6 +27,10 @@ function getIconPath() {
 
 function createMainWindow(initialUrl = null) {
   const isMac = process.platform === 'darwin';
+  const isLinux = process.platform === 'linux';
+  // Linux only: tab strip doubles as the titlebar unless the user opted out.
+  // `frame` can't change on a live window, so this is read once at creation.
+  const linuxFrameless = isLinux && loadSettings().tabsInTitlebar !== false;
 
   // Headless E2E: keep the window hidden so a local test run doesn't pop a
   // window or steal focus. The renderer still loads and is fully driveable via
@@ -49,6 +54,8 @@ function createMainWindow(initialUrl = null) {
       titleBarStyle: 'hiddenInset',
       trafficLightPosition: { x: 14, y: 14 },
     }),
+    // Linux: drop the OS frame so the in-app tab strip is the titlebar
+    ...(linuxFrameless && { frame: false }),
     webPreferences: {
       preload: path.join(__dirname, '..', 'preload.js'),
       contextIsolation: true,

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -134,6 +134,16 @@ async function initPlatformUI() {
 
     // Frameless on Linux: show + wire the in-app window controls
     document.getElementById('window-controls')?.classList.add('visible');
+
+    // Respect the desktop's button layout (GNOME defaults to close-only). Drop
+    // buttons the layout omits. Use .remove() — .window-control-btn's display:flex
+    // overrides the [hidden] attribute. null layout (non-GNOME) keeps all three.
+    const layout = await electronAPI.getWindowButtonLayout().catch(() => null);
+    if (layout) {
+      if (!layout.minimize) document.getElementById('minimize-btn')?.remove();
+      if (!layout.maximize) document.getElementById('maximize-btn')?.remove();
+    }
+
     document
       .getElementById('minimize-btn')
       ?.addEventListener('click', () => electronAPI.minimizeWindow());

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -123,12 +123,14 @@ async function initPlatformUI() {
   const platform = await electronAPI.getPlatform();
 
   if (platform === 'linux') {
+    // platform-linux governs the titlebar spacer width (shrinks the 76px macOS
+    // traffic-light gap to 12px), so it applies to Linux regardless of framing.
+    document.body.classList.add('platform-linux');
+
     // The window is only frameless when the user keeps tabs-in-titlebar on; with
     // the OS frame the system provides the controls, so skip the custom ones.
     const settings = await electronAPI.getSettings().catch(() => ({}));
     if (settings.tabsInTitlebar === false) return;
-
-    document.body.classList.add('platform-linux');
 
     // Frameless on Linux: show + wire the in-app window controls
     document.getElementById('window-controls')?.classList.add('visible');

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -123,7 +123,28 @@ async function initPlatformUI() {
   const platform = await electronAPI.getPlatform();
 
   if (platform === 'linux') {
+    // The window is only frameless when the user keeps tabs-in-titlebar on; with
+    // the OS frame the system provides the controls, so skip the custom ones.
+    const settings = await electronAPI.getSettings().catch(() => ({}));
+    if (settings.tabsInTitlebar === false) return;
+
     document.body.classList.add('platform-linux');
+
+    // Frameless on Linux: show + wire the in-app window controls
+    document.getElementById('window-controls')?.classList.add('visible');
+    document
+      .getElementById('minimize-btn')
+      ?.addEventListener('click', () => electronAPI.minimizeWindow());
+    document
+      .getElementById('maximize-btn')
+      ?.addEventListener('click', () => electronAPI.maximizeWindow());
+    document.getElementById('close-btn')?.addEventListener('click', () => electronAPI.closeWindow());
+
+    // Double-click the bare titlebar to toggle maximize (native behavior)
+    document.querySelector('.title-bar')?.addEventListener('dblclick', (e) => {
+      if (e.target.closest('.no-drag, button, .tab')) return; // ponytail: only bare titlebar
+      electronAPI.maximizeWindow();
+    });
   }
 }
 

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -781,6 +781,19 @@
                 </select>
               </div>
             </div>
+            <div class="row" data-linux-only>
+              <div class="row-body">
+                <p class="row-label">Tabs in title bar</p>
+                <p class="row-help">Use the tab strip as the window title bar. Takes effect after restart.</p>
+              </div>
+              <div class="row-control">
+                <button type="button" id="tabs-titlebar-restart" class="btn" hidden>Restart now</button>
+                <label class="toggle">
+                  <input type="checkbox" id="tabs-in-titlebar" />
+                  <span class="slider"></span>
+                </label>
+              </div>
+            </div>
           </div>
         </section>
 
@@ -1009,6 +1022,7 @@
 
       const fields = {
         themeMode: $('theme-mode'),
+        tabsInTitlebar: $('tabs-in-titlebar'),
         startAnt: $('start-ant-at-launch'),
         startIpfs: $('start-ipfs-at-launch'),
         blockUnverifiedEns: $('block-unverified-ens'),
@@ -1606,6 +1620,7 @@
 
       const currentFormState = () => ({
         theme: fields.themeMode.value || 'system',
+        tabsInTitlebar: fields.tabsInTitlebar.checked,
         startAntAtLaunch: fields.startAnt.checked,
         startIpfsAtLaunch: fields.startIpfs.checked,
         enableRadicleIntegration: isWindows ? false : fields.enableRadicle.checked,
@@ -1618,6 +1633,7 @@
       const applyFormState = (settings) => {
         if (!settings) return;
         fields.themeMode.value = settings.theme || 'system';
+        fields.tabsInTitlebar.checked = settings.tabsInTitlebar !== false;
         fields.startAnt.checked = settings.startAntAtLaunch !== false;
         fields.startIpfs.checked = settings.startIpfsAtLaunch !== false;
         fields.enableRadicle.checked = settings.enableRadicleIntegration === true;
@@ -1719,6 +1735,11 @@
       };
 
       fields.themeMode.addEventListener('change', save);
+      fields.tabsInTitlebar.addEventListener('change', () => {
+        save();
+        $('tabs-titlebar-restart').hidden = false;
+      });
+      $('tabs-titlebar-restart').addEventListener('click', () => freedomAPI.relaunchApp());
       fields.startAnt.addEventListener('change', save);
       fields.startIpfs.addEventListener('change', save);
       fields.enableRadicle.addEventListener('change', () => {
@@ -1757,6 +1778,12 @@
             // No official Radicle binaries for Windows yet.
             document
               .querySelectorAll('[data-radicle]')
+              .forEach((el) => (el.style.display = 'none'));
+          }
+          if (platform !== 'linux') {
+            // Frameless titlebar is a Linux-only option.
+            document
+              .querySelectorAll('[data-linux-only]')
               .forEach((el) => (el.style.display = 'none'));
           }
         } catch {

--- a/src/shared/ipc-channels.js
+++ b/src/shared/ipc-channels.js
@@ -64,6 +64,7 @@ module.exports = {
   WINDOW_TOGGLE_FULLSCREEN: 'window:toggle-fullscreen',
   WINDOW_NEW: 'window:new',
   WINDOW_GET_PLATFORM: 'window:get-platform',
+  WINDOW_GET_BUTTON_LAYOUT: 'window:get-button-layout',
 
   // App
   APP_SHOW_ABOUT: 'app:show-about',

--- a/src/shared/ipc-channels.js
+++ b/src/shared/ipc-channels.js
@@ -67,6 +67,7 @@ module.exports = {
 
   // App
   APP_SHOW_ABOUT: 'app:show-about',
+  APP_RELAUNCH: 'app:relaunch',
 
   // Profiles
   PROFILE_GET_ACTIVE: 'profile:get-active',


### PR DESCRIPTION
Make the tabs appear in the titlebar on Linux. There is a new switch in the appearance menu, but in order it to take effect it requires a restart. For that a button is provided next to the toggle when switched.

By default the tabs appear in the titlebar, with the setting the original behavior can be restored. The feature also respects the window manager's button layout, so in my case only the close button is displayed, but if the user has minimize + maximize + close buttons enabled then they are displayed.

New appearance (default):
<img width="2464" height="1684" alt="Screenshot From 2026-06-18 21-23-28" src="https://github.com/user-attachments/assets/0c516591-d68d-48a4-b17c-f02925848b81" />

Original appearance:
<img width="2488" height="1688" alt="Screenshot From 2026-06-18 21-22-59" src="https://github.com/user-attachments/assets/3cf44162-42ef-46d9-863c-892a31fd1a0c" />

Settings with restart button:
<img width="2488" height="1688" alt="Screenshot From 2026-06-18 21-23-12" src="https://github.com/user-attachments/assets/295ff509-0b39-46fe-ac6a-50ca9540f617" />

