### PR TITLE
Fix IPFS node menu version format and label (#103)

### DIFF
--- a/src/main/ipfs-manager.js
+++ b/src/main/ipfs-manager.js
@@ -27,7 +27,21 @@ let currentState = STATUS.STOPPED;
 let lastError = null;
 let activeNode = null;
 let healthCheckInterval = null;
-let pendingStart = false;
+
+// Serializes start/stop transitions. The renderer's optimistic toggle awaits
+// start()/stop() and treats the resolved status as the *settled* backend state
+// (see reconcileIpfsToggle in renderer/lib/ipfs-ui.js). To honor that contract
+// even when the user flips the switch mid-transition, every transition runs to
+// completion before the next begins — a start requested during a stop waits for
+// the stop, then runs, and only then does its promise resolve.
+let opChain = Promise.resolve();
+
+function enqueueOp(op) {
+  const result = opChain.then(op, op);
+  // A failing op must not poison the chain for the next transition.
+  opChain = result.catch(() => {});
+  return result;
+}
 
 function defaultNativeDiagnostics() {
   return {
@@ -153,19 +167,12 @@ function startDisabledIpfs() {
   log.info('[IPFS] Disabled for active profile');
 }
 
-async function startIpfs() {
+async function doStartIpfs() {
   if (currentState === STATUS.RUNNING || currentState === STATUS.STARTING) {
     log.info(`[IPFS] Ignoring start request, current state: ${currentState}`);
     return;
   }
 
-  if (currentState === STATUS.STOPPING) {
-    log.info('[IPFS] Currently stopping, queuing start for after stop completes');
-    pendingStart = true;
-    return;
-  }
-
-  pendingStart = false;
   updateState(STATUS.STARTING);
 
   if (isDisabledIpfsConfig()) {
@@ -212,8 +219,7 @@ async function startIpfs() {
   log.info(`[IPFS] ${nodeLabel} native node started at ${dataDir}`);
 }
 
-async function stopIpfs() {
-  pendingStart = false;
+async function doStopIpfs() {
   if (currentState === STATUS.STOPPED && !activeNode) {
     clearService('ipfs');
     return;
@@ -234,11 +240,16 @@ async function stopIpfs() {
   updateState(STATUS.STOPPED);
   clearErrorState('ipfs');
   clearService('ipfs');
+}
 
-  if (pendingStart) {
-    pendingStart = false;
-    setTimeout(() => startIpfs(), 100);
-  }
+// Public entry points. Each returns a promise that resolves once the transition
+// has fully settled, so awaiting start()/stop() yields the final node status.
+function startIpfs() {
+  return enqueueOp(doStartIpfs);
+}
+
+function stopIpfs() {
+  return enqueueOp(doStopIpfs);
 }
 
 async function serveNativeGatewayRequest({ path: gatewayPath, method, headers, signal }) {
@@ -292,13 +303,13 @@ function getActiveGatewayPort() {
 }
 
 function registerIpfsIpc() {
-  ipcMain.handle(IPC.IPFS_START, () => {
-    startIpfs();
+  ipcMain.handle(IPC.IPFS_START, async () => {
+    await startIpfs();
     return { status: currentState, error: lastError };
   });
 
-  ipcMain.handle(IPC.IPFS_STOP, () => {
-    stopIpfs();
+  ipcMain.handle(IPC.IPFS_STOP, async () => {
+    await stopIpfs();
     return { status: currentState, error: lastError };
   });
 

--- a/src/main/ipfs-manager.test.js
+++ b/src/main/ipfs-manager.test.js
@@ -278,6 +278,48 @@ describe('ipfs-manager', () => {
     expect(ctx.clearErrorState).toHaveBeenCalledWith('ipfs');
   });
 
+  test('a start requested mid-stop queues behind the stop and resolves once running', async () => {
+    const flush = () => new Promise((resolve) => setImmediate(resolve));
+    const ctx = loadIpfsManagerModule();
+    ctx.mod.registerIpfsIpc();
+
+    // Bring the node up.
+    await ctx.ipcMain.invoke(IPC.IPFS_START);
+    expect(ctx.nativeInstances).toHaveLength(1);
+
+    // Make the stop hang so a start can be requested while the node is STOPPING.
+    let releaseStop;
+    ctx.nativeInstances[0].stop.mockImplementation(
+      () => new Promise((resolve) => {
+        releaseStop = resolve;
+      })
+    );
+
+    const stopResult = ctx.ipcMain.invoke(IPC.IPFS_STOP);
+    await flush();
+
+    // Mid-stop the user flips back on. The start must queue behind the in-flight
+    // stop rather than be dropped or run concurrently.
+    const startResult = ctx.ipcMain.invoke(IPC.IPFS_START);
+    await flush();
+
+    // Still stopping: the queued start hasn't spun up a new node yet, and the
+    // reported status is the live transitional state.
+    expect(ctx.nativeInstances).toHaveLength(1);
+    await expect(ctx.ipcMain.invoke(IPC.IPFS_GET_STATUS)).resolves.toMatchObject({
+      status: 'stopping',
+    });
+
+    // Let the stop finish; the queued start then runs to completion.
+    releaseStop();
+
+    // The stop IPC settles to 'stopped', and crucially the start IPC resolves
+    // only once the node is actually back up — not with the transient 'stopping'.
+    expect((await stopResult).status).toBe('stopped');
+    expect((await startResult).status).toBe('running');
+    expect(ctx.nativeInstances).toHaveLength(2);
+  });
+
   test('moves to error and cleans up when the native node reports failure', async () => {
     const window = createWindowMock();
     const ctx = loadIpfsManagerModule({ windows: [window] });

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -537,7 +537,7 @@
               <span id="ipfs-active-requests-count">--</span>
             </div>
             <div class="ipfs-info-row">
-              <span class="ipfs-info-label">Data Read:</span>
+              <span class="ipfs-info-label">Session Download:</span>
               <span id="ipfs-data-read"></span>
             </div>
             <div class="ipfs-info-row">

--- a/src/renderer/lib/ipfs-ui.js
+++ b/src/renderer/lib/ipfs-ui.js
@@ -230,12 +230,12 @@ export const updateIpfsToggleState = () => {
 // it back through updateIpfsUi so the UI settles to the truth instead of the
 // intent we guessed.
 const reconcileToggleError = (expectedIntent, err) => {
+  // A newer click may have already changed the intent while this call was in
+  // flight; if so, this rejection is stale — bail (without logging the noise)
+  // so it can't wipe the newer intent or settle the switch from outdated status.
+  if (state.ipfsDesiredRunning !== expectedIntent) return;
   console.error('Failed to toggle IPFS', err);
   pushDebug(`Failed to toggle IPFS: ${err.message}`);
-  // A newer click may have already changed the intent while this call was in
-  // flight; if so, this rejection is stale — bail so it can't wipe the newer
-  // intent or settle the switch from outdated status.
-  if (state.ipfsDesiredRunning !== expectedIntent) return;
   // The call threw, so the action never took effect. Drop the optimistic intent
   // we applied on click — otherwise a held intent would mask the real status and
   // keep the switch on a state that never happened.

--- a/src/renderer/lib/ipfs-ui.js
+++ b/src/renderer/lib/ipfs-ui.js
@@ -76,14 +76,16 @@ const updateVersionFromDiagnostics = (diagnostics) => {
   if (ipfsVersionText) ipfsVersionText.textContent = state.ipfsVersionValue;
 };
 
-// The node counts as running for UI purposes when a pending toggle wants it on,
-// or — with no toggle in flight — when the live status says so. Toggle handling
-// and stats polling share this so a pending "on" doesn't leave the panel blank
-// while the backend is still reporting the stale 'stopped' status.
+// The real backend state, ignoring any pending user intent.
+const isIpfsLiveRunning = () =>
+  state.currentIpfsStatus === 'running' || state.currentIpfsStatus === 'starting';
+
+// What the UI should show: the user's target while a toggle is pending
+// (ipfsDesiredRunning !== null), otherwise the live backend state. The switch
+// and stats polling read this so the toggle reflects the latest click instantly
+// and never flickers back to a transient/stale backend status mid-transition.
 const isIpfsEffectivelyRunning = () =>
-  state.ipfsDesiredRunning !== null
-    ? state.ipfsDesiredRunning
-    : state.currentIpfsStatus === 'running' || state.currentIpfsStatus === 'starting';
+  state.ipfsDesiredRunning !== null ? state.ipfsDesiredRunning : isIpfsLiveRunning();
 
 const fetchNativeStats = async () => {
   if (!state.antMenuOpen) return;
@@ -136,12 +138,10 @@ export const updateIpfsUi = (status, error) => {
 
   if (!ipfsToggleBtn || !ipfsToggleSwitch) return;
 
-  // While a toggle is in flight (ipfsDesiredRunning !== null) the switch follows
-  // the user's intent and ignores transient/stale backend states. The intent is
-  // not cleared here: it's cleared when the initiating start()/stop() call
-  // settles (see settleToggle / reconcileToggleError), so once the action is
-  // truly done the switch follows live status — including re-syncing to
-  // 'running' when a stop failed and left the node up.
+  // While a toggle is pending (ipfsDesiredRunning !== null) the switch follows
+  // the user's target and ignores transient/stale backend states. The intent is
+  // cleared by the reconcile loop once it reaches the target or gives up (see
+  // reconcileIpfsToggle), after which the switch follows live status again.
   const showRunning = isIpfsEffectivelyRunning();
 
   ipfsToggleSwitch.classList.toggle('running', showRunning);
@@ -217,42 +217,52 @@ export const updateIpfsToggleState = () => {
   }
 };
 
-// The initiating start()/stop() call has resolved. If a newer click hasn't
-// superseded this action, the transition is over: drop the pending intent and
-// let the reported status drive the UI. This is what re-syncs the switch when a
-// stop "failed" but left the node running (status comes back 'running'), instead
-// of holding it off forever.
-const settleToggle = (expectedIntent, result) => {
-  if (state.ipfsDesiredRunning !== expectedIntent) return; // superseded by a newer click
-  state.ipfsDesiredRunning = null;
-  const { status, error } = result || {};
-  updateIpfsUi(status, error);
-};
+// True while the background reconcile loop is converging the backend toward the
+// user's target, so a flurry of clicks doesn't spawn overlapping loops.
+let ipfsReconciling = false;
 
-// A rejected start()/stop() IPC (a thrown call, not a `{ status: 'error' }`
-// result) skips the settle path, so the optimistic switch/polling state we
-// applied on click would otherwise linger. Re-query the real status and feed it
-// back through updateIpfsUi so the UI settles to the truth instead of the intent
-// we guessed.
-const reconcileToggleError = (expectedIntent, err) => {
-  // A newer click may have already changed the intent while this call was in
-  // flight; if so, this rejection is stale — bail (without logging the noise)
-  // so it can't wipe the newer intent or settle the switch from outdated status.
-  if (state.ipfsDesiredRunning !== expectedIntent) return;
-  console.error('Failed to toggle IPFS', err);
-  pushDebug(`Failed to toggle IPFS: ${err.message}`);
-  // The call threw, so the action never took effect. Drop the optimistic intent
-  // we applied on click — otherwise a held intent would mask the real status and
-  // keep the switch on a state that never happened.
-  state.ipfsDesiredRunning = null;
-  window.ipfs
-    ?.getStatus?.()
-    .then(({ status, error } = {}) => updateIpfsUi(status, error))
-    .catch(() => {
-      // Status re-query also failed; settle the switch on the last-known status
-      // and let the periodic refresh poll correct it later.
-      updateIpfsUi(state.currentIpfsStatus);
-    });
+// Drive the backend toward state.ipfsDesiredRunning. The click handler sets the
+// target and the switch instantly; this loop does the slow start()/stop() work
+// in the background and always converges to the *latest* target, so the user can
+// toggle rapidly and the node ends up where they last left the switch.
+//
+// Each iteration re-reads the target, so a click made mid-flight redirects the
+// loop. If an operation completes without reaching a still-unchanged target
+// (e.g. a stop that left the node running, or a start that failed), the loop
+// gives up rather than spinning, and the switch falls back to the real status.
+const reconcileIpfsToggle = async () => {
+  if (ipfsReconciling) return;
+  ipfsReconciling = true;
+  try {
+    while (state.ipfsDesiredRunning !== null && state.ipfsDesiredRunning !== isIpfsLiveRunning()) {
+      const target = state.ipfsDesiredRunning;
+      let status;
+      let error;
+      try {
+        const result = (target ? await window.ipfs.start() : await window.ipfs.stop()) || {};
+        ({ status, error } = result);
+      } catch (err) {
+        console.error('Failed to toggle IPFS', err);
+        pushDebug(`Failed to toggle IPFS: ${err.message}`);
+        // The call threw; re-query the real status so the UI reflects reality.
+        const live = await window.ipfs?.getStatus?.()?.catch(() => null);
+        status = live?.status ?? state.currentIpfsStatus;
+        error = live?.error;
+      }
+      updateIpfsUi(status, error);
+      // If the target hasn't changed but the op didn't reach it, don't spin —
+      // accept reality. If the target changed mid-flight, loop again toward it.
+      if (state.ipfsDesiredRunning === target && state.ipfsDesiredRunning !== isIpfsLiveRunning()) {
+        break;
+      }
+    }
+  } finally {
+    ipfsReconciling = false;
+    // Stop overriding the switch: the loop reached the target or gave up, so the
+    // live status is now the source of truth.
+    state.ipfsDesiredRunning = null;
+    updateIpfsUi(state.currentIpfsStatus);
+  }
 };
 
 export const initIpfsUi = () => {
@@ -289,30 +299,22 @@ export const initIpfsUi = () => {
     const mode = state.registry?.ipfs?.mode;
     if (mode === 'reused') return;
 
-    // Base the decision on a pending toggle if one is in flight, otherwise on
-    // the live status — so a quick second click reverses the user's last intent
-    // rather than reacting to a transient stopping/starting state.
-    const currentlyOn = isIpfsEffectivelyRunning();
+    // Flip to the opposite of whatever the switch currently shows (the pending
+    // target if one is set, otherwise live status), so each click reverses the
+    // last one even mid-transition.
+    const desired = !isIpfsEffectivelyRunning();
+    state.ipfsDesiredRunning = desired;
 
-    if (currentlyOn) {
-      state.ipfsDesiredRunning = false;
-      ipfsToggleSwitch?.classList.remove('running');
-      stopIpfsInfoPolling();
-      pushDebug('User toggled IPFS Off');
-      window.ipfs
-        .stop()
-        .then((result) => settleToggle(false, result))
-        .catch((err) => reconcileToggleError(false, err));
-    } else {
-      state.ipfsDesiredRunning = true;
-      ipfsToggleSwitch?.classList.add('running');
+    // Update the switch and stats panel instantly; the reconcile loop drives the
+    // backend toward this target in the background and coalesces rapid clicks.
+    ipfsToggleSwitch?.classList.toggle('running', desired);
+    if (desired) {
       startIpfsInfoPolling();
-      pushDebug('User toggled IPFS On');
-      window.ipfs
-        .start()
-        .then((result) => settleToggle(true, result))
-        .catch((err) => reconcileToggleError(true, err));
+    } else {
+      stopIpfsInfoPolling();
     }
+    pushDebug(`User toggled IPFS ${desired ? 'On' : 'Off'}`);
+    reconcileIpfsToggle();
   });
 
   // Listen for status updates from main process

--- a/src/renderer/lib/ipfs-ui.js
+++ b/src/renderer/lib/ipfs-ui.js
@@ -229,9 +229,13 @@ export const updateIpfsToggleState = () => {
 // we applied on click would otherwise linger. Re-query the real status and feed
 // it back through updateIpfsUi so the UI settles to the truth instead of the
 // intent we guessed.
-const reconcileToggleError = (err) => {
+const reconcileToggleError = (expectedIntent, err) => {
   console.error('Failed to toggle IPFS', err);
   pushDebug(`Failed to toggle IPFS: ${err.message}`);
+  // A newer click may have already changed the intent while this call was in
+  // flight; if so, this rejection is stale — bail so it can't wipe the newer
+  // intent or settle the switch from outdated status.
+  if (state.ipfsDesiredRunning !== expectedIntent) return;
   // The call threw, so the action never took effect. Drop the optimistic intent
   // we applied on click — otherwise a held intent would mask the real status and
   // keep the switch on a state that never happened.
@@ -293,7 +297,7 @@ export const initIpfsUi = () => {
       window.ipfs
         .stop()
         .then(({ status, error }) => updateIpfsUi(status, error))
-        .catch((err) => reconcileToggleError(err));
+        .catch((err) => reconcileToggleError(false, err));
     } else {
       state.ipfsDesiredRunning = true;
       ipfsToggleSwitch?.classList.add('running');
@@ -302,7 +306,7 @@ export const initIpfsUi = () => {
       window.ipfs
         .start()
         .then(({ status, error }) => updateIpfsUi(status, error))
-        .catch((err) => reconcileToggleError(err));
+        .catch((err) => reconcileToggleError(true, err));
     }
   });
 

--- a/src/renderer/lib/ipfs-ui.js
+++ b/src/renderer/lib/ipfs-ui.js
@@ -224,6 +224,28 @@ export const updateIpfsToggleState = () => {
   }
 };
 
+// A rejected start()/stop() IPC (a thrown call, not a `{ status: 'error' }`
+// result) skips the .then reconciliation, so the optimistic switch/polling state
+// we applied on click would otherwise linger. Re-query the real status and feed
+// it back through updateIpfsUi so the UI settles to the truth instead of the
+// intent we guessed.
+const reconcileToggleError = (err) => {
+  console.error('Failed to toggle IPFS', err);
+  pushDebug(`Failed to toggle IPFS: ${err.message}`);
+  // The call threw, so the action never took effect. Drop the optimistic intent
+  // we applied on click — otherwise a held intent would mask the real status and
+  // keep the switch on a state that never happened.
+  state.ipfsDesiredRunning = null;
+  window.ipfs
+    ?.getStatus?.()
+    .then(({ status, error }) => updateIpfsUi(status, error))
+    .catch(() => {
+      // Status re-query also failed; settle the switch on the last-known status
+      // and let the periodic refresh poll correct it later.
+      updateIpfsUi(state.currentIpfsStatus);
+    });
+};
+
 export const initIpfsUi = () => {
   // Initialize DOM elements
   ipfsToggleBtn = document.getElementById('ipfs-toggle-btn');
@@ -271,10 +293,7 @@ export const initIpfsUi = () => {
       window.ipfs
         .stop()
         .then(({ status, error }) => updateIpfsUi(status, error))
-        .catch((err) => {
-          console.error('Failed to toggle IPFS', err);
-          pushDebug(`Failed to toggle IPFS: ${err.message}`);
-        });
+        .catch((err) => reconcileToggleError(err));
     } else {
       state.ipfsDesiredRunning = true;
       ipfsToggleSwitch?.classList.add('running');
@@ -283,10 +302,7 @@ export const initIpfsUi = () => {
       window.ipfs
         .start()
         .then(({ status, error }) => updateIpfsUi(status, error))
-        .catch((err) => {
-          console.error('Failed to toggle IPFS', err);
-          pushDebug(`Failed to toggle IPFS: ${err.message}`);
-        });
+        .catch((err) => reconcileToggleError(err));
     }
   });
 

--- a/src/renderer/lib/ipfs-ui.js
+++ b/src/renderer/lib/ipfs-ui.js
@@ -49,13 +49,31 @@ const parseNativeBuildInfo = (raw) => {
   }
 };
 
-const formatNativeVersionLabel = (diagnostics = {}) => {
+const readNativeVersion = (diagnostics = {}) => {
   const buildInfo = parseNativeBuildInfo(diagnostics.nativeBuildInfo);
-  const version =
+  return (
     (typeof buildInfo?.version === 'string' && buildInfo.version) ||
     (typeof diagnostics.nativeVersion === 'string' && diagnostics.nativeVersion) ||
-    '';
-  return version ? `Freedom IPFS v${version}` : 'Freedom IPFS';
+    ''
+  );
+};
+
+// The native node only reports its version once it's actually running. Read it
+// off each stats poll and cache it the first time a real version appears — and
+// only then. A poll taken while the node is still spinning up (stopped status /
+// no diagnostics) shows the bare 'Freedom IPFS' fallback but does NOT mark the
+// version fetched, so later polls keep upgrading it instead of locking in the
+// fallback forever.
+const updateVersionFromDiagnostics = (diagnostics) => {
+  if (state.ipfsVersionFetched) return;
+  const version = readNativeVersion(diagnostics);
+  if (version) {
+    state.ipfsVersionValue = `Freedom IPFS v${version}`;
+    state.ipfsVersionFetched = true;
+  } else if (!state.ipfsVersionValue) {
+    state.ipfsVersionValue = 'Freedom IPFS';
+  }
+  if (ipfsVersionText) ipfsVersionText.textContent = state.ipfsVersionValue;
 };
 
 // The node counts as running for UI purposes when a pending toggle wants it on,
@@ -85,24 +103,11 @@ const fetchNativeStats = async () => {
     if (ipfsDataRead) {
       ipfsDataRead.textContent = formatBytes(stats.bytes_read || 0);
     }
+    updateVersionFromDiagnostics(status?.diagnostics);
   } catch {
     if (ipfsActiveRequestsCount) ipfsActiveRequestsCount.textContent = '0';
     if (ipfsDataRead) ipfsDataRead.textContent = '';
   }
-};
-
-const fetchVersionOnce = async () => {
-  if (state.ipfsVersionFetched) return;
-  state.ipfsVersionFetched = true;
-  let versionLabel = null;
-  try {
-    const status = await window.ipfs?.getStatus?.();
-    versionLabel = formatNativeVersionLabel(status?.diagnostics);
-  } catch {
-    // Fall back below; version display must not block status polling.
-  }
-  state.ipfsVersionValue = versionLabel || 'Freedom IPFS';
-  if (ipfsVersionText) ipfsVersionText.textContent = state.ipfsVersionValue;
 };
 
 export const startIpfsInfoPolling = () => {
@@ -113,8 +118,10 @@ export const startIpfsInfoPolling = () => {
 
   ipfsInfoPanel?.classList.add('visible');
 
+  // fetchNativeStats also reads the node version off the same getStatus call and
+  // upgrades the label once a real version is available (see
+  // updateVersionFromDiagnostics).
   fetchNativeStats();
-  if (!state.ipfsVersionFetched) fetchVersionOnce();
 
   if (state.ipfsInfoInterval) clearInterval(state.ipfsInfoInterval);
   state.ipfsInfoInterval = setInterval(fetchNativeStats, 1000);

--- a/src/renderer/lib/ipfs-ui.js
+++ b/src/renderer/lib/ipfs-ui.js
@@ -16,6 +16,10 @@ let ipfsStatusValue = null;
 // Binary availability state
 let ipfsBinaryAvailable = true;
 
+// Guards one-time listener/subscription wiring so re-running initIpfsUi (e.g.
+// to re-check binary availability) doesn't bind the click handler twice.
+let ipfsListenersAttached = false;
+
 export const stopIpfsInfoPolling = () => {
   if (state.ipfsInfoInterval) {
     clearInterval(state.ipfsInfoInterval);
@@ -51,7 +55,7 @@ const formatNativeVersionLabel = (diagnostics = {}) => {
     (typeof buildInfo?.version === 'string' && buildInfo.version) ||
     (typeof diagnostics.nativeVersion === 'string' && diagnostics.nativeVersion) ||
     '';
-  return version ? `freedom-ipfs ${version}` : 'freedom-ipfs';
+  return version ? `Freedom IPFS v${version}` : 'Freedom IPFS';
 };
 
 const fetchNativeStats = async () => {
@@ -88,7 +92,7 @@ const fetchVersionOnce = async () => {
   } catch {
     // Fall back below; version display must not block status polling.
   }
-  state.ipfsVersionValue = versionLabel || 'freedom-ipfs';
+  state.ipfsVersionValue = versionLabel || 'Freedom IPFS';
   if (ipfsVersionText) ipfsVersionText.textContent = state.ipfsVersionValue;
 };
 
@@ -108,42 +112,48 @@ export const startIpfsInfoPolling = () => {
 };
 
 export const updateIpfsUi = (status, error) => {
-  if (state.suppressIpfsRunningStatus && status === 'running') {
-    return;
-  }
-  if (status === 'stopped' || status === 'error') {
-    state.suppressIpfsRunningStatus = false;
-  }
-
   state.currentIpfsStatus = status;
 
-  // Update status line and toggle state from registry
+  // Reconcile a pending user toggle. Once the backend reaches the state the
+  // user asked for (or errors out), the transition is over and the live status
+  // drives the switch again. Until then we keep the pending intent so that a
+  // rapid on/off/on sequence — which makes the backend emit transient
+  // stopping/starting and stale stopped/running states — can't flip the switch
+  // out from under the user before the node data settles.
+  if (
+    status === 'error' ||
+    (state.ipfsDesiredRunning === true && status === 'running') ||
+    (state.ipfsDesiredRunning === false && status === 'stopped')
+  ) {
+    state.ipfsDesiredRunning = null;
+  }
+
+  // Update status line and toggle disabled/external state from registry
   updateIpfsStatusLine();
   updateIpfsToggleState();
 
   if (!ipfsToggleBtn || !ipfsToggleSwitch) return;
 
-  ipfsToggleSwitch.classList.remove('running');
-  switch (status) {
-    case 'running':
-    case 'starting':
-      ipfsToggleSwitch.classList.add('running');
-      break;
-    case 'error':
-      if (error) pushDebug(`IPFS Error: ${error}`);
-      break;
-    case 'stopping':
-    case 'stopped':
-    default:
-      // Clear status row when stopped
-      if (ipfsStatusRow) ipfsStatusRow.classList.remove('visible');
-      break;
+  // While a toggle is in flight the switch follows the user's intent; once it
+  // settles (ipfsDesiredRunning === null) it follows the live status.
+  const showRunning =
+    state.ipfsDesiredRunning !== null
+      ? state.ipfsDesiredRunning
+      : status === 'running' || status === 'starting';
+
+  ipfsToggleSwitch.classList.toggle('running', showRunning);
+
+  if (status === 'error') {
+    if (error) pushDebug(`IPFS Error: ${error}`);
+  } else if (!showRunning && ipfsStatusRow) {
+    // Clear the status row once the node is no longer running.
+    ipfsStatusRow.classList.remove('visible');
   }
 
   if (state.antMenuOpen) {
-    if (status === 'stopped') {
+    if (!showRunning) {
       stopIpfsInfoPolling();
-    } else if (!state.ipfsInfoInterval && ipfsToggleSwitch?.classList.contains('running')) {
+    } else if (!state.ipfsInfoInterval) {
       startIpfsInfoPolling();
     }
   }
@@ -227,6 +237,9 @@ export const initIpfsUi = () => {
     });
   }
 
+  if (ipfsListenersAttached) return;
+  ipfsListenersAttached = true;
+
   // Toggle button listener
   ipfsToggleBtn?.addEventListener('click', () => {
     if (!ipfsBinaryAvailable) return;
@@ -235,8 +248,16 @@ export const initIpfsUi = () => {
     const mode = state.registry?.ipfs?.mode;
     if (mode === 'reused') return;
 
-    if (state.currentIpfsStatus === 'running' || state.currentIpfsStatus === 'starting') {
-      state.suppressIpfsRunningStatus = true;
+    // Base the decision on a pending toggle if one is in flight, otherwise on
+    // the live status — so a quick second click reverses the user's last intent
+    // rather than reacting to a transient stopping/starting state.
+    const currentlyOn =
+      state.ipfsDesiredRunning !== null
+        ? state.ipfsDesiredRunning
+        : state.currentIpfsStatus === 'running' || state.currentIpfsStatus === 'starting';
+
+    if (currentlyOn) {
+      state.ipfsDesiredRunning = false;
       ipfsToggleSwitch?.classList.remove('running');
       stopIpfsInfoPolling();
       pushDebug('User toggled IPFS Off');
@@ -248,7 +269,7 @@ export const initIpfsUi = () => {
           pushDebug(`Failed to toggle IPFS: ${err.message}`);
         });
     } else {
-      state.suppressIpfsRunningStatus = false;
+      state.ipfsDesiredRunning = true;
       ipfsToggleSwitch?.classList.add('running');
       startIpfsInfoPolling();
       pushDebug('User toggled IPFS On');

--- a/src/renderer/lib/ipfs-ui.js
+++ b/src/renderer/lib/ipfs-ui.js
@@ -130,32 +130,18 @@ export const startIpfsInfoPolling = () => {
 export const updateIpfsUi = (status, error) => {
   state.currentIpfsStatus = status;
 
-  // Reconcile a pending user toggle. Once the backend confirms the state the
-  // user asked for, the transition is over and the live status drives the switch
-  // again. Until then we keep the pending intent so that a rapid on/off/on
-  // sequence — which makes the backend emit transient stopping/starting and
-  // stale stopped/running states — can't flip the switch out from under the user
-  // before the node data settles.
-  const reachedDesired =
-    (state.ipfsDesiredRunning === true && status === 'running') ||
-    (state.ipfsDesiredRunning === false && status === 'stopped');
-  // A failed *start* (intent was "on") ends that attempt, so let the switch fall
-  // back to the error/live status. A failed *stop* (intent was "off") leaves the
-  // node running, so we hold the user's intent rather than letting a later
-  // 'running' poll silently flip the switch back on.
-  const failedStart = status === 'error' && state.ipfsDesiredRunning === true;
-  if (reachedDesired || failedStart) {
-    state.ipfsDesiredRunning = null;
-  }
-
   // Update status line and toggle disabled/external state from registry
   updateIpfsStatusLine();
   updateIpfsToggleState();
 
   if (!ipfsToggleBtn || !ipfsToggleSwitch) return;
 
-  // While a toggle is in flight the switch follows the user's intent; once it
-  // settles (ipfsDesiredRunning === null) it follows the live status.
+  // While a toggle is in flight (ipfsDesiredRunning !== null) the switch follows
+  // the user's intent and ignores transient/stale backend states. The intent is
+  // not cleared here: it's cleared when the initiating start()/stop() call
+  // settles (see settleToggle / reconcileToggleError), so once the action is
+  // truly done the switch follows live status — including re-syncing to
+  // 'running' when a stop failed and left the node up.
   const showRunning = isIpfsEffectivelyRunning();
 
   ipfsToggleSwitch.classList.toggle('running', showRunning);
@@ -231,11 +217,23 @@ export const updateIpfsToggleState = () => {
   }
 };
 
+// The initiating start()/stop() call has resolved. If a newer click hasn't
+// superseded this action, the transition is over: drop the pending intent and
+// let the reported status drive the UI. This is what re-syncs the switch when a
+// stop "failed" but left the node running (status comes back 'running'), instead
+// of holding it off forever.
+const settleToggle = (expectedIntent, result) => {
+  if (state.ipfsDesiredRunning !== expectedIntent) return; // superseded by a newer click
+  state.ipfsDesiredRunning = null;
+  const { status, error } = result || {};
+  updateIpfsUi(status, error);
+};
+
 // A rejected start()/stop() IPC (a thrown call, not a `{ status: 'error' }`
-// result) skips the .then reconciliation, so the optimistic switch/polling state
-// we applied on click would otherwise linger. Re-query the real status and feed
-// it back through updateIpfsUi so the UI settles to the truth instead of the
-// intent we guessed.
+// result) skips the settle path, so the optimistic switch/polling state we
+// applied on click would otherwise linger. Re-query the real status and feed it
+// back through updateIpfsUi so the UI settles to the truth instead of the intent
+// we guessed.
 const reconcileToggleError = (expectedIntent, err) => {
   // A newer click may have already changed the intent while this call was in
   // flight; if so, this rejection is stale — bail (without logging the noise)
@@ -249,7 +247,7 @@ const reconcileToggleError = (expectedIntent, err) => {
   state.ipfsDesiredRunning = null;
   window.ipfs
     ?.getStatus?.()
-    .then(({ status, error }) => updateIpfsUi(status, error))
+    .then(({ status, error } = {}) => updateIpfsUi(status, error))
     .catch(() => {
       // Status re-query also failed; settle the switch on the last-known status
       // and let the periodic refresh poll correct it later.
@@ -303,7 +301,7 @@ export const initIpfsUi = () => {
       pushDebug('User toggled IPFS Off');
       window.ipfs
         .stop()
-        .then(({ status, error }) => updateIpfsUi(status, error))
+        .then((result) => settleToggle(false, result))
         .catch((err) => reconcileToggleError(false, err));
     } else {
       state.ipfsDesiredRunning = true;
@@ -312,7 +310,7 @@ export const initIpfsUi = () => {
       pushDebug('User toggled IPFS On');
       window.ipfs
         .start()
-        .then(({ status, error }) => updateIpfsUi(status, error))
+        .then((result) => settleToggle(true, result))
         .catch((err) => reconcileToggleError(true, err));
     }
   });

--- a/src/renderer/lib/ipfs-ui.js
+++ b/src/renderer/lib/ipfs-ui.js
@@ -58,9 +58,18 @@ const formatNativeVersionLabel = (diagnostics = {}) => {
   return version ? `Freedom IPFS v${version}` : 'Freedom IPFS';
 };
 
+// The node counts as running for UI purposes when a pending toggle wants it on,
+// or — with no toggle in flight — when the live status says so. Toggle handling
+// and stats polling share this so a pending "on" doesn't leave the panel blank
+// while the backend is still reporting the stale 'stopped' status.
+const isIpfsEffectivelyRunning = () =>
+  state.ipfsDesiredRunning !== null
+    ? state.ipfsDesiredRunning
+    : state.currentIpfsStatus === 'running' || state.currentIpfsStatus === 'starting';
+
 const fetchNativeStats = async () => {
   if (!state.antMenuOpen) return;
-  if (state.currentIpfsStatus === 'stopped') {
+  if (!isIpfsEffectivelyRunning()) {
     stopIpfsInfoPolling();
     return;
   }
@@ -97,7 +106,7 @@ const fetchVersionOnce = async () => {
 };
 
 export const startIpfsInfoPolling = () => {
-  if (!state.antMenuOpen || state.currentIpfsStatus === 'stopped') {
+  if (!state.antMenuOpen || !isIpfsEffectivelyRunning()) {
     stopIpfsInfoPolling();
     return;
   }
@@ -114,17 +123,21 @@ export const startIpfsInfoPolling = () => {
 export const updateIpfsUi = (status, error) => {
   state.currentIpfsStatus = status;
 
-  // Reconcile a pending user toggle. Once the backend reaches the state the
-  // user asked for (or errors out), the transition is over and the live status
-  // drives the switch again. Until then we keep the pending intent so that a
-  // rapid on/off/on sequence — which makes the backend emit transient
-  // stopping/starting and stale stopped/running states — can't flip the switch
-  // out from under the user before the node data settles.
-  if (
-    status === 'error' ||
+  // Reconcile a pending user toggle. Once the backend confirms the state the
+  // user asked for, the transition is over and the live status drives the switch
+  // again. Until then we keep the pending intent so that a rapid on/off/on
+  // sequence — which makes the backend emit transient stopping/starting and
+  // stale stopped/running states — can't flip the switch out from under the user
+  // before the node data settles.
+  const reachedDesired =
     (state.ipfsDesiredRunning === true && status === 'running') ||
-    (state.ipfsDesiredRunning === false && status === 'stopped')
-  ) {
+    (state.ipfsDesiredRunning === false && status === 'stopped');
+  // A failed *start* (intent was "on") ends that attempt, so let the switch fall
+  // back to the error/live status. A failed *stop* (intent was "off") leaves the
+  // node running, so we hold the user's intent rather than letting a later
+  // 'running' poll silently flip the switch back on.
+  const failedStart = status === 'error' && state.ipfsDesiredRunning === true;
+  if (reachedDesired || failedStart) {
     state.ipfsDesiredRunning = null;
   }
 
@@ -136,10 +149,7 @@ export const updateIpfsUi = (status, error) => {
 
   // While a toggle is in flight the switch follows the user's intent; once it
   // settles (ipfsDesiredRunning === null) it follows the live status.
-  const showRunning =
-    state.ipfsDesiredRunning !== null
-      ? state.ipfsDesiredRunning
-      : status === 'running' || status === 'starting';
+  const showRunning = isIpfsEffectivelyRunning();
 
   ipfsToggleSwitch.classList.toggle('running', showRunning);
 
@@ -251,10 +261,7 @@ export const initIpfsUi = () => {
     // Base the decision on a pending toggle if one is in flight, otherwise on
     // the live status — so a quick second click reverses the user's last intent
     // rather than reacting to a transient stopping/starting state.
-    const currentlyOn =
-      state.ipfsDesiredRunning !== null
-        ? state.ipfsDesiredRunning
-        : state.currentIpfsStatus === 'running' || state.currentIpfsStatus === 'starting';
+    const currentlyOn = isIpfsEffectivelyRunning();
 
     if (currentlyOn) {
       state.ipfsDesiredRunning = false;

--- a/src/renderer/lib/ipfs-ui.test.js
+++ b/src/renderer/lib/ipfs-ui.test.js
@@ -18,7 +18,7 @@ const loadIpfsModule = async (options = {}) => {
     ipfsInfoInterval: null,
     ipfsVersionFetched: options.ipfsVersionFetched ?? false,
     ipfsVersionValue: options.ipfsVersionValue || '',
-    suppressIpfsRunningStatus: options.suppressIpfsRunningStatus ?? false,
+    ipfsDesiredRunning: options.ipfsDesiredRunning ?? null,
     registry: {
       ipfs: {
         api: 'http://ipfs.test',
@@ -185,7 +185,7 @@ describe('ipfs-ui', () => {
     expect(ctx.elements.ipfsInfoPanel.classList.contains('visible')).toBe(true);
     expect(ctx.elements.ipfsActiveRequestsCount.textContent).toBe('3');
     expect(ctx.elements.ipfsDataRead.textContent).toBe('1.5 KB');
-    expect(ctx.elements.ipfsVersionText.textContent).toBe('freedom-ipfs 0.4.1');
+    expect(ctx.elements.ipfsVersionText.textContent).toBe('Freedom IPFS v0.4.1');
     expect(ctx.state.ipfsVersionFetched).toBe(true);
     expect(ctx.state.ipfsInfoInterval).toBe(2);
     expect(ctx.setIntervalMock).toHaveBeenCalledWith(expect.any(Function), 1000);
@@ -197,7 +197,7 @@ describe('ipfs-ui', () => {
     expect(ctx.elements.ipfsInfoPanel.classList.contains('visible')).toBe(false);
     expect(ctx.elements.ipfsActiveRequestsCount.textContent).toBe('0');
     expect(ctx.elements.ipfsDataRead.textContent).toBe('');
-    expect(ctx.elements.ipfsVersionText.textContent).toBe('freedom-ipfs 0.4.1');
+    expect(ctx.elements.ipfsVersionText.textContent).toBe('Freedom IPFS v0.4.1');
   });
 
   test('updates IPFS status lines, toggle state, and running transitions', async () => {
@@ -231,10 +231,13 @@ describe('ipfs-ui', () => {
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
     expect(ctx.state.currentIpfsStatus).toBe('starting');
 
-    ctx.state.suppressIpfsRunningStatus = true;
+    // While a stop is pending, a stale 'running' update must not flip the
+    // switch back on before the node data settles.
+    ctx.state.ipfsDesiredRunning = false;
     ctx.elements.ipfsToggleSwitch.classList.remove('running');
     ctx.mod.updateIpfsUi('running');
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
+    expect(ctx.state.ipfsDesiredRunning).toBe(false);
 
     ctx.mod.updateIpfsUi('error', 'offline');
     expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('IPFS Error: offline');
@@ -292,5 +295,37 @@ describe('ipfs-ui', () => {
 
     expect(ctx.ipfsApi.stop).toHaveBeenCalled();
     expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('User toggled IPFS Off');
+  });
+
+  test('keeps the switch on the latest intent through a rapid off/on toggle', async () => {
+    const ctx = await loadIpfsModule({
+      antMenuOpen: true,
+      currentIpfsStatus: 'running',
+      statusResult: { status: 'running', error: null },
+    });
+
+    ctx.mod.initIpfsUi();
+    await flushMicrotasks();
+
+    // Click off, then immediately back on before the backend has settled.
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    expect(ctx.state.ipfsDesiredRunning).toBe(false);
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    expect(ctx.state.ipfsDesiredRunning).toBe(true);
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+
+    // Transient backend states from the stop/start churn must not flip it off.
+    ctx.mod.updateIpfsUi('stopping');
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+    ctx.mod.updateIpfsUi('stopped');
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+    ctx.mod.updateIpfsUi('starting');
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+
+    // Once the backend confirms the requested state, the intent clears and the
+    // switch follows live status again.
+    ctx.mod.updateIpfsUi('running');
+    expect(ctx.state.ipfsDesiredRunning).toBeNull();
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
   });
 });

--- a/src/renderer/lib/ipfs-ui.test.js
+++ b/src/renderer/lib/ipfs-ui.test.js
@@ -314,6 +314,14 @@ describe('ipfs-ui', () => {
     expect(ctx.state.ipfsDesiredRunning).toBe(true);
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
 
+    // The reversal must actually reach the backend: stop() fired on the first
+    // click and start() on the second, in that order — not just settle the UI.
+    expect(ctx.ipfsApi.stop).toHaveBeenCalledTimes(1);
+    expect(ctx.ipfsApi.start).toHaveBeenCalledTimes(1);
+    expect(ctx.ipfsApi.stop.mock.invocationCallOrder[0]).toBeLessThan(
+      ctx.ipfsApi.start.mock.invocationCallOrder[0]
+    );
+
     // Transient backend states from the stop/start churn must not flip it off.
     ctx.mod.updateIpfsUi('stopping');
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
@@ -327,5 +335,84 @@ describe('ipfs-ui', () => {
     ctx.mod.updateIpfsUi('running');
     expect(ctx.state.ipfsDesiredRunning).toBeNull();
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+  });
+
+  test('clears intent on a failed start but holds it through a failed stop', async () => {
+    const ctx = await loadIpfsModule({
+      antMenuOpen: true,
+      currentIpfsStatus: 'starting',
+      statusResult: { status: 'starting', error: null },
+    });
+
+    ctx.mod.initIpfsUi();
+    await flushMicrotasks();
+
+    // Failed start (intent was "on"): the attempt is over, so intent clears and
+    // the switch falls back to the live status (off).
+    ctx.state.ipfsDesiredRunning = true;
+    ctx.mod.updateIpfsUi('error', 'offline');
+    expect(ctx.state.ipfsDesiredRunning).toBeNull();
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
+
+    // Failed stop (intent was "off"): the node may still be running, so intent
+    // is preserved and a later stale 'running' update can't flip it back on.
+    ctx.state.ipfsDesiredRunning = false;
+    ctx.mod.updateIpfsUi('error', 'stop failed');
+    expect(ctx.state.ipfsDesiredRunning).toBe(false);
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
+
+    ctx.mod.updateIpfsUi('running');
+    expect(ctx.state.ipfsDesiredRunning).toBe(false);
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
+  });
+
+  test('polls stats during a pending "on" toggle while live status is still stopped', async () => {
+    const ctx = await loadIpfsModule({
+      antMenuOpen: true,
+      currentIpfsStatus: 'stopped',
+      statusResult: {
+        status: 'stopped',
+        error: null,
+        diagnostics: {
+          nativeGatewayStats: JSON.stringify({ active_native_handles: 2, bytes_read: 2048 }),
+        },
+      },
+    });
+
+    ctx.mod.initIpfsUi();
+    await flushMicrotasks();
+
+    // User just clicked on; the backend hasn't confirmed yet (live status is
+    // still 'stopped'). Polling must run on the pending intent, not bail and
+    // leave the panel blank.
+    ctx.state.ipfsDesiredRunning = true;
+    ctx.mod.startIpfsInfoPolling();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(ctx.elements.ipfsInfoPanel.classList.contains('visible')).toBe(true);
+    expect(ctx.state.ipfsInfoInterval).not.toBeNull();
+    expect(ctx.elements.ipfsActiveRequestsCount.textContent).toBe('2');
+    expect(ctx.elements.ipfsDataRead.textContent).toBe('2.0 KB');
+  });
+
+  test('falls back to a bare product label when version diagnostics are missing', async () => {
+    const ctx = await loadIpfsModule({
+      antMenuOpen: true,
+      currentIpfsStatus: 'running',
+      statusResult: {
+        status: 'running',
+        error: null,
+        diagnostics: { nativeVersion: '', nativeBuildInfo: '' },
+      },
+    });
+
+    ctx.mod.initIpfsUi();
+    ctx.mod.startIpfsInfoPolling();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(ctx.elements.ipfsVersionText.textContent).toBe('Freedom IPFS');
+    expect(ctx.state.ipfsVersionValue).toBe('Freedom IPFS');
   });
 });

--- a/src/renderer/lib/ipfs-ui.test.js
+++ b/src/renderer/lib/ipfs-ui.test.js
@@ -415,4 +415,35 @@ describe('ipfs-ui', () => {
     expect(ctx.elements.ipfsVersionText.textContent).toBe('Freedom IPFS');
     expect(ctx.state.ipfsVersionValue).toBe('Freedom IPFS');
   });
+
+  test('reverts optimistic UI to real status when a toggle IPC rejects', async () => {
+    const ctx = await loadIpfsModule({
+      antMenuOpen: true,
+      currentIpfsStatus: 'stopped',
+      statusResult: { status: 'stopped', error: null },
+    });
+
+    ctx.mod.initIpfsUi();
+    await flushMicrotasks();
+
+    // start() throws at the IPC layer; a follow-up status query shows the node
+    // never came up.
+    ctx.ipfsApi.start.mockRejectedValueOnce(new Error('ipc boom'));
+    ctx.ipfsApi.getStatus.mockResolvedValueOnce({ status: 'stopped', error: null });
+
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    // Optimistically on right after the click.
+    expect(ctx.state.ipfsDesiredRunning).toBe(true);
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    // The rejection dropped the optimistic intent, re-queried status, and
+    // settled the switch back off instead of polling a node that never started.
+    expect(ctx.ipfsApi.getStatus).toHaveBeenCalled();
+    expect(ctx.state.ipfsDesiredRunning).toBeNull();
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
+    expect(ctx.state.ipfsInfoInterval).toBeNull();
+  });
 });

--- a/src/renderer/lib/ipfs-ui.test.js
+++ b/src/renderer/lib/ipfs-ui.test.js
@@ -446,4 +446,65 @@ describe('ipfs-ui', () => {
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
     expect(ctx.state.ipfsInfoInterval).toBeNull();
   });
+
+  test('reverts the switch back on when a stop() IPC rejects but the node is still running', async () => {
+    const ctx = await loadIpfsModule({
+      antMenuOpen: true,
+      currentIpfsStatus: 'running',
+      statusResult: { status: 'running', error: null },
+    });
+
+    ctx.mod.initIpfsUi();
+    await flushMicrotasks();
+
+    // stop() throws at the IPC layer; the node is in fact still running.
+    ctx.ipfsApi.stop.mockRejectedValueOnce(new Error('ipc boom'));
+    ctx.ipfsApi.getStatus.mockResolvedValueOnce({ status: 'running', error: null });
+
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    // Optimistically off right after the click.
+    expect(ctx.state.ipfsDesiredRunning).toBe(false);
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    // Re-queried status shows the node never stopped, so the switch flips back
+    // on and stats polling resumes.
+    expect(ctx.ipfsApi.getStatus).toHaveBeenCalled();
+    expect(ctx.state.ipfsDesiredRunning).toBeNull();
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+    expect(ctx.state.ipfsInfoInterval).not.toBeNull();
+  });
+
+  test('a stale rejected stop() does not wipe a newer "on" intent', async () => {
+    const ctx = await loadIpfsModule({
+      antMenuOpen: true,
+      currentIpfsStatus: 'running',
+      statusResult: { status: 'running', error: null },
+    });
+
+    ctx.mod.initIpfsUi();
+    await flushMicrotasks();
+    ctx.ipfsApi.getStatus.mockClear();
+
+    // First click off dispatches a stop() that will reject; the immediate second
+    // click on supersedes it with a start() we leave pending.
+    ctx.ipfsApi.stop.mockRejectedValueOnce(new Error('stale stop'));
+    ctx.ipfsApi.start.mockReturnValueOnce(new Promise(() => {}));
+
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    expect(ctx.state.ipfsDesiredRunning).toBe(false);
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    expect(ctx.state.ipfsDesiredRunning).toBe(true);
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    // The stale stop() rejection is for the superseded "off" intent, so it must
+    // bail without clearing the newer "on" intent. (A non-bailing reconcile
+    // would have nulled the intent.)
+    expect(ctx.state.ipfsDesiredRunning).toBe(true);
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+  });
 });

--- a/src/renderer/lib/ipfs-ui.test.js
+++ b/src/renderer/lib/ipfs-ui.test.js
@@ -507,4 +507,37 @@ describe('ipfs-ui', () => {
     expect(ctx.state.ipfsDesiredRunning).toBe(true);
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
   });
+
+  test('a stale rejected start() does not wipe a newer "off" intent', async () => {
+    const ctx = await loadIpfsModule({
+      antMenuOpen: true,
+      currentIpfsStatus: 'stopped',
+      statusResult: { status: 'stopped', error: null },
+    });
+
+    ctx.mod.initIpfsUi();
+    await flushMicrotasks();
+
+    // First click on dispatches a start() that will reject; the immediate second
+    // click off supersedes it with a stop() we leave pending.
+    ctx.ipfsApi.start.mockRejectedValueOnce(new Error('stale start'));
+    ctx.ipfsApi.stop.mockReturnValueOnce(new Promise(() => {}));
+
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    expect(ctx.state.ipfsDesiredRunning).toBe(true);
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    expect(ctx.state.ipfsDesiredRunning).toBe(false);
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    // The stale start() rejection is for the superseded "on" intent, so it must
+    // bail — leaving the newer "off" intent and switch untouched, and without
+    // logging the superseded failure.
+    expect(ctx.state.ipfsDesiredRunning).toBe(false);
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
+    expect(ctx.debugMocks.pushDebug).not.toHaveBeenCalledWith(
+      'Failed to toggle IPFS: stale start'
+    );
+  });
 });

--- a/src/renderer/lib/ipfs-ui.test.js
+++ b/src/renderer/lib/ipfs-ui.test.js
@@ -416,6 +416,40 @@ describe('ipfs-ui', () => {
     expect(ctx.state.ipfsVersionValue).toBe('Freedom IPFS');
   });
 
+  test('upgrades the version label once IPFS reports a real version after starting', async () => {
+    // Node has no version yet (still spinning up after a start from stopped).
+    let diagnostics = { nativeGatewayStats: JSON.stringify({ bytes_read: 0 }) };
+    const ctx = await loadIpfsModule({
+      antMenuOpen: true,
+      currentIpfsStatus: 'running',
+    });
+    ctx.ipfsApi.getStatus.mockImplementation(async () => ({
+      status: 'running',
+      error: null,
+      diagnostics,
+    }));
+
+    ctx.mod.initIpfsUi();
+    ctx.mod.startIpfsInfoPolling();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    // First poll ran before a version was available: show the fallback but do
+    // NOT cache it, so later polls can still upgrade.
+    expect(ctx.elements.ipfsVersionText.textContent).toBe('Freedom IPFS');
+    expect(ctx.state.ipfsVersionFetched).toBe(false);
+
+    // The node finishes starting and now reports a version; the next poll tick
+    // upgrades the label and caches it.
+    diagnostics = { nativeVersion: '0.4.2' };
+    const statsPoll = ctx.setIntervalMock.mock.calls.find((call) => call[1] === 1000)[0];
+    await statsPoll();
+    await flushMicrotasks();
+
+    expect(ctx.elements.ipfsVersionText.textContent).toBe('Freedom IPFS v0.4.2');
+    expect(ctx.state.ipfsVersionFetched).toBe(true);
+  });
+
   test('reverts optimistic UI to real status when a toggle IPC rejects', async () => {
     const ctx = await loadIpfsModule({
       antMenuOpen: true,

--- a/src/renderer/lib/ipfs-ui.test.js
+++ b/src/renderer/lib/ipfs-ui.test.js
@@ -297,41 +297,64 @@ describe('ipfs-ui', () => {
     expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith('User toggled IPFS Off');
   });
 
-  test('keeps the switch on the latest intent through a rapid off/on toggle', async () => {
+  test('switches the toggle instantly on each click and converges the backend to the final state', async () => {
     const ctx = await loadIpfsModule({
       antMenuOpen: true,
       currentIpfsStatus: 'running',
       statusResult: { status: 'running', error: null },
+      stopResult: { status: 'stopped', error: null },
+      startResult: { status: 'running', error: null },
     });
 
     ctx.mod.initIpfsUi();
     await flushMicrotasks();
 
-    // Click off, then immediately back on before the backend has settled.
+    // Each click flips the switch immediately — no waiting on the backend.
     ctx.elements.ipfsToggleBtn.dispatch('click');
     expect(ctx.state.ipfsDesiredRunning).toBe(false);
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
     ctx.elements.ipfsToggleBtn.dispatch('click');
     expect(ctx.state.ipfsDesiredRunning).toBe(true);
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
 
-    // The reversal must actually reach the backend: stop() fired on the first
-    // click and start() on the second, in that order — not just settle the UI.
+    // The background reconcile loop drives the node to the final "on" target
+    // (stop() then start(), in order), then clears the pending intent.
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
     expect(ctx.ipfsApi.stop).toHaveBeenCalledTimes(1);
     expect(ctx.ipfsApi.start).toHaveBeenCalledTimes(1);
     expect(ctx.ipfsApi.stop.mock.invocationCallOrder[0]).toBeLessThan(
       ctx.ipfsApi.start.mock.invocationCallOrder[0]
     );
-
-    // Transient backend states from the stop/start churn must not flip it off.
-    ctx.mod.updateIpfsUi('stopping');
+    expect(ctx.state.ipfsDesiredRunning).toBeNull();
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+  });
+
+  test('never flickers the switch to an intermediate backend status during convergence', async () => {
+    const ctx = await loadIpfsModule({
+      antMenuOpen: true,
+      currentIpfsStatus: 'stopped',
+      statusResult: { status: 'stopped', error: null },
+      startResult: { status: 'running', error: null },
+    });
+
+    ctx.mod.initIpfsUi();
+    await flushMicrotasks();
+
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    expect(ctx.state.ipfsDesiredRunning).toBe(true);
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+
+    // Stale/intermediate backend updates arriving mid-transition must not move
+    // the switch off the user's latest click.
     ctx.mod.updateIpfsUi('stopped');
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
     ctx.mod.updateIpfsUi('starting');
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
 
-    // Once the in-flight start() call settles, the superseded stop() result is
-    // ignored, the intent clears, and the switch follows the confirmed status.
+    // Once the loop reaches the target the intent clears and the switch stays on.
     await flushMicrotasks();
     await flushMicrotasks();
     expect(ctx.state.ipfsDesiredRunning).toBeNull();
@@ -533,67 +556,40 @@ describe('ipfs-ui', () => {
     expect(ctx.state.ipfsInfoInterval).not.toBeNull();
   });
 
-  test('a stale rejected stop() does not wipe a newer "on" intent', async () => {
-    const ctx = await loadIpfsModule({
-      antMenuOpen: true,
-      currentIpfsStatus: 'running',
-      statusResult: { status: 'running', error: null },
-    });
-
-    ctx.mod.initIpfsUi();
-    await flushMicrotasks();
-    ctx.ipfsApi.getStatus.mockClear();
-
-    // First click off dispatches a stop() that will reject; the immediate second
-    // click on supersedes it with a start() we leave pending.
-    ctx.ipfsApi.stop.mockRejectedValueOnce(new Error('stale stop'));
-    ctx.ipfsApi.start.mockReturnValueOnce(new Promise(() => {}));
-
-    ctx.elements.ipfsToggleBtn.dispatch('click');
-    expect(ctx.state.ipfsDesiredRunning).toBe(false);
-    ctx.elements.ipfsToggleBtn.dispatch('click');
-    expect(ctx.state.ipfsDesiredRunning).toBe(true);
-
-    await flushMicrotasks();
-    await flushMicrotasks();
-
-    // The stale stop() rejection is for the superseded "off" intent, so it must
-    // bail without clearing the newer "on" intent. (A non-bailing reconcile
-    // would have nulled the intent.)
-    expect(ctx.state.ipfsDesiredRunning).toBe(true);
-    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
-  });
-
-  test('a stale rejected start() does not wipe a newer "off" intent', async () => {
+  test('a click made while the reconcile loop is working redirects it to the new target', async () => {
     const ctx = await loadIpfsModule({
       antMenuOpen: true,
       currentIpfsStatus: 'stopped',
       statusResult: { status: 'stopped', error: null },
+      startResult: { status: 'running', error: null },
+      stopResult: { status: 'stopped', error: null },
     });
 
     ctx.mod.initIpfsUi();
     await flushMicrotasks();
 
-    // First click on dispatches a start() that will reject; the immediate second
-    // click off supersedes it with a stop() we leave pending.
-    ctx.ipfsApi.start.mockRejectedValueOnce(new Error('stale start'));
-    ctx.ipfsApi.stop.mockReturnValueOnce(new Promise(() => {}));
-
+    // Click on — the loop dispatches start() and suspends awaiting it. Before it
+    // resolves, click off: the switch follows instantly and the loop will pick up
+    // the new "off" target once start() returns.
     ctx.elements.ipfsToggleBtn.dispatch('click');
     expect(ctx.state.ipfsDesiredRunning).toBe(true);
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
     ctx.elements.ipfsToggleBtn.dispatch('click');
     expect(ctx.state.ipfsDesiredRunning).toBe(false);
-
-    await flushMicrotasks();
-    await flushMicrotasks();
-
-    // The stale start() rejection is for the superseded "on" intent, so it must
-    // bail — leaving the newer "off" intent and switch untouched, and without
-    // logging the superseded failure.
-    expect(ctx.state.ipfsDesiredRunning).toBe(false);
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
-    expect(ctx.debugMocks.pushDebug).not.toHaveBeenCalledWith(
-      'Failed to toggle IPFS: stale start'
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    // The loop reached the latest target: it started the node, then stopped it to
+    // honor the final "off" click, and the switch ends off with no pending intent.
+    expect(ctx.ipfsApi.start).toHaveBeenCalledTimes(1);
+    expect(ctx.ipfsApi.stop).toHaveBeenCalledTimes(1);
+    expect(ctx.ipfsApi.start.mock.invocationCallOrder[0]).toBeLessThan(
+      ctx.ipfsApi.stop.mock.invocationCallOrder[0]
     );
+    expect(ctx.state.ipfsDesiredRunning).toBeNull();
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
   });
 });

--- a/src/renderer/lib/ipfs-ui.test.js
+++ b/src/renderer/lib/ipfs-ui.test.js
@@ -330,40 +330,62 @@ describe('ipfs-ui', () => {
     ctx.mod.updateIpfsUi('starting');
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
 
-    // Once the backend confirms the requested state, the intent clears and the
-    // switch follows live status again.
-    ctx.mod.updateIpfsUi('running');
+    // Once the in-flight start() call settles, the superseded stop() result is
+    // ignored, the intent clears, and the switch follows the confirmed status.
+    await flushMicrotasks();
+    await flushMicrotasks();
     expect(ctx.state.ipfsDesiredRunning).toBeNull();
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
   });
 
-  test('clears intent on a failed start but holds it through a failed stop', async () => {
+  test('settles the switch off when a start fails to bring the node up', async () => {
     const ctx = await loadIpfsModule({
       antMenuOpen: true,
-      currentIpfsStatus: 'starting',
-      statusResult: { status: 'starting', error: null },
+      currentIpfsStatus: 'stopped',
+      statusResult: { status: 'stopped', error: null },
+      startResult: { status: 'error', error: 'boom' },
     });
 
     ctx.mod.initIpfsUi();
     await flushMicrotasks();
 
-    // Failed start (intent was "on"): the attempt is over, so intent clears and
-    // the switch falls back to the live status (off).
-    ctx.state.ipfsDesiredRunning = true;
-    ctx.mod.updateIpfsUi('error', 'offline');
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    // Optimistically on right after the click.
+    expect(ctx.state.ipfsDesiredRunning).toBe(true);
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+
+    await flushMicrotasks();
+
+    // start() reported the node never came up: intent clears and the switch
+    // settles off to match reality.
     expect(ctx.state.ipfsDesiredRunning).toBeNull();
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
+  });
 
-    // Failed stop (intent was "off"): the node may still be running, so intent
-    // is preserved and a later stale 'running' update can't flip it back on.
-    ctx.state.ipfsDesiredRunning = false;
-    ctx.mod.updateIpfsUi('error', 'stop failed');
+  test('re-syncs the switch back on when a stop settles but the node is still running', async () => {
+    const ctx = await loadIpfsModule({
+      antMenuOpen: true,
+      currentIpfsStatus: 'running',
+      statusResult: { status: 'running', error: null },
+      // The stop didn't take effect — the node reports it's still running.
+      stopResult: { status: 'running', error: null },
+    });
+
+    ctx.mod.initIpfsUi();
+    await flushMicrotasks();
+
+    ctx.elements.ipfsToggleBtn.dispatch('click');
+    // Optimistically off right after the click.
     expect(ctx.state.ipfsDesiredRunning).toBe(false);
     expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
 
-    ctx.mod.updateIpfsUi('running');
-    expect(ctx.state.ipfsDesiredRunning).toBe(false);
-    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(false);
+    await flushMicrotasks();
+
+    // The stop settled but the node is still up: rather than stay stuck off, the
+    // intent clears and the switch re-syncs to the live 'running' status.
+    expect(ctx.state.ipfsDesiredRunning).toBeNull();
+    expect(ctx.elements.ipfsToggleSwitch.classList.contains('running')).toBe(true);
+    expect(ctx.state.ipfsInfoInterval).not.toBeNull();
   });
 
   test('polls stats during a pending "on" toggle while live status is still stopped', async () => {

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -96,7 +96,10 @@ export const state = {
   ipfsInfoInterval: null,
   ipfsVersionFetched: false,
   ipfsVersionValue: '',
-  suppressIpfsRunningStatus: false,
+  // null = no toggle in flight; true/false = the running state the user just
+  // requested but which the backend hasn't confirmed yet. Lets the switch hold
+  // the user's intent through transient backend states (see ipfs-ui.js).
+  ipfsDesiredRunning: null,
 
   // Radicle state
   currentRadicleStatus: 'stopped',


### PR DESCRIPTION
## Summary

Addresses the version-format mismatch from #103 (item 1) plus a related label change, and reworks the IPFS toggle in the Nodes menu so it switches **instantly** — matching the Swarm/Ant toggle — while the backend reconciles to the user's intended final state in the background.

### Version format & label
- **Version format** — the IPFS version now renders as `Freedom IPFS v0.4.x` (with a `v` prefix) to match the Swarm/Ant section's `Ant v0.5.x`, instead of `freedom-ipfs 0.4.x`. The fallback `Freedom IPFS` label is no longer cached before a real version arrives, so a later poll can still upgrade it once the node reports its version.
- **Label** — renamed the `Data Read` row to `Session Download`.

### Instant toggle with background reconciliation
The toggle no longer waits on the backend or exposes any queuing/"please wait" state — clicking flips the switch immediately, and rapid on/off clicking is honored, with the node driven to whatever state the switch was last left in.

- **Optimistic UI** — a new `state.ipfsDesiredRunning` (replacing `suppressIpfsRunningStatus`) records the user's latest intent: `null` when no toggle is in flight, otherwise the requested running state. The switch and stats panel follow this intent and ignore transient/stale backend statuses, so they never flicker back mid-transition.
- **Background reconcile loop** — `reconcileIpfsToggle` drives the backend toward the latest target, re-reading the intent each iteration so a click made mid-flight redirects it (e.g. a stop-then-start coalesces correctly). It clears the intent once the live status matches, an operation genuinely fails, or an IPC call rejects, after which the switch follows live status again.
- **Serialized backend transitions** — the renderer's optimistic loop relies on `start()`/`stop()` resolving with the *settled* backend status. The IPC handlers previously broke that contract: they fired `startIpfs()`/`stopIpfs()` without awaiting and returned the transient status, and a start requested mid-stop was deferred via a `pendingStart` + `setTimeout` hack. A click during a `stopping` transition therefore resolved as `stopping`, the reconcile loop gave up, and the switch snapped back instead of moving. Transitions are now serialized through an operation chain: each start/stop runs to completion before the next begins and resolves only once the node has settled, and the IPC handlers `await` the result. The `pendingStart` queuing hack is removed.

## Note on #103 items 2 & 3 (not addressed here)

Items 2 (peer counts) and 3 (bandwidth parity with the old Kubo display) are **not** included. The `freedom-ipfs` native addon is a retrieval-only in-process gateway with no libp2p swarm: it exposes no connected/visible peer counts and no bandwidth metric beyond `bytes_read` (already surfaced as the renamed `Session Download` row). Implementing those would require new functionality in the native addon, so they're left for a follow-up.

## Testing

- `npx jest src/renderer/lib/ipfs-ui.test.js` — passing, with new coverage for instant toggling, mid-transition redirects, intermediate-status flicker, failed-start/failed-stop reconciliation, and IPC rejection handling.
- `npx jest src/main/ipfs-manager.test.js` — passing, with a new test asserting a start requested mid-stop queues behind the stop and resolves only once the node is `running`.
- Full suite green.
