### PR TITLE
fix: app icon on linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,11 @@
       "icon": "assets/icons",
       "category": "Network;WebBrowser",
       "executableName": "freedom",
+      "desktop": {
+        "entry": {
+          "StartupWMClass": "freedom-browser"
+        }
+      },
       "mimeTypes": [
         "x-scheme-handler/ipfs",
         "x-scheme-handler/ipns",


### PR DESCRIPTION
Fix the app icon on linux

With the fix:
<img width="2880" height="1718" alt="Screenshot From 2026-06-18 21-49-35" src="https://github.com/user-attachments/assets/0deb3ac7-6785-40b7-88a9-237a52cadcf4" />

Without the fix:
<img width="2880" height="1718" alt="Screenshot From 2026-06-18 21-50-39" src="https://github.com/user-attachments/assets/d9a8cb0e-80c7-4c61-8dc0-e8465ccfd1c7" />
