### PR TITLE
test(profiles): cover remaining v0.8.0 upgrade-migration gaps (#107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,35 @@ jobs:
           path: coverage/
           if-no-files-found: error
 
+  # v0.8.0 upgrade / profile-migration coverage on all three desktop platforms.
+  # The bee->ant carry has OS-specific filesystem semantics (Windows EPERM on
+  # locked handles, rename-vs-copy fallbacks), so the migration + profile
+  # resolver/paths suites must be green on Windows and macOS too — not just the
+  # ubuntu-only `test` job. Pure jest, no display or native nodes required. (#107)
+  migration-cross-platform:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run migration + profile suites
+        run: npm run test:migration
+
   # freedom-ipfs native addon smoke for every desktop addon target currently
   # published in the pinned prebuilt manifest. This downloads the real release
   # artifact, loads it in Node, starts native freedom-ipfs, and retrieves a real

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
   # The bee->ant carry has OS-specific filesystem semantics (Windows EPERM on
   # locked handles, rename-vs-copy fallbacks), so the migration + profile
   # resolver/paths suites must be green on Windows and macOS too — not just the
-  # ubuntu-only `test` job. Pure jest, no display or native nodes required. (#107)
+  # ubuntu-only `test` job. Pure jest, no display or native nodes required.
   migration-cross-platform:
     strategy:
       fail-fast: false

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "npm run test:unit",
     "test:unit": "jest",
     "test:coverage": "jest --coverage --runInBand --forceExit",
+    "test:migration": "jest --runInBand src/main/migrate-user-data.test.js src/main/__tests__/integration/v08-upgrade.test.js src/main/profile-resolver.test.js src/main/profile-paths.test.js src/main/profile-catalog.test.js src/main/identity/__tests__/integration/postage-publisher-continuity.test.js",
     "test:e2e": "playwright test --project=harness",
     "test:e2e:live": "playwright test --project=live",
     "test:e2e:onboarding": "playwright test --project=live test-e2e/live/onboarding-identity.spec.js",

--- a/src/main/__tests__/integration/v08-upgrade.test.js
+++ b/src/main/__tests__/integration/v08-upgrade.test.js
@@ -322,7 +322,7 @@ describe('v0.8.0 upgrade path (end-to-end, in place)', () => {
     expect(fs.existsSync(path.join(userDataDir, 'ipfs-data', 'blocks', 'CIQ.data'))).toBe(true);
   });
 
-  // #107: crash mid bee→ant migration must be recoverable on the next launch —
+  // A crash mid bee→ant migration must be recoverable on the next launch —
   // no lost keystore, no duplicated/corrupted data. This drives the merge path
   // (ant-data already present because antd self-generated a throwaway identity),
   // injects a Windows-EPERM-style failure part way through the carry, then
@@ -372,7 +372,7 @@ describe('v0.8.0 upgrade path (end-to-end, in place)', () => {
     expect(fs.existsSync(path.join(antData, 'identity.json'))).toBe(false);
   });
 
-  // #107: a v0.7.x install kept its Radicle identity in a profile-local
+  // A v0.7.x install kept its Radicle identity in a profile-local
   // radicle-data/. On upgrade the default profile is catalog-managed, so the
   // Radicle home moves to the short, app-owned <appRoot>/R/<slot> (radicle-node
   // canonicalizes RAD_HOME before binding its control.sock, which has a hard

--- a/src/main/__tests__/integration/v08-upgrade.test.js
+++ b/src/main/__tests__/integration/v08-upgrade.test.js
@@ -321,4 +321,86 @@ describe('v0.8.0 upgrade path (end-to-end, in place)', () => {
     expect(fs.existsSync(path.join(userDataDir, 'ipfs-data', 'config'))).toBe(true);
     expect(fs.existsSync(path.join(userDataDir, 'ipfs-data', 'blocks', 'CIQ.data'))).toBe(true);
   });
+
+  // #107: crash mid bee→ant migration must be recoverable on the next launch —
+  // no lost keystore, no duplicated/corrupted data. This drives the merge path
+  // (ant-data already present because antd self-generated a throwaway identity),
+  // injects a Windows-EPERM-style failure part way through the carry, then
+  // relaunches and asserts the identity + postage stamps land intact.
+  test('recovers a crash-interrupted bee→ant migration on the next launch', () => {
+    writeLegacyInstall(userDataDir);
+    // antd already ran once and self-generated a throwaway identity into
+    // ant-data/ — forcing the item-by-item carry (not the whole-dir rename).
+    const antData = path.join(userDataDir, 'ant-data');
+    fs.mkdirSync(antData, { recursive: true });
+    fs.writeFileSync(path.join(antData, 'identity.json'), JSON.stringify({ throwaway: true }));
+
+    const beeAnt = loadModule('../../migrate-user-data', userDataDir);
+
+    // Interrupt the carry on the stamperstore move — before the keystore, which
+    // moves LAST, is committed (see BEE_CARRY_ITEMS ordering in the migrator).
+    const realRename = fs.renameSync.bind(fs);
+    const spy = jest.spyOn(fs, 'renameSync').mockImplementation((src, dest) => {
+      if (String(dest).endsWith(`${path.sep}stamperstore`)) {
+        const err = new Error('EPERM: operation not permitted');
+        err.code = 'EPERM';
+        throw err;
+      }
+      return realRename(src, dest);
+    });
+
+    // First launch crashes part way: it reports failure and stays pending.
+    expect(beeAnt.mod.migrateBeeDataToAntData()).toBe(false);
+    expect(beeAnt.mod.isBeeDataMigrationPending()).toBe(true);
+    // The keystore never moved, so it's still safe in bee-data (nothing to lose).
+    expect(fs.existsSync(path.join(antData, 'keys', 'swarm.key'))).toBe(false);
+    expect(
+      fs.readFileSync(path.join(userDataDir, 'bee-data', 'keys', 'swarm.key'), 'utf-8')
+    ).toBe(SWARM_KEYSTORE);
+
+    spy.mockRestore();
+
+    // Relaunch: the migration finishes and no data is lost or duplicated.
+    expect(beeAnt.mod.migrateBeeDataToAntData()).toBe(true);
+    expect(beeAnt.mod.isBeeDataMigrationPending()).toBe(false);
+    expect(fs.readFileSync(path.join(antData, 'keys', 'swarm.key'), 'utf-8')).toBe(SWARM_KEYSTORE);
+    expect(fs.readFileSync(path.join(antData, 'stamperstore', 'batch'), 'utf-8')).toBe(
+      'postage-batch-data'
+    );
+    expect(fs.readFileSync(path.join(antData, 'config.yaml'), 'utf-8')).toContain(BEE_PASSWORD);
+    // antd's throwaway identity was dropped — it must not win over the migrated key.
+    expect(fs.existsSync(path.join(antData, 'identity.json'))).toBe(false);
+  });
+
+  // #107: a v0.7.x install kept its Radicle identity in a profile-local
+  // radicle-data/. On upgrade the default profile is catalog-managed, so the
+  // Radicle home moves to the short, app-owned <appRoot>/R/<slot> (radicle-node
+  // canonicalizes RAD_HOME before binding its control.sock, which has a hard
+  // sockaddr_un length limit). This exercises copyProfileRadicleDataIfNeeded on
+  // the full upgrade path — the pre-upgrade identity must be carried across.
+  test('carries the Radicle identity to the short Radicle home on the full upgrade path', () => {
+    writeLegacyInstall(userDataDir);
+    const legacyRadicle = path.join(userDataDir, 'radicle-data');
+    fs.mkdirSync(path.join(legacyRadicle, 'keys'), { recursive: true });
+    fs.writeFileSync(path.join(legacyRadicle, 'keys', 'radicle.pub'), 'radicle-public-key');
+
+    // Load profile-paths and resolve the default profile in the SAME module
+    // graph so getRadicleDataDir() sees the active catalog profile.
+    const paths = loadModule('../../profile-paths', userDataDir);
+    const resolver = require('../../profile-resolver');
+    resolver.initializeProfile(paths.app, { argv: ['electron', '.'], env: {}, now: NOW });
+
+    const radicleDir = paths.mod.getRadicleDataDir();
+
+    // The default profile (slot 0) uses the short app-owned Radicle home, which
+    // is shorter than the profile-local radicle-data/ it replaces.
+    expect(radicleDir).toBe(path.join(userDataDir, 'R', '0'));
+    expect(radicleDir.length).toBeLessThan(legacyRadicle.length);
+    // The pre-upgrade Radicle identity is carried into the short home...
+    expect(fs.readFileSync(path.join(radicleDir, 'keys', 'radicle.pub'), 'utf-8')).toBe(
+      'radicle-public-key'
+    );
+    // ...by copy, not move: the original profile-local data is left in place.
+    expect(fs.existsSync(path.join(legacyRadicle, 'keys', 'radicle.pub'))).toBe(true);
+  });
 });

--- a/src/main/profile-resolver.js
+++ b/src/main/profile-resolver.js
@@ -27,7 +27,7 @@ const { isProfileLocked } = require('./profile-lock');
 // dirs (see warnAboutLegacyDevData). Developers who want to keep old dev state
 // can point FREEDOM_DEV_HOME (or explicit data-path overrides) at it. This is
 // deliberately weaker than the packaged upgrade path, which adopts existing
-// userData in place and runs the bee->ant migration. Decision tracked in #107.
+// userData in place and runs the bee->ant migration.
 const LEGACY_DEV_DATA_DIRS = ['identity-data', 'bee-data', 'ant-data', 'ipfs-data', 'radicle-data'];
 const LEGACY_DEV_DATA_WARNING_FILE = 'legacy-dev-data-warning.json';
 

--- a/src/main/profile-resolver.js
+++ b/src/main/profile-resolver.js
@@ -18,6 +18,16 @@ const {
 } = require('./profile-catalog');
 const { isProfileLocked } = require('./profile-lock');
 
+// Pre-profile dev builds wrote node/identity data directly into the repo
+// checkout (`<repoRoot>/bee-data`, `identity-data`, etc.). The profile system
+// moved dev data to `Freedom Dev/<checkout>/Profiles/<id>/`. By design we do
+// NOT auto-migrate this legacy repo-root data into the new default profile:
+// dev data is disposable/regenerable and re-onboarding is cheap, so on upgrade
+// the app boots a fresh default profile and only *warns* about the stranded
+// dirs (see warnAboutLegacyDevData). Developers who want to keep old dev state
+// can point FREEDOM_DEV_HOME (or explicit data-path overrides) at it. This is
+// deliberately weaker than the packaged upgrade path, which adopts existing
+// userData in place and runs the bee->ant migration. Decision tracked in #107.
 const LEGACY_DEV_DATA_DIRS = ['identity-data', 'bee-data', 'ant-data', 'ipfs-data', 'radicle-data'];
 const LEGACY_DEV_DATA_WARNING_FILE = 'legacy-dev-data-warning.json';
 

--- a/src/main/profile-resolver.test.js
+++ b/src/main/profile-resolver.test.js
@@ -266,7 +266,7 @@ describe('profile resolver', () => {
     expect(logger.warn).toHaveBeenCalledTimes(2);
   });
 
-  // #107: warn-only is the accepted behavior for dev pre-profile data. Legacy
+  // Warn-only is the accepted behavior for dev pre-profile data. Legacy
   // repo-root dirs must be left untouched (not moved) and must NOT be copied
   // into the new default profile — the dev boots a fresh default profile.
   test('does not auto-migrate legacy dev repo-root data into the default profile', () => {

--- a/src/main/profile-resolver.test.js
+++ b/src/main/profile-resolver.test.js
@@ -266,6 +266,45 @@ describe('profile resolver', () => {
     expect(logger.warn).toHaveBeenCalledTimes(2);
   });
 
+  // #107: warn-only is the accepted behavior for dev pre-profile data. Legacy
+  // repo-root dirs must be left untouched (not moved) and must NOT be copied
+  // into the new default profile — the dev boots a fresh default profile.
+  test('does not auto-migrate legacy dev repo-root data into the default profile', () => {
+    const appDataDir = track(makeTempDir());
+    const repoRoot = track(makeRepoRoot());
+    const legacyBeeData = path.join(repoRoot, 'bee-data');
+    fs.mkdirSync(legacyBeeData);
+    fs.writeFileSync(path.join(legacyBeeData, 'swarm.key'), 'legacy-secret');
+    const app = createAppMock({
+      isPackaged: false,
+      appPaths: { appData: appDataDir },
+    });
+    const {
+      LEGACY_DEV_DATA_DIRS,
+      resolveProfile,
+      warnAboutLegacyDevData,
+    } = require('./profile-resolver');
+
+    const profile = resolveProfile(app, {
+      argv: ['electron', '.'],
+      env: {},
+      repoRoot,
+      now: '2026-05-25T00:00:00.000Z',
+    });
+    warnAboutLegacyDevData(profile, { logger: { warn: jest.fn() } });
+
+    // Legacy data stays exactly where it was — nothing moved or deleted.
+    expect(fs.existsSync(path.join(legacyBeeData, 'swarm.key'))).toBe(true);
+    expect(fs.readFileSync(path.join(legacyBeeData, 'swarm.key'), 'utf-8')).toBe('legacy-secret');
+
+    // The new default profile is fresh — none of the legacy node dirs were
+    // copied in.
+    expect(profile.userDataDir).not.toBe(fs.realpathSync(repoRoot));
+    for (const dirName of LEGACY_DEV_DATA_DIRS) {
+      expect(fs.existsSync(path.join(profile.userDataDir, dirName))).toBe(false);
+    }
+  });
+
   test('persists active profile node updates to metadata and catalog', () => {
     const userDataDir = track(makeTempDir());
     const app = createAppMock({ isPackaged: true, userDataDir });


### PR DESCRIPTION
Closes the remaining test gaps in #107 and runs the migration suites cross-platform so the Windows path is verified.

## What this covers

Three unchecked items from #107, on one branch:

1. **Dev pre-profile data — decision: warn-only is acceptable.** Legacy repo-root dev data (`<repoRoot>/bee-data`, `identity-data`, …) is intentionally *not* auto-migrated into `Profiles/default/` — dev data is disposable/regenerable and `FREEDOM_DEV_HOME` is the opt-in escape hatch. Codified as a rationale comment at the code site plus a resolver test asserting the legacy dirs are neither moved nor copied into the fresh default profile.
2. **Interrupted bee→ant migration (Windows EPERM).** New full-upgrade-path integration test: an EPERM-style failure part way through the item-by-item carry (before the keystore, which moves last) → the launch reports failure and stays pending with the keystore safe in `bee-data`; the next launch completes with no lost or duplicated identity/stamps. Backed by a new `migration-cross-platform` CI job running the migration + profile suites on **ubuntu / windows / macos**.
3. **Radicle short-home copy on the full upgrade path.** Test drives `copyProfileRadicleDataIfNeeded` through `initializeProfile` (not a hand-built profile object): the pre-upgrade profile-local `radicle-data/` identity is carried into the short app-owned `<appRoot>/R/<slot>` home.

## Changes

- `src/main/profile-resolver.js` — rationale comment codifying the warn-only decision.
- `src/main/profile-resolver.test.js` — no-auto-migration assertion for legacy dev data.
- `src/main/__tests__/integration/v08-upgrade.test.js` — interrupted bee→ant recovery + Radicle short-home upgrade tests.
- `package.json` — `test:migration` script.
- `.github/workflows/ci.yml` — `migration-cross-platform` job (ubuntu/windows/macos).

## Verification

- `npm run test:migration` — 56 passed locally.
- CI: `test` ✅ and `migration-cross-platform` green on **ubuntu ✅ · windows ✅ · macos ✅**.

## Notes / not in scope

- The Windows coverage here is the filesystem-semantics EPERM path (injected fault on a real Windows runner), not a genuine locked-OS-handle repro. A truest #90 reproduction (holding an open handle to force a real EPERM) would be a follow-up.