### PR TITLE
fix(linux): focus cold-started profile windows instead of GNOME notification

### DIFF
--- a/src/main/windows/mainWindow.js
+++ b/src/main/windows/mainWindow.js
@@ -78,6 +78,17 @@ function createMainWindow(initialUrl = null) {
 
   window.on('ready-to-show', () => {
     window.setTitle(currentWindowTitle);
+
+    // Linux cold start: a freshly-spawned profile process has no valid
+    // startup-activation token, so Mutter denies focus to the new window and
+    // posts a "'Freedom' is ready" notification instead of raising it. Nudge
+    // focus with the always-on-top toggle, which bypasses focus-stealing
+    // prevention. Skip the headless test path, which deliberately stays hidden.
+    if (isLinux && !hideWindow) {
+      window.setAlwaysOnTop(true);
+      window.focus();
+      window.setAlwaysOnTop(false);
+    }
   });
 
   window.on('page-title-updated', (event) => {


### PR DESCRIPTION
## Summary

Fixes #133. On Linux (GNOME/Mutter), switching to a not-yet-running profile via the hamburger menu cold-starts a new detached Electron process. Its window has no valid startup-activation token, so Mutter denies focus and posts a **`"Freedom" is ready`** notification instead of raising it.

This nudges focus in the cold-start window's `ready-to-show` handler using the always-on-top toggle, which bypasses Mutter's focus-stealing prevention (the issue's recommended Option A — no native deps, ~10 lines):

```js
if (isLinux && !hideWindow) {
  window.setAlwaysOnTop(true);
  window.focus();
  window.setAlwaysOnTop(false);
}
```

- Gated to `process.platform === 'linux'` and to genuine cold starts — the headless `FREEDOM_TEST_HIDE_WINDOW` path is skipped, so E2E tests are unaffected.
- macOS / Windows behavior unchanged.

## Testing

Verified on a real **GNOME Shell 49.0 / Wayland (Mutter)**, Ubuntu 25.10 aarch64 VM:

- **Manual:** switching to a not-yet-running profile via the hamburger menu now raises and focuses the new window — no `"… is ready"` notification.
- **Automated sanity** on the real `createMainWindow()` path: cold-start window comes up visible + focused, and `alwaysOnTop` is correctly toggled back to `false` (window not left floating).
- **Headless guard:** with `FREEDOM_TEST_HIDE_WINDOW=1` the window stays hidden and the nudge is skipped — no E2E regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
