### PR TITLE
[codex] Update Colibri and harden ENS fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@adraffy/ens-normalize": "^1.11.1",
-        "@corpus-core/colibri-stateless": "^1.1.26",
+        "@corpus-core/colibri-stateless": "^1.1.30",
         "@ensdomains/content-hash": "^3.0.0",
         "@ethersphere/bee-js": "^12.2.1",
         "@metamask/browser-passworder": "^6.0.0",
@@ -1813,9 +1813,9 @@
       "license": "MIT"
     },
     "node_modules/@corpus-core/colibri-stateless": {
-      "version": "1.1.28",
-      "resolved": "https://registry.npmjs.org/@corpus-core/colibri-stateless/-/colibri-stateless-1.1.28.tgz",
-      "integrity": "sha512-4Fc4j9dW2mXMbUx0wW4gVjuxJDSgbkWpC/ZC8UmjNxNVpT8J+VLoRO/9dwIFyKrcHpuZy4FKuLAPe7PIsHULSA==",
+      "version": "1.1.30",
+      "resolved": "https://registry.npmjs.org/@corpus-core/colibri-stateless/-/colibri-stateless-1.1.30.tgz",
+      "integrity": "sha512-U/oFj14tKfGZUESGxEegJt1d8B0OZYGclXUQl8HIN5ttTUS0QQML//DPvR9k0PsVU9xz7ZWFt3B4pk0Ij6P/Kg==",
       "license": "MIT"
     },
     "node_modules/@develar/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
   },
   "dependencies": {
     "@adraffy/ens-normalize": "^1.11.1",
-    "@corpus-core/colibri-stateless": "^1.1.26",
+    "@corpus-core/colibri-stateless": "^1.1.30",
     "@ensdomains/content-hash": "^3.0.0",
     "@ethersphere/bee-js": "^12.2.1",
     "@metamask/browser-passworder": "^6.0.0",

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -876,7 +876,7 @@ async function tryColibriPath(name, callData) {
         block: null,
       };
     }
-    if (err.code === 'CALL_EXCEPTION') {
+    if (err.code === 'CALL_EXCEPTION' && getRevertData(err)) {
       // Verified revert with an unknown selector — same semantics as the
       // quorum path's NO_CONTENTHASH bucket. Upstream maps that to
       // RESOLUTION_ERROR for addr lookups and "no contenthash" for content.

--- a/src/main/ens-resolver.js
+++ b/src/main/ens-resolver.js
@@ -971,7 +971,13 @@ async function tryDirectResolve(rpcUrl, name, callData, userConfigured) {
       block,
     };
   }
-  return { outcome: 'not_found', reason: leg.reason || 'NO_RESOLVER', trust, block };
+  return {
+    outcome: 'not_found',
+    reason: leg.reason || 'NO_RESOLVER',
+    error: leg.error?.message,
+    trust,
+    block,
+  };
 }
 
 // Degraded resolution against a single RPC. Shared by the K<3 config
@@ -1005,7 +1011,13 @@ async function resolveSingleSourceUnverified(url, name, callData, anchor, timeou
     };
   }
   if (legResult.status === 'not_found') {
-    return { outcome: 'not_found', reason: legResult.reason || 'NO_RESOLVER', trust, block };
+    return {
+      outcome: 'not_found',
+      reason: legResult.reason || 'NO_RESOLVER',
+      error: legResult.error?.message,
+      trust,
+      block,
+    };
   }
   throw legResult.error || new Error('Single-provider resolution failed');
 }
@@ -1308,6 +1320,12 @@ async function doResolveEnsContent(normalized) {
       trust,
     };
     if (consensus.error) out.error = consensus.error;
+    if (out.reason === 'NO_CONTENTHASH' && out.error) {
+      // Unknown UR/CCIP reverts are transient failures, not authoritative
+      // empty records. Let reloads re-probe instead of pinning a negative.
+      log.info(`[ens] NO_CONTENTHASH for ${normalized} (not cached)`);
+      return out;
+    }
     return cacheContentResult(normalized, out);
   }
 

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -1902,6 +1902,24 @@ describe('ens-resolver', () => {
       expect(result.trust.method).toBe('colibri');
     });
 
+    test('CALL_EXCEPTION without revert data falls through to public RPC quorum', async () => {
+      withColibri();
+      const err = Object.assign(new Error('missing response from Colibri prover'), {
+        code: 'CALL_EXCEPTION',
+        info: { error: { code: -32603, message: 'no response' } },
+      });
+      mockResolveViaColibri.mockRejectedValue(err);
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
+
+      const result = await resolveEnsContent('prover-down.eth');
+
+      expect(result.type).toBe('ok');
+      expect(result.uri).toBe(`ipfs://${IPFS_V0}`);
+      expect(mockUrResolve).toHaveBeenCalled();
+      expect(result.trust.method).not.toBe('colibri');
+      expect(result.trust.quorum).toEqual({ k: 3, m: 2, achieved: true });
+    });
+
     test('non-revert error falls through to the quorum path by default', async () => {
       withColibri();
       mockResolveViaColibri.mockRejectedValue(new Error('proof verification failed'));

--- a/src/main/ens-resolver.test.js
+++ b/src/main/ens-resolver.test.js
@@ -460,6 +460,27 @@ describe('ens-resolver', () => {
       expect(mockUrResolve.mock.calls.length).toBe(callsAfterCold);
     });
 
+    test('does not cache transient NO_CONTENTHASH errors', async () => {
+      mockUrResolve.mockRejectedValue(
+        new Error('response not found during CCIP fetch: 3dnsService:: CCIP_001')
+      );
+
+      const first = await resolveEnsContent('transient-negative.box');
+      const callsAfterFailure = mockUrResolve.mock.calls.length;
+
+      expect(first.type).toBe('not_found');
+      expect(first.reason).toBe('NO_CONTENTHASH');
+      expect(first.error).toContain('CCIP');
+
+      mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
+
+      const second = await resolveEnsContent('transient-negative.box');
+
+      expect(second.type).toBe('ok');
+      expect(second.uri).toBe(`ipfs://${IPFS_V0}`);
+      expect(mockUrResolve.mock.calls.length).toBeGreaterThan(callsAfterFailure);
+    });
+
     test('makes K UR calls per cold resolution (one per quorum leg)', async () => {
       mockUrResolve.mockResolvedValue(urReturnsBytes(ipfsContenthashFor(IPFS_V0)));
 

--- a/src/main/ens/colibri-resolver.js
+++ b/src/main/ens/colibri-resolver.js
@@ -13,6 +13,7 @@ const { universalResolverCall, universalResolverReverse, hostOf } = require('../
 // threat model legible.
 const PRIVACY_MODE = 'basic';
 const CHAIN_ID = 1;
+const MAX_LATEST_AGE_SECONDS = 60;
 
 let cachedClient = null;
 let cachedClientKey = null;
@@ -77,6 +78,7 @@ async function buildClient({ key, proverUrl, zkProof, generation }) {
     zk_proof: zkProof,
     privacy_mode: PRIVACY_MODE,
     proofStrategy: Strategy.VerifiedOnly,
+    max_latest_age_seconds: MAX_LATEST_AGE_SECONDS,
   });
 
   if (generation !== buildGeneration) {

--- a/src/main/ens/colibri-resolver.test.js
+++ b/src/main/ens/colibri-resolver.test.js
@@ -100,6 +100,7 @@ describe('resolveViaColibri', () => {
       zk_proof: true,
       privacy_mode: 'basic',
       proofStrategy: Strategy.VerifiedOnly,
+      max_latest_age_seconds: 60,
     });
   });
 


### PR DESCRIPTION
## Summary
- update `@corpus-core/colibri-stateless` to `^1.1.30` / lockfile `1.1.30`
- make the Colibri latest-proof freshness window explicit at 60 seconds
- only classify Colibri `CALL_EXCEPTION`s as verified resolver reverts when revert data is present, so prover/network outages fall through to the public RPC quorum

## Root Cause
A Colibri/prover outage can be wrapped as an ethers `CALL_EXCEPTION`. The ENS Colibri path treated every `CALL_EXCEPTION` as a verified Universal Resolver revert, which could incorrectly produce `NO_CONTENTHASH` instead of falling back to the RPC quorum.

## Validation
- `npm test -- src/main/ens/colibri-resolver.test.js src/main/ens-resolver.test.js --runInBand`
- live Colibri Universal Resolver smoke against `vitalik.eth` with `@corpus-core/colibri-stateless@1.1.30`
- `npm test`
- `npm run lint`
- `npm run test:coverage` (sandboxed attempt failed because local `antd` bind was blocked; escalated rerun passed)
- `npm ci --ignore-scripts`
- `npm run lint`
- `npm run test:coverage`
