### PR TITLE
feat(session): restore open tabs across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Freedom will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Session restore: open tabs return on the next launch — after a quit or a crash — keeping tab order, pinned state, and the active tab
+  - Only the active tab loads at launch; the rest load when first clicked
+  - Settings > Behavior > On startup switches between "Continue where you left off" (default) and "Start with home page"
+
 ### Changed
 
 - Updated bundled [Ant](https://github.com/solardev-xyz/ant) to 0.5.36: fixes the ~250 MiB upload stall, adds upload-side Reed-Solomon encoding, end-to-end Swarm content encryption, local pinning, and ACT access control

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ The address bar also provides **autocomplete suggestions** from browsing history
 - **Tab Management**: Close tabs with `Cmd+W` or middle-click.
 - **Drag & Drop Reordering**: Rearrange tabs by dragging.
 - **Per-Tab State**: Each tab maintains its own navigation history, address bar state, and bzz/ipfs base.
+- **Session Restore**: Open tabs (order, pinned state, active tab) come back on the next launch — including after a crash. Restored tabs load lazily: only the active tab loads at launch; the rest load when first activated. Per-tab back/forward history is not restored (current URL only).
 - **Link Handling**: Links that open new windows are captured and opened in new tabs instead.
 
 ### Navigation Controls
@@ -350,6 +351,7 @@ Access built-in browser pages using the `freedom://` protocol:
 ### Settings & UI
 
 - **Theme**: Light, Dark, or System (follows OS preference).
+- **On Startup**: Settings > Behavior > On startup — "Continue where you left off" (default) restores the previous session's tabs; "Start with home page" opens a single home tab.
 - **Node Auto-start**: Toggle whether Swarm and IPFS nodes start automatically at launch (enabled by default).
 - **Experimental**: Enable Radicle integration (Beta) and set `Start Radicle node when Freedom opens`.
 - **Auto-Updates**: Toggle automatic update checks (enabled by default).

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -154,6 +154,7 @@ protocol.registerSchemesAsPrivileged([
   { scheme: 'ipns', privileges: DWEB_PROTOCOL_PRIVILEGES },
 ]);
 const { registerSettingsIpc, loadSettings } = require('./settings-store');
+const { registerSessionIpc, getRestorableWindowCount } = require('./session-store');
 const { registerBookmarksIpc } = require('./bookmarks-store');
 const { registerHistoryIpc, closeDb: closeHistoryDb } = require('./history');
 const { registerFaviconsIpc } = require('./favicons');
@@ -254,6 +255,7 @@ async function bootstrap() {
     onNewWindow: createMainWindow,
   });
   registerSettingsIpc();
+  registerSessionIpc();
   registerBookmarksIpc();
   registerHistoryIpc();
   registerFaviconsIpc();
@@ -349,7 +351,14 @@ async function bootstrap() {
   const coldStartUrl = process.argv.includes('--open-settings')
     ? PROFILE_SETTINGS_DEEPLINK
     : null;
-  const mainWindow = createMainWindow(coldStartUrl);
+  // Slot 0 restores the previous session's first window into the window we
+  // create anyway (session:get-restore returns null when there is nothing to
+  // restore or the startup setting is "home page"); any further persisted
+  // windows are recreated one per slot.
+  const mainWindow = createMainWindow(coldStartUrl, { sessionRestoreSlot: 0 });
+  for (let slot = 1; slot < getRestorableWindowCount(); slot += 1) {
+    createMainWindow(null, { sessionRestoreSlot: slot });
+  }
 
   if (!TEST_MODE) {
     await promptForDefaultExternalCandidates(activeProfile, {

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -61,6 +61,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   getSettings: () => ipcRenderer.invoke('settings:get'),
   saveSettings: (settings) => ipcRenderer.invoke('settings:save', settings),
+  // Session restore (src/main/session-store.js). `updateSessionState` is the
+  // renderer's debounced tab-strip snapshot; `getSessionToRestore` fetches
+  // the persisted snapshot for this window's restore slot (or null).
+  updateSessionState: (snapshot) => ipcRenderer.send('session:update', snapshot),
+  getSessionToRestore: (slot) => ipcRenderer.invoke('session:get-restore', slot),
   getBookmarks: () => ipcRenderer.invoke('bookmarks:get'),
   addBookmark: (bookmark) => ipcRenderer.invoke('bookmarks:add', bookmark),
   updateBookmark: (originalTarget, bookmark) =>

--- a/src/main/session-store.js
+++ b/src/main/session-store.js
@@ -1,0 +1,195 @@
+const log = require('./logger');
+const { app, ipcMain } = require('electron');
+const path = require('path');
+const fs = require('fs');
+const IPC = require('../shared/ipc-channels');
+const { loadSettings } = require('./settings-store');
+
+// Per-profile session persistence backing "Continue where you left off".
+//
+// The renderer captures the tab strip (debounced ~1s, see
+// src/renderer/lib/session-restore.js) and sends snapshots here; this module
+// is the single writer of `<userData>/session.json`. Single-writer is safe
+// without a cross-process file lock (the updater-owner-lock pattern) because
+// profile-lock.js already enforces one *process* per profile — a second
+// launch of the same profile hands off focus and exits. Multiple windows of
+// a profile are multiple BrowserWindows inside this one process, so their
+// snapshots are serialized through this module's in-memory map.
+//
+// File shape (version 1):
+//   { version: 1, windows: [{ tabs: [{url, title, pinned, faviconUrl}],
+//                             activeTabIndex }] }
+//
+// A corrupt or truncated session.json (crash mid-write, disk trouble)
+// degrades to a fresh session — reads never throw past this module.
+
+const SESSION_FILE = 'session.json';
+const SESSION_FILE_VERSION = 1;
+const MAX_TABS_PER_WINDOW = 500;
+const MAX_FAVICON_CHARS = 65536;
+
+// Live snapshots keyed by the owning window's webContents id. Written to
+// disk as a whole on every accepted update.
+const liveWindowSnapshots = new Map();
+
+// EPHEMERAL-WINDOW GUARD (private-windows follow-up, feature/private-windows):
+// windows flagged ephemeral are excluded from session persistence — the
+// writer refuses their snapshots outright. When private windows land, call
+// markWindowSessionEphemeral(window.webContents.id) at window creation so a
+// private window can never leak tabs into session.json.
+const ephemeralWindowIds = new Set();
+
+// Windows persisted by the previous run, loaded once at registration and
+// served to renderers via SESSION_GET_RESTORE. Kept in memory so later
+// writes can't clobber the data before every window has restored.
+let persistedWindows = null;
+
+let appIsQuitting = false;
+
+function getSessionPath() {
+  return path.join(app.getPath('userData'), SESSION_FILE);
+}
+
+function shouldRestoreSession() {
+  return loadSettings().onStartup !== 'homepage';
+}
+
+function sanitizeTab(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  const url = typeof entry.url === 'string' ? entry.url : '';
+  if (!url || url === 'about:blank') return null;
+  const faviconUrl =
+    typeof entry.faviconUrl === 'string' && entry.faviconUrl.length <= MAX_FAVICON_CHARS
+      ? entry.faviconUrl
+      : null;
+  return {
+    url,
+    title: typeof entry.title === 'string' ? entry.title : '',
+    pinned: entry.pinned === true,
+    faviconUrl,
+  };
+}
+
+function sanitizeWindowSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object' || !Array.isArray(snapshot.tabs)) {
+    return null;
+  }
+  const tabs = snapshot.tabs.slice(0, MAX_TABS_PER_WINDOW).map(sanitizeTab).filter(Boolean);
+  const rawIndex = snapshot.activeTabIndex;
+  const activeTabIndex = Number.isInteger(rawIndex)
+    ? Math.min(Math.max(rawIndex, 0), Math.max(tabs.length - 1, 0))
+    : 0;
+  return { tabs, activeTabIndex };
+}
+
+function readPersistedWindows() {
+  const filePath = getSessionPath();
+  try {
+    if (!fs.existsSync(filePath)) return [];
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    if (!parsed || !Array.isArray(parsed.windows)) return [];
+    return parsed.windows.map(sanitizeWindowSnapshot).filter((win) => win && win.tabs.length > 0);
+  } catch (err) {
+    log.warn('Corrupt session.json, starting a fresh session:', err.message);
+    return [];
+  }
+}
+
+function ensurePersistedWindowsLoaded() {
+  if (persistedWindows === null) {
+    persistedWindows = readPersistedWindows();
+  }
+  return persistedWindows;
+}
+
+// Atomic write: temp file + rename, so a crash mid-write leaves either the
+// previous session or the new one — never a truncated file.
+function writeSessionFile() {
+  const filePath = getSessionPath();
+  const tmpPath = `${filePath}.tmp`;
+  const state = {
+    version: SESSION_FILE_VERSION,
+    windows: [...liveWindowSnapshots.values()],
+  };
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(tmpPath, JSON.stringify(state), 'utf-8');
+    fs.renameSync(tmpPath, filePath);
+    return true;
+  } catch (err) {
+    log.error('Failed to write session.json:', err);
+    return false;
+  }
+}
+
+// Number of windows the previous session persisted (0 when the startup
+// setting is "Start with home page"). Bootstrap recreates one window per
+// slot; slot 0 is the first window it creates anyway.
+function getRestorableWindowCount() {
+  if (!shouldRestoreSession()) return 0;
+  return ensurePersistedWindowsLoaded().length;
+}
+
+// See the EPHEMERAL-WINDOW GUARD note above.
+function markWindowSessionEphemeral(webContentsId) {
+  if (Number.isInteger(webContentsId)) {
+    ephemeralWindowIds.add(webContentsId);
+  }
+}
+
+// Called from mainWindow.js when a BrowserWindow closes. A window the user
+// closes mid-session is forgotten (its tabs shouldn't reappear next launch),
+// with two exceptions that both mean "the session is ending, keep the file
+// for next launch's restore": app quit, and the last remaining window.
+function handleSessionWindowClosed(webContentsId) {
+  ephemeralWindowIds.delete(webContentsId);
+  if (appIsQuitting) return;
+  if (!liveWindowSnapshots.has(webContentsId)) return;
+  if (liveWindowSnapshots.size <= 1) return;
+  liveWindowSnapshots.delete(webContentsId);
+  writeSessionFile();
+}
+
+function registerSessionIpc() {
+  ensurePersistedWindowsLoaded();
+
+  app.on('before-quit', () => {
+    appIsQuitting = true;
+  });
+
+  // Renderer → main snapshot updates. The renderer already debounces (~1s),
+  // so each accepted update is written straight through, atomically.
+  ipcMain.on(IPC.SESSION_UPDATE, (event, snapshot) => {
+    const senderId = event?.sender?.id;
+    if (!Number.isInteger(senderId)) return;
+    // EPHEMERAL-WINDOW GUARD — see markWindowSessionEphemeral().
+    if (ephemeralWindowIds.has(senderId)) return;
+    const clean = sanitizeWindowSnapshot(snapshot);
+    if (!clean) return;
+    liveWindowSnapshots.set(senderId, clean);
+    writeSessionFile();
+  });
+
+  // A window launched with a restoreSlot query param asks for its persisted
+  // snapshot. Returns null when there is nothing to restore (fresh profile,
+  // corrupt file, or startup setting = home page). The served snapshot also
+  // seeds the live map so a window whose tabs never change before the next
+  // quit still keeps its entry in session.json.
+  ipcMain.handle(IPC.SESSION_GET_RESTORE, (event, slot) => {
+    if (!shouldRestoreSession()) return null;
+    const windows = ensurePersistedWindowsLoaded();
+    const snapshot = Number.isInteger(slot) && windows[slot] ? windows[slot] : null;
+    const senderId = event?.sender?.id;
+    if (snapshot && Number.isInteger(senderId) && !ephemeralWindowIds.has(senderId)) {
+      liveWindowSnapshots.set(senderId, snapshot);
+    }
+    return snapshot;
+  });
+}
+
+module.exports = {
+  getRestorableWindowCount,
+  handleSessionWindowClosed,
+  markWindowSessionEphemeral,
+  registerSessionIpc,
+};

--- a/src/main/session-store.test.js
+++ b/src/main/session-store.test.js
@@ -1,0 +1,242 @@
+const fs = require('fs');
+const path = require('path');
+const IPC = require('../shared/ipc-channels');
+const {
+  createTempUserDataDir,
+  loadMainModule,
+  removeTempUserDataDir,
+} = require('../../test/helpers/main-process-test-utils');
+
+function loadSessionStore(options = {}) {
+  return loadMainModule(require.resolve('./session-store'), {
+    ...options,
+    extraMocks: {
+      ...(options.extraMocks || {}),
+      [require.resolve('./logger')]: () => ({
+        error: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+      }),
+    },
+  });
+}
+
+const sessionPath = (dir) => path.join(dir, 'session.json');
+
+const writeSessionFile = (dir, content) =>
+  fs.writeFileSync(
+    sessionPath(dir),
+    typeof content === 'string' ? content : JSON.stringify(content),
+    'utf-8'
+  );
+
+const readSessionFile = (dir) => JSON.parse(fs.readFileSync(sessionPath(dir), 'utf-8'));
+
+const sampleWindow = () => ({
+  tabs: [
+    { url: 'https://example.com/', title: 'Example', pinned: false, faviconUrl: null },
+    {
+      url: 'freedom://history',
+      title: 'History',
+      pinned: true,
+      faviconUrl: 'data:image/png;base64,AAAA',
+    },
+  ],
+  activeTabIndex: 1,
+});
+
+// Serve the restore snapshot for `slot` as a renderer with webContents id
+// `senderId` would receive it. ipcMain mock's invoke() passes an empty
+// event, so we call the registered handler directly to control the sender.
+const invokeGetRestore = (ipcMain, slot, senderId = 100) =>
+  ipcMain.handlers.get(IPC.SESSION_GET_RESTORE)({ sender: { id: senderId } }, slot);
+
+const emitUpdate = (ipcMain, senderId, snapshot) =>
+  ipcMain.emit(IPC.SESSION_UPDATE, { sender: { id: senderId } }, snapshot);
+
+describe('session-store', () => {
+  let userDataDir;
+
+  beforeEach(() => {
+    userDataDir = createTempUserDataDir();
+  });
+
+  afterEach(() => {
+    removeTempUserDataDir(userDataDir);
+  });
+
+  describe('restore payloads', () => {
+    test('serves the persisted window snapshot for its slot', async () => {
+      writeSessionFile(userDataDir, { version: 1, windows: [sampleWindow()] });
+      const { mod, ipcMain } = loadSessionStore({ userDataDir });
+      mod.registerSessionIpc();
+
+      expect(mod.getRestorableWindowCount()).toBe(1);
+      const payload = await invokeGetRestore(ipcMain, 0);
+      expect(payload).toEqual(sampleWindow());
+      expect(await invokeGetRestore(ipcMain, 1)).toBeNull();
+    });
+
+    test('a corrupt (truncated) session.json degrades to a fresh session', async () => {
+      writeSessionFile(userDataDir, '{"version":1,"windows":[{"tabs":[{"url":"ht');
+      const { mod, ipcMain } = loadSessionStore({ userDataDir });
+      mod.registerSessionIpc();
+
+      expect(mod.getRestorableWindowCount()).toBe(0);
+      expect(await invokeGetRestore(ipcMain, 0)).toBeNull();
+    });
+
+    test('a structurally wrong session.json degrades to a fresh session', async () => {
+      writeSessionFile(userDataDir, { version: 1, windows: 'not-an-array' });
+      const { mod, ipcMain } = loadSessionStore({ userDataDir });
+      mod.registerSessionIpc();
+
+      expect(mod.getRestorableWindowCount()).toBe(0);
+      expect(await invokeGetRestore(ipcMain, 0)).toBeNull();
+    });
+
+    test('windows whose tabs all fail sanitization are dropped', async () => {
+      writeSessionFile(userDataDir, {
+        version: 1,
+        windows: [
+          { tabs: [{ url: '' }, { url: 'about:blank' }, 'junk', null], activeTabIndex: 0 },
+          sampleWindow(),
+        ],
+      });
+      const { mod, ipcMain } = loadSessionStore({ userDataDir });
+      mod.registerSessionIpc();
+
+      // The all-junk window disappears; the valid one shifts to slot 0.
+      expect(mod.getRestorableWindowCount()).toBe(1);
+      expect(await invokeGetRestore(ipcMain, 0)).toEqual(sampleWindow());
+    });
+
+    test('startup setting "homepage" disables restore without touching the file', async () => {
+      fs.writeFileSync(
+        path.join(userDataDir, 'settings.json'),
+        JSON.stringify({ onStartup: 'homepage' }),
+        'utf-8'
+      );
+      writeSessionFile(userDataDir, { version: 1, windows: [sampleWindow()] });
+      const { mod, ipcMain } = loadSessionStore({ userDataDir });
+      mod.registerSessionIpc();
+
+      expect(mod.getRestorableWindowCount()).toBe(0);
+      expect(await invokeGetRestore(ipcMain, 0)).toBeNull();
+      // The persisted session is not deleted — flipping the setting back
+      // before the next quit would restore it again.
+      expect(readSessionFile(userDataDir).windows).toHaveLength(1);
+    });
+  });
+
+  describe('snapshot updates', () => {
+    test('writes sanitized snapshots and clamps the active index', () => {
+      const { mod, ipcMain } = loadSessionStore({ userDataDir });
+      mod.registerSessionIpc();
+
+      emitUpdate(ipcMain, 1, {
+        tabs: [
+          { url: 'https://a.example/', title: 'A', pinned: 'yes', faviconUrl: 42, junk: true },
+          { url: 'about:blank', title: 'skipped' },
+          { url: 'bzz://name.eth/', title: 7, pinned: true },
+        ],
+        activeTabIndex: 99,
+      });
+
+      const written = readSessionFile(userDataDir);
+      expect(written).toEqual({
+        version: 1,
+        windows: [
+          {
+            tabs: [
+              { url: 'https://a.example/', title: 'A', pinned: false, faviconUrl: null },
+              { url: 'bzz://name.eth/', title: '', pinned: true, faviconUrl: null },
+            ],
+            activeTabIndex: 1,
+          },
+        ],
+      });
+      // Atomic write: no temp file left behind.
+      expect(fs.existsSync(`${sessionPath(userDataDir)}.tmp`)).toBe(false);
+    });
+
+    test('malformed snapshots are refused without clobbering the file', () => {
+      const { mod, ipcMain } = loadSessionStore({ userDataDir });
+      mod.registerSessionIpc();
+
+      emitUpdate(ipcMain, 1, { tabs: [{ url: 'https://a.example/' }], activeTabIndex: 0 });
+      emitUpdate(ipcMain, 1, { tabs: 'garbage' });
+      emitUpdate(ipcMain, 1, null);
+
+      expect(readSessionFile(userDataDir).windows[0].tabs[0].url).toBe('https://a.example/');
+    });
+
+    test('EPHEMERAL-WINDOW GUARD: flagged windows never reach session.json', () => {
+      const { mod, ipcMain } = loadSessionStore({ userDataDir });
+      mod.registerSessionIpc();
+      mod.markWindowSessionEphemeral(7);
+
+      emitUpdate(ipcMain, 7, { tabs: [{ url: 'https://private.example/' }], activeTabIndex: 0 });
+      expect(fs.existsSync(sessionPath(userDataDir))).toBe(false);
+
+      emitUpdate(ipcMain, 1, { tabs: [{ url: 'https://a.example/' }], activeTabIndex: 0 });
+      const written = readSessionFile(userDataDir);
+      expect(JSON.stringify(written)).not.toContain('private.example');
+    });
+  });
+
+  describe('window lifecycle', () => {
+    test('closing one of several windows forgets it; the last window is kept', () => {
+      const { mod, ipcMain } = loadSessionStore({ userDataDir });
+      mod.registerSessionIpc();
+
+      emitUpdate(ipcMain, 1, { tabs: [{ url: 'https://one.example/' }], activeTabIndex: 0 });
+      emitUpdate(ipcMain, 2, { tabs: [{ url: 'https://two.example/' }], activeTabIndex: 0 });
+
+      // Mid-session close of window 1: its tabs must not reappear next launch.
+      mod.handleSessionWindowClosed(1);
+      let written = readSessionFile(userDataDir);
+      expect(written.windows).toHaveLength(1);
+      expect(written.windows[0].tabs[0].url).toBe('https://two.example/');
+
+      // The last window closing means the session is ending (e.g. macOS
+      // close-then-quit) — keep its snapshot for the next launch.
+      mod.handleSessionWindowClosed(2);
+      written = readSessionFile(userDataDir);
+      expect(written.windows).toHaveLength(1);
+      expect(written.windows[0].tabs[0].url).toBe('https://two.example/');
+    });
+
+    test('windows destroyed during quit are kept for the next restore', () => {
+      const { mod, ipcMain, app } = loadSessionStore({ userDataDir });
+      mod.registerSessionIpc();
+
+      emitUpdate(ipcMain, 1, { tabs: [{ url: 'https://one.example/' }], activeTabIndex: 0 });
+      emitUpdate(ipcMain, 2, { tabs: [{ url: 'https://two.example/' }], activeTabIndex: 0 });
+
+      app.emit('before-quit');
+      mod.handleSessionWindowClosed(1);
+      mod.handleSessionWindowClosed(2);
+
+      expect(readSessionFile(userDataDir).windows).toHaveLength(2);
+    });
+
+    test('a window that restored but never changed keeps its session entry', async () => {
+      writeSessionFile(userDataDir, { version: 1, windows: [sampleWindow()] });
+      const { mod, ipcMain } = loadSessionStore({ userDataDir });
+      mod.registerSessionIpc();
+
+      // Window 5 restores slot 0 and never sends an update. Another window
+      // updates, forcing a rewrite of the file — the restored window's tabs
+      // must survive it.
+      await invokeGetRestore(ipcMain, 0, 5);
+      emitUpdate(ipcMain, 6, { tabs: [{ url: 'https://new.example/' }], activeTabIndex: 0 });
+
+      const written = readSessionFile(userDataDir);
+      expect(written.windows).toHaveLength(2);
+      expect(written.windows.map((w) => w.tabs[0].url)).toEqual(
+        expect.arrayContaining(['https://example.com/', 'https://new.example/'])
+      );
+    });
+  });
+});

--- a/src/main/settings-store.js
+++ b/src/main/settings-store.js
@@ -50,6 +50,11 @@ const DEFAULT_SETTINGS = {
   showIpfsProgressStatus: false,
   sidebarOpen: false,
   sidebarWidth: 320,
+  // What a launch shows: 'continue' restores the previous session's tabs
+  // from the per-profile session.json (see session-store.js); 'homepage'
+  // starts with a single home tab. Continue is the daily-driver default
+  // and reaches existing users through the defaults merge.
+  onStartup: 'continue',
   // Linux only: render the tab strip as the window titlebar (frameless window).
   // Off by default so Linux users get the native OS frame; opt in via Settings.
   tabsInTitlebar: false,

--- a/src/main/windows/mainWindow.js
+++ b/src/main/windows/mainWindow.js
@@ -3,6 +3,7 @@ const { app, BrowserWindow } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const { loadSettings } = require('../settings-store');
+const { handleSessionWindowClosed } = require('../session-store');
 
 let currentWindowTitle = 'Freedom';
 
@@ -25,7 +26,7 @@ function getIconPath() {
   return iconPath;
 }
 
-function createMainWindow(initialUrl = null) {
+function createMainWindow(initialUrl = null, options = {}) {
   const isMac = process.platform === 'darwin';
   const isLinux = process.platform === 'linux';
   // Linux only: tab strip doubles as the titlebar when the user opts in.
@@ -65,10 +66,20 @@ function createMainWindow(initialUrl = null) {
     },
   });
 
-  // Load index.html with optional initial URL as query parameter
+  // Load index.html with optional initial URL and session-restore slot as
+  // query parameters. The slot (assigned by bootstrap, see index.js) tells
+  // the renderer which persisted window of session.json to restore; windows
+  // opened later (Cmd+N etc.) carry no slot and start fresh.
   const indexPath = path.join(__dirname, '..', '..', 'renderer', 'index.html');
+  const query = {};
   if (initialUrl) {
-    window.loadFile(indexPath, { query: { initialUrl } });
+    query.initialUrl = initialUrl;
+  }
+  if (Number.isInteger(options.sessionRestoreSlot)) {
+    query.restoreSlot = String(options.sessionRestoreSlot);
+  }
+  if (Object.keys(query).length > 0) {
+    window.loadFile(indexPath, { query });
   } else {
     window.loadFile(indexPath);
   }
@@ -96,8 +107,11 @@ function createMainWindow(initialUrl = null) {
     window.setTitle(currentWindowTitle);
   });
 
+  // Captured now: webContents is already destroyed when 'closed' fires.
+  const sessionWindowId = window.webContents.id;
   window.on('closed', () => {
     mainWindows.delete(window);
+    handleSessionWindowClosed(sessionWindowId);
   });
 
 

--- a/src/renderer/lib/session-restore.js
+++ b/src/renderer/lib/session-restore.js
@@ -1,0 +1,111 @@
+// Session persistence — renderer side of "Continue where you left off".
+//
+// Captures the tab strip as a serializable snapshot and ships it (debounced
+// ~1s) to the main-process session store (src/main/session-store.js), the
+// single writer of the per-profile session.json. tabs.js registers a
+// snapshot provider at init and calls `persistSessionSoon()` from its
+// mutation paths; everything else lives here so the tabs.js diff stays
+// small (an upcoming tab-strip branch also reworks that file).
+import { getInternalPageName } from './page-urls.js';
+
+const electronAPI = window.electronAPI;
+
+export const SESSION_SNAPSHOT_DEBOUNCE_MS = 1000;
+
+// Favicons are cached as data: URLs; anything larger than this is dropped
+// from the snapshot rather than bloating session.json (the favicon pipeline
+// repopulates it on the next real load anyway).
+const MAX_PERSISTED_FAVICON_CHARS = 65536;
+
+let snapshotProvider = null;
+let debounceTimer = null;
+
+// tabs.js registers `() => ({ tabs, activeTabId })` here during init.
+export const initSessionPersistence = (provider) => {
+  snapshotProvider = provider;
+};
+
+/**
+ * Serialize live tab objects into the persisted session shape:
+ * `{ tabs: [{url, title, pinned, faviconUrl}], activeTabIndex }`.
+ *
+ * - Tabs without a useful URL (never-navigated about:blank parks) are
+ *   skipped; `activeTabIndex` is computed against the serialized list.
+ * - Internal pages are normalized to their `freedom://<name>` form — the
+ *   resolved `file://…/pages/…` URL is install-location-specific, and the
+ *   friendly form round-trips through the normal open path on restore
+ *   (including the home page, which persists as `freedom://home`).
+ * - Per-tab back/forward history is NOT captured: Electron's <webview>
+ *   exposes no API to export or re-seed a NavigationHistory, so restore is
+ *   URL-only by design.
+ */
+export const serializeSessionTabs = (tabs, activeTabId) => {
+  const serialized = [];
+  let activeTabIndex = 0;
+  for (const tab of tabs || []) {
+    const rawUrl = tab?.url || tab?.navigationState?.currentPageUrl || '';
+    if (!rawUrl || rawUrl === 'about:blank') continue;
+    const internalName = rawUrl.startsWith('freedom://') ? null : getInternalPageName(rawUrl);
+    const url = internalName ? `freedom://${internalName}` : rawUrl;
+    const faviconUrl =
+      typeof tab.favicon === 'string' && tab.favicon.length <= MAX_PERSISTED_FAVICON_CHARS
+        ? tab.favicon
+        : null;
+    if (tab.id === activeTabId) {
+      activeTabIndex = serialized.length;
+    }
+    serialized.push({
+      url,
+      title: typeof tab.title === 'string' ? tab.title : '',
+      pinned: tab.pinned === true,
+      faviconUrl,
+    });
+  }
+  return { tabs: serialized, activeTabIndex };
+};
+
+const sendSnapshotNow = () => {
+  if (!snapshotProvider || !electronAPI?.updateSessionState) return;
+  try {
+    const { tabs, activeTabId } = snapshotProvider();
+    electronAPI.updateSessionState(serializeSessionTabs(tabs, activeTabId));
+  } catch {
+    // Persistence must never break tab handling.
+  }
+};
+
+// Debounced (trailing-edge, ~1s) snapshot request. Tab mutations call this
+// freely; bursts (rapid loads, drags, mass tab closes) collapse into one
+// IPC message + one atomic write in the main process. Because the file is
+// rewritten continuously, a crashed session restores too — at worst the
+// final debounce window (~1s of changes) is lost.
+export const persistSessionSoon = () => {
+  if (!snapshotProvider || !electronAPI?.updateSessionState) return;
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+  }
+  debounceTimer = setTimeout(() => {
+    debounceTimer = null;
+    sendSnapshotNow();
+  }, SESSION_SNAPSHOT_DEBOUNCE_MS);
+};
+
+/**
+ * Fetch the persisted window snapshot this window should restore, or null.
+ * Only windows launched with a `restoreSlot` query parameter (assigned by
+ * the main process at startup) restore anything; user-opened windows
+ * (Cmd+N) carry no slot and start fresh.
+ */
+export const getSessionToRestore = async (urlParams) => {
+  const rawSlot = urlParams?.get?.('restoreSlot');
+  if (rawSlot === null || rawSlot === undefined) return null;
+  const slot = Number(rawSlot);
+  if (!Number.isInteger(slot) || slot < 0) return null;
+  try {
+    const payload = await electronAPI?.getSessionToRestore?.(slot);
+    if (!payload || !Array.isArray(payload.tabs) || payload.tabs.length === 0) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+};

--- a/src/renderer/lib/session-restore.test.js
+++ b/src/renderer/lib/session-restore.test.js
@@ -1,0 +1,317 @@
+/**
+ * Session restore — renderer side.
+ *
+ * Covers the pure tab-strip serialization (what lands in session.json),
+ * the ~1s debounced snapshot shipping, the restore-payload fetch, and the
+ * placeholder-tab mechanism in tabs.js (lazy materialization on first
+ * activation — the foundation for future tab hibernation).
+ */
+
+// Mock environment mirrors tabs.test.js: tabs.js and page-urls.js read
+// window/document at import time.
+const mockElectronAPI = {
+  setWindowTitle: jest.fn(),
+  updateSessionState: jest.fn(),
+  getSessionToRestore: jest.fn(),
+};
+
+const createMockWebview = (tabId) => ({
+  setAttribute: jest.fn(),
+  addEventListener: jest.fn(),
+  classList: {
+    toggle: jest.fn(),
+    add: jest.fn(),
+    remove: jest.fn(),
+  },
+  dataset: { tabId },
+  getURL: jest.fn(() => 'about:blank'),
+  remove: jest.fn(),
+});
+
+beforeAll(() => {
+  global.window = {
+    electronAPI: { ...mockElectronAPI, getSettings: jest.fn(() => Promise.resolve({})) },
+    location: { href: 'file:///app/index.html' },
+    addEventListener: jest.fn(),
+    internalPages: {
+      routable: {
+        home: 'home.html',
+        history: 'history.html',
+        settings: 'settings.html',
+      },
+    },
+  };
+
+  global.document = {
+    createElement: jest.fn((tag) => {
+      if (tag === 'webview') {
+        return createMockWebview(0);
+      }
+      return {
+        className: '',
+        classList: { add: jest.fn(), toggle: jest.fn() },
+        dataset: {},
+        appendChild: jest.fn(),
+        addEventListener: jest.fn(),
+        innerHTML: '',
+      };
+    }),
+    getElementById: jest.fn(() => null),
+  };
+
+  global.URL = URL;
+});
+
+afterEach(() => {
+  mockElectronAPI.updateSessionState.mockClear();
+  mockElectronAPI.getSessionToRestore.mockReset();
+});
+
+describe('serializeSessionTabs', () => {
+  test('serializes url/title/pinned/faviconUrl in tab order with the active index', async () => {
+    const { serializeSessionTabs } = await import('./session-restore.js');
+
+    const tabs = [
+      {
+        id: 1,
+        url: 'https://example.com/',
+        title: 'Example',
+        pinned: true,
+        favicon: 'data:image/png;base64,AA',
+      },
+      { id: 2, url: 'bzz://name.eth/', title: 'Swarm site', favicon: null },
+    ];
+
+    expect(serializeSessionTabs(tabs, 2)).toEqual({
+      tabs: [
+        {
+          url: 'https://example.com/',
+          title: 'Example',
+          pinned: true,
+          faviconUrl: 'data:image/png;base64,AA',
+        },
+        { url: 'bzz://name.eth/', title: 'Swarm site', pinned: false, faviconUrl: null },
+      ],
+      activeTabIndex: 1,
+    });
+  });
+
+  test('normalizes internal pages (including home) to their freedom:// form', async () => {
+    const { serializeSessionTabs } = await import('./session-restore.js');
+
+    const tabs = [
+      { id: 1, url: 'file:///app/pages/history.html', title: 'History' },
+      { id: 2, url: 'file:///app/pages/home.html', title: 'New Tab' },
+      // A still-resolving internal tab already carries the friendly form.
+      { id: 3, url: 'freedom://settings/appearance', title: 'Settings' },
+    ];
+
+    expect(serializeSessionTabs(tabs, 1).tabs.map((t) => t.url)).toEqual([
+      'freedom://history',
+      'freedom://home',
+      'freedom://settings/appearance',
+    ]);
+  });
+
+  test('skips blank tabs and computes the active index against the kept list', async () => {
+    const { serializeSessionTabs } = await import('./session-restore.js');
+
+    const tabs = [
+      { id: 1, url: 'about:blank', title: 'parked' },
+      { id: 2, url: '', navigationState: { currentPageUrl: 'https://from-nav-state.example/' } },
+      { id: 3, url: 'https://active.example/', title: 'Active' },
+    ];
+
+    const result = serializeSessionTabs(tabs, 3);
+    expect(result.tabs.map((t) => t.url)).toEqual([
+      'https://from-nav-state.example/',
+      'https://active.example/',
+    ]);
+    expect(result.activeTabIndex).toBe(1);
+  });
+
+  test('drops oversized favicons and non-string titles', async () => {
+    const { serializeSessionTabs } = await import('./session-restore.js');
+
+    const tabs = [{ id: 1, url: 'https://a.example/', title: 42, favicon: 'x'.repeat(70000) }];
+
+    expect(serializeSessionTabs(tabs, 1).tabs[0]).toEqual({
+      url: 'https://a.example/',
+      title: '',
+      pinned: false,
+      faviconUrl: null,
+    });
+  });
+
+  test('handles empty input', async () => {
+    const { serializeSessionTabs } = await import('./session-restore.js');
+
+    expect(serializeSessionTabs([], null)).toEqual({ tabs: [], activeTabIndex: 0 });
+    expect(serializeSessionTabs(undefined, null)).toEqual({ tabs: [], activeTabIndex: 0 });
+  });
+});
+
+describe('persistSessionSoon', () => {
+  test('coalesces a burst of mutations into one snapshot after ~1s', async () => {
+    jest.useFakeTimers();
+    try {
+      const { initSessionPersistence, persistSessionSoon, SESSION_SNAPSHOT_DEBOUNCE_MS } =
+        await import('./session-restore.js');
+
+      const tabs = [{ id: 1, url: 'https://example.com/', title: 'Example' }];
+      initSessionPersistence(() => ({ tabs, activeTabId: 1 }));
+
+      persistSessionSoon();
+      persistSessionSoon();
+      persistSessionSoon();
+
+      jest.advanceTimersByTime(SESSION_SNAPSHOT_DEBOUNCE_MS - 1);
+      expect(mockElectronAPI.updateSessionState).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
+      expect(mockElectronAPI.updateSessionState).toHaveBeenCalledTimes(1);
+      expect(mockElectronAPI.updateSessionState).toHaveBeenCalledWith({
+        tabs: [{ url: 'https://example.com/', title: 'Example', pinned: false, faviconUrl: null }],
+        activeTabIndex: 0,
+      });
+
+      // The snapshot reflects state at send time, not schedule time.
+      tabs.push({ id: 2, url: 'https://b.example/', title: 'B' });
+      persistSessionSoon();
+      jest.advanceTimersByTime(SESSION_SNAPSHOT_DEBOUNCE_MS);
+      expect(mockElectronAPI.updateSessionState).toHaveBeenCalledTimes(2);
+      expect(mockElectronAPI.updateSessionState.mock.calls[1][0].tabs).toHaveLength(2);
+    } finally {
+      const { initSessionPersistence } = await import('./session-restore.js');
+      initSessionPersistence(null);
+      jest.useRealTimers();
+    }
+  });
+
+  test('is a no-op before a provider is registered', async () => {
+    const { initSessionPersistence, persistSessionSoon } = await import('./session-restore.js');
+    initSessionPersistence(null);
+
+    expect(() => persistSessionSoon()).not.toThrow();
+    expect(mockElectronAPI.updateSessionState).not.toHaveBeenCalled();
+  });
+});
+
+describe('getSessionToRestore', () => {
+  test('returns null when the window has no restore slot', async () => {
+    const { getSessionToRestore } = await import('./session-restore.js');
+
+    expect(await getSessionToRestore(new URLSearchParams(''))).toBeNull();
+    expect(mockElectronAPI.getSessionToRestore).not.toHaveBeenCalled();
+  });
+
+  test('fetches the payload for the window restore slot', async () => {
+    const { getSessionToRestore } = await import('./session-restore.js');
+    const payload = { tabs: [{ url: 'https://example.com/' }], activeTabIndex: 0 };
+    mockElectronAPI.getSessionToRestore.mockResolvedValue(payload);
+
+    expect(await getSessionToRestore(new URLSearchParams('restoreSlot=1'))).toBe(payload);
+    expect(mockElectronAPI.getSessionToRestore).toHaveBeenCalledWith(1);
+  });
+
+  test('degrades to null on empty, malformed, or failing payloads', async () => {
+    const { getSessionToRestore } = await import('./session-restore.js');
+    const params = new URLSearchParams('restoreSlot=0');
+
+    mockElectronAPI.getSessionToRestore.mockResolvedValue(null);
+    expect(await getSessionToRestore(params)).toBeNull();
+
+    mockElectronAPI.getSessionToRestore.mockResolvedValue({ tabs: [] });
+    expect(await getSessionToRestore(params)).toBeNull();
+
+    mockElectronAPI.getSessionToRestore.mockRejectedValue(new Error('boom'));
+    expect(await getSessionToRestore(params)).toBeNull();
+
+    expect(await getSessionToRestore(new URLSearchParams('restoreSlot=junk'))).toBeNull();
+  });
+});
+
+describe('placeholder tabs (lazy restore in tabs.js)', () => {
+  test('createPlaceholderTab adds a webview-less tab that renders persisted state', async () => {
+    const { initSessionPersistence } = await import('./session-restore.js');
+    initSessionPersistence(null); // isolate from the debounce tests
+    const { createPlaceholderTab, getTabs } = await import('./tabs.js');
+
+    const tab = createPlaceholderTab({
+      url: 'https://example.com/',
+      title: 'Example',
+      pinned: true,
+      faviconUrl: 'data:image/png;base64,AA',
+    });
+
+    expect(tab.isPlaceholder).toBe(true);
+    expect(tab.webview).toBeNull();
+    expect(tab.title).toBe('Example');
+    expect(tab.pinned).toBe(true);
+    expect(tab.favicon).toBe('data:image/png;base64,AA');
+    expect(getTabs()).toContain(tab);
+    expect(createPlaceholderTab({ url: '' })).toBeNull();
+  });
+
+  test('switchTab materializes a placeholder: internal pages load their resolved URL', async () => {
+    const { createPlaceholderTab, switchTab, getActiveTab } = await import('./tabs.js');
+
+    const tab = createPlaceholderTab({ url: 'freedom://history', title: 'History' });
+    expect(tab.webview).toBeNull();
+
+    switchTab(tab.id);
+
+    expect(getActiveTab()).toBe(tab);
+    expect(tab.isPlaceholder).toBe(false);
+    expect(tab.webview).toBeTruthy();
+    const srcCalls = tab.webview.setAttribute.mock.calls.filter(([attr]) => attr === 'src');
+    expect(srcCalls.at(-1)?.[1]).toBe('file:///app/pages/history.html');
+  });
+
+  test('materializing a dweb placeholder parks on about:blank and routes through loadTarget', async () => {
+    jest.useFakeTimers();
+    try {
+      const { createPlaceholderTab, switchTab, setLoadTargetHandler } = await import('./tabs.js');
+      const onLoadTarget = jest.fn();
+      setLoadTargetHandler(onLoadTarget);
+
+      const tab = createPlaceholderTab({ url: 'bzz://name.eth/', title: 'Swarm site' });
+      switchTab(tab.id);
+
+      const srcCalls = tab.webview.setAttribute.mock.calls.filter(([attr]) => attr === 'src');
+      expect(srcCalls.at(-1)?.[1]).toBe('about:blank');
+
+      jest.runOnlyPendingTimers();
+      expect(onLoadTarget).toHaveBeenCalledWith('bzz://name.eth/');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('switching to an already-materialized tab does not rebuild its webview', async () => {
+    const { createPlaceholderTab, switchTab, createTab } = await import('./tabs.js');
+
+    const tab = createPlaceholderTab({ url: 'https://keep.example/', title: 'Keep' });
+    switchTab(tab.id);
+    const firstWebview = tab.webview;
+
+    const other = createTab('https://other.example/');
+    switchTab(other.id);
+    switchTab(tab.id);
+
+    expect(tab.webview).toBe(firstWebview);
+  });
+
+  test('closing a placeholder tab works without a webview', async () => {
+    const { createPlaceholderTab, closeTab, getTabs, createTab, switchTab } =
+      await import('./tabs.js');
+
+    // Keep another tab active so closing the placeholder doesn't close the window.
+    const anchor = createTab('https://anchor.example/');
+    switchTab(anchor.id);
+    const tab = createPlaceholderTab({ url: 'https://gone.example/', title: 'Gone' });
+
+    expect(() => closeTab(tab.id)).not.toThrow();
+    expect(getTabs().find((t) => t.id === tab.id)).toBeUndefined();
+  });
+});

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -13,6 +13,11 @@ import {
   showLinkStatus,
   setLinkStatusSide,
 } from './link-status.js';
+import {
+  initSessionPersistence,
+  persistSessionSoon,
+  getSessionToRestore,
+} from './session-restore.js';
 
 const electronAPI = window.electronAPI;
 
@@ -445,6 +450,9 @@ const createWebview = (tabId, initialUrl) => {
           tab.favicon = null;
           renderTabs();
         }
+        // Session capture for URL commits that don't re-render the strip
+        // (renderTabs is the other capture hook).
+        persistSessionSoon();
       }
       if (tabId === tabState.activeTabId && onWebviewEvent) {
         onWebviewEvent('did-navigate', { tabId, event });
@@ -832,6 +840,12 @@ const updateTabElement = (tabEl, tab, isActive, isBeforeActive) => {
 
 // Render the tab bar incrementally
 const renderTabs = () => {
+  // Doubles as the session-capture hook: every tab-strip mutation
+  // (open/close/reorder/pin/activate/title/favicon/load state) re-renders,
+  // so scheduling the debounced session snapshot here keeps the capture
+  // surface to two call sites (see also the did-navigate handler, which
+  // can commit a URL change without re-rendering).
+  persistSessionSoon();
   if (!tabBar) return;
 
   const activeIndex = tabState.tabs.findIndex((t) => t.id === tabState.activeTabId);
@@ -908,24 +922,34 @@ const resolveInternalPageUrl = (url) => {
   return target.subPath ? `${pageUrl}#${target.subPath}` : pageUrl;
 };
 
+// Resolve the initial <webview> src for a target URL.
+// Direct loads: empty/null (use homeUrl), http(s), about:blank, and
+// the app's own `homeUrl` (production: file:///…/pages/home.html).
+// Anything else parks on about:blank while `onLoadTarget` resolves
+// it — this keeps dweb URLs working (their resolution pipeline takes
+// ~50 ms) without producing the GUEST_VIEW_MANAGER_CALL log noise
+// that pointing the webview at homeUrl first did, and prevents
+// hostile schemes from ever becoming a direct webview navigation.
+// Trusted internal freedom:// pages resolve to their real file://…/pages URL up
+// front and load directly — no about:blank parking step (which otherwise leaves
+// a blank entry in the back history; see resolveInternalPageUrl). tab.url keeps
+// the friendly freedom:// form so the address bar and singleton-tab reuse still
+// match on it while the page loads.
+// Shared by createTab and materializePlaceholderTab so restored tabs load
+// through exactly the same allowlist as freshly opened ones.
+const resolveWebviewSrcForUrl = (url) => {
+  const resolvedInternalUrl = resolveInternalPageUrl(url);
+  const isDirect = resolvedInternalUrl != null || isDirectLoadUrl(url);
+  return {
+    webviewUrl: resolvedInternalUrl || (isDirect ? url || homeUrl : 'about:blank'),
+    isDirect,
+  };
+};
+
 // Create a new tab
 export const createTab = (url = null) => {
   const tabId = tabState.nextTabId++;
-  // Direct loads: empty/null (use homeUrl), http(s), about:blank, and
-  // the app's own `homeUrl` (production: file:///…/pages/home.html).
-  // Anything else parks on about:blank while `onLoadTarget` resolves
-  // it — this keeps dweb URLs working (their resolution pipeline takes
-  // ~50 ms) without producing the GUEST_VIEW_MANAGER_CALL log noise
-  // that pointing the webview at homeUrl first did, and prevents
-  // hostile schemes from ever becoming a direct webview navigation.
-  // Trusted internal freedom:// pages resolve to their real file://…/pages URL up
-  // front and load directly — no about:blank parking step (which otherwise leaves
-  // a blank entry in the back history; see resolveInternalPageUrl). tab.url keeps
-  // the friendly freedom:// form so the address bar and singleton-tab reuse still
-  // match on it while the page loads.
-  const resolvedInternalUrl = resolveInternalPageUrl(url);
-  const isDirect = resolvedInternalUrl != null || isDirectLoadUrl(url);
-  const webviewUrl = resolvedInternalUrl || (isDirect ? url || homeUrl : 'about:blank');
+  const { webviewUrl, isDirect } = resolveWebviewSrcForUrl(url);
   const webview = createWebview(tabId, webviewUrl);
 
   const tab = {
@@ -958,6 +982,56 @@ export const createTab = (url = null) => {
 
   pushDebug(`Created tab ${tabId}`);
   return tab;
+};
+
+// --- Placeholder tabs (lazy session restore / future tab hibernation) ------
+//
+// A placeholder tab is a tab-strip entry with NO <webview> yet:
+// `tab.isPlaceholder === true`, `tab.webview === null`. It renders its
+// persisted title/favicon like any other tab, and only materializes (creates
+// and loads its webview) on first activation via switchTab. Session restore
+// creates one placeholder per persisted tab so a 20-tab session doesn't load
+// 20 pages at launch; the same mechanism is the foundation for hibernating
+// idle tabs later (drop the webview, set isPlaceholder back to true).
+
+// Create a placeholder tab from a persisted session entry
+// ({url, title, pinned, faviconUrl}). Does not activate it.
+export const createPlaceholderTab = ({ url, title = '', pinned = false, faviconUrl = null }) => {
+  if (!url) return null;
+  const tabId = tabState.nextTabId++;
+  const tab = {
+    id: tabId,
+    url,
+    title: title || 'New Tab',
+    isLoading: false,
+    pinned: pinned === true,
+    favicon: faviconUrl || null,
+    webview: null,
+    isPlaceholder: true,
+    navigationState: createNavigationState(),
+  };
+  tabState.tabs.push(tab);
+  renderTabs();
+  pushTabMenuState();
+  pushDebug(`Created placeholder tab ${tabId}: ${url}`);
+  return tab;
+};
+
+// Give a placeholder tab its real webview and start loading `tab.url`.
+// Mirrors createTab's load path (same direct-load allowlist, same
+// about:blank + loadTarget resolution for dweb schemes).
+const materializePlaceholderTab = (tab) => {
+  if (!tab || !tab.isPlaceholder || tab.webview) return;
+  const { webviewUrl, isDirect } = resolveWebviewSrcForUrl(tab.url);
+  tab.webview = createWebview(tab.id, webviewUrl);
+  tab.isPlaceholder = false;
+  webviewContainer?.appendChild(tab.webview);
+  if (!isDirect) {
+    setTimeout(() => {
+      if (onLoadTarget) onLoadTarget(tab.url);
+    }, 50);
+  }
+  pushDebug(`Materialized placeholder tab ${tab.id}: ${tab.url}`);
 };
 
 // Remove webview event listeners to prevent memory leaks
@@ -1204,6 +1278,12 @@ export const hideTabContextMenu = () => {
 export const switchTab = (tabId, options = {}) => {
   const tab = tabState.tabs.find((t) => t.id === tabId);
   if (!tab) return;
+
+  // Restored placeholder tabs get their webview on first activation
+  // (lazy session restore — see the placeholder section above).
+  if (tab.isPlaceholder) {
+    materializePlaceholderTab(tab);
+  }
 
   // Reset the link-hover preview before swapping active tabs:
   // - immediate clear so the previous tab's URL never trails into the new tab
@@ -1673,9 +1753,41 @@ export const initTabs = async () => {
     }
   });
 
-  // Create initial tab - check for initialUrl query parameter (from "open in new window")
+  // Wire up session persistence: session-restore.js serializes and ships
+  // debounced snapshots to the main process (single writer of session.json).
+  initSessionPersistence(() => ({
+    tabs: tabState.tabs,
+    activeTabId: tabState.activeTabId,
+  }));
+
+  // Create initial tab(s). Precedence: an initialUrl query parameter (from
+  // "open in new window") loads alongside any restored session; a persisted
+  // session restores as lazy placeholder tabs; otherwise a fresh home tab.
   const urlParams = new URLSearchParams(window.location.search);
   const initialUrl = urlParams.get('initialUrl');
+  // Restore the persisted session (if this window was launched with a
+  // restore slot) as placeholder tabs. Only the active tab materializes —
+  // and only when no initialUrl is about to open its own active tab.
+  const sessionPayload = await getSessionToRestore(urlParams);
+  let restoredTabs = false;
+  if (sessionPayload) {
+    const created = [];
+    for (const entry of sessionPayload.tabs) {
+      const tab = createPlaceholderTab(entry);
+      if (tab) created.push(tab);
+    }
+    if (created.length > 0) {
+      restoredTabs = true;
+      if (!initialUrl) {
+        const rawIndex = sessionPayload.activeTabIndex;
+        const activeIndex = Number.isInteger(rawIndex)
+          ? Math.min(Math.max(rawIndex, 0), created.length - 1)
+          : 0;
+        switchTab(created[activeIndex].id);
+      }
+      pushDebug(`Restored ${created.length} tab(s) from previous session`);
+    }
+  }
   if (initialUrl) {
     // Create tab with about:blank to avoid home page flash, then navigate to target
     const tab = createTab('about:blank');
@@ -1688,7 +1800,7 @@ export const initTabs = async () => {
       // Use loadTarget for proper URL resolution (handles dweb URLs, ENS, etc.)
       setTimeout(() => onLoadTarget(initialUrl), 50);
     }
-  } else {
+  } else if (!restoredTabs) {
     createTab(homeUrl);
   }
 };

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -622,6 +622,29 @@
             </svg>
             Appearance
           </button>
+          <button type="button" class="nav-item" data-target="behavior">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <line x1="4" y1="21" x2="4" y2="14"></line>
+              <line x1="4" y1="10" x2="4" y2="3"></line>
+              <line x1="12" y1="21" x2="12" y2="12"></line>
+              <line x1="12" y1="8" x2="12" y2="3"></line>
+              <line x1="20" y1="21" x2="20" y2="16"></line>
+              <line x1="20" y1="12" x2="20" y2="3"></line>
+              <line x1="1" y1="14" x2="7" y2="14"></line>
+              <line x1="9" y1="8" x2="15" y2="8"></line>
+              <line x1="17" y1="16" x2="23" y2="16"></line>
+            </svg>
+            Behavior
+          </button>
           <button type="button" class="nav-item" data-target="profile">
             <svg
               width="16"
@@ -790,6 +813,27 @@
                   <input type="checkbox" id="tabs-in-titlebar" />
                   <span class="slider"></span>
                 </label>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Behavior -->
+        <section class="section" id="behavior">
+          <h2 class="section-title">Behavior</h2>
+          <div class="card">
+            <div class="row">
+              <div class="row-body">
+                <p class="row-label">On startup</p>
+                <p class="row-help">
+                  Continue restores the tabs you had open when Freedom last closed.
+                </p>
+              </div>
+              <div class="row-control">
+                <select id="on-startup">
+                  <option value="continue">Continue where you left off</option>
+                  <option value="homepage">Start with home page</option>
+                </select>
               </div>
             </div>
           </div>
@@ -1027,6 +1071,7 @@
       const fields = {
         themeMode: $('theme-mode'),
         tabsInTitlebar: $('tabs-in-titlebar'),
+        onStartup: $('on-startup'),
         startAnt: $('start-ant-at-launch'),
         startIpfs: $('start-ipfs-at-launch'),
         blockUnverifiedEns: $('block-unverified-ens'),
@@ -1419,6 +1464,7 @@
       const currentFormState = () => ({
         theme: fields.themeMode.value || 'system',
         tabsInTitlebar: fields.tabsInTitlebar.checked,
+        onStartup: fields.onStartup.value || 'continue',
         startAntAtLaunch: fields.startAnt.checked,
         startIpfsAtLaunch: fields.startIpfs.checked,
         enableRadicleIntegration: isWindows ? false : fields.enableRadicle.checked,
@@ -1433,6 +1479,7 @@
         if (!settings) return;
         fields.themeMode.value = settings.theme || 'system';
         fields.tabsInTitlebar.checked = settings.tabsInTitlebar === true;
+        fields.onStartup.value = settings.onStartup === 'homepage' ? 'homepage' : 'continue';
         fields.startAnt.checked = settings.startAntAtLaunch !== false;
         fields.startIpfs.checked = settings.startIpfsAtLaunch !== false;
         fields.enableRadicle.checked = settings.enableRadicleIntegration === true;
@@ -1535,6 +1582,7 @@
       };
 
       fields.themeMode.addEventListener('change', save);
+      fields.onStartup.addEventListener('change', save);
       fields.tabsInTitlebar.addEventListener('change', () => {
         save();
         $('tabs-titlebar-restart').hidden = false;

--- a/src/shared/ipc-channels.js
+++ b/src/shared/ipc-channels.js
@@ -44,6 +44,10 @@ module.exports = {
   SETTINGS_SAVE: 'settings:save',
   SETTINGS_UPDATED: 'settings:updated',
 
+  // Session restore (per-profile session.json, see src/main/session-store.js)
+  SESSION_UPDATE: 'session:update',
+  SESSION_GET_RESTORE: 'session:get-restore',
+
   // Bzz routing (Swarm)
   BZZ_SET_BASE: 'bzz:set-base',
   BZZ_CLEAR_BASE: 'bzz:clear-base',

--- a/test-e2e/session-restore.spec.js
+++ b/test-e2e/session-restore.spec.js
@@ -1,0 +1,144 @@
+// Session restore — open tabs survive an app relaunch.
+//
+// Unlike the other harness specs this manages its own Electron lifecycle
+// instead of using the shared fixtures: the whole point is a second launch
+// against the same FREEDOM_TEST_USER_DATA dir, and the fixture tears its
+// temp dir down with the app.
+
+const { test, expect, _electron: electron } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+async function launchApp(userDataDir) {
+  const app = await electron.launch({
+    args: ['.'],
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      FREEDOM_TEST_MODE: '1',
+      FREEDOM_TEST_USER_DATA: userDataDir,
+      ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+      LANG: 'en_US.UTF-8',
+    },
+    timeout: 20_000,
+  });
+  const win = await app.firstWindow();
+  await win.waitForLoadState('domcontentloaded');
+  await win.waitForSelector('[data-test="address-input"]', { state: 'visible' });
+  return { app, win };
+}
+
+// Summarize the persisted session for deterministic polling: the renderer
+// debounces snapshots ~1s, so we wait for the exact end state (3 tabs,
+// first pinned, third active) before quitting.
+function sessionSummary(userDataDir) {
+  try {
+    const raw = fs.readFileSync(path.join(userDataDir, 'session.json'), 'utf-8');
+    const win = JSON.parse(raw).windows?.[0];
+    if (!win) return '';
+    return `${win.tabs.length}:${win.tabs[0]?.pinned}:${win.activeTabIndex}`;
+  } catch {
+    return '';
+  }
+}
+
+test('restores tabs in order with pinned state, loading only the active tab', async () => {
+  test.setTimeout(120_000);
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'freedom-e2e-session-'));
+  let app;
+  try {
+    let win;
+    ({ app, win } = await launchApp(userDataDir));
+
+    const tabs = win.locator('[data-test="tab"]');
+    const input = win.locator('[data-test="address-input"]');
+
+    // Tab 1: internal History page.
+    await input.click();
+    await input.fill('freedom://history');
+    await input.press('Enter');
+    await expect(tabs.first()).toContainText('History');
+
+    // Tab 2: harness-stubbed https page.
+    await win.locator('[data-test="new-tab-btn"]').click();
+    await input.click();
+    await input.fill('https://example.com');
+    await input.press('Enter');
+    // The committed navigation may normalize to a trailing slash.
+    await expect(input).toHaveValue(/^https:\/\/example\.com\/?$/);
+
+    // Tab 3: stays on the home page and remains the active tab.
+    await win.locator('[data-test="new-tab-btn"]').click();
+    await expect(tabs).toHaveCount(3);
+
+    // Pin tab 1 via its context menu (already leftmost, so order is stable).
+    await tabs.first().click({ button: 'right' });
+    await win.locator('#tab-context-menu [data-action="pin"]').click();
+    await expect(tabs.first()).toHaveClass(/pinned/);
+
+    // Wait for the debounced snapshot to land in session.json.
+    await expect.poll(() => sessionSummary(userDataDir), { timeout: 15_000 }).toBe('3:true:2');
+
+    await app.close();
+
+    // Relaunch against the same profile dir.
+    ({ app, win } = await launchApp(userDataDir));
+    const restoredTabs = win.locator('[data-test="tab"]');
+    await expect(restoredTabs).toHaveCount(3);
+
+    // Order and pinned state kept; persisted titles shown on placeholders.
+    await expect(restoredTabs.nth(0)).toHaveClass(/pinned/);
+    await expect(restoredTabs.nth(0)).toContainText('History');
+    await expect(restoredTabs.nth(2)).toHaveClass(/active/);
+
+    // Lazy restore: only the active tab materialized a webview.
+    await expect(win.locator('#webview-container webview')).toHaveCount(1);
+
+    // Activating a placeholder materializes it on demand.
+    await restoredTabs.nth(0).click();
+    await expect(restoredTabs.nth(0)).toHaveClass(/active/);
+    await expect(win.locator('#webview-container webview')).toHaveCount(2);
+  } finally {
+    if (app) {
+      await app.close().catch(() => {});
+    }
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+});
+
+test('startup setting "homepage" skips restore', async () => {
+  test.setTimeout(120_000);
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'freedom-e2e-session-'));
+  let app;
+  try {
+    let win;
+    ({ app, win } = await launchApp(userDataDir));
+    const tabs = win.locator('[data-test="tab"]');
+
+    await win.locator('[data-test="new-tab-btn"]').click();
+    await expect(tabs).toHaveCount(2);
+    const input = win.locator('[data-test="address-input"]');
+    await input.click();
+    await input.fill('freedom://history');
+    await input.press('Enter');
+    await expect(tabs.nth(1)).toContainText('History');
+
+    await expect.poll(() => sessionSummary(userDataDir), { timeout: 15_000 }).toMatch(/^2:/);
+
+    // Flip the startup behavior (same IPC the settings page uses).
+    await win.evaluate(() => window.electronAPI.saveSettings({ onStartup: 'homepage' }));
+    await app.close();
+
+    ({ app, win } = await launchApp(userDataDir));
+    await expect(win.locator('[data-test="tab"]')).toHaveCount(1);
+    await expect(win.locator('[data-test="tab"]').first()).toContainText('New Tab');
+  } finally {
+    if (app) {
+      await app.close().catch(() => {});
+    }
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What / why

Quitting Freedom loses all open tabs today — only the in-memory closed-tab stack exists. This adds per-profile session persistence with a "Continue where you left off" startup default (wave-2 daily-driver feature; the tab-strip-upgrades branch follows on top of this).

- `src/main/session-store.js`: single writer of `<profile userData>/session.json`, atomic write (temp file + rename). Schema v1: `{version, windows: [{tabs: [{url, title, pinned, faviconUrl}], activeTabIndex}]}`.
- `src/renderer/lib/session-restore.js`: captures the tab strip debounced ~1s and ships snapshots over `session:update`; pure `serializeSessionTabs()` for testability. Internal pages persist in their `freedom://<name>` form (resolved `file://…/pages/…` URLs are install-location-specific); the home page persists as `freedom://home`.
- `tabs.js` changes are deliberately surgical for the upcoming tab-strip branch: two capture hooks (`renderTabs` + the `did-navigate` handler), one extraction (`resolveWebviewSrcForUrl`, shared by `createTab` and placeholder materialization), the placeholder block, and the restore block in `initTabs`.

## Lazy restore design

Restored tabs are **placeholder tabs**: tab-strip entries with `tab.isPlaceholder === true` and `tab.webview === null` that render the persisted title/favicon. `switchTab` materializes a placeholder on first activation (`materializePlaceholderTab`), reusing exactly `createTab`'s load path — same direct-load allowlist, same about:blank parking + `loadTarget` resolution for dweb schemes. Only the active tab loads at launch. The mechanism is intentionally clean and named so future tab hibernation can reuse it (drop the webview, flip `isPlaceholder` back on).

Internal singleton pages (freedom://settings etc.) restore as placeholders like any other tab; singleton semantics hold because at most one such tab existed at capture time.

## Multi-window finding

Investigated before choosing the locking strategy: `profile-lock.js` enforces **one process per profile** — a second launch of the same profile requests focus via the handoff files and exits. So `session.json` can never have cross-process writers and the updater-owner-lock pattern is unnecessary here. "Multiple windows of one profile" means multiple BrowserWindows inside that single process; the session store keys live snapshots by webContents id and persists all of them (`windows[]`). On launch, slot 0 restores into the first window and any additional persisted windows are recreated one per slot (windows opened later via Cmd+N carry no slot and start fresh). Closing a window mid-session forgets its tabs; the last window closing (macOS close-then-quit) and app quit both keep the file for the next restore.

## Crash recovery / corrupt file

The file is rewritten atomically on every accepted snapshot, so a crashed session restores the same way a quit does — at worst the final ~1s debounce window of changes is lost. A corrupt / truncated / mis-shaped `session.json` degrades to a fresh session (unit-tested), and "Start with home page" never deletes the file — flipping the setting back restores again.

## Settings

New Behavior section in freedom://settings with "On startup": Continue where you left off (default) / Start with home page; `onStartup` key added to the settings-store defaults (migration-safe via the defaults merge).

## Known limitation (by design)

Per-tab back/forward history is not restorable — Electron's `<webview>` has no API to export or re-seed navigation history. Restore is URL-only.

## Private-windows hook

Grep-able `EPHEMERAL-WINDOW GUARD` in `session-store.js` + `markWindowSessionEphemeral(webContentsId)`: the writer refuses snapshots from flagged windows (unit-tested). The private-windows branch wires this at private-window creation.

## Tests

Ran locally on macOS (arm64):

- Jest targeted: `session-store.test.js` + `session-restore.test.js` — 26 passed (restore payloads, corrupt-file fallback, sanitization + atomic write, ephemeral guard, window-close/quit lifecycle, serialization, debounce coalescing, placeholder materialization incl. dweb `loadTarget` routing).
- Jest full suite: 106 suites / 2162 tests passed, 17 skipped (pre-existing skips).
- `npx eslint .` clean; prettier applied to the new files only.
- Playwright harness project, full run including the new `test-e2e/session-restore.spec.js` (relaunches the app against the same `FREEDOM_TEST_USER_DATA`, asserts 3 tabs restored in order, pinned state kept, active tab restored, exactly one webview materialized at launch, materialization on placeholder click, and that the homepage setting skips restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
