### PR TITLE
fix(ant): bump bundled antd to v0.5.33 for real postage batch TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Freedom will be documented in this file.
 - Existing Bee node data is migrated to Ant on first launch after upgrading, so the injected Swarm identity (overlay address, postage stamps, chequebook) is preserved
 - Updated the bundled Ant node to v0.5.21; runtime postage-batch management (added in v0.5.8) means publishing to Swarm (buying stamps, uploading data/files/sites) works end-to-end in light mode, and the Bee-compatible `/wallet` and stamp-purchase behavior (v0.5.19) means balance checks and feed/post retrieval work without Ant-specific browser logic
 - Bundled IPFS runtime moves from Kubo 0.41.0 to `freedom-ipfs` 0.4.1 native addons for macOS, Linux, and Windows
+- Updated the bundled Ant node to v0.5.33; the wallet → nodes → storage panel now shows each postage stamp's real, decreasing time-remaining (derived from chainstate) instead of a flat 3650-day placeholder, including in the default ultra-light node mode
 
 ## [0.7.4] - 2026-06-01
 

--- a/scripts/fetch-ant.js
+++ b/scripts/fetch-ant.js
@@ -15,7 +15,7 @@ const ANT_REPO = process.env.ANT_REPO || 'solardev-xyz/ant';
 // could ship a different Ant than CI validated. Override via ANT_RELEASE_TAG
 // for local testing of newer releases; set it to `latest` to resolve the
 // repo's most recent published release.
-const PINNED_RELEASE_TAG = 'v0.5.29';
+const PINNED_RELEASE_TAG = 'v0.5.33';
 // In-repo trust root for the pinned release: the sha256 of its SHA256SUMS
 // asset, recorded at pin time (trust-on-first-use by the author). The release
 // downloads its SHA256SUMS from the same GitHub release as the binaries, so
@@ -24,7 +24,7 @@ const PINNED_RELEASE_TAG = 'v0.5.29';
 // that tampering detectable. Update alongside PINNED_RELEASE_TAG on every
 // deliberate bump: `shasum -a 256` the freshly downloaded SHA256SUMS.
 const PINNED_SHA256SUMS_DIGEST =
-  'b5f6033594681c8311037f6af9c67d310597bca175eb04935cd3e1894ccc0ee2';
+  '4647fb92f635ded61de1afda45fcb72766c93138ae8d2019eb56ec93e226df9d';
 const ANT_RELEASE_TAG = process.env.ANT_RELEASE_TAG || PINNED_RELEASE_TAG;
 
 function fetchReleaseOnce() {


### PR DESCRIPTION
Closes #129.

## Problem
The wallet → nodes → storage panel showed **"3650 days" (10 years)** as time-remaining for every postage stamp, regardless of the duration purchased. Root cause was upstream: antd's bee-shaped `/stamps` returned a fixed `batchTTL` placeholder (~`315360000`s) because the chainstate TTL enrichment only ran when an operator `--gnosis-rpc-url` was set — and Freedom's default **ultra-light** config sets none.

## Fix
Upstream `solardev-xyz/ant#22` (shipped in **v0.5.33**) wires ant's existing default `--gnosis-logs-rpc-url` (`https://rpc.gnosischain.com`) in as a **read-only fallback** for the gateway, so reads (`/stamps` `batchTTL`/`amount`, `/wallet`, `/chainstate`) get a real, chain-derived value even with no operator RPC. Writes stay gated on the explicit operator RPC + funded key.

This PR adopts it on the freedom-browser side:

- **Bump pinned ant release** in `scripts/fetch-ant.js`: `v0.5.29` → `v0.5.33`, with the updated `PINNED_SHA256SUMS_DIGEST`.
- **No config change needed.** We launch antd with only `--config` + `--no-control-socket` and never set `--gnosis-logs-rpc-url=""`, so the read-only fallback is active by default. Ultra-light keeps `blockchain-rpc-endpoint: ""` and `swap-enable: false` — writes stay disabled, reads get real TTL. (Resolves the open question in task #2 of the issue.)
- **No renderer change.** `stamp-manager.js` formats whatever `ttlSeconds` it's given, so the corrected upstream value flows through automatically.

## Verification
- `node scripts/fetch-ant.js` downloads all platform binaries and **verifies `SHA256SUMS` against the new pinned digest** ✓
- `./ant-bin/mac-arm64/antd --version` → `antd 0.5.33` ✓
- `src/main/ant-manager.test.js` → 25/25 pass ✓
- Upstream PR #22 verified the TTL math against a live depth-22 batch on Gnosis mainnet (26.26 days, matching across both the public-fallback and operator RPC paths).

## Acceptance
- [x] Storage panel shows realistic, decreasing time-remaining per stamp (not a flat 3650 days)
- [x] Works in the default ultra-light node mode