### PR TITLE
feat(ipfs): gate progress messages behind an experimental setting (default off)

### DIFF
--- a/src/main/settings-store.js
+++ b/src/main/settings-store.js
@@ -42,6 +42,12 @@ const DEFAULT_SETTINGS = {
   // endpoints, prover, quorum params) lives in the network registry —
   // this is the one ENS-navigation setting kept here.
   blockUnverifiedEns: true,
+  // Experimental: when true, IPFS request progress phases ("Finding
+  // providers…", "Searching the DHT…", etc.) are surfaced in the link
+  // hover preview bar during ipfs:// / ipns:// loads. Off by default so the
+  // preview bar stays a pure hover-URL surface; opt in via Settings →
+  // Experimental. A follow-up will generalize this to other protocols.
+  showIpfsProgressStatus: false,
   sidebarOpen: false,
   sidebarWidth: 320,
   // Linux only: render the tab strip as the window titlebar (frameless window).

--- a/src/main/settings-store.test.js
+++ b/src/main/settings-store.test.js
@@ -48,6 +48,7 @@ describe('settings-store', () => {
         sidebarOpen: false,
         sidebarWidth: 320,
         blockUnverifiedEns: true,
+        showIpfsProgressStatus: false,
       })
     );
     expect(nativeTheme.themeSource).toBe('system');

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -68,7 +68,14 @@ const isIpfsProgressUrl = (value) => {
   return normalized.startsWith('ipfs://') || normalized.startsWith('ipns://');
 };
 
+// Experimental opt-in (Settings → Experimental, default off). Mirrors the
+// `showIpfsProgressStatus` setting, seeded in initNavigation and kept live via
+// the `settings:updated` broadcast. While off, the IPFS progress poller never
+// starts, so the link bar stays a pure hover-URL surface.
+let ipfsProgressStatusEnabled = false;
+
 const shouldShowIpfsProgress = ({ data = {}, tab = null, navState = null } = {}) => {
+  if (!ipfsProgressStatusEnabled) return false;
   const candidates = [
     data.url,
     data.pendingNavigationUrl,
@@ -1792,6 +1799,16 @@ export const initNavigation = () => {
       bookmarkBarOverride = settings.showBookmarkBar;
       electronAPI?.setBookmarkBarChecked?.(bookmarkBarOverride);
     }
+    ipfsProgressStatusEnabled = settings?.showIpfsProgressStatus === true;
+  });
+
+  // Keep the IPFS-progress opt-in live. When it's switched off mid-load, stop
+  // any running poller so the link bar reverts to hover URLs immediately.
+  window.addEventListener('settings:updated', (event) => {
+    const next = event.detail?.showIpfsProgressStatus === true;
+    if (next === ipfsProgressStatusEnabled) return;
+    ipfsProgressStatusEnabled = next;
+    if (!next) stopIpfsProgressStatus({ immediate: true });
   });
 
   // Address bar events

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -550,11 +550,14 @@ describe('navigation', () => {
   });
 
   test('processes webview lifecycle events and records history', async () => {
-    const ctx = await loadNavigationModule();
+    const ctx = await loadNavigationModule({
+      initialSettings: { showBookmarkBar: true, showIpfsProgressStatus: true },
+    });
     const onHistoryRecorded = jest.fn();
 
     ctx.mod.setOnHistoryRecorded(onHistoryRecorded);
     await ctx.mod.initNavigation();
+    await flushMicrotasks();
 
     ctx.tabsMocks.webviewEventHandler('did-start-loading', {
       tabId: ctx.activeRef.tab.id,
@@ -828,8 +831,11 @@ describe('navigation', () => {
   });
 
   test('starts IPFS progress polling only for IPFS/IPNS navigations', async () => {
-    const ctx = await loadNavigationModule();
+    const ctx = await loadNavigationModule({
+      initialSettings: { showBookmarkBar: true, showIpfsProgressStatus: true },
+    });
     await ctx.mod.initNavigation();
+    await flushMicrotasks();
 
     ctx.tabsMocks.webviewEventHandler('did-start-loading', {
       tabId: ctx.activeRef.tab.id,
@@ -850,6 +856,36 @@ describe('navigation', () => {
 
     expect(ctx.ipfsProgressMocks.startIpfsProgressStatus).toHaveBeenCalled();
     expect(ctx.ipfsProgressMocks.stopIpfsProgressStatus).not.toHaveBeenCalled();
+  });
+
+  test('IPFS progress polling stays gated behind the experimental flag', async () => {
+    const ctx = await loadNavigationModule({
+      initialSettings: { showBookmarkBar: true, showIpfsProgressStatus: false },
+    });
+    await ctx.mod.initNavigation();
+    await flushMicrotasks();
+
+    // Flag off (default): an ipfs:// load must not start the progress poller.
+    ctx.tabsMocks.webviewEventHandler('did-start-loading', {
+      tabId: ctx.activeRef.tab.id,
+      pendingNavigationUrl: 'ipfs://bafybeigdyrzt',
+    });
+    expect(ctx.ipfsProgressMocks.startIpfsProgressStatus).not.toHaveBeenCalled();
+
+    // Enabling it live (settings:updated broadcast) lets the next load start it.
+    ctx.windowHandlers['settings:updated']({ detail: { showIpfsProgressStatus: true } });
+    ctx.tabsMocks.webviewEventHandler('did-start-loading', {
+      tabId: ctx.activeRef.tab.id,
+      pendingNavigationUrl: 'ipfs://bafybeigdyrzt',
+    });
+    expect(ctx.ipfsProgressMocks.startIpfsProgressStatus).toHaveBeenCalled();
+
+    // Disabling it live stops any running poller immediately.
+    ctx.ipfsProgressMocks.stopIpfsProgressStatus.mockClear();
+    ctx.windowHandlers['settings:updated']({ detail: { showIpfsProgressStatus: false } });
+    expect(ctx.ipfsProgressMocks.stopIpfsProgressStatus).toHaveBeenCalledWith({
+      immediate: true,
+    });
   });
 
   test('restores tab state on tab switches and updates navigation display', async () => {

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -953,14 +953,7 @@
             </div>
             <div class="row">
               <div class="row-body">
-                <p class="row-label">
-                  Show IPFS load progress in the link bar
-                  <span style="color: var(--text-muted); font-weight: 400">(Beta)</span>
-                </p>
-                <p class="row-help">
-                  Surfaces IPFS request phases (resolving names, finding providers, DHT fallback…)
-                  in the link preview bar while ipfs:// and ipns:// pages load.
-                </p>
+                <p class="row-label">Show IPFS load progress in the status bar</p>
               </div>
               <div class="row-control">
                 <label class="toggle">

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -951,6 +951,24 @@
                 </label>
               </div>
             </div>
+            <div class="row">
+              <div class="row-body">
+                <p class="row-label">
+                  Show IPFS load progress in the link bar
+                  <span style="color: var(--text-muted); font-weight: 400">(Beta)</span>
+                </p>
+                <p class="row-help">
+                  Surfaces IPFS request phases (resolving names, finding providers, DHT fallback…)
+                  in the link preview bar while ipfs:// and ipns:// pages load.
+                </p>
+              </div>
+              <div class="row-control">
+                <label class="toggle">
+                  <input type="checkbox" id="show-ipfs-progress-status" />
+                  <span class="slider"></span>
+                </label>
+              </div>
+            </div>
             <div class="row" id="swarm-mode-row">
               <div class="row-body">
                 <p class="row-label">Swarm node mode</p>
@@ -1022,6 +1040,7 @@
         startRadicleRow: $('start-radicle-row'),
         startRadicle: $('start-radicle-at-launch'),
         enableIdentity: $('enable-identity-wallet'),
+        showIpfsProgressStatus: $('show-ipfs-progress-status'),
         autoUpdate: $('auto-update'),
       };
 
@@ -1411,6 +1430,7 @@
         enableRadicleIntegration: isWindows ? false : fields.enableRadicle.checked,
         startRadicleAtLaunch: isWindows ? false : fields.startRadicle.checked,
         enableIdentityWallet: fields.enableIdentity.checked,
+        showIpfsProgressStatus: fields.showIpfsProgressStatus.checked,
         autoUpdate: fields.autoUpdate.checked,
         blockUnverifiedEns: fields.blockUnverifiedEns.checked,
       });
@@ -1424,6 +1444,7 @@
         fields.enableRadicle.checked = settings.enableRadicleIntegration === true;
         fields.startRadicle.checked = settings.startRadicleAtLaunch === true;
         fields.enableIdentity.checked = settings.enableIdentityWallet === true;
+        fields.showIpfsProgressStatus.checked = settings.showIpfsProgressStatus === true;
         fields.autoUpdate.checked = settings.autoUpdate !== false;
         fields.blockUnverifiedEns.checked = settings.blockUnverifiedEns !== false;
         setFieldEnabled(fields.enableRadicle, fields.startRadicleRow, fields.startRadicle);
@@ -1533,6 +1554,7 @@
       });
       fields.startRadicle.addEventListener('change', save);
       fields.enableIdentity.addEventListener('change', save);
+      fields.showIpfsProgressStatus.addEventListener('change', save);
       fields.autoUpdate.addEventListener('change', save);
       fields.blockUnverifiedEns.addEventListener('change', save);
 


### PR DESCRIPTION
Re #123

## Summary

IPFS request progress phases ("Resolving IPNS name…", "Finding providers…", "Searching the DHT…", etc.) are surfaced in the link hover preview bar during `ipfs://` / `ipns://` loads (added in `d061e78`). Per the revised scope on #123, we **keep** that behavior but make it **opt-in** behind a **Settings → Experimental** toggle, **default off** — so the preview bar stays a pure hover-URL surface unless the user asks for the detail.

> **Note:** the branch name (`fix/ipfs-progress-debug-logging`) is a leftover from an earlier approach that was dropped after offline discussion. The implementation here is the experimental-flag approach, not debug logging. Happy to recreate under a better-named branch if preferred.

> **Terminology:** the user-facing toggle label reads "Show IPFS load progress in the **status bar**" (the conventional name for the hover-URL overlay), while the code and inline comments call the same surface the "link hover preview bar." Same element, two names — flagging it so the mismatch isn't read as two separate features.

## Changes

- **`settings-store.js`** — new `showIpfsProgressStatus` setting, default `false`.
- **`settings.html`** — toggle in the Experimental section ("Show IPFS load progress in the status bar"), wired through `fields` / `currentFormState` / `applyFormState` / the change-to-save listener.
- **`navigation.js`** — `shouldShowIpfsProgress` is now gated on a cached `ipfsProgressStatusEnabled` flag, seeded from settings in `initNavigation` and kept live via the existing `settings:updated` broadcast. Switching the flag off mid-load stops any running poller immediately.
- **Tests** — `settings-store.test.js` asserts the new default; `navigation.test.js` covers the gated-off default, live-enable, and live-disable paths (existing IPFS-progress tests updated to enable the flag).

## Behavior

| Flag | Link preview bar |
| --- | --- |
| **Off** (default) | Hover URLs only — no IPFS status text; the poller never runs. |
| **On** | IPFS phase messages appear during `ipfs://` / `ipns://` loads, as before. |

Toggling takes effect without a restart.

## Out of scope (follow-up)

Generalizing these progress/status messages to other protocols (Swarm/`bzz://`, ENS) and broadening the message-derivation layer beyond IPFS — tracked in #131.

## Testing

Full suite green: 105 suites / 2079 tests passing. Lint clean on changed files; `settings.html` is Prettier-clean (the two test files Prettier still flags were already non-conformant on `main` and are left untouched to avoid unrelated reformatting).
