### PR TITLE
chore(build): update bundled Ant to 0.5.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Freedom will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Updated bundled [Ant](https://github.com/solardev-xyz/ant) to 0.5.36: fixes the ~250 MiB upload stall, adds upload-side Reed-Solomon encoding, end-to-end Swarm content encryption, local pinning, and ACT access control
+- The Swarm node's API now comes up instantly on start, so the node menu shows peers counting up live instead of sitting at 0 during startup
+
 ## [0.8.0] - 2026-07-02
 
 ### Added

--- a/scripts/fetch-ant.js
+++ b/scripts/fetch-ant.js
@@ -15,7 +15,7 @@ const ANT_REPO = process.env.ANT_REPO || 'solardev-xyz/ant';
 // could ship a different Ant than CI validated. Override via ANT_RELEASE_TAG
 // for local testing of newer releases; set it to `latest` to resolve the
 // repo's most recent published release.
-const PINNED_RELEASE_TAG = 'v0.5.33';
+const PINNED_RELEASE_TAG = 'v0.5.36';
 // In-repo trust root for the pinned release: the sha256 of its SHA256SUMS
 // asset, recorded at pin time (trust-on-first-use by the author). The release
 // downloads its SHA256SUMS from the same GitHub release as the binaries, so
@@ -24,7 +24,7 @@ const PINNED_RELEASE_TAG = 'v0.5.33';
 // that tampering detectable. Update alongside PINNED_RELEASE_TAG on every
 // deliberate bump: `shasum -a 256` the freshly downloaded SHA256SUMS.
 const PINNED_SHA256SUMS_DIGEST =
-  '4647fb92f635ded61de1afda45fcb72766c93138ae8d2019eb56ec93e226df9d';
+  'a551283ab539d59bcf5fa2cd40fab20488feb9169fa1293814879e757eff3ff0';
 const ANT_RELEASE_TAG = process.env.ANT_RELEASE_TAG || PINNED_RELEASE_TAG;
 
 function fetchReleaseOnce() {


### PR DESCRIPTION
## Summary

Bumps the bundled Ant node from **v0.5.33 to v0.5.36**: `PINNED_RELEASE_TAG` and `PINNED_SHA256SUMS_DIGEST` updated together in `scripts/fetch-ant.js` (per the release playbook), plus an Unreleased changelog entry.

The headline for Freedom is v0.5.36's startup fix ([solardev-xyz/ant#38](https://github.com/solardev-xyz/ant/issues/38), [#39](https://github.com/solardev-xyz/ant/issues/39), fixed in [ant#40](https://github.com/solardev-xyz/ant/pull/40)): the HTTP API now binds before chain init, so the node menu shows Swarm peers counting up live from launch instead of sitting at 0 until chain init finishes — and a slow Gnosis RPC can no longer trip Freedom's 60 s health-gate startup timeout.

Also picked up along the way:
- **0.5.35**: push-path throughput (~250 MiB upload stall fix), feed head-finding fix, concurrent chain init
- **0.5.34**: upload-side Reed-Solomon encoding, end-to-end Swarm content encryption, local pinning, ACT access control

## Verification

- `npm run ant:download`: all six platform targets download, checksum-verify against the pinned SHA256SUMS digest, and install; `antd --version` reports 0.5.36
- `npm run check-binaries`: passes
- Real-binary migration guard (`bee-to-ant-migration.test.js`): 2/2 pass against the released binary
- Startup probe of the released darwin-arm64 binary: `/health` answers 200 within 0.5 s of spawn (`chainReady:false` → `true` at ~2.5 s), `/peers` counts up live (0 → 1 → 15 → 60 → 80) with no connection-refused window

Note: `ant-bin/` is gitignored, so the diff is only the pin + changelog; CI re-fetches the pinned release at build time and validates the digest.
