### PR TITLE
feat(linux): default 'Tabs in title bar' to off

### DIFF
--- a/src/main/settings-store.js
+++ b/src/main/settings-store.js
@@ -51,7 +51,8 @@ const DEFAULT_SETTINGS = {
   sidebarOpen: false,
   sidebarWidth: 320,
   // Linux only: render the tab strip as the window titlebar (frameless window).
-  tabsInTitlebar: true,
+  // Off by default so Linux users get the native OS frame; opt in via Settings.
+  tabsInTitlebar: false,
 };
 
 let cachedSettings = null;

--- a/src/main/windows/mainWindow.js
+++ b/src/main/windows/mainWindow.js
@@ -28,9 +28,9 @@ function getIconPath() {
 function createMainWindow(initialUrl = null) {
   const isMac = process.platform === 'darwin';
   const isLinux = process.platform === 'linux';
-  // Linux only: tab strip doubles as the titlebar unless the user opted out.
+  // Linux only: tab strip doubles as the titlebar when the user opts in.
   // `frame` can't change on a live window, so this is read once at creation.
-  const linuxFrameless = isLinux && loadSettings().tabsInTitlebar !== false;
+  const linuxFrameless = isLinux && loadSettings().tabsInTitlebar === true;
 
   // Headless E2E: keep the window hidden so a local test run doesn't pop a
   // window or steal focus. The renderer still loads and is fully driveable via

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -134,10 +134,10 @@ async function initPlatformUI() {
     // traffic-light gap to 12px), so it applies to Linux regardless of framing.
     document.body.classList.add('platform-linux');
 
-    // The window is only frameless when the user keeps tabs-in-titlebar on; with
-    // the OS frame the system provides the controls, so skip the custom ones.
+    // The window is only frameless when the user opts in to tabs-in-titlebar;
+    // with the OS frame the system provides the controls, so skip the custom ones.
     const settings = await electronAPI.getSettings().catch(() => ({}));
-    if (settings.tabsInTitlebar === false) return;
+    if (settings.tabsInTitlebar !== true) return;
 
     // Frameless on Linux: show + wire the in-app window controls
     document.getElementById('window-controls')?.classList.add('visible');

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -1431,7 +1431,7 @@
       const applyFormState = (settings) => {
         if (!settings) return;
         fields.themeMode.value = settings.theme || 'system';
-        fields.tabsInTitlebar.checked = settings.tabsInTitlebar !== false;
+        fields.tabsInTitlebar.checked = settings.tabsInTitlebar === true;
         fields.startAnt.checked = settings.startAntAtLaunch !== false;
         fields.startIpfs.checked = settings.startIpfsAtLaunch !== false;
         fields.enableRadicle.checked = settings.enableRadicleIntegration === true;


### PR DESCRIPTION
Closes #137

## Summary

On Linux the window shipped frameless by default, with the in-app tab strip acting as the OS title bar. This flips the default so Linux users get the **native window frame** out of the box. The tab-strip titlebar is now opt-in via Settings → *Tabs in title bar* (takes effect after restart, since `frame` can't change on a live window).

## Changes

- `src/main/settings-store.js` — default `tabsInTitlebar` flipped from `true` to `false`.
- Switched the read idiom from *on unless explicitly false* to *on only when explicitly true* so an unset value reads as off:
  - `src/main/windows/mainWindow.js` — `linuxFrameless` now requires `=== true`.
  - `src/renderer/index.js` — custom window controls only wired when `=== true` (also fixes the getSettings error-fallback `{}` case, which previously showed custom controls on a framed window).
  - `src/renderer/pages/settings.html` — checkbox reflects `=== true`.

## Behavior

| User state | Before | After |
|---|---|---|
| New Linux user (no setting) | frameless (tabs as titlebar) | native frame |
| Explicitly enabled | frameless | frameless |
| Explicitly disabled | native frame | native frame |

macOS (`hiddenInset`) and Windows are unaffected.

## Testing

- CI green (test + e2e across macOS/Windows/Linux).
- Manual Linux verification pending.