### PR TITLE
fix(dweb): friendly error page when Swarm/IPFS node is disabled

### DIFF
--- a/src/renderer/lib/navigation-utils-helpers.test.js
+++ b/src/renderer/lib/navigation-utils-helpers.test.js
@@ -190,6 +190,18 @@ describe('navigation-utils extracted helpers', () => {
         homeUrlNormalized: 'file:///app/pages/home.html',
       })
     ).toBe('');
+
+    // A tab parked on an error page restores the friendly target from the
+    // `url` param, not the raw file:// error.html URL.
+    expect(
+      mod.deriveSwitchedTabDisplay({
+        url: 'file:///app/pages/error.html?error=ERR_CONNECTION_REFUSED&url=ipfs%3A%2F%2Fvitalik.eth&protocol=ipfs&retry=ipfs%3A%2F%2Fvitalik.eth',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+        ipfsRoutePrefix: 'http://127.0.0.1:8080/ipfs/',
+        ipnsRoutePrefix: 'http://127.0.0.1:8080/ipns/',
+      })
+    ).toBe('ipfs://vitalik.eth');
   });
 
   test('computes bookmark bar state and extracts original urls from error pages', async () => {

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -417,7 +417,13 @@ export const deriveSwitchedTabDisplay = ({
     return addressBarSnapshot;
   }
 
-  const urlToDerive = url.startsWith('view-source:') ? url.slice(12) : url;
+  const strippedUrl = url.startsWith('view-source:') ? url.slice(12) : url;
+  // A tab parked on `pages/error.html?...&url=<original>` should restore the
+  // friendly original target (e.g. `ipfs://vitalik.eth`), not the raw
+  // `file://.../error.html?...` URL Chromium actually committed. Mirrors the
+  // active-tab did-navigate handler, which derives the address bar from the
+  // error page's `url` param.
+  const urlToDerive = getOriginalUrlFromErrorPage(strippedUrl) || strippedUrl;
   const internalPageName = getInternalPageName(urlToDerive);
   if (internalPageName && internalPageName !== 'home') {
     return `freedom://${internalPageName}`;

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -21,6 +21,7 @@ import {
   formatBzzUrl,
   formatIpfsUrl,
   formatRadicleUrl,
+  looksLikeBzzInput,
   deriveDisplayValue,
   deriveBzzBaseFromUrl,
   deriveRadBaseFromUrl,
@@ -125,6 +126,16 @@ const buildErrorPageUrl = (errorCode, targetUrl, extras = {}) => {
   if (extras.retry) errorUrl.searchParams.set('retry', extras.retry);
   return errorUrl.toString();
 };
+
+// True when the IPFS node can't currently serve content — disabled for this
+// profile, or stopped/errored. Used to route ipfs:// / ipns:// navigations to
+// the friendly error page instead of letting the ipfs: protocol handler return
+// a raw JSON 503 body that Chromium would render verbatim. `starting` and
+// `running` are allowed through (the load proceeds normally).
+const isIpfsNodeUnavailable = () =>
+  state.registry?.ipfs?.mode === 'disabled' ||
+  state.currentIpfsStatus === 'stopped' ||
+  state.currentIpfsStatus === 'error';
 
 // Cancel any pending Swarm content probe on the given navState and clear it.
 //
@@ -1314,6 +1325,34 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
   // Try IPFS (ipfs://, ipns://, or raw CID)
   const ipfsTarget = formatIpfsUrl(value, state.ipfsRoutePrefix);
   if (ipfsTarget) {
+    // Node disabled or not running: surface the friendly "node not running"
+    // page rather than letting webview.loadURL hit the ipfs: handler, which
+    // returns a raw JSON 503 body Chromium renders verbatim. Reuses error.html
+    // via the same ERR_CONNECTION_REFUSED path the Swarm probe uses, and the
+    // Radicle disabled gate above. Unlike Swarm, `state.ipfsRoutePrefix` keeps
+    // a native fallback even when disabled, so `formatIpfsUrl` still resolves —
+    // hence the explicit availability check here.
+    if (isIpfsNodeUnavailable()) {
+      // Prefer the ENS-named load URL when the resolver supplied one, so the
+      // error page's display + retry preserve the ENS host (ipfs://name.eth)
+      // rather than the resolved CID — the ipfs: handler re-resolves the host
+      // per request, so the named form is loadable. See buildErrorPageUrl's
+      // note on ENS-backed retries.
+      const ipfsErrorUrl = options.ipfsLoadUrl || ipfsTarget.displayValue;
+      const protocol = ipfsErrorUrl.toLowerCase().startsWith('ipns://') ? 'ipns' : 'ipfs';
+      pushDebug(`[AddressBar] IPFS node unavailable — error page for ${ipfsErrorUrl}`);
+      addressInput.value = value.trim();
+      const errorUrl = buildErrorPageUrl('ERR_CONNECTION_REFUSED', ipfsErrorUrl, {
+        protocol,
+        retry: ipfsErrorUrl,
+      });
+      navState.pendingNavigationUrl = errorUrl;
+      navState.hasNavigatedDuringCurrentLoad = false;
+      webview.loadURL(errorUrl);
+      syncBzzBase(null);
+      syncRadBase(null);
+      return;
+    }
     const cidMatch = ipfsTarget.displayValue.match(/^ipfs:\/\/([A-Za-z0-9]+)/);
     const ipnsMatch = ipfsTarget.displayValue.match(/^ipns:\/\/([A-Za-z0-9.-]+)/);
     // Load via the native `ipfs:`/`ipns:` schemes so the main-process
@@ -1332,6 +1371,30 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
     pushDebug(`[AddressBar] Loading IPFS target, set to: ${ipfsDisplayValue}`);
     webview.loadURL(ipfsLoadUrl);
     pushDebug(`Loading ${ipfsTarget.displayValue} via ${ipfsLoadUrl}`);
+    syncBzzBase(null);
+    syncRadBase(null);
+    return;
+  }
+
+  // Swarm node disabled or not running: `state.bzzRoutePrefix` is null, so
+  // `formatBzzUrl` below returns null and the navigation would otherwise fall
+  // through to "Ignoring empty input or invalid URL" — a silent failure. Detect
+  // the Swarm intent from the raw input and show the same friendly "node not
+  // running" page the probe produces for an unreachable node (see
+  // startBzzNavigationWithProbe / error.html). Mirrors the Radicle disabled gate
+  // above.
+  if (!state.bzzRoutePrefix && looksLikeBzzInput(value)) {
+    const trimmed = value.trim();
+    const retry = /^bzz:/i.test(trimmed) ? trimmed : `bzz://${trimmed}`;
+    pushDebug(`[AddressBar] Swarm node unavailable — error page for ${trimmed}`);
+    addressInput.value = trimmed;
+    const errorUrl = buildErrorPageUrl('ERR_CONNECTION_REFUSED', retry, {
+      protocol: 'swarm',
+      retry,
+    });
+    navState.pendingNavigationUrl = errorUrl;
+    navState.hasNavigatedDuringCurrentLoad = false;
+    webview.loadURL(errorUrl);
     syncBzzBase(null);
     syncRadBase(null);
     return;

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -132,10 +132,21 @@ const buildErrorPageUrl = (errorCode, targetUrl, extras = {}) => {
 // the friendly error page instead of letting the ipfs: protocol handler return
 // a raw JSON 503 body that Chromium would render verbatim. `starting` and
 // `running` are allowed through (the load proceeds normally).
-const isIpfsNodeUnavailable = () =>
-  state.registry?.ipfs?.mode === 'disabled' ||
-  state.currentIpfsStatus === 'stopped' ||
-  state.currentIpfsStatus === 'error';
+const isIpfsNodeUnavailable = () => {
+  // The Nodes-menu switch sets `ipfsDesiredRunning` synchronously, but the
+  // actual `window.ipfs.stop()` and the resulting `stopped` status event lag
+  // behind (see ipfs-ui.js reconcileIpfsToggle). A navigation fired immediately
+  // after flipping the switch off would otherwise still see `currentIpfsStatus:
+  // 'running'` and let the load hit the ipfs: handler's raw 503. Honor the
+  // just-set intent so the friendly page shows right away. `null` means no
+  // pending toggle — fall through to the committed mode/status below.
+  if (state.ipfsDesiredRunning === false) return true;
+  return (
+    state.registry?.ipfs?.mode === 'disabled' ||
+    state.currentIpfsStatus === 'stopped' ||
+    state.currentIpfsStatus === 'error'
+  );
+};
 
 // Cancel any pending Swarm content probe on the given navState and clear it.
 //
@@ -1341,7 +1352,13 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
       const ipfsErrorUrl = options.ipfsLoadUrl || ipfsTarget.displayValue;
       const protocol = ipfsErrorUrl.toLowerCase().startsWith('ipns://') ? 'ipns' : 'ipfs';
       pushDebug(`[AddressBar] IPFS node unavailable — error page for ${ipfsErrorUrl}`);
-      addressInput.value = value.trim();
+      // Route through the per-tab helper (not a raw `addressInput.value` write):
+      // a background ENS/dweb navigation carries a specific `targetWebview`, so a
+      // direct write would clobber the foreground tab's address bar and skip
+      // storing the snapshot on the target tab. Mirror the normal IPFS path's
+      // `displayOverride || ipfsTarget.displayValue` so an ENS-backed target keeps
+      // its ENS host in the display.
+      setAddressDisplayForTab(displayOverride || ipfsTarget.displayValue, targetTabId);
       const errorUrl = buildErrorPageUrl('ERR_CONNECTION_REFUSED', ipfsErrorUrl, {
         protocol,
         retry: ipfsErrorUrl,
@@ -1385,10 +1402,20 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
   // above.
   if (!state.bzzRoutePrefix && looksLikeBzzInput(value)) {
     const trimmed = value.trim();
-    const retry = /^bzz:/i.test(trimmed) ? trimmed : `bzz://${trimmed}`;
-    pushDebug(`[AddressBar] Swarm node unavailable — error page for ${trimmed}`);
-    addressInput.value = trimmed;
-    const errorUrl = buildErrorPageUrl('ERR_CONNECTION_REFUSED', retry, {
+    const bzzForm = /^bzz:/i.test(trimmed) ? trimmed : `bzz://${trimmed}`;
+    // Preserve the ENS host on the retry URL when the resolver supplied one
+    // (`bzz://name.eth`), mirroring the probe path (startBzzNavigationWithProbe):
+    // the bzz: handler re-resolves the host per request, so "Try Again" keeps the
+    // ENS name and origin rather than the resolved hash. Non-ENS input keeps the
+    // bare bzz form.
+    const retry = options.bzzLoadUrl || bzzForm;
+    const displayValue = displayOverride || bzzForm;
+    pushDebug(`[AddressBar] Swarm node unavailable — error page for ${displayValue}`);
+    // Per-tab helper (not a raw `addressInput.value` write) so a background
+    // ENS/dweb navigation with an explicit `targetWebview` updates the target
+    // tab's snapshot instead of clobbering the foreground address bar.
+    setAddressDisplayForTab(displayValue, targetTabId);
+    const errorUrl = buildErrorPageUrl('ERR_CONNECTION_REFUSED', displayValue, {
       protocol: 'swarm',
       retry,
     });
@@ -1565,6 +1592,25 @@ const retryErrorPageOrReload = (webview, hard) => {
     pushDebug(`${hard ? 'Hard reload' : 'Reload'} re-resolving ENS: ${committedDisplay}`);
     loadTarget(committedDisplay);
     return;
+  }
+
+  // A committed dweb URL (`ipfs://<cid>`, `ipns://<name>`, `bzz://<hash>`) whose
+  // node has since been disabled/stopped must reload through `loadTarget` so the
+  // navigation-layer gate routes it to the friendly error page. A raw
+  // `webview.reload()` would re-hit the `ipfs:`/`bzz:` protocol handler and
+  // render its 503 JSON body verbatim. When the node is still available we keep
+  // the plain reload — no re-probe, preserving the happy-path behaviour.
+  const dwebScheme = committedDisplay.match(/^(ipfs|ipns|bzz):\/\//i)?.[1]?.toLowerCase();
+  if (dwebScheme) {
+    const nodeUnavailable =
+      dwebScheme === 'bzz' ? !state.bzzRoutePrefix : isIpfsNodeUnavailable();
+    if (nodeUnavailable) {
+      pushDebug(
+        `${hard ? 'Hard reload' : 'Reload'} dweb node unavailable — routing ${committedDisplay} to error page`
+      );
+      loadTarget(committedDisplay);
+      return;
+    }
   }
 
   if (hard) {

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -75,6 +75,8 @@ const loadNavigationModule = async (options = {}) => {
     radicleBase: 'http://127.0.0.1:8780',
     enableRadicleIntegration: options.enableRadicleIntegration || false,
     currentRadicleStatus: options.currentRadicleStatus || 'running',
+    currentIpfsStatus: options.currentIpfsStatus || 'running',
+    registry: options.registry || { ipfs: { mode: 'bundled' } },
     knownEnsNames: new Map(),
     ensProtocols: new Map(),
     ensTrustByName: new Map(),
@@ -198,12 +200,19 @@ const loadNavigationModule = async (options = {}) => {
       };
     }),
     formatIpfsUrl: jest.fn((input, prefix) => {
-      if (!input.startsWith('ipfs://')) return null;
+      // Both `ipfs://` and `ipns://` are 7-char schemes, so slice(7) is shared.
+      if (!input.startsWith('ipfs://') && !input.startsWith('ipns://')) return null;
       return {
         targetUrl: `${prefix}${input.slice(7)}`,
         displayValue: input,
         baseUrl: `${prefix}${input.slice(7).split('/')[0]}/`,
       };
+    }),
+    looksLikeBzzInput: jest.fn((input) => {
+      const raw = (input || '').trim();
+      if (!raw) return false;
+      if (/^bzz:/i.test(raw)) return true;
+      return /^[a-fA-F0-9]{64}([a-fA-F0-9]{64})?$/.test(raw.split('/')[0]);
     }),
     formatRadicleUrl: jest.fn((input) => {
       if (!input.startsWith('rad://')) return null;
@@ -827,6 +836,114 @@ describe('navigation', () => {
       await flushMicrotasks();
 
       expect(ctx.activeRef.tab.webview.loadURL).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disabled / not-running node error pages', () => {
+    const VALID_HASH = 'a'.repeat(64);
+
+    test('Swarm: shows the friendly error page instead of failing silently when the node is unavailable', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+      // Disabled/stopped Ant node nulls the route prefix (see service-registry
+      // → state.bzzRoutePrefix). Previously this made formatBzzUrl return null
+      // and the navigation fell through to "Ignoring empty input" — silently.
+      ctx.state.bzzRoutePrefix = null;
+
+      ctx.mod.loadTarget(`bzz://${VALID_HASH}`);
+      await flushMicrotasks();
+
+      // No probe should be started (the node can't be probed), and the webview
+      // should land on error.html with the Swarm-specific params.
+      expect(ctx.electronAPI.startSwarmProbe).not.toHaveBeenCalled();
+      const loadedUrl = ctx.activeRef.tab.webview.loadURL.mock.calls.at(-1)[0];
+      expect(loadedUrl).toContain('pages/error.html');
+      expect(loadedUrl).toContain('error=ERR_CONNECTION_REFUSED');
+      expect(loadedUrl).toContain('protocol=swarm');
+      expect(loadedUrl).toContain(encodeURIComponent(`bzz://${VALID_HASH}`));
+    });
+
+    test('Swarm: bare hash input is still routed to the error page when disabled', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+      ctx.state.bzzRoutePrefix = null;
+
+      ctx.mod.loadTarget(VALID_HASH);
+      await flushMicrotasks();
+
+      const loadedUrl = ctx.activeRef.tab.webview.loadURL.mock.calls.at(-1)[0];
+      expect(loadedUrl).toContain('pages/error.html');
+      expect(loadedUrl).toContain('protocol=swarm');
+      // Retry must be a loadable scheme URL, not the bare hash.
+      expect(loadedUrl).toContain(encodeURIComponent(`bzz://${VALID_HASH}`));
+    });
+
+    test('IPFS: shows the friendly error page instead of raw JSON when the node is disabled', async () => {
+      const ctx = await loadNavigationModule({ registry: { ipfs: { mode: 'disabled' } } });
+      await ctx.mod.initNavigation();
+
+      ctx.mod.loadTarget('ipfs://QmTest');
+      await flushMicrotasks();
+
+      const loadedUrl = ctx.activeRef.tab.webview.loadURL.mock.calls.at(-1)[0];
+      expect(loadedUrl).toContain('pages/error.html');
+      expect(loadedUrl).toContain('error=ERR_CONNECTION_REFUSED');
+      expect(loadedUrl).toContain('protocol=ipfs');
+      expect(loadedUrl).toContain(encodeURIComponent('ipfs://QmTest'));
+    });
+
+    test('IPNS: error page carries protocol=ipns', async () => {
+      const ctx = await loadNavigationModule({ registry: { ipfs: { mode: 'disabled' } } });
+      await ctx.mod.initNavigation();
+
+      ctx.mod.loadTarget('ipns://k51qtest');
+      await flushMicrotasks();
+
+      const loadedUrl = ctx.activeRef.tab.webview.loadURL.mock.calls.at(-1)[0];
+      expect(loadedUrl).toContain('pages/error.html');
+      expect(loadedUrl).toContain('protocol=ipns');
+      expect(loadedUrl).toContain(encodeURIComponent('ipns://k51qtest'));
+    });
+
+    test('IPFS: ENS-backed retry preserves the ENS host, not the resolved CID', async () => {
+      const ctx = await loadNavigationModule({ registry: { ipfs: { mode: 'disabled' } } });
+      await ctx.mod.initNavigation();
+
+      // Mirrors the ENS resolution path: value is the resolved CID form, while
+      // options.ipfsLoadUrl carries the user-facing ENS-named URL.
+      ctx.mod.loadTarget('ipfs://QmResolvedCid', null, null, {
+        ipfsLoadUrl: 'ipfs://vitalik.eth',
+      });
+      await flushMicrotasks();
+
+      const loadedUrl = ctx.activeRef.tab.webview.loadURL.mock.calls.at(-1)[0];
+      expect(loadedUrl).toContain('pages/error.html');
+      expect(loadedUrl).toContain(encodeURIComponent('ipfs://vitalik.eth'));
+      expect(loadedUrl).not.toContain(encodeURIComponent('ipfs://QmResolvedCid'));
+    });
+
+    test('IPFS: shows the error page when the node is stopped', async () => {
+      const ctx = await loadNavigationModule({ currentIpfsStatus: 'stopped' });
+      await ctx.mod.initNavigation();
+
+      ctx.mod.loadTarget('ipfs://QmTest');
+      await flushMicrotasks();
+
+      const loadedUrl = ctx.activeRef.tab.webview.loadURL.mock.calls.at(-1)[0];
+      expect(loadedUrl).toContain('pages/error.html');
+      expect(loadedUrl).toContain('protocol=ipfs');
+    });
+
+    test('IPFS: a running node navigates normally (no error page)', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      ctx.mod.loadTarget('ipfs://QmTest');
+      await flushMicrotasks();
+
+      const loadedUrl = ctx.activeRef.tab.webview.loadURL.mock.calls.at(-1)[0];
+      expect(loadedUrl).toBe('ipfs://QmTest');
+      expect(loadedUrl).not.toContain('error.html');
     });
   });
 

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -878,6 +878,27 @@ describe('navigation', () => {
       expect(loadedUrl).toContain(encodeURIComponent(`bzz://${VALID_HASH}`));
     });
 
+    test('Swarm: ENS-backed retry preserves the ENS host, not the resolved hash', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+      ctx.state.bzzRoutePrefix = null;
+
+      // Mirrors the ENS resolution recursion: value is the resolved hash form,
+      // while displayOverride / options.bzzLoadUrl carry the ENS-named URL. The
+      // disabled path must keep the ENS host on the error/retry URL, matching
+      // the probe path (startBzzNavigationWithProbe).
+      ctx.mod.loadTarget(`bzz://${VALID_HASH}`, 'bzz://vitalik.eth', null, {
+        bzzLoadUrl: 'bzz://vitalik.eth',
+      });
+      await flushMicrotasks();
+
+      const loadedUrl = ctx.activeRef.tab.webview.loadURL.mock.calls.at(-1)[0];
+      expect(loadedUrl).toContain('pages/error.html');
+      expect(loadedUrl).toContain('protocol=swarm');
+      expect(loadedUrl).toContain(`retry=${encodeURIComponent('bzz://vitalik.eth')}`);
+      expect(loadedUrl).not.toContain(encodeURIComponent(`bzz://${VALID_HASH}`));
+    });
+
     test('IPFS: shows the friendly error page instead of raw JSON when the node is disabled', async () => {
       const ctx = await loadNavigationModule({ registry: { ipfs: { mode: 'disabled' } } });
       await ctx.mod.initNavigation();
@@ -927,6 +948,75 @@ describe('navigation', () => {
       await ctx.mod.initNavigation();
 
       ctx.mod.loadTarget('ipfs://QmTest');
+      await flushMicrotasks();
+
+      const loadedUrl = ctx.activeRef.tab.webview.loadURL.mock.calls.at(-1)[0];
+      expect(loadedUrl).toContain('pages/error.html');
+      expect(loadedUrl).toContain('protocol=ipfs');
+    });
+
+    test('IPFS: background-tab error page leaves the foreground address bar alone', async () => {
+      const tabA = createTab(1, 'https://a.example', { title: 'Tab A' });
+      const tabB = createTab(2, 'about:blank', { title: 'Tab B' });
+      const ctx = await loadNavigationModule({
+        firstTab: tabA,
+        tabs: [tabA, tabB],
+        activeTab: tabB,
+        registry: { ipfs: { mode: 'disabled' } },
+      });
+      ctx.tabsRef.list = [tabA, tabB];
+      ctx.activeRef.tab = tabB;
+      await ctx.mod.initNavigation();
+      ctx.elements.addressInput.value = 'about:blank';
+
+      // A background ENS/dweb navigation targets Tab A while Tab B is foreground.
+      ctx.mod.loadTarget('ipfs://QmBackground', null, tabA.webview);
+      await flushMicrotasks();
+
+      // Error page loads in Tab A's webview, not the active tab's.
+      const loadedUrl = tabA.webview.loadURL.mock.calls.at(-1)[0];
+      expect(loadedUrl).toContain('pages/error.html');
+      expect(loadedUrl).toContain('protocol=ipfs');
+      // Foreground (Tab B) address bar is untouched...
+      expect(ctx.elements.addressInput.value).toBe('about:blank');
+      // ...and Tab A's snapshot carries the resolved display for switchback.
+      expect(tabA.navigationState.addressBarSnapshot).toBe('ipfs://QmBackground');
+    });
+
+    test('Swarm: background-tab error page leaves the foreground address bar alone', async () => {
+      const tabA = createTab(1, 'https://a.example', { title: 'Tab A' });
+      const tabB = createTab(2, 'about:blank', { title: 'Tab B' });
+      const ctx = await loadNavigationModule({
+        firstTab: tabA,
+        tabs: [tabA, tabB],
+        activeTab: tabB,
+      });
+      ctx.tabsRef.list = [tabA, tabB];
+      ctx.activeRef.tab = tabB;
+      await ctx.mod.initNavigation();
+      ctx.state.bzzRoutePrefix = null;
+      ctx.elements.addressInput.value = 'about:blank';
+
+      ctx.mod.loadTarget(`bzz://${VALID_HASH}`, null, tabA.webview);
+      await flushMicrotasks();
+
+      const loadedUrl = tabA.webview.loadURL.mock.calls.at(-1)[0];
+      expect(loadedUrl).toContain('pages/error.html');
+      expect(loadedUrl).toContain('protocol=swarm');
+      expect(ctx.elements.addressInput.value).toBe('about:blank');
+      expect(tabA.navigationState.addressBarSnapshot).toBe(`bzz://${VALID_HASH}`);
+    });
+
+    test('IPFS: honors a just-flipped-off Nodes-menu toggle before the status catches up', async () => {
+      // Reproduces navigating immediately after switching the node off: the
+      // toggle sets ipfsDesiredRunning=false synchronously, but currentIpfsStatus
+      // still reads 'running' until the async stop lands. The guard must honor
+      // the pending intent so the friendly page shows instead of the raw 503.
+      const ctx = await loadNavigationModule({ currentIpfsStatus: 'running' });
+      await ctx.mod.initNavigation();
+      ctx.state.ipfsDesiredRunning = false;
+
+      ctx.mod.loadTarget('ipfs://QmStillRunning');
       await flushMicrotasks();
 
       const loadedUrl = ctx.activeRef.tab.webview.loadURL.mock.calls.at(-1)[0];
@@ -1988,6 +2078,64 @@ describe('navigation', () => {
       expect(ctx.activeRef.tab.webview.reload).not.toHaveBeenCalled();
       expect(ctx.electronAPI.resolveEns).not.toHaveBeenCalled();
       expect(ctx.electronAPI.invalidateEnsContent).not.toHaveBeenCalled();
+    });
+
+    test('reload of a bare-CID IPFS page routes to the error page when the node is disabled', async () => {
+      const ctx = await loadNavigationModule({ registry: { ipfs: { mode: 'disabled' } } });
+      installEnsParser(ctx);
+      await ctx.mod.initNavigation();
+
+      // Node was running when the page loaded; committedDisplayUrl holds the
+      // bare-CID ipfs URL. It has since been disabled — a plain webview.reload()
+      // would re-hit the ipfs: handler and render its raw JSON 503.
+      const cidUrl = 'ipfs://bafybeihhofqwesc552xtojljmjslqryb6fco4kvfgpujf44dm2jp4e6jxm/';
+      commitDisplay(ctx, cidUrl);
+      ctx.activeRef.tab.webview.getURL.mockReturnValue(cidUrl);
+      ctx.activeRef.tab.webview.loadURL.mockClear();
+
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: false });
+      await flushMicrotasks();
+
+      expect(ctx.activeRef.tab.webview.reload).not.toHaveBeenCalled();
+      const loadedUrl = ctx.activeRef.tab.webview.loadURL.mock.calls.at(-1)[0];
+      expect(loadedUrl).toContain('pages/error.html');
+      expect(loadedUrl).toContain('protocol=ipfs');
+    });
+
+    test('reload of a bare-hash Swarm page routes to the error page when the node is disabled', async () => {
+      const ctx = await loadNavigationModule();
+      installEnsParser(ctx);
+      await ctx.mod.initNavigation();
+      ctx.state.bzzRoutePrefix = null;
+
+      const hashUrl = `bzz://${'a'.repeat(64)}/`;
+      commitDisplay(ctx, hashUrl);
+      ctx.activeRef.tab.webview.getURL.mockReturnValue(hashUrl);
+      ctx.activeRef.tab.webview.loadURL.mockClear();
+
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: false });
+      await flushMicrotasks();
+
+      expect(ctx.activeRef.tab.webview.reload).not.toHaveBeenCalled();
+      const loadedUrl = ctx.activeRef.tab.webview.loadURL.mock.calls.at(-1)[0];
+      expect(loadedUrl).toContain('pages/error.html');
+      expect(loadedUrl).toContain('protocol=swarm');
+    });
+
+    test('reload of a bare-CID IPFS page still uses webview.reload() when the node is available', async () => {
+      const ctx = await loadNavigationModule();
+      installEnsParser(ctx);
+      await ctx.mod.initNavigation();
+
+      const cidUrl = 'ipfs://bafybeihhofqwesc552xtojljmjslqryb6fco4kvfgpujf44dm2jp4e6jxm/';
+      commitDisplay(ctx, cidUrl);
+      ctx.activeRef.tab.webview.getURL.mockReturnValue(cidUrl);
+
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: false });
+      await flushMicrotasks();
+
+      expect(ctx.activeRef.tab.webview.reload).toHaveBeenCalled();
+      expect(ctx.electronAPI.resolveEns).not.toHaveBeenCalled();
     });
 
     test('reload from an ENS error page recovers via the original-URL branch', async () => {

--- a/src/renderer/lib/url-utils.js
+++ b/src/renderer/lib/url-utils.js
@@ -166,6 +166,19 @@ export const deriveBzzBaseFromUrl = (input) => {
   return null;
 };
 
+// True when `input` is intended as a Swarm/bzz navigation target — either the
+// `bzz:` / `bzz://` scheme or a bare Swarm hash. `formatBzzUrl` returns null
+// when the route prefix is unavailable (node disabled/stopped), so callers use
+// this to detect Swarm intent and surface a friendly "node not running" page
+// instead of dropping the navigation silently. Mirrors the hash/scheme
+// detection `formatBzzUrl` itself performs.
+export const looksLikeBzzInput = (input) => {
+  const raw = (input || '').trim();
+  if (!raw) return false;
+  if (/^bzz:/i.test(raw)) return true;
+  return isValidSwarmHash(raw.split('/')[0]);
+};
+
 export const formatBzzUrl = (input, bzzRoutePrefix) => {
   const raw = (input || '').trim();
   if (!raw) {

--- a/src/renderer/lib/url-utils.test.js
+++ b/src/renderer/lib/url-utils.test.js
@@ -4,6 +4,7 @@ import {
   deriveBzzBaseFromUrl,
   parseHashInput,
   formatBzzUrl,
+  looksLikeBzzInput,
   deriveDisplayValue,
   isValidCid,
   parseIpfsInput,
@@ -160,6 +161,32 @@ describe('url-utils', () => {
     test('returns null for bzz path without hash', () => {
       const url = 'http://127.0.0.1:1633/bzz/';
       expect(deriveBzzBaseFromUrl(url)).toBeNull();
+    });
+  });
+
+  describe('looksLikeBzzInput', () => {
+    const HASH = 'a'.repeat(64);
+
+    test('detects bzz:// and bzz: scheme inputs', () => {
+      expect(looksLikeBzzInput(`bzz://${HASH}`)).toBe(true);
+      expect(looksLikeBzzInput(`bzz://${HASH}/index.html`)).toBe(true);
+      expect(looksLikeBzzInput(`bzz:${HASH}`)).toBe(true);
+      expect(looksLikeBzzInput('  BZZ://name.eth  ')).toBe(true);
+    });
+
+    test('detects bare Swarm hashes (with or without a path)', () => {
+      expect(looksLikeBzzInput(HASH)).toBe(true);
+      expect(looksLikeBzzInput(`${HASH}/page.html`)).toBe(true);
+      expect(looksLikeBzzInput('a'.repeat(128))).toBe(true);
+    });
+
+    test('rejects non-Swarm inputs', () => {
+      expect(looksLikeBzzInput('')).toBe(false);
+      expect(looksLikeBzzInput(null)).toBe(false);
+      expect(looksLikeBzzInput('example.com')).toBe(false);
+      expect(looksLikeBzzInput('ipfs://QmTest')).toBe(false);
+      expect(looksLikeBzzInput('https://example.com')).toBe(false);
+      expect(looksLikeBzzInput('a'.repeat(63))).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Restores a friendly error page when a Swarm or IPFS node is **disabled in the Nodes menu** (or stopped). Previously:

- **Swarm (`bzz://`)** failed **silently** — nothing loaded.
- **IPFS (`ipfs://` / `ipns://`)** rendered an **ugly raw JSON 503** body.

Radicle still shows its friendly disabled/offline page, so this brings Swarm and IPFS back in line.

Fixes #134.

## Root cause

The Nodes-menu "disable" feature is new in 0.8-dev (`f85f9ac`, *"honor explicit node modes"*), which nulls the service-registry `api`/`gateway` for a disabled node. In the renderer:

- **Swarm** — nulled `antBase` → `state.bzzRoutePrefix` becomes `null` → `formatBzzUrl` returns `null` → `loadTarget` fell through to *"Ignoring empty input or invalid URL"* (silent).
- **IPFS** — `state.ipfsBase` keeps a native fallback, so `formatIpfsUrl` still resolves; the webview loaded `ipfs://` and the protocol handler's `jsonErrorResponse(503)` rendered verbatim. (The raw-JSON behavior actually predates 0.8 — since the `ipfs://`-scheme promotion in v0.7.1.)

Both are successful HTTP responses with 5xx bodies, not network failures, so the `did-fail-load` → `error.html` fallback never fired.

## Fix

Gate at the navigation layer in `loadTarget`, mirroring the existing Radicle disabled gate, and route to the existing `error.html` via `buildErrorPageUrl(...)`. No main-process or error-page changes.

- **Swarm guard** — when the input looks like a Swarm target but `state.bzzRoutePrefix` is `null`, route to `error.html?error=ERR_CONNECTION_REFUSED&protocol=swarm`. Restores the exact 0.7.x probe→error path.
- **IPFS guard** — new `isIpfsNodeUnavailable()` (`registry.ipfs.mode === 'disabled'` or `currentIpfsStatus` in `stopped`/`error`); routes to `error.html` with `protocol=ipfs`/`ipns`. ENS-backed targets preserve the ENS host in the display/retry URL. `starting`/`running` pass through unchanged. This is a new friendly page (the `ipfs://` scheme never had one).
- New exported `looksLikeBzzInput()` to detect Swarm intent once the route prefix is gone.

## Tests

- 7 navigation tests: silent-swarm→error page, bare-hash swarm, ipfs-disabled, ipns `protocol=ipns`, ENS-backed retry preserves host, ipfs-stopped, ipfs-running-normal.
- `looksLikeBzzInput` unit coverage.
- Full suite green; lint clean.

## Notes / out of scope

- Transient "node still starting" for IPFS (navigate mid-boot) still returns the handler's 503 — would need an IPFS navigation probe like Swarm's.
- Cold-start race: a navigation in the brief window before the first registry update could show a false "node not running" page; window is tiny and restored tabs bypass `loadTarget`.
