### PR TITLE
build(ant): bump pinned antd release to v0.5.29

### DIFF
--- a/scripts/fetch-ant.js
+++ b/scripts/fetch-ant.js
@@ -15,7 +15,7 @@ const ANT_REPO = process.env.ANT_REPO || 'solardev-xyz/ant';
 // could ship a different Ant than CI validated. Override via ANT_RELEASE_TAG
 // for local testing of newer releases; set it to `latest` to resolve the
 // repo's most recent published release.
-const PINNED_RELEASE_TAG = 'v0.5.28';
+const PINNED_RELEASE_TAG = 'v0.5.29';
 // In-repo trust root for the pinned release: the sha256 of its SHA256SUMS
 // asset, recorded at pin time (trust-on-first-use by the author). The release
 // downloads its SHA256SUMS from the same GitHub release as the binaries, so
@@ -24,7 +24,7 @@ const PINNED_RELEASE_TAG = 'v0.5.28';
 // that tampering detectable. Update alongside PINNED_RELEASE_TAG on every
 // deliberate bump: `shasum -a 256` the freshly downloaded SHA256SUMS.
 const PINNED_SHA256SUMS_DIGEST =
-  '487d0d98599627a317cae0e9664a270b09231718d1f86b5ea470e8a15b848faa';
+  'b5f6033594681c8311037f6af9c67d310597bca175eb04935cd3e1894ccc0ee2';
 const ANT_RELEASE_TAG = process.env.ANT_RELEASE_TAG || PINNED_RELEASE_TAG;
 
 function fetchReleaseOnce() {


### PR DESCRIPTION
## Summary
Bumps the pinned Ant (`antd`) release from **v0.5.28 → v0.5.29** (latest published release of `solardev-xyz/ant`, released 2026-06-22).

- `PINNED_RELEASE_TAG`: `v0.5.28` → `v0.5.29`
- `PINNED_SHA256SUMS_DIGEST`: updated to the sha256 of the v0.5.29 `SHA256SUMS` asset (`b5f6033594681c8311037f6af9c67d310597bca175eb04935cd3e1894ccc0ee2`)

## Verification
- `npm run ant:download` installs and checksum-verifies all targets (mac arm64/x64, linux x64/arm64, win x64) against the new pinned digest ✅
- SHA256SUMS verified against the in-repo pinned digest ✅
- `./ant-bin/mac-arm64/antd --version` reports `antd 0.5.29` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)