### PR TITLE
chore: bump version to 0.8.0-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freedom-browser",
-  "version": "0.7.5-dev",
+  "version": "0.8.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freedom-browser",
-      "version": "0.7.5-dev",
+      "version": "0.8.0-dev",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freedom-browser",
-  "version": "0.7.5-dev",
+  "version": "0.8.0-dev",
   "license": "MPL-2.0",
   "description": "Freedom – A browser for the decentralized web, with Swarm, IPFS, and ENS as first-class protocols.",
   "author": {


### PR DESCRIPTION
Bumps the working version from 0.7.5-dev to 0.8.0-dev.