### PR TITLE
feat(tabs): audio indicators, mute, tab search, MRU cycling, QoL context-menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,15 @@ All notable changes to Freedom will be documented in this file.
 - Session restore: open tabs return on the next launch — after a quit or a crash — keeping tab order, pinned state, and the active tab
   - Only the active tab loads at launch; the rest load when first clicked
   - Settings > Behavior > On startup switches between "Continue where you left off" (default) and "Start with home page"
+- Tab strip upgrades:
+  - Audio indicator on tabs playing sound; click it or use "Mute Tab" in the tab context menu to mute/unmute (mute survives navigation)
+  - Tab search popover (`Cmd/Ctrl+Shift+A`, also View > Search Tabs): fuzzy filter on title/URL across the current window's tabs, Enter to switch
+  - Optional most-recently-used Ctrl+Tab cycling with a held-Ctrl switcher overlay (Settings > Behavior, off by default)
+  - Tab context menu: "Close Tabs to the Left" (pinned tabs protected, like close-to-the-right), "Copy URL", and "Reopen Closed Tab"
 
 ### Changed
+
+- New tabs open next to the active tab instead of at the end of the strip; tabs opened from links group after their opener (Settings > Behavior to restore append-at-end)
 
 - Updated bundled [Ant](https://github.com/solardev-xyz/ant) to 0.5.36: fixes the ~250 MiB upload stall, adds upload-side Reed-Solomon encoding, end-to-end Swarm content encryption, local pinning, and ACT access control
 - The Swarm node's API now comes up instantly on start, so the node menu shows peers counting up live instead of sitting at 0 during startup

--- a/README.md
+++ b/README.md
@@ -266,8 +266,11 @@ The address bar also provides **autocomplete suggestions** from browsing history
 
 ### Tabbed Browsing
 
-- **Multiple Tabs**: Open multiple pages simultaneously with `Cmd+T`.
-- **Tab Management**: Close tabs with `Cmd+W` or middle-click.
+- **Multiple Tabs**: Open multiple pages simultaneously with `Cmd+T`. New tabs open next to the active tab by default (tabs opened from links stay grouped after their opener); switch to append-at-end in Settings > Behavior.
+- **Tab Management**: Close tabs with `Cmd+W` or middle-click. The tab context menu also offers close others / to the right / to the left (pinned tabs are never swept), pin, mute, copy URL, and reopen closed tab.
+- **Audio Indicators & Mute**: Tabs playing sound show a speaker icon; click it (or use "Mute Tab" in the context menu) to mute or unmute the tab. Mute survives navigation within the tab.
+- **Tab Search**: `Cmd+Shift+A` / `Ctrl+Shift+A` opens a popover listing the current window's tabs with fuzzy filtering on title and URL — arrow keys + Enter to switch.
+- **MRU Tab Cycling**: Optional (Settings > Behavior): Ctrl+Tab cycles tabs in most-recently-used order with an Alt-Tab-style switcher while Ctrl is held.
 - **Drag & Drop Reordering**: Rearrange tabs by dragging.
 - **Per-Tab State**: Each tab maintains its own navigation history, address bar state, and bzz/ipfs base.
 - **Session Restore**: Open tabs (order, pinned state, active tab) come back on the next launch — including after a crash. Restored tabs load lazily: only the active tab loads at launch; the rest load when first activated. Per-tab back/forward history is not restored (current URL only).
@@ -284,7 +287,8 @@ The address bar also provides **autocomplete suggestions** from browsing history
   - `Cmd+T` / `Ctrl+T`: New tab
   - `Cmd+W` / `Ctrl+W` / `Ctrl+F4`: Close tab
   - `Cmd+Shift+T` / `Ctrl+Shift+T`: Reopen last closed tab
-  - `Ctrl+PgDn` / `Ctrl+Tab`: Next tab
+  - `Cmd+Shift+A` / `Ctrl+Shift+A`: Search tabs
+  - `Ctrl+PgDn` / `Ctrl+Tab`: Next tab (`Ctrl+Tab` cycles most-recently-used tabs instead when enabled in Settings > Behavior)
   - `Ctrl+PgUp` / `Ctrl+Shift+Tab`: Previous tab
   - `Ctrl+Shift+PgDn`: Move tab right
   - `Ctrl+Shift+PgUp`: Move tab left

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -295,6 +295,17 @@ function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
       },
     },
     {
+      id: 'search-tabs',
+      label: 'Search Tabs...',
+      accelerator: 'CmdOrCtrl+Shift+A',
+      click: () => {
+        const win = getTargetWindow();
+        if (win) {
+          win.webContents.send('tab:search');
+        }
+      },
+    },
+    {
       id: 'move-tab-right',
       label: 'Move Tab Right',
       accelerator: 'Ctrl+Shift+PageDown',
@@ -509,6 +520,7 @@ ipcMain.on('menu:update-tab-state', (_event, state) => {
   setEnabled('reload', hasTabs);
   setEnabled('next-tab', hasMultipleTabs);
   setEnabled('prev-tab', hasMultipleTabs);
+  setEnabled('search-tabs', hasTabs);
   setEnabled('move-tab-right', hasMultipleTabs && activeIndex < tabCount - 1);
   setEnabled('move-tab-left', hasMultipleTabs && activeIndex > 0);
   setEnabled('reopen-closed-tab', hasClosedTabs);

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -249,6 +249,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('tab:reopen-closed', handler);
     return () => ipcRenderer.removeListener('tab:reopen-closed', handler);
   },
+  onTabSearch: (callback) => {
+    const handler = () => callback();
+    ipcRenderer.on('tab:search', handler);
+    return () => ipcRenderer.removeListener('tab:search', handler);
+  },
   updateTabMenuState: (state) => ipcRenderer.send('menu:update-tab-state', state),
   setBookmarkBarToggleEnabled: (enabled) =>
     ipcRenderer.send('menu:set-bookmark-bar-toggle-enabled', enabled),

--- a/src/main/settings-store.js
+++ b/src/main/settings-store.js
@@ -55,6 +55,11 @@ const DEFAULT_SETTINGS = {
   // starts with a single home tab. Continue is the daily-driver default
   // and reaches existing users through the defaults merge.
   onStartup: 'continue',
+  // When true (default), user-opened tabs and target=_blank child tabs are
+  // inserted right of the active tab (children group after their opener)
+  // instead of appended at the end of the strip. Modern-browser default;
+  // the toggle lives in Settings > Behavior.
+  openNewTabNextToActive: true,
   // Linux only: render the tab strip as the window titlebar (frameless window).
   // Off by default so Linux users get the native OS frame; opt in via Settings.
   tabsInTitlebar: false,

--- a/src/main/settings-store.js
+++ b/src/main/settings-store.js
@@ -60,6 +60,10 @@ const DEFAULT_SETTINGS = {
   // instead of appended at the end of the strip. Modern-browser default;
   // the toggle lives in Settings > Behavior.
   openNewTabNextToActive: true,
+  // When true, Ctrl+Tab cycles tabs in most-recently-used order with a
+  // held-Ctrl switcher overlay (Alt-Tab style) instead of strip order.
+  // Off by default to preserve the existing sequential behavior.
+  mruTabSwitching: false,
   // Linux only: render the tab strip as the window titlebar (frameless window).
   // Off by default so Linux users get the native OS frame; opt in via Settings.
   tabsInTitlebar: false,

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -2672,6 +2672,11 @@
       <div id="tab-search-list" class="tab-search-list" data-test="tab-search-list"></div>
     </div>
 
+    <!-- MRU Tab Switcher (Ctrl+Tab while "Cycle tabs by recent use" is on) -->
+    <div id="tab-mru-switcher" class="tab-mru-switcher hidden" data-test="tab-mru-switcher">
+      <div id="tab-mru-list" class="tab-mru-list"></div>
+    </div>
+
     <!-- Page Context Menu -->
     <div id="page-context-menu" class="context-menu hidden">
       <!-- Page actions (shown when clicking on page background) -->

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -2653,9 +2653,13 @@
       <button class="context-menu-item" data-action="close">Close Tab</button>
       <button class="context-menu-item" data-action="close-others">Close Other Tabs</button>
       <button class="context-menu-item" data-action="close-right">Close Tabs to the Right</button>
+      <button class="context-menu-item" data-action="close-left">Close Tabs to the Left</button>
       <div class="context-menu-separator"></div>
       <button class="context-menu-item" data-action="pin">Pin Tab</button>
       <button class="context-menu-item" data-action="mute">Mute Tab</button>
+      <button class="context-menu-item" data-action="copy-url">Copy URL</button>
+      <div class="context-menu-separator"></div>
+      <button class="context-menu-item" data-action="reopen-closed">Reopen Closed Tab</button>
     </div>
 
     <!-- Tab Search Popover (Cmd/Ctrl+Shift+A) -->

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -2658,6 +2658,20 @@
       <button class="context-menu-item" data-action="mute">Mute Tab</button>
     </div>
 
+    <!-- Tab Search Popover (Cmd/Ctrl+Shift+A) -->
+    <div id="tab-search" class="tab-search hidden" data-test="tab-search">
+      <input
+        id="tab-search-input"
+        class="tab-search-input"
+        type="text"
+        placeholder="Search tabs by title or address"
+        spellcheck="false"
+        autocomplete="off"
+        data-test="tab-search-input"
+      />
+      <div id="tab-search-list" class="tab-search-list" data-test="tab-search-list"></div>
+    </div>
+
     <!-- Page Context Menu -->
     <div id="page-context-menu" class="context-menu hidden">
       <!-- Page actions (shown when clicking on page background) -->

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -2655,6 +2655,7 @@
       <button class="context-menu-item" data-action="close-right">Close Tabs to the Right</button>
       <div class="context-menu-separator"></div>
       <button class="context-menu-item" data-action="pin">Pin Tab</button>
+      <button class="context-menu-item" data-action="mute">Mute Tab</button>
     </div>
 
     <!-- Page Context Menu -->

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -36,6 +36,7 @@ import {
   createTab,
   openOrFocusInternalPage,
 } from './lib/tabs.js';
+import { initTabSearch, hideTabSearch } from './lib/tab-search.js';
 import {
   initNavigation,
   loadTarget,
@@ -630,6 +631,7 @@ const closeAllMenus = () => {
   hideBookmarkContextMenu();
   hidePageContextMenu();
   hideChromeInputContextMenu();
+  hideTabSearch();
 };
 
 // Close everything including autocomplete (used by backdrop)
@@ -733,6 +735,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   initNavigation(); // Sets up event handler with tabs module
   initLinkStatus();
   initTabs(); // Creates first tab and starts loading home page
+  initTabSearch({ onOpening: onAnyMenuOpening }); // Cmd/Ctrl+Shift+A tab search popover
   initAutocomplete(); // Address bar autocomplete
   initPageContextMenu(); // Page context menu for webviews
   initChromeInputContextMenu({ onOpening: onAnyMenuOpening }); // Address bar edit menu

--- a/src/renderer/lib/tab-mru.js
+++ b/src/renderer/lib/tab-mru.js
@@ -1,0 +1,24 @@
+// Most-recently-used tab order — pure list operations backing the MRU
+// Ctrl+Tab switcher in tabs.js. The order is a plain array of tab ids,
+// most recent first; tabs.js owns the array and feeds every mutation
+// through these helpers so the ordering rules stay unit-testable.
+
+/**
+ * Move `id` to the front of the MRU order (adding it if absent).
+ * Returns a new array; the input is not mutated.
+ */
+export const touchMru = (order, id) => [id, ...(order || []).filter((x) => x !== id)];
+
+/**
+ * Drop `id` from the MRU order (no-op if absent). Returns a new array.
+ */
+export const removeFromMru = (order, id) => (order || []).filter((x) => x !== id);
+
+/**
+ * Step a selection index through a cyclic list. `direction` is +1 (next,
+ * Ctrl+Tab) or -1 (previous, Ctrl+Shift+Tab); wraps at both ends.
+ */
+export const cycleIndex = (length, current, direction) => {
+  if (!Number.isInteger(length) || length <= 0) return 0;
+  return (((current + direction) % length) + length) % length;
+};

--- a/src/renderer/lib/tab-mru.test.js
+++ b/src/renderer/lib/tab-mru.test.js
@@ -1,0 +1,64 @@
+import { touchMru, removeFromMru, cycleIndex } from './tab-mru.js';
+
+describe('touchMru', () => {
+  test('adds an unseen id at the front', () => {
+    expect(touchMru([], 1)).toEqual([1]);
+    expect(touchMru([2, 3], 1)).toEqual([1, 2, 3]);
+  });
+
+  test('moves an existing id to the front, keeping relative order of the rest', () => {
+    expect(touchMru([1, 2, 3], 3)).toEqual([3, 1, 2]);
+    expect(touchMru([1, 2, 3], 2)).toEqual([2, 1, 3]);
+  });
+
+  test('re-touching the front id is a no-op ordering', () => {
+    expect(touchMru([1, 2, 3], 1)).toEqual([1, 2, 3]);
+  });
+
+  test('does not mutate the input', () => {
+    const order = [1, 2, 3];
+    touchMru(order, 3);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  test('tolerates a missing order', () => {
+    expect(touchMru(undefined, 7)).toEqual([7]);
+  });
+});
+
+describe('removeFromMru', () => {
+  test('removes the id wherever it sits', () => {
+    expect(removeFromMru([1, 2, 3], 2)).toEqual([1, 3]);
+    expect(removeFromMru([1, 2, 3], 1)).toEqual([2, 3]);
+  });
+
+  test('is a no-op for unknown ids', () => {
+    expect(removeFromMru([1, 2], 9)).toEqual([1, 2]);
+    expect(removeFromMru([], 9)).toEqual([]);
+  });
+
+  test('does not mutate the input', () => {
+    const order = [1, 2];
+    removeFromMru(order, 1);
+    expect(order).toEqual([1, 2]);
+  });
+});
+
+describe('cycleIndex', () => {
+  test('advances and wraps forward', () => {
+    expect(cycleIndex(3, 0, 1)).toBe(1);
+    expect(cycleIndex(3, 2, 1)).toBe(0);
+  });
+
+  test('retreats and wraps backward', () => {
+    expect(cycleIndex(3, 0, -1)).toBe(2);
+    expect(cycleIndex(3, 1, -1)).toBe(0);
+  });
+
+  test('degenerate lengths clamp to 0', () => {
+    expect(cycleIndex(0, 0, 1)).toBe(0);
+    expect(cycleIndex(-1, 5, 1)).toBe(0);
+    expect(cycleIndex(1, 0, 1)).toBe(0);
+    expect(cycleIndex(1, 0, -1)).toBe(0);
+  });
+});

--- a/src/renderer/lib/tab-search-filter.js
+++ b/src/renderer/lib/tab-search-filter.js
@@ -1,0 +1,77 @@
+// Fuzzy filtering for the tab search popover (tab-search.js). Pure module —
+// no DOM, no tab-state imports — so the ranking rules are unit-testable in
+// isolation.
+
+/**
+ * Score how well `query` matches `text` (case-insensitive).
+ *
+ * Ranking, best to worst:
+ *   1. Substring matches — earlier is better, and a match starting at the
+ *      beginning or after a separator (whitespace, `/ . : - _`) gets a
+ *      word-boundary bonus ("git" in "GitHub" beats "git" in "digit").
+ *   2. Subsequence matches — every query character appears in order;
+ *      consecutive runs score higher than scattered hits.
+ *
+ * @param {string} query
+ * @param {string} text
+ * @returns {number} score >= 0 on match, -1 when `query` doesn't match.
+ *   The empty query matches everything with score 0.
+ */
+export const fuzzyScore = (query, text) => {
+  if (!query) return 0;
+  if (!text) return -1;
+  const q = String(query).toLowerCase();
+  const t = String(text).toLowerCase();
+
+  const substringIndex = t.indexOf(q);
+  if (substringIndex !== -1) {
+    let score = Math.max(1000 - substringIndex, 500);
+    if (substringIndex === 0 || /[\s/.:\-_]/.test(t[substringIndex - 1])) {
+      score += 100;
+    }
+    return score;
+  }
+
+  // Subsequence walk: greedy left-to-right, +10 for extending a consecutive
+  // run, +1 for a scattered hit.
+  let searchFrom = 0;
+  let lastMatch = -2;
+  let score = 0;
+  for (const ch of q) {
+    const found = t.indexOf(ch, searchFrom);
+    if (found === -1) return -1;
+    score += found === lastMatch + 1 ? 10 : 1;
+    lastMatch = found;
+    searchFrom = found + 1;
+  }
+  return score;
+};
+
+/**
+ * Filter and rank tab entries against a query. Each entry is matched on
+ * both `title` and `url`; the better of the two scores wins. Ties keep the
+ * input order (stable), and an empty/whitespace query returns all entries
+ * unranked — so the popover's default view preserves strip order.
+ *
+ * @param {Array<{title?: string, url?: string}>} entries
+ * @param {string} query
+ * @returns {Array} matching entries, best first
+ */
+export const filterTabEntries = (entries, query) => {
+  const items = Array.isArray(entries) ? entries : [];
+  const trimmed = typeof query === 'string' ? query.trim() : '';
+  if (!trimmed) return items.slice();
+
+  return items
+    .map((entry, index) => ({
+      entry,
+      index,
+      score: Math.max(
+        fuzzyScore(trimmed, entry?.title || ''),
+        fuzzyScore(trimmed, entry?.url || '')
+      ),
+    }))
+    .filter((item) => item.score >= 0)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((item) => item.entry);
+};

--- a/src/renderer/lib/tab-search-filter.test.js
+++ b/src/renderer/lib/tab-search-filter.test.js
@@ -1,0 +1,102 @@
+import { fuzzyScore, filterTabEntries } from './tab-search-filter.js';
+
+describe('fuzzyScore', () => {
+  test('empty query matches everything with score 0', () => {
+    expect(fuzzyScore('', 'anything')).toBe(0);
+    expect(fuzzyScore('', '')).toBe(0);
+  });
+
+  test('empty text never matches a non-empty query', () => {
+    expect(fuzzyScore('a', '')).toBe(-1);
+  });
+
+  test('is case-insensitive', () => {
+    expect(fuzzyScore('GITHUB', 'github.com')).toBeGreaterThan(0);
+    expect(fuzzyScore('github', 'GitHub — Home')).toBeGreaterThan(0);
+  });
+
+  test('substring beats subsequence', () => {
+    const substring = fuzzyScore('doc', 'documentation');
+    const subsequence = fuzzyScore('doc', 'д d-o!c'); // scattered d..o..c
+    expect(substring).toBeGreaterThan(subsequence);
+  });
+
+  test('earlier substring match ranks higher', () => {
+    expect(fuzzyScore('news', 'news.site.example')).toBeGreaterThan(
+      fuzzyScore('news', 'example.site/news')
+    );
+  });
+
+  test('word-boundary substring gets a bonus over mid-word', () => {
+    // Both are substring matches at index > 0; only the one after a
+    // separator gets the boundary bonus.
+    expect(fuzzyScore('hub', 'git hub')).toBeGreaterThan(fuzzyScore('hub', 'ggithubb'));
+  });
+
+  test('subsequence must be in order', () => {
+    expect(fuzzyScore('cba', 'abc')).toBe(-1);
+    expect(fuzzyScore('abc', 'a1b2c3')).toBeGreaterThan(0);
+  });
+
+  test('consecutive subsequence runs beat scattered hits', () => {
+    expect(fuzzyScore('abc', 'xxabcyy-z')).toBeGreaterThan(500 - 1); // substring, actually
+    // Pure subsequence comparison: "ab" consecutive vs scattered.
+    expect(fuzzyScore('abz', 'abxz')).toBeGreaterThan(fuzzyScore('abz', 'axbxz'));
+  });
+});
+
+describe('filterTabEntries', () => {
+  const entries = [
+    { id: 1, title: 'New Tab', url: 'freedom://home' },
+    { id: 2, title: 'GitHub — build software', url: 'https://github.com/' },
+    { id: 3, title: 'Documentation', url: 'https://docs.example/' },
+    { id: 4, title: 'Swarm Foundation', url: 'bzz://swarm.eth' },
+  ];
+
+  test('empty and whitespace-only queries return all entries in order', () => {
+    expect(filterTabEntries(entries, '')).toEqual(entries);
+    expect(filterTabEntries(entries, '   ')).toEqual(entries);
+    expect(filterTabEntries(entries, undefined)).toEqual(entries);
+  });
+
+  test('matches on title', () => {
+    const result = filterTabEntries(entries, 'github');
+    expect(result.map((e) => e.id)).toEqual([2]);
+  });
+
+  test('matches on URL too', () => {
+    const result = filterTabEntries(entries, 'bzz');
+    expect(result.map((e) => e.id)).toEqual([4]);
+  });
+
+  test('takes the better score of title vs URL', () => {
+    // "docs" is a substring of tab 3's URL only; the title has no match.
+    const result = filterTabEntries(entries, 'docs');
+    expect(result.map((e) => e.id)).toEqual([3]);
+  });
+
+  test('non-matching queries filter everything out', () => {
+    expect(filterTabEntries(entries, 'zzzzqqq')).toEqual([]);
+  });
+
+  test('stable order on ties, best match first otherwise', () => {
+    const dupes = [
+      { id: 1, title: 'Alpha page', url: 'https://a.example' },
+      { id: 2, title: 'Alpha page', url: 'https://b.example' },
+      { id: 3, title: 'Contains alpha late in title', url: 'https://c.example' },
+    ];
+    const result = filterTabEntries(dupes, 'alpha');
+    // 1 and 2 tie (same title, boundary substring at 0) and keep input order.
+    expect(result.map((e) => e.id)).toEqual([1, 2, 3]);
+  });
+
+  test('placeholder-shaped entries (persisted title/url only) are searchable', () => {
+    const placeholders = [{ id: 9, title: 'Restored Page', url: 'https://restored.example/x' }];
+    expect(filterTabEntries(placeholders, 'restored').map((e) => e.id)).toEqual([9]);
+  });
+
+  test('tolerates missing fields', () => {
+    expect(filterTabEntries([{ id: 1 }], 'a')).toEqual([]);
+    expect(filterTabEntries(null, 'a')).toEqual([]);
+  });
+});

--- a/src/renderer/lib/tab-search.js
+++ b/src/renderer/lib/tab-search.js
@@ -1,0 +1,251 @@
+// Tab search popover (Cmd/Ctrl+Shift+A, or View → Search Tabs).
+//
+// Lists the current window's open tabs — pinned tabs first, then strip
+// order — with favicon, title, URL, and an audio badge for audible tabs.
+// Typing fuzzy-filters on title/URL (tab-search-filter.js); ArrowUp/Down +
+// Enter (or click) activates a tab, Esc closes. Placeholder tabs from lazy
+// session restore appear via their persisted title/URL and materialize on
+// activation like any other switch.
+//
+// Scope: the current window only. Every window's tab strip lives in its own
+// renderer process, so enumerating (and focusing) tabs of other windows of
+// the profile would need new main-process aggregation IPC — deliberately
+// out of scope for this popover's first cut.
+
+import { getTabs, getActiveTab, switchTab, getTabAudioState } from './tabs.js';
+import { closeMenus } from './menus.js';
+import { showMenuBackdrop, hideMenuBackdrop } from './menu-backdrop.js';
+import { filterTabEntries } from './tab-search-filter.js';
+import { pushDebug } from './debug.js';
+
+const electronAPI = window.electronAPI;
+
+// Default globe icon for entries without a favicon (same shape as the strip).
+const GLOBE_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>`;
+// Small speaker badge for audible entries.
+const AUDIO_BADGE_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" fill="currentColor" stroke="none"/><path d="M15.5 8.5a5 5 0 0 1 0 7"/></svg>`;
+
+let popover = null;
+let input = null;
+let listEl = null;
+let onOpening = null;
+
+let isOpen = false;
+let entries = [];
+let filtered = [];
+let selectedIndex = 0;
+
+// Snapshot the current tab strip as searchable entries: pinned first, then
+// strip order (stable within each group).
+const buildEntries = () => {
+  const tabs = getTabs();
+  const activeId = getActiveTab()?.id ?? null;
+  const ordered = [...tabs.filter((t) => t.pinned), ...tabs.filter((t) => !t.pinned)];
+  return ordered.map((tab) => ({
+    id: tab.id,
+    title: tab.title || 'New Tab',
+    url: tab.url || '',
+    favicon: typeof tab.favicon === 'string' ? tab.favicon : null,
+    pinned: tab.pinned === true,
+    isActive: tab.id === activeId,
+    audioState: getTabAudioState(tab),
+  }));
+};
+
+const renderList = () => {
+  if (!listEl) return;
+  listEl.innerHTML = '';
+
+  if (filtered.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'tab-search-empty';
+    empty.textContent = 'No matching tabs';
+    listEl.appendChild(empty);
+    return;
+  }
+
+  filtered.forEach((entry, index) => {
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'tab-search-item';
+    row.dataset.test = 'tab-search-item';
+    row.dataset.tabId = String(entry.id);
+    row.classList.toggle('selected', index === selectedIndex);
+
+    const icon = document.createElement('span');
+    icon.className = 'tab-search-item-icon';
+    if (entry.favicon) {
+      const img = document.createElement('img');
+      img.src = entry.favicon;
+      img.alt = '';
+      icon.appendChild(img);
+    } else {
+      icon.innerHTML = GLOBE_SVG;
+    }
+    row.appendChild(icon);
+
+    const text = document.createElement('span');
+    text.className = 'tab-search-item-text';
+    const title = document.createElement('span');
+    title.className = 'tab-search-item-title';
+    title.textContent = entry.title;
+    const url = document.createElement('span');
+    url.className = 'tab-search-item-url';
+    url.textContent = entry.url;
+    text.appendChild(title);
+    text.appendChild(url);
+    row.appendChild(text);
+
+    if (entry.audioState === 'audible') {
+      const badge = document.createElement('span');
+      badge.className = 'tab-search-item-audio';
+      badge.dataset.test = 'tab-search-item-audio';
+      badge.innerHTML = AUDIO_BADGE_SVG;
+      row.appendChild(badge);
+    }
+
+    if (entry.isActive) {
+      const current = document.createElement('span');
+      current.className = 'tab-search-item-current';
+      current.textContent = 'Current';
+      row.appendChild(current);
+    }
+
+    row.addEventListener('click', () => activateEntry(index));
+    // Track the pointer like a menu: hovering moves the selection.
+    row.addEventListener('mousemove', () => {
+      if (selectedIndex !== index) {
+        selectedIndex = index;
+        updateSelection();
+      }
+    });
+
+    listEl.appendChild(row);
+  });
+};
+
+const updateSelection = () => {
+  if (!listEl) return;
+  const rows = listEl.querySelectorAll('.tab-search-item');
+  rows.forEach((row, index) => {
+    row.classList.toggle('selected', index === selectedIndex);
+    if (index === selectedIndex) {
+      row.scrollIntoView?.({ block: 'nearest' });
+    }
+  });
+};
+
+const refilter = () => {
+  filtered = filterTabEntries(entries, input?.value || '');
+  selectedIndex = 0;
+  renderList();
+};
+
+const activateEntry = (index) => {
+  const entry = filtered[index];
+  hideTabSearch();
+  if (!entry) return;
+  switchTab(entry.id);
+  pushDebug(`[TabSearch] Activated tab ${entry.id}`);
+};
+
+export const isTabSearchOpen = () => isOpen;
+
+export const showTabSearch = () => {
+  if (!popover || !input || !listEl) return;
+  // Dismiss the other transient surfaces before taking the stage.
+  closeMenus();
+  onOpening?.();
+  showMenuBackdrop();
+
+  isOpen = true;
+  entries = buildEntries();
+  input.value = '';
+  filtered = filterTabEntries(entries, '');
+  selectedIndex = 0;
+  renderList();
+  popover.classList.remove('hidden');
+  input.focus();
+};
+
+export const hideTabSearch = () => {
+  if (!popover) return;
+  const wasVisible = isOpen;
+  popover.classList.add('hidden');
+  isOpen = false;
+  if (wasVisible) {
+    hideMenuBackdrop();
+  }
+};
+
+export const toggleTabSearch = () => {
+  if (isOpen) {
+    hideTabSearch();
+  } else {
+    showTabSearch();
+  }
+};
+
+const onInputKeydown = (event) => {
+  switch (event.key) {
+    case 'ArrowDown':
+      event.preventDefault();
+      if (filtered.length > 0) {
+        selectedIndex = (selectedIndex + 1) % filtered.length;
+        updateSelection();
+      }
+      break;
+    case 'ArrowUp':
+      event.preventDefault();
+      if (filtered.length > 0) {
+        selectedIndex = (selectedIndex - 1 + filtered.length) % filtered.length;
+        updateSelection();
+      }
+      break;
+    case 'Enter':
+      event.preventDefault();
+      activateEntry(selectedIndex);
+      break;
+    case 'Escape':
+      event.preventDefault();
+      hideTabSearch();
+      break;
+  }
+};
+
+/**
+ * Wire the popover. `options.onOpening` mirrors the tab/bookmark context
+ * menus' opening hook — index.js uses it to dismiss autocomplete etc.
+ */
+export const initTabSearch = (options = {}) => {
+  popover = document.getElementById('tab-search');
+  input = document.getElementById('tab-search-input');
+  listEl = document.getElementById('tab-search-list');
+  onOpening = options.onOpening || null;
+  if (!popover || !input || !listEl) return;
+
+  input.addEventListener('input', refilter);
+  input.addEventListener('keydown', onInputKeydown);
+
+  // Keep clicks inside the popover from bubbling to document-level
+  // close-everything handlers.
+  popover.addEventListener('mousedown', (event) => {
+    event.stopPropagation();
+  });
+
+  // View → Search Tabs (accelerator registered in src/main/menu.js — works
+  // even while a webview has focus).
+  electronAPI?.onTabSearch?.(() => {
+    toggleTabSearch();
+  });
+
+  // Renderer-side fallback shortcut for when chrome has focus.
+  window.addEventListener('keydown', (event) => {
+    if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === 'a') {
+      event.preventDefault();
+      toggleTabSearch();
+    }
+  });
+
+  window.addEventListener('blur', hideTabSearch);
+};

--- a/src/renderer/lib/tab-search.test.js
+++ b/src/renderer/lib/tab-search.test.js
@@ -1,0 +1,256 @@
+// Tab search popover behavior — open/filter/keyboard-activate, backdrop
+// integration, and placeholder listing. tabs.js is mocked so the popover is
+// exercised against a controlled tab list (fake-dom, same harness style as
+// tabs-ui.test.js).
+
+const { createDocument, createElement } = require('../../../test/helpers/fake-dom.js');
+
+const originalWindow = global.window;
+const originalDocument = global.document;
+
+const loadTabSearchModule = async ({ tabs, activeTabId } = {}) => {
+  jest.resetModules();
+
+  const tabsState = {
+    tabs: tabs || [],
+    activeTabId: activeTabId ?? null,
+  };
+
+  const tabsMocks = {
+    getTabs: jest.fn(() => tabsState.tabs),
+    getActiveTab: jest.fn(() => tabsState.tabs.find((t) => t.id === tabsState.activeTabId) || null),
+    switchTab: jest.fn((tabId) => {
+      tabsState.activeTabId = tabId;
+    }),
+    getTabAudioState: jest.fn((tab) => (tab.isMuted ? 'muted' : tab.isAudible ? 'audible' : null)),
+  };
+  const menusMocks = { closeMenus: jest.fn() };
+  const backdropMocks = {
+    showMenuBackdrop: jest.fn(),
+    hideMenuBackdrop: jest.fn(),
+  };
+
+  const popover = createElement('div', { classes: ['tab-search', 'hidden'] });
+  const input = createElement('input');
+  input.focus = jest.fn();
+  const list = createElement('div');
+  popover.appendChild(input);
+  popover.appendChild(list);
+
+  const document = createDocument({
+    elementsById: {
+      'tab-search': popover,
+      'tab-search-input': input,
+      'tab-search-list': list,
+    },
+  });
+
+  const windowHandlers = {};
+  const electronHandlers = {};
+  global.window = {
+    electronAPI: {
+      onTabSearch: jest.fn((callback) => {
+        electronHandlers.tabSearch = callback;
+      }),
+    },
+    addEventListener: jest.fn((event, handler) => {
+      windowHandlers[event] = handler;
+    }),
+  };
+  global.document = document;
+
+  jest.doMock('./tabs.js', () => tabsMocks);
+  jest.doMock('./menus.js', () => menusMocks);
+  jest.doMock('./menu-backdrop.js', () => backdropMocks);
+  jest.doMock('./debug.js', () => ({ pushDebug: jest.fn() }));
+
+  const mod = await import('./tab-search.js');
+
+  return {
+    mod,
+    tabsMocks,
+    menusMocks,
+    backdropMocks,
+    elements: { popover, input, list },
+    windowHandlers,
+    electronHandlers,
+    tabsState,
+  };
+};
+
+const sampleTabs = () => [
+  { id: 1, title: 'Pinned Docs', url: 'https://docs.example/', pinned: true },
+  { id: 2, title: 'New Tab', url: 'freedom://home' },
+  { id: 3, title: 'GitHub', url: 'https://github.com/', isAudible: true },
+  {
+    id: 4,
+    title: 'Restored Placeholder',
+    url: 'https://restored.example/',
+    isPlaceholder: true,
+    webview: null,
+  },
+];
+
+const rowsOf = (list) => list.children.filter((el) => el.dataset.test === 'tab-search-item');
+
+describe('tab search popover', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    jest.restoreAllMocks();
+  });
+
+  test('opens listing pinned tabs first (placeholders included), current window order', async () => {
+    const { mod, elements, backdropMocks, menusMocks } = await loadTabSearchModule({
+      tabs: sampleTabs(),
+      activeTabId: 2,
+    });
+    const onOpening = jest.fn();
+    mod.initTabSearch({ onOpening });
+
+    mod.showTabSearch();
+    expect(mod.isTabSearchOpen()).toBe(true);
+    expect(elements.popover.classList.contains('hidden')).toBe(false);
+    expect(menusMocks.closeMenus).toHaveBeenCalled();
+    expect(onOpening).toHaveBeenCalled();
+    expect(backdropMocks.showMenuBackdrop).toHaveBeenCalled();
+    expect(elements.input.focus).toHaveBeenCalled();
+
+    const rows = rowsOf(elements.list);
+    expect(rows.map((row) => row.dataset.tabId)).toEqual(['1', '2', '3', '4']);
+    // Placeholder listed by persisted title/URL.
+    const placeholderRow = rows[3];
+    expect(placeholderRow.querySelector('.tab-search-item-title').textContent).toBe(
+      'Restored Placeholder'
+    );
+    // Audible tab gets an audio badge; others don't.
+    expect(rows[2].querySelector('.tab-search-item-audio')).toBeTruthy();
+    expect(rows[0].querySelector('.tab-search-item-audio')).toBe(null);
+  });
+
+  test('typing fuzzy-filters and Enter activates the selected tab', async () => {
+    const { mod, elements, tabsMocks } = await loadTabSearchModule({
+      tabs: sampleTabs(),
+      activeTabId: 2,
+    });
+    mod.initTabSearch();
+    mod.showTabSearch();
+
+    elements.input.value = 'github';
+    elements.input.dispatch('input');
+    let rows = rowsOf(elements.list);
+    expect(rows.map((row) => row.dataset.tabId)).toEqual(['3']);
+
+    elements.input.dispatch('keydown', { key: 'Enter', preventDefault: jest.fn() });
+    expect(tabsMocks.switchTab).toHaveBeenCalledWith(3);
+    expect(mod.isTabSearchOpen()).toBe(false);
+  });
+
+  test('arrow keys move the selection with wrap-around', async () => {
+    const { mod, elements, tabsMocks } = await loadTabSearchModule({
+      tabs: sampleTabs(),
+      activeTabId: 2,
+    });
+    mod.initTabSearch();
+    mod.showTabSearch();
+
+    const prevent = jest.fn();
+    elements.input.dispatch('keydown', { key: 'ArrowDown', preventDefault: prevent });
+    elements.input.dispatch('keydown', { key: 'ArrowDown', preventDefault: prevent });
+    let rows = rowsOf(elements.list);
+    expect(rows[2].classList.contains('selected')).toBe(true);
+
+    elements.input.dispatch('keydown', { key: 'ArrowUp', preventDefault: prevent });
+    elements.input.dispatch('keydown', { key: 'ArrowUp', preventDefault: prevent });
+    elements.input.dispatch('keydown', { key: 'ArrowUp', preventDefault: prevent });
+    rows = rowsOf(elements.list);
+    // 0 -> wraps to the last row.
+    expect(rows[3].classList.contains('selected')).toBe(true);
+
+    elements.input.dispatch('keydown', { key: 'Enter', preventDefault: prevent });
+    expect(tabsMocks.switchTab).toHaveBeenCalledWith(4);
+  });
+
+  test('Escape and window blur close the popover and hide the backdrop', async () => {
+    const { mod, elements, backdropMocks, windowHandlers } = await loadTabSearchModule({
+      tabs: sampleTabs(),
+      activeTabId: 2,
+    });
+    mod.initTabSearch();
+
+    mod.showTabSearch();
+    elements.input.dispatch('keydown', { key: 'Escape', preventDefault: jest.fn() });
+    expect(mod.isTabSearchOpen()).toBe(false);
+    expect(backdropMocks.hideMenuBackdrop).toHaveBeenCalledTimes(1);
+
+    mod.showTabSearch();
+    windowHandlers.blur();
+    expect(mod.isTabSearchOpen()).toBe(false);
+    expect(backdropMocks.hideMenuBackdrop).toHaveBeenCalledTimes(2);
+  });
+
+  test('clicking a row activates that tab', async () => {
+    const { mod, elements, tabsMocks } = await loadTabSearchModule({
+      tabs: sampleTabs(),
+      activeTabId: 2,
+    });
+    mod.initTabSearch();
+    mod.showTabSearch();
+
+    const rows = rowsOf(elements.list);
+    rows[0].dispatch('click');
+    expect(tabsMocks.switchTab).toHaveBeenCalledWith(1);
+    expect(mod.isTabSearchOpen()).toBe(false);
+  });
+
+  test('keyboard shortcut and menu IPC both toggle the popover', async () => {
+    const { mod, windowHandlers, electronHandlers } = await loadTabSearchModule({
+      tabs: sampleTabs(),
+      activeTabId: 2,
+    });
+    mod.initTabSearch();
+
+    // Renderer fallback: Cmd/Ctrl+Shift+A.
+    windowHandlers.keydown({
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: true,
+      key: 'A',
+      preventDefault: jest.fn(),
+    });
+    expect(mod.isTabSearchOpen()).toBe(true);
+    windowHandlers.keydown({
+      metaKey: false,
+      ctrlKey: true,
+      shiftKey: true,
+      key: 'a',
+      preventDefault: jest.fn(),
+    });
+    expect(mod.isTabSearchOpen()).toBe(false);
+
+    // Main-menu accelerator round trip (View -> Search Tabs).
+    electronHandlers.tabSearch();
+    expect(mod.isTabSearchOpen()).toBe(true);
+    electronHandlers.tabSearch();
+    expect(mod.isTabSearchOpen()).toBe(false);
+  });
+
+  test('shows an empty state when nothing matches', async () => {
+    const { mod, elements } = await loadTabSearchModule({
+      tabs: sampleTabs(),
+      activeTabId: 2,
+    });
+    mod.initTabSearch();
+    mod.showTabSearch();
+
+    elements.input.value = 'zzzz-no-match';
+    elements.input.dispatch('input');
+    expect(rowsOf(elements.list)).toEqual([]);
+    const empty = elements.list.children.find((el) => el.classList.contains('tab-search-empty'));
+    expect(empty).toBeTruthy();
+
+    // Enter with no matches is a no-op close, not a crash.
+    elements.input.dispatch('keydown', { key: 'Enter', preventDefault: jest.fn() });
+    expect(mod.isTabSearchOpen()).toBe(false);
+  });
+});

--- a/src/renderer/lib/tabs-strip-features.test.js
+++ b/src/renderer/lib/tabs-strip-features.test.js
@@ -368,3 +368,124 @@ describe('tab audio indicator + mute', () => {
     expect(placeholder.webview.setAudioMuted).toHaveBeenCalledWith(true);
   });
 });
+
+describe('open new tabs next to the active tab', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    jest.restoreAllMocks();
+  });
+
+  describe('computeNewTabInsertIndex (pure)', () => {
+    let computeNewTabInsertIndex;
+    beforeAll(async () => {
+      ({
+        mod: { computeNewTabInsertIndex },
+      } = await loadTabsModule());
+    });
+
+    const tab = (id, extra = {}) => ({ id, ...extra });
+
+    test('appends at the end when the setting is off', () => {
+      const tabs = [tab(1), tab(2), tab(3)];
+      expect(computeNewTabInsertIndex(tabs, 1, false)).toBe(3);
+    });
+
+    test('appends at the end when the active tab is unknown', () => {
+      const tabs = [tab(1), tab(2)];
+      expect(computeNewTabInsertIndex(tabs, 99, true)).toBe(2);
+      expect(computeNewTabInsertIndex(tabs, null, true)).toBe(2);
+    });
+
+    test('inserts right of the active tab', () => {
+      const tabs = [tab(1), tab(2), tab(3)];
+      expect(computeNewTabInsertIndex(tabs, 1, true)).toBe(1);
+      expect(computeNewTabInsertIndex(tabs, 2, true)).toBe(2);
+      expect(computeNewTabInsertIndex(tabs, 3, true)).toBe(3);
+    });
+
+    test('groups after the active tab existing children', () => {
+      const tabs = [tab(1), tab(10, { openerTabId: 1 }), tab(11, { openerTabId: 1 }), tab(2)];
+      expect(computeNewTabInsertIndex(tabs, 1, true)).toBe(3);
+      // Children of a different opener are not skipped.
+      expect(computeNewTabInsertIndex(tabs, 2, true)).toBe(4);
+    });
+
+    test('never splits the pinned block', () => {
+      const tabs = [tab(1, { pinned: true }), tab(2, { pinned: true }), tab(3)];
+      expect(computeNewTabInsertIndex(tabs, 1, true)).toBe(2);
+    });
+  });
+
+  test('new tabs open right of the active tab by default', async () => {
+    const { mod } = await loadTabsModule();
+    await mod.initTabs();
+
+    const tabA = mod.getActiveTab();
+    const tabB = mod.createTab('https://b.example/');
+    // Switch back to A and open another tab: it must land between A and B.
+    mod.switchTab(tabA.id);
+    const tabC = mod.createTab('https://c.example/');
+
+    expect(mod.getTabs().map((t) => t.id)).toEqual([tabA.id, tabC.id, tabB.id]);
+    expect(mod.getActiveTab().id).toBe(tabC.id);
+  });
+
+  test('link-opened child tabs group after their opener in open order', async () => {
+    const { mod } = await loadTabsModule();
+    await mod.initTabs();
+
+    const opener = mod.getActiveTab();
+    const trailing = mod.createTab('https://trailing.example/');
+    mod.switchTab(opener.id);
+
+    const child1 = mod.openInNewTabWithTarget('https://child-1.example/', null);
+    mod.switchTab(opener.id);
+    const child2 = mod.openInNewTabWithTarget('https://child-2.example/', null);
+
+    expect(mod.getTabs().map((t) => t.id)).toEqual([opener.id, child1.id, child2.id, trailing.id]);
+  });
+
+  test('setting off restores append-at-end (settings:updated round trip)', async () => {
+    const { mod, windowHandlers } = await loadTabsModule();
+    await mod.initTabs();
+
+    windowHandlers['settings:updated']({ detail: { openNewTabNextToActive: false } });
+
+    const tabA = mod.getActiveTab();
+    const tabB = mod.createTab('https://b.example/');
+    mod.switchTab(tabA.id);
+    const tabC = mod.createTab('https://c.example/');
+
+    expect(mod.getTabs().map((t) => t.id)).toEqual([tabA.id, tabB.id, tabC.id]);
+  });
+
+  test('honors the persisted setting at init', async () => {
+    const { mod } = await loadTabsModule({ settings: { openNewTabNextToActive: false } });
+    await mod.initTabs();
+
+    const tabA = mod.getActiveTab();
+    const tabB = mod.createTab('https://b.example/');
+    mod.switchTab(tabA.id);
+    const tabC = mod.createTab('https://c.example/');
+
+    expect(mod.getTabs().map((t) => t.id)).toEqual([tabA.id, tabB.id, tabC.id]);
+  });
+
+  test('placeholder restore order is untouched; a new tab lands next to the materialized active tab', async () => {
+    const { mod } = await loadTabsModule();
+    await mod.initTabs();
+
+    // Restored session: three placeholders appended in persisted order.
+    const p1 = mod.createPlaceholderTab({ url: 'https://one.example/', title: 'One' });
+    const p2 = mod.createPlaceholderTab({ url: 'https://two.example/', title: 'Two' });
+    const p3 = mod.createPlaceholderTab({ url: 'https://three.example/', title: 'Three' });
+    const home = mod.getTabs()[0];
+    expect(mod.getTabs().map((t) => t.id)).toEqual([home.id, p1.id, p2.id, p3.id]);
+
+    // Activate the middle placeholder (materializes) and open a new tab.
+    mod.switchTab(p2.id);
+    const fresh = mod.createTab('https://fresh.example/');
+    expect(mod.getTabs().map((t) => t.id)).toEqual([home.id, p1.id, p2.id, fresh.id, p3.id]);
+  });
+});

--- a/src/renderer/lib/tabs-strip-features.test.js
+++ b/src/renderer/lib/tabs-strip-features.test.js
@@ -1,0 +1,370 @@
+// Tab strip upgrades — audio indicator + mute, open-next-to-active
+// insertion, MRU Ctrl+Tab cycling, and context-menu completeness (close
+// left, copy URL, reopen closed). Uses the same fake-DOM module harness as
+// tabs-ui.test.js, extended with the audio webview surface and the new
+// context-menu actions.
+
+const { createDocument, createElement } = require('../../../test/helpers/fake-dom.js');
+
+const originalWindow = global.window;
+const originalDocument = global.document;
+
+const HOME_URL = 'freedom://home';
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createElectronApi = (options = {}) => {
+  const handlers = {};
+  const register = (name) =>
+    jest.fn((callback) => {
+      handlers[name] = callback;
+    });
+
+  return {
+    handlers,
+    api: {
+      setWindowTitle: jest.fn(),
+      updateTabMenuState: jest.fn(),
+      closeWindow: jest.fn(),
+      copyText: jest.fn().mockResolvedValue(true),
+      getSettings: jest.fn().mockResolvedValue(options.settings || {}),
+      getWebviewPreloadPath: jest.fn().mockResolvedValue('/tmp/webview-preload.js'),
+      getCachedFavicon: jest.fn().mockResolvedValue('data:image/png;base64,favicon'),
+      onNewTab: register('newTab'),
+      onCloseTab: register('closeTab'),
+      onNewTabWithUrl: register('newTabWithUrl'),
+      onNavigateToUrl: register('navigateToUrl'),
+      onLoadUrl: register('loadUrl'),
+      onToggleDevTools: register('toggleDevTools'),
+      onCloseDevTools: register('closeDevTools'),
+      onCloseAllDevTools: register('closeAllDevTools'),
+      onFocusAddressBar: register('focusAddressBar'),
+      onReload: register('reload'),
+      onHardReload: register('hardReload'),
+      onNextTab: register('nextTab'),
+      onPrevTab: register('prevTab'),
+      onMoveTabLeft: register('moveTabLeft'),
+      onMoveTabRight: register('moveTabRight'),
+      onReopenClosedTab: register('reopenClosedTab'),
+    },
+  };
+};
+
+const createWebview = (createdWebviews) => {
+  const webview = createElement('webview');
+  const addEventListener = webview.addEventListener.bind(webview);
+  const removeEventListener = webview.removeEventListener.bind(webview);
+
+  webview.addEventListener = jest.fn((event, handler) => {
+    addEventListener(event, handler);
+  });
+  webview.removeEventListener = jest.fn((event, handler) => {
+    removeEventListener(event, handler);
+  });
+  webview._devToolsOpen = false;
+  webview._audioMuted = false;
+  webview._audible = false;
+  webview.getURL = jest.fn(() => webview.src || 'about:blank');
+  webview.setAudioMuted = jest.fn((muted) => {
+    webview._audioMuted = muted;
+  });
+  webview.isAudioMuted = jest.fn(() => webview._audioMuted);
+  webview.isCurrentlyAudible = jest.fn(() => webview._audible);
+  webview.openDevTools = jest.fn(() => {
+    webview._devToolsOpen = true;
+  });
+  webview.closeDevTools = jest.fn(() => {
+    webview._devToolsOpen = false;
+  });
+  webview.isDevToolsOpened = jest.fn(() => webview._devToolsOpen);
+  createdWebviews.push(webview);
+  return webview;
+};
+
+const CONTEXT_MENU_ACTIONS = [
+  'close',
+  'close-others',
+  'close-right',
+  'close-left',
+  'pin',
+  'mute',
+  'copy-url',
+  'reopen-closed',
+];
+
+const buildTabContextMenu = () => {
+  const tabContextMenu = createElement('div', { classes: ['hidden'] });
+  const actions = {};
+
+  CONTEXT_MENU_ACTIONS.forEach((action) => {
+    const button = createElement('button');
+    button.dataset.action = action;
+    tabContextMenu.appendChild(button);
+    actions[action] = button;
+  });
+
+  return { tabContextMenu, actions };
+};
+
+const loadTabsModule = async (options = {}) => {
+  jest.resetModules();
+
+  const createdWebviews = [];
+  const { api: electronAPI, handlers: electronHandlers } = createElectronApi(options);
+  const tabBar = createElement('div');
+  const newTabBtn = createElement('button');
+  const webviewContainer = createElement('div');
+  const bzzWebview = createElement('webview');
+  const addressInput = createElement('input');
+  const mruSwitcher = createElement('div', { classes: ['hidden'] });
+  const mruList = createElement('div');
+  mruSwitcher.appendChild(mruList);
+  const { tabContextMenu, actions } = buildTabContextMenu();
+  const document = createDocument({
+    elementsById: {
+      'tab-bar': tabBar,
+      'new-tab-btn': newTabBtn,
+      'webview-container': webviewContainer,
+      'tab-context-menu': tabContextMenu,
+      'bzz-webview': bzzWebview,
+      'address-input': addressInput,
+      'tab-mru-switcher': mruSwitcher,
+      'tab-mru-list': mruList,
+    },
+    createElementOverride: (tagName) => {
+      if (tagName === 'webview') {
+        return createWebview(createdWebviews);
+      }
+      return createElement(tagName);
+    },
+  });
+  const windowHandlers = {};
+
+  addressInput.focus = jest.fn();
+  addressInput.select = jest.fn();
+
+  global.window = {
+    electronAPI,
+    innerWidth: 800,
+    innerHeight: 600,
+    location: {
+      href: 'file:///app/index.html',
+      search: options.search || '',
+    },
+    addEventListener: jest.fn((event, handler) => {
+      windowHandlers[event] = handler;
+    }),
+  };
+
+  global.document = document;
+
+  jest.doMock('./debug.js', () => ({ pushDebug: jest.fn() }));
+  jest.doMock('./menus.js', () => ({ closeMenus: jest.fn() }));
+  jest.doMock('./bookmarks-ui.js', () => ({ hideBookmarkContextMenu: jest.fn() }));
+  jest.doMock('./menu-backdrop.js', () => ({
+    showMenuBackdrop: jest.fn(),
+    hideMenuBackdrop: jest.fn(),
+  }));
+  jest.doMock('./page-context-menu.js', () => ({ setupWebviewContextMenu: jest.fn() }));
+  jest.doMock('./link-status.js', () => ({
+    clearLinkStatus: jest.fn(),
+    clearHoverStatus: jest.fn(),
+    showLinkStatus: jest.fn(),
+    setLinkStatusSide: jest.fn(),
+  }));
+  jest.doMock('./page-urls.js', () => ({
+    homeUrl: options.homeUrl || HOME_URL,
+    getInternalPageName: (url) =>
+      typeof url === 'string' && url.includes('/pages/history.html') ? 'history' : null,
+    internalPages: {},
+  }));
+
+  const mod = await import('./tabs.js');
+
+  return {
+    mod,
+    electronAPI,
+    electronHandlers,
+    createdWebviews,
+    elements: {
+      tabBar,
+      newTabBtn,
+      webviewContainer,
+      tabContextMenu,
+      bzzWebview,
+      addressInput,
+      mruSwitcher,
+      mruList,
+      actions,
+    },
+    windowHandlers,
+    documentHandlers: document.handlers,
+  };
+};
+
+const findTabElement = (tabBar, tabId) =>
+  tabBar.children.find((child) => child.dataset.tabId === tabId) || null;
+
+const openContextMenu = (tabEl) => {
+  tabEl.dispatch('contextmenu', {
+    preventDefault: jest.fn(),
+    stopPropagation: jest.fn(),
+    clientX: 100,
+    clientY: 100,
+  });
+};
+
+describe('tab audio indicator + mute', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('getTabAudioState reducer: muted wins over audible', async () => {
+    const { mod } = await loadTabsModule();
+    expect(mod.getTabAudioState(null)).toBe(null);
+    expect(mod.getTabAudioState({})).toBe(null);
+    expect(mod.getTabAudioState({ isAudible: true })).toBe('audible');
+    expect(mod.getTabAudioState({ isMuted: true })).toBe('muted');
+    expect(mod.getTabAudioState({ isMuted: true, isAudible: true })).toBe('muted');
+  });
+
+  test('media events drive the audible flag and the strip indicator', async () => {
+    jest.useFakeTimers();
+    const { mod, elements } = await loadTabsModule();
+    await mod.initTabs();
+
+    const tab = mod.getActiveTab();
+    const tabEl = findTabElement(elements.tabBar, tab.id);
+    expect(tabEl.dataset.audioState).toBeUndefined();
+
+    tab.webview._audible = true;
+    tab.webview.dispatch('media-started-playing');
+    expect(tab.isAudible).toBe(true);
+    expect(tabEl.dataset.audioState).toBe('audible');
+
+    tab.webview._audible = false;
+    tab.webview.dispatch('media-paused');
+    expect(tab.isAudible).toBe(false);
+    expect(tabEl.dataset.audioState).toBeUndefined();
+  });
+
+  test('falls back to the media event when isCurrentlyAudible is unavailable', async () => {
+    jest.useFakeTimers();
+    const { mod } = await loadTabsModule();
+    await mod.initTabs();
+
+    const tab = mod.getActiveTab();
+    delete tab.webview.isCurrentlyAudible;
+
+    tab.webview.dispatch('media-started-playing');
+    expect(tab.isAudible).toBe(true);
+    tab.webview.dispatch('media-paused');
+    expect(tab.isAudible).toBe(false);
+  });
+
+  test('delayed re-sample converges the indicator on the real audible state', async () => {
+    jest.useFakeTimers();
+    const { mod } = await loadTabsModule();
+    await mod.initTabs();
+
+    const tab = mod.getActiveTab();
+    // Media starts but audio is not audible yet (fade-in): the event edge
+    // samples false, the recheck later flips it to true.
+    tab.webview._audible = false;
+    tab.webview.dispatch('media-started-playing');
+    // isCurrentlyAudible() returned false, overriding the event fallback.
+    expect(tab.isAudible).toBe(false);
+
+    tab.webview._audible = true;
+    jest.runOnlyPendingTimers();
+    expect(tab.isAudible).toBe(true);
+    // The recheck must not reschedule itself into a standing poll.
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test('toggleMuteTab applies webContents mute and shows the muted indicator', async () => {
+    jest.useFakeTimers();
+    const { mod, elements } = await loadTabsModule();
+    await mod.initTabs();
+
+    const tab = mod.getActiveTab();
+    const tabEl = findTabElement(elements.tabBar, tab.id);
+
+    // Muted wins over audible.
+    tab.webview._audible = true;
+    tab.webview.dispatch('media-started-playing');
+    mod.toggleMuteTab(tab.id);
+    expect(tab.isMuted).toBe(true);
+    expect(tab.webview.setAudioMuted).toHaveBeenCalledWith(true);
+    expect(tabEl.dataset.audioState).toBe('muted');
+
+    mod.toggleMuteTab(tab.id);
+    expect(tab.isMuted).toBe(false);
+    expect(tab.webview.setAudioMuted).toHaveBeenLastCalledWith(false);
+    expect(tabEl.dataset.audioState).toBe('audible');
+  });
+
+  test('clicking the tab audio button toggles mute without switching tabs', async () => {
+    const { mod, elements } = await loadTabsModule();
+    await mod.initTabs();
+
+    const first = mod.getActiveTab();
+    mod.createTab('https://second.example');
+    const firstEl = findTabElement(elements.tabBar, first.id);
+    const audioBtn = firstEl.querySelector('.tab-audio');
+    expect(audioBtn).toBeTruthy();
+
+    const stopPropagation = jest.fn();
+    audioBtn.dispatch('click', { stopPropagation });
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(first.isMuted).toBe(true);
+    // The click must not activate the (background) first tab.
+    expect(mod.getActiveTab().id).not.toBe(first.id);
+  });
+
+  test('context menu offers Mute Tab / Unmute Tab', async () => {
+    const { mod, elements } = await loadTabsModule();
+    await mod.initTabs();
+
+    const tab = mod.getActiveTab();
+    const tabEl = findTabElement(elements.tabBar, tab.id);
+
+    openContextMenu(tabEl);
+    expect(elements.actions.mute.textContent).toBe('Mute Tab');
+    elements.tabContextMenu.dispatch('click', { target: elements.actions.mute });
+    expect(tab.isMuted).toBe(true);
+
+    openContextMenu(tabEl);
+    expect(elements.actions.mute.textContent).toBe('Unmute Tab');
+    elements.tabContextMenu.dispatch('click', { target: elements.actions.mute });
+    expect(tab.isMuted).toBe(false);
+  });
+
+  test('placeholder tabs: mute is materialize-safe', async () => {
+    const { mod } = await loadTabsModule();
+    await mod.initTabs();
+
+    const placeholder = mod.createPlaceholderTab({
+      url: 'https://restored.example/',
+      title: 'Restored',
+    });
+    expect(placeholder.webview).toBe(null);
+
+    // Toggling mute on a placeholder must not throw and must stick.
+    mod.toggleMuteTab(placeholder.id);
+    expect(placeholder.isMuted).toBe(true);
+
+    // Materialize on activation; dom-ready applies the deferred mute.
+    mod.switchTab(placeholder.id);
+    await flushMicrotasks();
+    expect(placeholder.webview).toBeTruthy();
+    placeholder.webview.dispatch('dom-ready');
+    expect(placeholder.webview.setAudioMuted).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/renderer/lib/tabs-strip-features.test.js
+++ b/src/renderer/lib/tabs-strip-features.test.js
@@ -489,3 +489,167 @@ describe('open new tabs next to the active tab', () => {
     expect(mod.getTabs().map((t) => t.id)).toEqual([home.id, p1.id, p2.id, fresh.id, p3.id]);
   });
 });
+
+describe('MRU Ctrl+Tab cycling', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    jest.restoreAllMocks();
+  });
+
+  const ctrlTab = (windowHandlers, { shift = false } = {}) => {
+    windowHandlers.keydown({
+      ctrlKey: true,
+      metaKey: false,
+      shiftKey: shift,
+      key: 'Tab',
+      preventDefault: jest.fn(),
+    });
+  };
+
+  const releaseCtrl = (windowHandlers) => {
+    windowHandlers.keyup({ key: 'Control' });
+  };
+
+  const selectedRow = (mruList) =>
+    mruList.children.find((row) => row.classList.contains('selected')) || null;
+
+  // Three tabs, most recently used order [C, B, A] (A = initial home tab).
+  const setupThreeTabs = async (settings = { mruTabSwitching: true }) => {
+    const harness = await loadTabsModule({ settings });
+    await harness.mod.initTabs();
+    const tabA = harness.mod.getActiveTab();
+    const tabB = harness.mod.createTab('https://b.example/');
+    const tabC = harness.mod.createTab('https://c.example/');
+    return { ...harness, tabA, tabB, tabC };
+  };
+
+  test('disabled: Ctrl+Tab stays sequential and shows no switcher', async () => {
+    const { mod, elements, windowHandlers, tabA, tabB, tabC } = await setupThreeTabs({
+      mruTabSwitching: false,
+    });
+
+    // Strip order [A, B, C] (each new tab was active when the next opened),
+    // active C. Sequential next wraps to A.
+    expect(mod.getActiveTab().id).toBe(tabC.id);
+    ctrlTab(windowHandlers);
+    expect(mod.getActiveTab().id).toBe(tabA.id);
+    expect(elements.mruSwitcher.classList.contains('hidden')).toBe(true);
+
+    ctrlTab(windowHandlers, { shift: true });
+    expect(mod.getActiveTab().id).toBe(tabC.id);
+    void tabB;
+  });
+
+  test('enabled: Ctrl+Tab opens the switcher on the previous tab; releasing Ctrl commits', async () => {
+    const { mod, elements, windowHandlers, tabB, tabC } = await setupThreeTabs();
+
+    expect(mod.getActiveTab().id).toBe(tabC.id);
+    ctrlTab(windowHandlers);
+    // Overlay is visible, tab not switched yet (held-Ctrl preview).
+    expect(elements.mruSwitcher.classList.contains('hidden')).toBe(false);
+    expect(mod.getActiveTab().id).toBe(tabC.id);
+    // Selection sits on the most recently used other tab: B.
+    expect(selectedRow(elements.mruList)?.dataset.tabId).toBe(String(tabB.id));
+
+    releaseCtrl(windowHandlers);
+    expect(elements.mruSwitcher.classList.contains('hidden')).toBe(true);
+    expect(mod.getActiveTab().id).toBe(tabB.id);
+  });
+
+  test('repeated Ctrl+Tab while held cycles further; Shift cycles backwards', async () => {
+    const { mod, elements, windowHandlers, tabA, tabC } = await setupThreeTabs();
+
+    ctrlTab(windowHandlers);
+    ctrlTab(windowHandlers);
+    // MRU order [C, B, A] -> two steps from C lands on A.
+    expect(selectedRow(elements.mruList)?.dataset.tabId).toBe(String(tabA.id));
+
+    // One step back returns to B, another back to C (wrap behavior).
+    ctrlTab(windowHandlers, { shift: true });
+    ctrlTab(windowHandlers, { shift: true });
+    expect(selectedRow(elements.mruList)?.dataset.tabId).toBe(String(tabC.id));
+
+    releaseCtrl(windowHandlers);
+    // Committing the current tab is a no-op switch.
+    expect(mod.getActiveTab().id).toBe(tabC.id);
+  });
+
+  test('Escape cancels the switch without committing', async () => {
+    const { mod, elements, windowHandlers, tabC } = await setupThreeTabs();
+
+    ctrlTab(windowHandlers);
+    windowHandlers.keydown({ key: 'Escape', ctrlKey: true, preventDefault: jest.fn() });
+    expect(elements.mruSwitcher.classList.contains('hidden')).toBe(true);
+
+    // The later Ctrl release must not commit anything.
+    releaseCtrl(windowHandlers);
+    expect(mod.getActiveTab().id).toBe(tabC.id);
+  });
+
+  test('window blur mid-hold commits the selection', async () => {
+    const { mod, windowHandlers, tabB } = await setupThreeTabs();
+
+    ctrlTab(windowHandlers);
+    windowHandlers.blur();
+    expect(mod.getActiveTab().id).toBe(tabB.id);
+  });
+
+  test('MRU order updates on activation and prunes closed tabs', async () => {
+    const { mod, elements, windowHandlers, tabA, tabB, tabC } = await setupThreeTabs();
+
+    // Re-activate A: MRU becomes [A, C, B].
+    mod.switchTab(tabA.id);
+    ctrlTab(windowHandlers);
+    expect(selectedRow(elements.mruList)?.dataset.tabId).toBe(String(tabC.id));
+    releaseCtrl(windowHandlers);
+    expect(mod.getActiveTab().id).toBe(tabC.id);
+
+    // Close B; MRU [C, A] — switcher must not offer the closed tab.
+    mod.closeTab(tabB.id);
+    ctrlTab(windowHandlers);
+    const ids = elements.mruList.children.map((row) => row.dataset.tabId);
+    expect(ids).toEqual([String(tabC.id), String(tabA.id)]);
+    releaseCtrl(windowHandlers);
+    expect(mod.getActiveTab().id).toBe(tabA.id);
+  });
+
+  test('never-activated placeholders participate and materialize on commit', async () => {
+    const { mod, elements, windowHandlers } = await setupThreeTabs();
+
+    const placeholder = mod.createPlaceholderTab({
+      url: 'https://restored.example/',
+      title: 'Restored',
+    });
+    expect(placeholder.webview).toBe(null);
+
+    // Placeholder was never activated, so it trails the MRU list (last row).
+    ctrlTab(windowHandlers);
+    const rows = elements.mruList.children;
+    expect(rows[rows.length - 1].dataset.tabId).toBe(String(placeholder.id));
+
+    // Cycle onto it (3 known tabs first, so 3 steps total from index 0).
+    ctrlTab(windowHandlers);
+    ctrlTab(windowHandlers);
+    expect(selectedRow(elements.mruList)?.dataset.tabId).toBe(String(placeholder.id));
+
+    releaseCtrl(windowHandlers);
+    expect(mod.getActiveTab().id).toBe(placeholder.id);
+    expect(placeholder.webview).toBeTruthy();
+    expect(placeholder.isPlaceholder).toBe(false);
+  });
+
+  test('single tab: Ctrl+Tab is a no-op (no overlay)', async () => {
+    const { mod, elements, windowHandlers } = await loadTabsModule({
+      settings: { mruTabSwitching: true },
+    }).then(async (harness) => {
+      await harness.mod.initTabs();
+      return harness;
+    });
+
+    ctrlTab(windowHandlers);
+    expect(elements.mruSwitcher.classList.contains('hidden')).toBe(true);
+    releaseCtrl(windowHandlers);
+    expect(mod.getTabs()).toHaveLength(1);
+  });
+});

--- a/src/renderer/lib/tabs-strip-features.test.js
+++ b/src/renderer/lib/tabs-strip-features.test.js
@@ -653,3 +653,104 @@ describe('MRU Ctrl+Tab cycling', () => {
     expect(mod.getTabs()).toHaveLength(1);
   });
 });
+
+describe('context-menu completeness: close left, copy URL, reopen closed', () => {
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    jest.restoreAllMocks();
+  });
+
+  test('Close Tabs to the Left mirrors close-right semantics incl. pinned protection', async () => {
+    const { mod, elements } = await loadTabsModule();
+    await mod.initTabs();
+
+    const tabA = mod.getActiveTab();
+    const tabB = mod.createTab('https://b.example/');
+    const tabC = mod.createTab('https://c.example/');
+
+    // Pin A — it must survive a close-left sweep.
+    const tabAEl = findTabElement(elements.tabBar, tabA.id);
+    openContextMenu(tabAEl);
+    elements.tabContextMenu.dispatch('click', { target: elements.actions.pin });
+    expect(mod.getTabs().find((t) => t.id === tabA.id).pinned).toBe(true);
+
+    // From C, close everything to the left: only B closes.
+    const tabCEl = findTabElement(elements.tabBar, tabC.id);
+    openContextMenu(tabCEl);
+    expect(elements.actions['close-left'].disabled).toBe(false);
+    elements.tabContextMenu.dispatch('click', { target: elements.actions['close-left'] });
+
+    expect(mod.getTabs().map((t) => t.id)).toEqual([tabA.id, tabC.id]);
+    void tabB;
+  });
+
+  test('Close Tabs to the Left is disabled when nothing unpinned is to the left', async () => {
+    const { mod, elements } = await loadTabsModule();
+    await mod.initTabs();
+
+    const tabA = mod.getActiveTab();
+    mod.createTab('https://b.example/');
+
+    // Leftmost tab: nothing to its left.
+    openContextMenu(findTabElement(elements.tabBar, tabA.id));
+    expect(elements.actions['close-left'].disabled).toBe(true);
+  });
+
+  test('Copy URL puts the tab URL on the clipboard (placeholders use the persisted URL)', async () => {
+    const { mod, elements, electronAPI } = await loadTabsModule();
+    await mod.initTabs();
+
+    const tab = mod.createTab('https://copy-me.example/page');
+    openContextMenu(findTabElement(elements.tabBar, tab.id));
+    expect(elements.actions['copy-url'].disabled).toBe(false);
+    elements.tabContextMenu.dispatch('click', { target: elements.actions['copy-url'] });
+    expect(electronAPI.copyText).toHaveBeenCalledWith('https://copy-me.example/page');
+
+    // Placeholder tab (no webview): the persisted URL is copied as-is.
+    const placeholder = mod.createPlaceholderTab({
+      url: 'https://restored.example/deep/link',
+      title: 'Restored',
+    });
+    openContextMenu(findTabElement(elements.tabBar, placeholder.id));
+    elements.tabContextMenu.dispatch('click', { target: elements.actions['copy-url'] });
+    expect(electronAPI.copyText).toHaveBeenLastCalledWith('https://restored.example/deep/link');
+  });
+
+  test('Copy URL normalizes resolved internal pages to their freedom:// form', async () => {
+    const { mod, elements, electronAPI } = await loadTabsModule();
+    await mod.initTabs();
+
+    const tab = mod.createTab('https://placeholder.example/');
+    // Simulate a loaded internal page: tab.url holds the resolved file:// URL
+    // (the harness page-urls mock maps /pages/history.html -> 'history').
+    tab.url = 'file:///app/pages/history.html';
+
+    openContextMenu(findTabElement(elements.tabBar, tab.id));
+    elements.tabContextMenu.dispatch('click', { target: elements.actions['copy-url'] });
+    expect(electronAPI.copyText).toHaveBeenLastCalledWith('freedom://history');
+  });
+
+  test('Reopen Closed Tab surfaces the closedTabsStack and disables when empty', async () => {
+    const { mod, elements } = await loadTabsModule();
+    await mod.initTabs();
+
+    const keeper = mod.getActiveTab();
+
+    // Nothing closed yet: item disabled.
+    openContextMenu(findTabElement(elements.tabBar, keeper.id));
+    expect(elements.actions['reopen-closed'].disabled).toBe(true);
+
+    // Close a real page; reopening from the menu restores it.
+    const doomed = mod.createTab('https://doomed.example/');
+    mod.closeTab(doomed.id);
+    expect(mod.getTabs().map((t) => t.id)).toEqual([keeper.id]);
+
+    openContextMenu(findTabElement(elements.tabBar, keeper.id));
+    expect(elements.actions['reopen-closed'].disabled).toBe(false);
+    elements.tabContextMenu.dispatch('click', { target: elements.actions['reopen-closed'] });
+
+    expect(mod.getTabs()).toHaveLength(2);
+    expect(mod.getActiveTab().url).toBe('https://doomed.example/');
+  });
+});

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -268,6 +268,82 @@ const createNavigationState = () => ({
   swarmProbeVersion: 0,
 });
 
+// --- Tab audio state (indicator + mute) ------------------------------------
+
+/**
+ * Pure reducer for the tab-strip audio indicator.
+ * Muted wins over audible so a muted tab keeps showing the muted-speaker
+ * affordance (and stays unmutable) even while no sound is being produced.
+ *
+ * @param {{isMuted?: boolean, isAudible?: boolean}|null} tab
+ * @returns {'muted'|'audible'|null} indicator to render, or null for none
+ */
+export const getTabAudioState = (tab) => {
+  if (!tab) return null;
+  if (tab.isMuted === true) return 'muted';
+  if (tab.isAudible === true) return 'audible';
+  return null;
+};
+
+// Sample a webview's audibility and update the tab flag. `fallback` is what
+// the triggering media event implies, used when isCurrentlyAudible isn't
+// available (tests, detached webviews) or throws (guest not attached yet).
+const applyTabAudibleState = (tabId, fallback) => {
+  const tab = tabState.tabs.find((t) => t.id === tabId);
+  if (!tab || !tab.webview) return;
+  let audible = fallback === true;
+  try {
+    if (typeof tab.webview.isCurrentlyAudible === 'function') {
+      audible = tab.webview.isCurrentlyAudible() === true;
+    }
+  } catch {
+    audible = fallback === true;
+  }
+  if (tab.isAudible !== audible) {
+    tab.isAudible = audible;
+    renderTabs();
+  }
+};
+
+// One delayed re-sample per media edge (never self-rescheduling) so the
+// indicator converges on the real audible state without a standing poll.
+const AUDIBLE_RECHECK_MS = 1000;
+const scheduleAudibleRecheck = (tabId) => {
+  const tab = tabState.tabs.find((t) => t.id === tabId);
+  if (!tab) return;
+  if (tab.audioStateTimer) {
+    clearTimeout(tab.audioStateTimer);
+  }
+  tab.audioStateTimer = setTimeout(() => {
+    tab.audioStateTimer = null;
+    applyTabAudibleState(tabId, tab.isAudible);
+  }, AUDIBLE_RECHECK_MS);
+};
+
+// Push tab.isMuted down to the webview when one exists. Placeholder tabs
+// have no webview yet — the flag is kept on the tab and applied by the
+// dom-ready handler once the tab materializes. Muting is webContents-level,
+// so it survives navigation without any extra bookkeeping.
+const applyMuteToWebview = (tab) => {
+  if (!tab?.webview || typeof tab.webview.setAudioMuted !== 'function') return;
+  try {
+    tab.webview.setAudioMuted(tab.isMuted === true);
+  } catch {
+    // Guest not attached yet — dom-ready re-applies.
+  }
+};
+
+// Toggle mute for a tab. Placeholder-safe: flips the tab flag immediately
+// (indicator updates) and defers the webview call to materialization.
+export const toggleMuteTab = (tabId) => {
+  const tab = tabState.tabs.find((t) => t.id === tabId);
+  if (!tab) return;
+  tab.isMuted = tab.isMuted !== true;
+  applyMuteToWebview(tab);
+  renderTabs();
+  pushDebug(`${tab.isMuted ? 'Muted' : 'Unmuted'} tab ${tabId}`);
+};
+
 // Get navigation state of the active tab
 export const getActiveTabState = () => {
   const tab = getActiveTab();
@@ -508,9 +584,32 @@ const createWebview = (tabId, initialUrl) => {
       }
     },
     'dom-ready': () => {
+      // Re-apply the tab-level mute flag once the webview is attached and
+      // ready. Covers mutes toggled before attach (placeholder tabs muted
+      // pre-materialization, races right after createTab) — webview methods
+      // throw until the guest is live, so this is the reliable apply point.
+      const tab = tabState.tabs.find((t) => t.id === tabId);
+      if (tab?.isMuted) {
+        applyMuteToWebview(tab);
+      }
       if (tabId === tabState.activeTabId && onWebviewEvent) {
         onWebviewEvent('dom-ready', { tabId });
       }
+    },
+    // Audio indicator state. Electron's <webview> emits media-started-playing /
+    // media-paused (there is no per-webview audio-state-changed event — that
+    // one only exists on main-process webContents), so on each media edge we
+    // sample isCurrentlyAudible() where available and fall back to what the
+    // event implies. A single delayed re-sample catches audibility settling
+    // after the event (e.g. a video whose audio track fades in, or another
+    // media element still playing when one pauses).
+    'media-started-playing': () => {
+      applyTabAudibleState(tabId, true);
+      scheduleAudibleRecheck(tabId);
+    },
+    'media-paused': () => {
+      applyTabAudibleState(tabId, false);
+      scheduleAudibleRecheck(tabId);
     },
     'console-message': (event) => {
       if (tabId === tabState.activeTabId) {
@@ -613,6 +712,12 @@ const isInternalPageUrl = (url) =>
 // Loading spinner (same style as address bar)
 const SPINNER_HTML = `<span class="tab-icon-spinner"></span>`;
 
+// Audio indicator icons — speaker (tab is audible) and muted speaker (tab is
+// muted). Both live inside the .tab-audio button; CSS picks one via the
+// tab's data-audio-state attribute.
+const AUDIO_ON_SVG = `<svg class="tab-audio-on" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" fill="currentColor" stroke="none"/><path d="M15.5 8.5a5 5 0 0 1 0 7"/><path d="M18.5 5.5a9 9 0 0 1 0 13"/></svg>`;
+const AUDIO_MUTED_SVG = `<svg class="tab-audio-muted" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" fill="currentColor" stroke="none"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>`;
+
 // Map to track existing tab DOM elements by tab ID
 const tabElements = new Map();
 
@@ -652,6 +757,18 @@ const createTabElement = (tab) => {
   }
 
   tabEl.appendChild(iconContainer);
+
+  // Audio indicator / mute toggle (hidden unless the tab is audible or
+  // muted — visibility driven by the tab's data-audio-state attribute).
+  const audioBtn = document.createElement('button');
+  audioBtn.className = 'tab-audio';
+  audioBtn.dataset.test = 'tab-audio';
+  audioBtn.innerHTML = AUDIO_ON_SVG + AUDIO_MUTED_SVG;
+  audioBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    toggleMuteTab(tab.id);
+  });
+  tabEl.appendChild(audioBtn);
 
   // Tab title
   const titleEl = document.createElement('span');
@@ -814,6 +931,18 @@ const updateTabElement = (tabEl, tab, isActive, isBeforeActive) => {
     }
   }
 
+  // Update audio indicator (speaker / muted speaker / hidden)
+  const audioState = getTabAudioState(tab);
+  if (audioState) {
+    tabEl.dataset.audioState = audioState;
+  } else {
+    delete tabEl.dataset.audioState;
+  }
+  const audioBtn = tabEl.querySelector('.tab-audio');
+  if (audioBtn) {
+    audioBtn.title = audioState === 'muted' ? 'Unmute tab' : 'Mute tab';
+  }
+
   // Update title
   const titleEl = tabEl.querySelector('.tab-title');
   const newTitle = tab.title || 'New Tab';
@@ -957,6 +1086,8 @@ export const createTab = (url = null) => {
     url: url || homeUrl,
     title: 'New Tab',
     isLoading: false,
+    isAudible: false,
+    isMuted: false,
     webview,
     navigationState: createNavigationState(),
   };
@@ -1004,6 +1135,8 @@ export const createPlaceholderTab = ({ url, title = '', pinned = false, faviconU
     url,
     title: title || 'New Tab',
     isLoading: false,
+    isAudible: false,
+    isMuted: false,
     pinned: pinned === true,
     favicon: faviconUrl || null,
     webview: null,
@@ -1078,6 +1211,10 @@ export const closeTab = (tabId) => {
   if (tab.suppressNextStopTimer) {
     clearTimeout(tab.suppressNextStopTimer);
     tab.suppressNextStopTimer = null;
+  }
+  if (tab.audioStateTimer) {
+    clearTimeout(tab.audioStateTimer);
+    tab.audioStateTimer = null;
   }
 
   // Remove event listeners before removing webview (prevents memory leak)
@@ -1230,6 +1367,12 @@ const showContextMenu = (x, y, tabId) => {
   const pinBtn = tabContextMenu.querySelector('[data-action="pin"]');
   if (pinBtn) {
     pinBtn.textContent = tab.pinned ? 'Unpin Tab' : 'Pin Tab';
+  }
+
+  // Update mute button text
+  const muteBtn = tabContextMenu.querySelector('[data-action="mute"]');
+  if (muteBtn) {
+    muteBtn.textContent = tab.isMuted ? 'Unmute Tab' : 'Mute Tab';
   }
 
   // Disable "Close Tabs to the Right" if there are no tabs to the right (excluding pinned)
@@ -1488,6 +1631,9 @@ export const initTabs = async () => {
           break;
         case 'pin':
           togglePinTab(contextMenuTabId);
+          break;
+        case 'mute':
+          toggleMuteTab(contextMenuTabId);
           break;
       }
       hideTabContextMenu();

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -1333,6 +1333,31 @@ const closeTabsToRight = (tabId) => {
   pushDebug(`Closed ${tabsToClose.length} tabs to the right`);
 };
 
+// Close all tabs to the left of the specified one (mirror of
+// closeTabsToRight, including the pinned-tab protection).
+const closeTabsToLeft = (tabId) => {
+  const tabIndex = tabState.tabs.findIndex((t) => t.id === tabId);
+  if (tabIndex === -1) return;
+
+  const tabsToClose = tabState.tabs.slice(0, tabIndex).filter((t) => !t.pinned);
+  for (const tab of tabsToClose) {
+    closeTab(tab.id);
+  }
+  pushDebug(`Closed ${tabsToClose.length} tabs to the left`);
+};
+
+// The URL "Copy URL" puts on the clipboard for a tab. Internal pages
+// normalize to their friendly freedom://<name> form — the resolved
+// file://…/pages/… URL is install-location-specific and useless to share
+// (same normalization the session snapshot applies). Placeholder tabs work
+// out of the box: their persisted URL lives on tab.url.
+const getShareableUrlForTab = (tab) => {
+  const url = tab?.url || '';
+  if (!url || url === 'about:blank') return '';
+  const internalName = url.startsWith('freedom://') ? null : getInternalPageName(url);
+  return internalName ? `freedom://${internalName}` : url;
+};
+
 // Reopen the last closed tab
 export const reopenLastClosedTab = () => {
   const entry = closedTabsStack.pop();
@@ -1550,6 +1575,25 @@ const showContextMenu = (x, y, tabId) => {
   const closeOthersBtn = tabContextMenu.querySelector('[data-action="close-others"]');
   if (closeOthersBtn) {
     closeOthersBtn.disabled = otherTabs.length === 0;
+  }
+
+  // Disable "Close Tabs to the Left" if there are no tabs to the left (excluding pinned)
+  const tabsToLeft = tabState.tabs.slice(0, tabIndex).filter((t) => !t.pinned);
+  const closeLeftBtn = tabContextMenu.querySelector('[data-action="close-left"]');
+  if (closeLeftBtn) {
+    closeLeftBtn.disabled = tabsToLeft.length === 0;
+  }
+
+  // Disable "Copy URL" when the tab has nothing shareable yet
+  const copyUrlBtn = tabContextMenu.querySelector('[data-action="copy-url"]');
+  if (copyUrlBtn) {
+    copyUrlBtn.disabled = !getShareableUrlForTab(tab);
+  }
+
+  // Disable "Reopen Closed Tab" when the closed-tabs stack is empty
+  const reopenBtn = tabContextMenu.querySelector('[data-action="reopen-closed"]');
+  if (reopenBtn) {
+    reopenBtn.disabled = closedTabsStack.length === 0;
   }
 
   // Position menu
@@ -1824,11 +1868,25 @@ export const initTabs = async () => {
         case 'close-right':
           closeTabsToRight(contextMenuTabId);
           break;
+        case 'close-left':
+          closeTabsToLeft(contextMenuTabId);
+          break;
         case 'pin':
           togglePinTab(contextMenuTabId);
           break;
         case 'mute':
           toggleMuteTab(contextMenuTabId);
+          break;
+        case 'copy-url': {
+          const tab = tabState.tabs.find((t) => t.id === contextMenuTabId);
+          const url = getShareableUrlForTab(tab);
+          if (url) {
+            electronAPI?.copyText?.(url);
+          }
+          break;
+        }
+        case 'reopen-closed':
+          reopenLastClosedTab();
           break;
       }
       hideTabContextMenu();

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -18,6 +18,7 @@ import {
   persistSessionSoon,
   getSessionToRestore,
 } from './session-restore.js';
+import { touchMru, removeFromMru, cycleIndex } from './tab-mru.js';
 
 const electronAPI = window.electronAPI;
 
@@ -94,6 +95,8 @@ let tabBar = null;
 let newTabBtn = null;
 let webviewContainer = null;
 let tabContextMenu = null;
+let mruSwitcherEl = null;
+let mruListEl = null;
 
 // Context menu state
 let contextMenuTabId = null;
@@ -1287,8 +1290,9 @@ export const closeTab = (tabId) => {
     }
   }
 
-  // Remove from array
+  // Remove from array and from the MRU order
   tabState.tabs.splice(tabIndex, 1);
+  mruOrder = removeFromMru(mruOrder, tabId);
 
   // If this was the active tab, switch to another
   if (tabState.activeTabId === tabId) {
@@ -1379,6 +1383,115 @@ export const switchToPrevTab = () => {
   const currentIndex = tabState.tabs.findIndex((t) => t.id === tabState.activeTabId);
   const prevIndex = (currentIndex - 1 + tabState.tabs.length) % tabState.tabs.length;
   switchTab(tabState.tabs[prevIndex].id);
+};
+
+// --- MRU Ctrl+Tab cycling (setting, default off) ----------------------------
+//
+// When enabled (Settings > Behavior), Ctrl+Tab cycles tabs in most-recently-
+// used order with a small centered switcher overlay while Ctrl stays held
+// (Alt-Tab style); releasing Ctrl commits the selection, Escape cancels.
+// When disabled, Ctrl+Tab keeps the sequential strip-order behavior.
+// Ctrl+PageDown/PageUp and Cmd+Shift+]/[ stay sequential either way.
+
+let mruTabSwitching = false;
+
+// Tab ids, most recently activated first. Maintained on every activation
+// (switchTab), pruned on close. Restored placeholder tabs join the order
+// the first time they're activated; until then they trail in strip order.
+let mruOrder = [];
+
+// Held-Ctrl switcher state. `switcherEntries` is a snapshot of the tab list
+// taken when the switcher opens so cycling is stable even if titles/favicons
+// update mid-hold.
+let mruSwitcherOpen = false;
+let mruSwitcherEntries = [];
+let mruSwitcherIndex = 0;
+
+// Plain globe for switcher rows (GLOBE_ICON_SVG carries tab-strip icon
+// classes with absolute positioning that don't apply here).
+const SWITCHER_GLOBE_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>`;
+
+// Current tabs in MRU order: known-recent ids first, then any tabs never
+// activated this session (e.g. still-placeholder restored tabs) in strip
+// order. Placeholders participate normally — committing to one activates
+// (and thus materializes) it.
+const mruOrderedTabs = () => {
+  const remaining = new Map(tabState.tabs.map((t) => [t.id, t]));
+  const ordered = [];
+  for (const id of mruOrder) {
+    const tab = remaining.get(id);
+    if (tab) {
+      ordered.push(tab);
+      remaining.delete(id);
+    }
+  }
+  for (const tab of tabState.tabs) {
+    if (remaining.has(tab.id)) ordered.push(tab);
+  }
+  return ordered;
+};
+
+const renderMruSwitcher = () => {
+  if (!mruListEl) return;
+  mruListEl.innerHTML = '';
+  mruSwitcherEntries.forEach((tab, index) => {
+    const row = document.createElement('div');
+    row.className = 'tab-mru-item';
+    row.dataset.test = 'tab-mru-item';
+    row.dataset.tabId = String(tab.id);
+    row.classList.toggle('selected', index === mruSwitcherIndex);
+
+    const icon = document.createElement('span');
+    icon.className = 'tab-mru-item-icon';
+    if (tab.favicon) {
+      const img = document.createElement('img');
+      img.src = tab.favicon;
+      img.alt = '';
+      icon.appendChild(img);
+    } else {
+      icon.innerHTML = SWITCHER_GLOBE_SVG;
+    }
+    row.appendChild(icon);
+
+    const title = document.createElement('span');
+    title.className = 'tab-mru-item-title';
+    title.textContent = tab.title || 'New Tab';
+    row.appendChild(title);
+
+    mruListEl.appendChild(row);
+  });
+};
+
+// Advance the switcher (opening it on the first Ctrl+Tab of a hold).
+// direction: +1 for Ctrl+Tab, -1 for Ctrl+Shift+Tab.
+const cycleMruSwitcher = (direction) => {
+  if (tabState.tabs.length < 2) return;
+  if (!mruSwitcherOpen) {
+    mruSwitcherEntries = mruOrderedTabs();
+    mruSwitcherIndex = 0; // the active tab leads its own MRU order
+    mruSwitcherOpen = true;
+    mruSwitcherEl?.classList.remove('hidden');
+  }
+  mruSwitcherIndex = cycleIndex(mruSwitcherEntries.length, mruSwitcherIndex, direction);
+  renderMruSwitcher();
+};
+
+const closeMruSwitcher = () => {
+  if (!mruSwitcherOpen) return;
+  mruSwitcherOpen = false;
+  mruSwitcherEntries = [];
+  mruSwitcherIndex = 0;
+  mruSwitcherEl?.classList.add('hidden');
+};
+
+// Releasing Ctrl (or losing window focus mid-hold) commits the selection.
+const commitMruSwitcher = () => {
+  if (!mruSwitcherOpen) return;
+  const selected = mruSwitcherEntries[mruSwitcherIndex];
+  closeMruSwitcher();
+  if (selected && selected.id !== tabState.activeTabId) {
+    switchTab(selected.id);
+  }
 };
 
 // Toggle pin state for a tab
@@ -1476,6 +1589,10 @@ export const switchTab = (tabId, options = {}) => {
   if (tab.isPlaceholder) {
     materializePlaceholderTab(tab);
   }
+
+  // Every activation refreshes the most-recently-used order (used by the
+  // MRU Ctrl+Tab switcher; cheap enough to maintain unconditionally).
+  mruOrder = touchMru(mruOrder, tabId);
 
   // Reset the link-hover preview before swapping active tabs:
   // - immediate clear so the previous tab's URL never trails into the new tab
@@ -1663,6 +1780,11 @@ export const openOrFocusInternalPage = (pageName, subPath = null) => {
 const applyTabBehaviorSettings = (settings) => {
   if (!settings || typeof settings !== 'object') return;
   openNewTabNextToActive = settings.openNewTabNextToActive !== false;
+  mruTabSwitching = settings.mruTabSwitching === true;
+  // Turning the feature off mid-hold shouldn't leave a stale overlay.
+  if (!mruTabSwitching) {
+    closeMruSwitcher();
+  }
 };
 
 // Initialize tabs module
@@ -1672,9 +1794,11 @@ export const initTabs = async () => {
   newTabBtn = document.getElementById('new-tab-btn');
   webviewContainer = document.getElementById('webview-container');
   tabContextMenu = document.getElementById('tab-context-menu');
+  mruSwitcherEl = document.getElementById('tab-mru-switcher');
+  mruListEl = document.getElementById('tab-mru-list');
 
-  // Tab-behavior settings (insertion position). Failures keep the
-  // in-code defaults, which mirror DEFAULT_SETTINGS.
+  // Tab-behavior settings (insertion position, MRU cycling). Failures keep
+  // the in-code defaults, which mirror DEFAULT_SETTINGS.
   try {
     applyTabBehaviorSettings(await electronAPI?.getSettings?.());
   } catch {
@@ -1724,7 +1848,12 @@ export const initTabs = async () => {
       hideTabContextMenu();
     }
   });
-  window.addEventListener('blur', hideTabContextMenu);
+  window.addEventListener('blur', () => {
+    hideTabContextMenu();
+    // Focus loss mid-Ctrl-hold: the keyup will never arrive, so commit the
+    // MRU selection now rather than leaving a stale overlay behind.
+    commitMruSwitcher();
+  });
 
   // Hide context menu when webview gets focus
   const webviewElement = document.getElementById('bzz-webview');
@@ -1913,25 +2042,41 @@ export const initTabs = async () => {
         addressInput.select();
       }
     }
-    // Ctrl+Tab / Ctrl+PageDown - Next tab (all platforms)
-    // Cmd+Shift+] - Next tab (macOS alternative)
+    // Ctrl+Tab / Ctrl+Shift+Tab - Next / previous tab (all platforms).
+    // With MRU cycling enabled (Settings > Behavior) these instead drive
+    // the held-Ctrl most-recently-used switcher; releasing Ctrl commits
+    // (see the keyup handler below), Escape cancels.
+    if (event.ctrlKey && event.key === 'Tab') {
+      event.preventDefault();
+      if (mruTabSwitching) {
+        cycleMruSwitcher(event.shiftKey ? -1 : 1);
+      } else if (event.shiftKey) {
+        switchToPrevTab();
+      } else {
+        switchToNextTab();
+      }
+    }
+    // Ctrl+PageDown - Next tab; Cmd+Shift+] - Next tab (macOS alternative).
+    // Always sequential, regardless of the MRU setting.
     if (
-      (event.ctrlKey && event.key === 'Tab' && !event.shiftKey) ||
       (event.ctrlKey && event.key === 'PageDown' && !event.shiftKey) ||
       (event.metaKey && event.shiftKey && event.key === ']')
     ) {
       event.preventDefault();
       switchToNextTab();
     }
-    // Ctrl+Shift+Tab / Ctrl+PageUp - Previous tab (all platforms)
-    // Cmd+Shift+[ - Previous tab (macOS alternative)
+    // Ctrl+PageUp - Previous tab; Cmd+Shift+[ - Previous tab (macOS
+    // alternative). Always sequential, regardless of the MRU setting.
     if (
-      (event.ctrlKey && event.key === 'Tab' && event.shiftKey) ||
       (event.ctrlKey && event.key === 'PageUp' && !event.shiftKey) ||
       (event.metaKey && event.shiftKey && event.key === '[')
     ) {
       event.preventDefault();
       switchToPrevTab();
+    }
+    // Escape cancels an in-progress MRU switch without committing.
+    if (event.key === 'Escape') {
+      closeMruSwitcher();
     }
     // Ctrl+Shift+PageDown - Move tab right
     if (event.ctrlKey && event.shiftKey && event.key === 'PageDown') {
@@ -1967,6 +2112,13 @@ export const initTabs = async () => {
     if (event.key === 'F12') {
       event.preventDefault();
       toggleDevTools();
+    }
+  });
+
+  // Releasing Ctrl commits an in-progress MRU switch (no-op otherwise).
+  window.addEventListener('keyup', (event) => {
+    if (event.key === 'Control') {
+      commitMruSwitcher();
     }
   });
 

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -1075,8 +1075,49 @@ const resolveWebviewSrcForUrl = (url) => {
   };
 };
 
-// Create a new tab
-export const createTab = (url = null) => {
+// Behavior setting (Settings > Behavior, default ON — must match
+// DEFAULT_SETTINGS in src/main/settings-store.js): insert new tabs right of
+// the active tab instead of appending at the end of the strip. Loaded at
+// init and kept fresh via the settings:updated broadcast.
+let openNewTabNextToActive = true;
+
+/**
+ * Where a newly created tab should be inserted.
+ *
+ * With the next-to-active behavior disabled (or no resolvable active tab),
+ * tabs append at the end — the pre-setting behavior. Enabled, the new tab
+ * goes right of the active tab, with two adjustments:
+ *  - consecutive child tabs of the active tab (same `openerTabId`) stay
+ *    grouped: the next child lands after its youngest sibling, so links
+ *    opened from one page keep their opening order;
+ *  - the pinned block is never split: insertion skips past pinned tabs
+ *    (relevant when the active tab is pinned).
+ *
+ * Pure — exported for unit tests.
+ *
+ * @param {Array} tabs - current tab list
+ * @param {number|null} activeTabId
+ * @param {boolean} nextToActive - the setting value
+ * @returns {number} index to splice the new tab into
+ */
+export const computeNewTabInsertIndex = (tabs, activeTabId, nextToActive) => {
+  if (!nextToActive) return tabs.length;
+  const activeIndex = tabs.findIndex((t) => t.id === activeTabId);
+  if (activeIndex === -1) return tabs.length;
+  let index = activeIndex + 1;
+  while (index < tabs.length && tabs[index].openerTabId === activeTabId) {
+    index++;
+  }
+  while (index < tabs.length && tabs[index].pinned) {
+    index++;
+  }
+  return index;
+};
+
+// Create a new tab. `options.openerTabId` marks the tab as a child of the
+// tab it was opened from (target=_blank / dweb link opens) so consecutive
+// children group after their opener — see computeNewTabInsertIndex.
+export const createTab = (url = null, options = {}) => {
   const tabId = tabState.nextTabId++;
   const { webviewUrl, isDirect } = resolveWebviewSrcForUrl(url);
   const webview = createWebview(tabId, webviewUrl);
@@ -1091,8 +1132,16 @@ export const createTab = (url = null) => {
     webview,
     navigationState: createNavigationState(),
   };
+  if (options.openerTabId !== null && options.openerTabId !== undefined) {
+    tab.openerTabId = options.openerTabId;
+  }
 
-  tabState.tabs.push(tab);
+  const insertIndex = computeNewTabInsertIndex(
+    tabState.tabs,
+    tabState.activeTabId,
+    openNewTabNextToActive
+  );
+  tabState.tabs.splice(insertIndex, 0, tab);
   webviewContainer?.appendChild(webview);
 
   // Switch to the new tab
@@ -1547,7 +1596,11 @@ export const openInNewTabWithTarget = (url, targetName) => {
   // Critically, this also makes `tab.url` reflect the actual target,
   // so the `tab-switched` handler can derive a meaningful address bar
   // value immediately instead of leaving it empty until ENS resolves.
-  const newTab = createTab(url);
+  //
+  // The active tab at this point is the opener (link clicks and
+  // setWindowOpenHandler-routed window.opens both originate from the
+  // foreground page), so record it for child-tab grouping.
+  const newTab = createTab(url, { openerTabId: tabState.activeTabId });
 
   if (targetName && newTab) {
     namedTargets.set(targetName, newTab.id);
@@ -1605,6 +1658,13 @@ export const openOrFocusInternalPage = (pageName, subPath = null) => {
   return createTab(fullUrl);
 };
 
+// Apply the tab-behavior settings this module reacts to. Called with the
+// full settings object at init and on every settings:updated broadcast.
+const applyTabBehaviorSettings = (settings) => {
+  if (!settings || typeof settings !== 'object') return;
+  openNewTabNextToActive = settings.openNewTabNextToActive !== false;
+};
+
 // Initialize tabs module
 export const initTabs = async () => {
   // Initialize DOM elements
@@ -1612,6 +1672,17 @@ export const initTabs = async () => {
   newTabBtn = document.getElementById('new-tab-btn');
   webviewContainer = document.getElementById('webview-container');
   tabContextMenu = document.getElementById('tab-context-menu');
+
+  // Tab-behavior settings (insertion position). Failures keep the
+  // in-code defaults, which mirror DEFAULT_SETTINGS.
+  try {
+    applyTabBehaviorSettings(await electronAPI?.getSettings?.());
+  } catch {
+    // Defaults stay in effect.
+  }
+  window.addEventListener('settings:updated', (event) => {
+    applyTabBehaviorSettings(event.detail);
+  });
 
   // Context menu event handlers
   if (tabContextMenu) {

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -836,6 +836,21 @@
                 </select>
               </div>
             </div>
+            <div class="row">
+              <div class="row-body">
+                <p class="row-label">Open new tabs next to the active tab</p>
+                <p class="row-help">
+                  New tabs open to the right of the current tab instead of at the end of the tab
+                  strip. Tabs opened from links stay grouped after the tab that opened them.
+                </p>
+              </div>
+              <div class="row-control">
+                <label class="toggle">
+                  <input type="checkbox" id="open-new-tab-next-to-active" />
+                  <span class="slider"></span>
+                </label>
+              </div>
+            </div>
           </div>
         </section>
 
@@ -1072,6 +1087,7 @@
         themeMode: $('theme-mode'),
         tabsInTitlebar: $('tabs-in-titlebar'),
         onStartup: $('on-startup'),
+        openNewTabNextToActive: $('open-new-tab-next-to-active'),
         startAnt: $('start-ant-at-launch'),
         startIpfs: $('start-ipfs-at-launch'),
         blockUnverifiedEns: $('block-unverified-ens'),
@@ -1465,6 +1481,7 @@
         theme: fields.themeMode.value || 'system',
         tabsInTitlebar: fields.tabsInTitlebar.checked,
         onStartup: fields.onStartup.value || 'continue',
+        openNewTabNextToActive: fields.openNewTabNextToActive.checked,
         startAntAtLaunch: fields.startAnt.checked,
         startIpfsAtLaunch: fields.startIpfs.checked,
         enableRadicleIntegration: isWindows ? false : fields.enableRadicle.checked,
@@ -1480,6 +1497,7 @@
         fields.themeMode.value = settings.theme || 'system';
         fields.tabsInTitlebar.checked = settings.tabsInTitlebar === true;
         fields.onStartup.value = settings.onStartup === 'homepage' ? 'homepage' : 'continue';
+        fields.openNewTabNextToActive.checked = settings.openNewTabNextToActive !== false;
         fields.startAnt.checked = settings.startAntAtLaunch !== false;
         fields.startIpfs.checked = settings.startIpfsAtLaunch !== false;
         fields.enableRadicle.checked = settings.enableRadicleIntegration === true;
@@ -1583,6 +1601,7 @@
 
       fields.themeMode.addEventListener('change', save);
       fields.onStartup.addEventListener('change', save);
+      fields.openNewTabNextToActive.addEventListener('change', save);
       fields.tabsInTitlebar.addEventListener('change', () => {
         save();
         $('tabs-titlebar-restart').hidden = false;

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -851,6 +851,21 @@
                 </label>
               </div>
             </div>
+            <div class="row">
+              <div class="row-body">
+                <p class="row-label">Cycle tabs by recent use</p>
+                <p class="row-help">
+                  Ctrl+Tab switches tabs in most-recently-used order, showing a switcher while
+                  Ctrl is held. When off, Ctrl+Tab moves through tabs in strip order.
+                </p>
+              </div>
+              <div class="row-control">
+                <label class="toggle">
+                  <input type="checkbox" id="mru-tab-switching" />
+                  <span class="slider"></span>
+                </label>
+              </div>
+            </div>
           </div>
         </section>
 
@@ -1088,6 +1103,7 @@
         tabsInTitlebar: $('tabs-in-titlebar'),
         onStartup: $('on-startup'),
         openNewTabNextToActive: $('open-new-tab-next-to-active'),
+        mruTabSwitching: $('mru-tab-switching'),
         startAnt: $('start-ant-at-launch'),
         startIpfs: $('start-ipfs-at-launch'),
         blockUnverifiedEns: $('block-unverified-ens'),
@@ -1482,6 +1498,7 @@
         tabsInTitlebar: fields.tabsInTitlebar.checked,
         onStartup: fields.onStartup.value || 'continue',
         openNewTabNextToActive: fields.openNewTabNextToActive.checked,
+        mruTabSwitching: fields.mruTabSwitching.checked,
         startAntAtLaunch: fields.startAnt.checked,
         startIpfsAtLaunch: fields.startIpfs.checked,
         enableRadicleIntegration: isWindows ? false : fields.enableRadicle.checked,
@@ -1498,6 +1515,7 @@
         fields.tabsInTitlebar.checked = settings.tabsInTitlebar === true;
         fields.onStartup.value = settings.onStartup === 'homepage' ? 'homepage' : 'continue';
         fields.openNewTabNextToActive.checked = settings.openNewTabNextToActive !== false;
+        fields.mruTabSwitching.checked = settings.mruTabSwitching === true;
         fields.startAnt.checked = settings.startAntAtLaunch !== false;
         fields.startIpfs.checked = settings.startIpfsAtLaunch !== false;
         fields.enableRadicle.checked = settings.enableRadicleIntegration === true;
@@ -1602,6 +1620,7 @@
       fields.themeMode.addEventListener('change', save);
       fields.onStartup.addEventListener('change', save);
       fields.openNewTabNextToActive.addEventListener('change', save);
+      fields.mruTabSwitching.addEventListener('change', save);
       fields.tabsInTitlebar.addEventListener('change', () => {
         save();
         $('tabs-titlebar-restart').hidden = false;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -9,6 +9,7 @@
 @import './styles/toggle-switch.css';
 @import './styles/window-controls.css';
 @import './styles/autocomplete.css';
+@import './styles/tab-search.css';
 @import './styles/update-toast.css';
 @import './styles/github-bridge.css';
 @import './styles/sidebar.css';

--- a/src/renderer/styles/light-theme.css
+++ b/src/renderer/styles/light-theme.css
@@ -24,6 +24,10 @@
   background: rgba(0, 0, 0, 0.1);
 }
 
+[data-theme='light'] .tab-audio:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
 [data-theme='light'] .icon-btn:hover,
 [data-theme='light'] .menu-button:hover,
 [data-theme='light'] .menu-button[aria-expanded='true'] {

--- a/src/renderer/styles/tab-search.css
+++ b/src/renderer/styles/tab-search.css
@@ -1,0 +1,141 @@
+/* Tab search popover (Cmd/Ctrl+Shift+A) — anchored under the tab strip.
+   Themed entirely via the shared CSS variables so dark/light both work. */
+
+.tab-search {
+  position: fixed;
+  top: 42px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 460px;
+  max-width: calc(100vw - 32px);
+  z-index: 10000;
+  background: var(--menu-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  -webkit-app-region: no-drag;
+}
+
+.tab-search.hidden {
+  display: none;
+}
+
+.tab-search-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+}
+
+.tab-search-input:focus {
+  border-color: var(--accent);
+}
+
+.tab-search-list {
+  max-height: 50vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.tab-search-empty {
+  padding: 12px;
+  color: var(--muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+.tab-search-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  font-family: inherit;
+  text-align: left;
+  border-radius: 6px;
+  cursor: default;
+}
+
+.tab-search-item.selected {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+[data-theme='light'] .tab-search-item.selected {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.tab-search-item-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+}
+
+.tab-search-item-icon img,
+.tab-search-item-icon svg {
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  object-fit: contain;
+}
+
+.tab-search-item-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.tab-search-item-title {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.tab-search-item-url {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.tab-search-item-audio {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  color: var(--accent);
+}
+
+.tab-search-item-audio svg {
+  width: 13px;
+  height: 13px;
+}
+
+.tab-search-item-current {
+  flex-shrink: 0;
+  font-size: 10px;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+}

--- a/src/renderer/styles/tabs.css
+++ b/src/renderer/styles/tabs.css
@@ -231,6 +231,56 @@
   opacity: 1;
 }
 
+/* Audio indicator / mute toggle — hidden unless the tab is audible or muted
+   (data-audio-state set by tabs.js). Clicking toggles mute. */
+.tab-audio {
+  display: none;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  cursor: default;
+}
+
+.tab[data-audio-state] .tab-audio {
+  display: flex;
+}
+
+.tab-audio:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.tab-audio svg {
+  width: 12px;
+  height: 12px;
+  display: none;
+}
+
+.tab[data-audio-state='audible'] .tab-audio .tab-audio-on {
+  display: block;
+}
+
+.tab[data-audio-state='muted'] .tab-audio .tab-audio-muted {
+  display: block;
+}
+
+.tab[data-audio-state='muted'] .tab-audio {
+  color: var(--muted);
+}
+
+/* Hide the audio button (like the close button) when tabs get very narrow */
+@container (max-width: 80px) {
+  .tab-audio {
+    display: none !important;
+  }
+}
+
 .tab-title {
   flex: 1;
   overflow: hidden;

--- a/src/renderer/styles/tabs.css
+++ b/src/renderer/styles/tabs.css
@@ -363,6 +363,75 @@
     color 0.15s ease;
 }
 
+/* MRU tab switcher overlay (Ctrl+Tab with "Cycle tabs by recent use" on) */
+.tab-mru-switcher {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10000;
+  background: var(--menu-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  padding: 8px;
+  min-width: 260px;
+  max-width: 420px;
+}
+
+.tab-mru-switcher.hidden {
+  display: none;
+}
+
+.tab-mru-list {
+  display: flex;
+  flex-direction: column;
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.tab-mru-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px;
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 13px;
+}
+
+.tab-mru-item.selected {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+[data-theme='light'] .tab-mru-item.selected {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.tab-mru-item-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+}
+
+.tab-mru-item-icon img,
+.tab-mru-item-icon svg {
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  object-fit: contain;
+}
+
+.tab-mru-item-title {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 /* Pinned tabs */
 .tab.pinned {
   width: 36px;

--- a/src/shared/ipc-channels.js
+++ b/src/shared/ipc-channels.js
@@ -127,6 +127,7 @@ module.exports = {
   TAB_MOVE_LEFT: 'tab:move-left',
   TAB_MOVE_RIGHT: 'tab:move-right',
   TAB_REOPEN_CLOSED: 'tab:reopen-closed',
+  TAB_SEARCH: 'tab:search',
 
   // Bookmarks bar
   BOOKMARKS_TOGGLE_BAR: 'bookmarks:toggle-bar',

--- a/test-e2e/tab-strip.spec.js
+++ b/test-e2e/tab-strip.spec.js
@@ -1,0 +1,52 @@
+// Tab strip upgrades — tab search popover, mute via tab context menu, and
+// the context-menu completeness items (close left, copy URL, reopen closed).
+
+const { test, expect } = require('./fixtures');
+
+const searchShortcut = process.platform === 'darwin' ? 'Meta+Shift+A' : 'Control+Shift+A';
+
+// Focus the browser chrome (not a webview) so renderer-level keyboard
+// shortcuts land, then open the tab search popover.
+async function openTabSearch(window) {
+  await window.locator('[data-test="address-input"]').click();
+  await window.keyboard.press(searchShortcut);
+  await expect(window.locator('[data-test="tab-search"]')).toBeVisible();
+}
+
+test('tab search opens, filters, and activates a tab', async ({ window }) => {
+  const tabs = window.locator('[data-test="tab"]');
+  const input = window.locator('[data-test="address-input"]');
+
+  // Give the first tab a distinct title via an internal page.
+  await input.click();
+  await input.fill('freedom://history');
+  await input.press('Enter');
+  await expect(tabs.first()).toContainText('History');
+
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(tabs).toHaveCount(3);
+
+  await openTabSearch(window);
+  const items = window.locator('[data-test="tab-search-item"]');
+  await expect(items).toHaveCount(3);
+
+  // Filter down to the History tab, activate with Enter.
+  await window.locator('[data-test="tab-search-input"]').fill('history');
+  await expect(items).toHaveCount(1);
+  await window.keyboard.press('Enter');
+  await expect(window.locator('[data-test="tab-search"]')).toBeHidden();
+  await expect(tabs.first()).toHaveClass(/active/);
+});
+
+test('Escape closes tab search without switching tabs', async ({ window }) => {
+  const tabs = window.locator('[data-test="tab"]');
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(tabs).toHaveCount(2);
+  await expect(tabs.nth(1)).toHaveClass(/active/);
+
+  await openTabSearch(window);
+  await window.keyboard.press('Escape');
+  await expect(window.locator('[data-test="tab-search"]')).toBeHidden();
+  await expect(tabs.nth(1)).toHaveClass(/active/);
+});

--- a/test-e2e/tab-strip.spec.js
+++ b/test-e2e/tab-strip.spec.js
@@ -56,6 +56,40 @@ test('new tabs open next to the active tab by default', async ({ window }) => {
   expect(ids).toEqual(['1', '3', '2']);
 });
 
+test.describe('MRU Ctrl+Tab cycling (setting on)', () => {
+  test.use({ seedSettings: { mruTabSwitching: true } });
+
+  test('held Ctrl shows the switcher; releasing commits the MRU tab', async ({ window }) => {
+    const tabs = window.locator('[data-test="tab"]');
+
+    // Three tabs; activation order 1 -> 2 -> 3 -> 1 gives MRU [1, 3, 2].
+    await window.locator('[data-test="new-tab-btn"]').click();
+    await window.locator('[data-test="new-tab-btn"]').click();
+    await expect(tabs).toHaveCount(3);
+    await tabs.first().click();
+    await expect(tabs.first()).toHaveClass(/active/);
+
+    // Focus chrome so the renderer keydown handler sees the keys.
+    await window.locator('[data-test="address-input"]').click();
+
+    await window.keyboard.down('Control');
+    await window.keyboard.press('Tab');
+    const switcher = window.locator('[data-test="tab-mru-switcher"]');
+    await expect(switcher).toBeVisible();
+    // Selection previews the most recently used other tab (tab 3); the
+    // active tab hasn't changed yet.
+    await expect(window.locator('[data-test="tab-mru-item"].selected')).toHaveAttribute(
+      'data-tab-id',
+      '3'
+    );
+    await expect(tabs.first()).toHaveClass(/active/);
+
+    await window.keyboard.up('Control');
+    await expect(switcher).toBeHidden();
+    await expect(window.locator('[data-test="tab"][data-tab-id="3"]')).toHaveClass(/active/);
+  });
+});
+
 test('Escape closes tab search without switching tabs', async ({ window }) => {
   const tabs = window.locator('[data-test="tab"]');
   await window.locator('[data-test="new-tab-btn"]').click();

--- a/test-e2e/tab-strip.spec.js
+++ b/test-e2e/tab-strip.spec.js
@@ -101,3 +101,81 @@ test('Escape closes tab search without switching tabs', async ({ window }) => {
   await expect(window.locator('[data-test="tab-search"]')).toBeHidden();
   await expect(tabs.nth(1)).toHaveClass(/active/);
 });
+
+test('Mute Tab context-menu item toggles the muted indicator', async ({ window }) => {
+  const tab = window.locator('[data-test="tab"]').first();
+  const audioBtn = tab.locator('[data-test="tab-audio"]');
+
+  // No audio state initially: indicator hidden.
+  await expect(audioBtn).toBeHidden();
+
+  await tab.click({ button: 'right' });
+  const muteItem = window.locator('#tab-context-menu [data-action="mute"]');
+  await expect(muteItem).toHaveText('Mute Tab');
+  await muteItem.click();
+
+  // Muted: indicator shows the muted speaker even without audio playing.
+  await expect(tab).toHaveAttribute('data-audio-state', 'muted');
+  await expect(audioBtn).toBeVisible();
+
+  // Clicking the indicator unmutes (and hides it again — nothing audible).
+  await audioBtn.click();
+  await expect(audioBtn).toBeHidden();
+
+  await tab.click({ button: 'right' });
+  await expect(muteItem).toHaveText('Mute Tab');
+  await window.keyboard.press('Escape');
+});
+
+test('Close Tabs to the Left protects pinned tabs', async ({ window }) => {
+  const tabs = window.locator('[data-test="tab"]');
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(tabs).toHaveCount(3);
+
+  // Pin the leftmost tab.
+  await tabs.first().click({ button: 'right' });
+  await window.locator('#tab-context-menu [data-action="pin"]').click();
+  await expect(tabs.first()).toHaveClass(/pinned/);
+
+  // Close-left from the rightmost tab: only the middle tab goes.
+  await tabs.nth(2).click({ button: 'right' });
+  await window.locator('#tab-context-menu [data-action="close-left"]').click();
+  await expect(tabs).toHaveCount(2);
+  await expect(tabs.first()).toHaveClass(/pinned/);
+});
+
+test('Copy URL puts the tab address on the clipboard', async ({ window, electronApp }) => {
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill('https://example.com');
+  await input.press('Enter');
+  await expect(input).toHaveValue(/^https:\/\/example\.com\/?$/);
+
+  const tab = window.locator('[data-test="tab"]').first();
+  await tab.click({ button: 'right' });
+  await window.locator('#tab-context-menu [data-action="copy-url"]').click();
+
+  await expect
+    .poll(() => electronApp.evaluate(({ clipboard }) => clipboard.readText()))
+    .toMatch(/^https:\/\/example\.com\/?$/);
+});
+
+test('Reopen Closed Tab context-menu item restores the last closed tab', async ({ window }) => {
+  const tabs = window.locator('[data-test="tab"]');
+  const input = window.locator('[data-test="address-input"]');
+
+  // Second tab on an internal page with a distinct title, then close it.
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await input.click();
+  await input.fill('freedom://history');
+  await input.press('Enter');
+  await expect(tabs.nth(1)).toContainText('History');
+  await tabs.nth(1).locator('[data-test="tab-close"]').click();
+  await expect(tabs).toHaveCount(1);
+
+  await tabs.first().click({ button: 'right' });
+  await window.locator('#tab-context-menu [data-action="reopen-closed"]').click();
+  await expect(tabs).toHaveCount(2);
+  await expect(tabs.nth(1)).toContainText('History');
+});

--- a/test-e2e/tab-strip.spec.js
+++ b/test-e2e/tab-strip.spec.js
@@ -39,6 +39,23 @@ test('tab search opens, filters, and activates a tab', async ({ window }) => {
   await expect(tabs.first()).toHaveClass(/active/);
 });
 
+test('new tabs open next to the active tab by default', async ({ window }) => {
+  const tabs = window.locator('[data-test="tab"]');
+  await expect(tabs).toHaveCount(1);
+
+  // Tab 2 opens right of tab 1 and becomes active.
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(tabs).toHaveCount(2);
+
+  // Switch back to tab 1; the next new tab must slot between 1 and 2.
+  await tabs.first().click();
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(tabs).toHaveCount(3);
+
+  const ids = await tabs.evaluateAll((els) => els.map((el) => el.dataset.tabId));
+  expect(ids).toEqual(['1', '3', '2']);
+});
+
 test('Escape closes tab search without switching tabs', async ({ window }) => {
   const tabs = window.locator('[data-test="tab"]');
   await window.locator('[data-test="new-tab-btn"]').click();

--- a/test-e2e/tab-strip.spec.js
+++ b/test-e2e/tab-strip.spec.js
@@ -13,6 +13,20 @@ async function openTabSearch(window) {
   await expect(window.locator('[data-test="tab-search"]')).toBeVisible();
 }
 
+// Right-click a tab and click a context-menu action, then run `verify`.
+// Retried as a unit: a stray window blur (e.g. the previous Electron
+// instance releasing OS focus) can close the menu between the right-click
+// and the item click, turning the click into a no-op.
+async function clickTabContextAction(window, tabLocator, action, verify) {
+  await expect(async () => {
+    await tabLocator.click({ button: 'right' });
+    const menu = window.locator('#tab-context-menu');
+    await expect(menu).toBeVisible({ timeout: 1000 });
+    await menu.locator(`[data-action="${action}"]`).click({ timeout: 1000 });
+    await verify();
+  }).toPass({ timeout: 15_000 });
+}
+
 test('tab search opens, filters, and activates a tab', async ({ window }) => {
   const tabs = window.locator('[data-test="tab"]');
   const input = window.locator('[data-test="address-input"]');
@@ -109,21 +123,23 @@ test('Mute Tab context-menu item toggles the muted indicator', async ({ window }
   // No audio state initially: indicator hidden.
   await expect(audioBtn).toBeHidden();
 
-  await tab.click({ button: 'right' });
-  const muteItem = window.locator('#tab-context-menu [data-action="mute"]');
-  await expect(muteItem).toHaveText('Mute Tab');
-  await muteItem.click();
-
-  // Muted: indicator shows the muted speaker even without audio playing.
-  await expect(tab).toHaveAttribute('data-audio-state', 'muted');
+  // Muted via the context menu: indicator shows the muted speaker even
+  // without audio playing.
+  await clickTabContextAction(window, tab, 'mute', async () => {
+    await expect(tab).toHaveAttribute('data-audio-state', 'muted', { timeout: 1000 });
+  });
   await expect(audioBtn).toBeVisible();
 
   // Clicking the indicator unmutes (and hides it again — nothing audible).
   await audioBtn.click();
   await expect(audioBtn).toBeHidden();
 
-  await tab.click({ button: 'right' });
-  await expect(muteItem).toHaveText('Mute Tab');
+  // Menu label reflects the unmuted state again.
+  const muteItem = window.locator('#tab-context-menu [data-action="mute"]');
+  await expect(async () => {
+    await tab.click({ button: 'right' });
+    await expect(muteItem).toHaveText('Mute Tab', { timeout: 1000 });
+  }).toPass({ timeout: 15_000 });
   await window.keyboard.press('Escape');
 });
 
@@ -134,14 +150,14 @@ test('Close Tabs to the Left protects pinned tabs', async ({ window }) => {
   await expect(tabs).toHaveCount(3);
 
   // Pin the leftmost tab.
-  await tabs.first().click({ button: 'right' });
-  await window.locator('#tab-context-menu [data-action="pin"]').click();
-  await expect(tabs.first()).toHaveClass(/pinned/);
+  await clickTabContextAction(window, tabs.first(), 'pin', async () => {
+    await expect(tabs.first()).toHaveClass(/pinned/, { timeout: 1000 });
+  });
 
   // Close-left from the rightmost tab: only the middle tab goes.
-  await tabs.nth(2).click({ button: 'right' });
-  await window.locator('#tab-context-menu [data-action="close-left"]').click();
-  await expect(tabs).toHaveCount(2);
+  await clickTabContextAction(window, tabs.nth(2), 'close-left', async () => {
+    await expect(tabs).toHaveCount(2, { timeout: 1000 });
+  });
   await expect(tabs.first()).toHaveClass(/pinned/);
 });
 
@@ -153,12 +169,13 @@ test('Copy URL puts the tab address on the clipboard', async ({ window, electron
   await expect(input).toHaveValue(/^https:\/\/example\.com\/?$/);
 
   const tab = window.locator('[data-test="tab"]').first();
-  await tab.click({ button: 'right' });
-  await window.locator('#tab-context-menu [data-action="copy-url"]').click();
-
-  await expect
-    .poll(() => electronApp.evaluate(({ clipboard }) => clipboard.readText()))
-    .toMatch(/^https:\/\/example\.com\/?$/);
+  await clickTabContextAction(window, tab, 'copy-url', async () => {
+    await expect
+      .poll(() => electronApp.evaluate(({ clipboard }) => clipboard.readText()), {
+        timeout: 2000,
+      })
+      .toMatch(/^https:\/\/example\.com\/?$/);
+  });
 });
 
 test('Reopen Closed Tab context-menu item restores the last closed tab', async ({ window }) => {
@@ -174,8 +191,8 @@ test('Reopen Closed Tab context-menu item restores the last closed tab', async (
   await tabs.nth(1).locator('[data-test="tab-close"]').click();
   await expect(tabs).toHaveCount(1);
 
-  await tabs.first().click({ button: 'right' });
-  await window.locator('#tab-context-menu [data-action="reopen-closed"]').click();
-  await expect(tabs).toHaveCount(2);
+  await clickTabContextAction(window, tabs.first(), 'reopen-closed', async () => {
+    await expect(tabs).toHaveCount(2, { timeout: 1000 });
+  });
   await expect(tabs.nth(1)).toContainText('History');
 });


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #153 (session restore); GitHub will retarget to main when #153 merges. Only the commits after aa15942 are this PR.**

Tab strip upgrades from the daily-driver roadmap (item 6), one commit per sub-feature for reviewability.

## What & why

### 1. Audio indicator + click-to-mute (`e843668`)
Tabs playing sound show a speaker icon; clicking it — or the new **Mute Tab** context-menu item — toggles `setAudioMuted()` on the webview, so mute survives navigation (webContents-level). Electron's `<webview>` emits `media-started-playing` / `media-paused` but **no** `audio-state-changed` (that event only exists on main-process webContents), so audibility is sampled via `isCurrentlyAudible()` on those edges plus one delayed re-sample (no standing poll). A muted tab keeps showing the muted-speaker icon even while silent, so it stays discoverable/unmutable.

**Placeholder safety:** mute state lives on the tab object; placeholders (webview === null) toggle freely and the flag is applied on `dom-ready` when they materialize.

### 2. Tab search popover (`7e8da95`)
`Cmd/Ctrl+Shift+A` (and **View → Search Tabs**, so the accelerator works while a webview has focus) opens a popover anchored under the tab strip: pinned tabs first, then strip order, with favicon, title, URL, audio badge on audible tabs. Fuzzy filter on title/URL (substring beats subsequence; word-boundary and consecutive-run bonuses), arrows + Enter or click to activate, Esc closes. Placeholders are listed via their persisted title/URL and materialize on activation.

**Scope note:** current window only. Each window's tab strip lives in its own renderer process, so cross-window enumeration + focus would need new main-process aggregation IPC — deliberately out of scope for this first cut (the PR body promised honesty here).

### 3. Open new tabs next to active tab (`8ceb264`)
New setting under **Settings → Behavior**, **default ON — this is a behavior change** from append-at-end and is easy to flip at review (one default). Applies to user-opened tabs and `target=_blank`/dweb child tabs; consecutive children of the same opener group after it in open order, and insertion never splits the pinned block. Restored placeholder order is unaffected.

### 4. MRU Ctrl+Tab cycling (`1169805`)
New setting under **Settings → Behavior**, default OFF. When on, Ctrl+Tab / Ctrl+Shift+Tab drive a small centered switcher in most-recently-used order while Ctrl is held (Alt-Tab style): release commits, Esc cancels, window blur commits (the keyup can never arrive). When off, behavior is unchanged sequential switching. Ctrl+PageDown/PageUp and Cmd+Shift+]/[ stay sequential either way. MRU order is maintained on every activation and pruned on close; never-activated placeholders trail the list in strip order and materialize when committed to.

### 5. Context-menu completeness (`9314c85`)
- **Close Tabs to the Left** — exact mirror of close-to-the-right, incl. pinned-tab protection and disabled state.
- **Copy URL** — copies the tab's URL; resolved internal pages normalize to their shareable `freedom://<name>` form (same rule as the session snapshot); placeholders copy their persisted URL.
- **Reopen Closed Tab** — surfaces the existing `closedTabsStack` (disabled while empty); `Cmd/Ctrl+Shift+T` unchanged.

### Session-restore interplay (verified)
All order/activation changes flow through `renderTabs`, which is the session snapshot capture hook — MRU switches and next-to-active insertions are persisted; the session-restore e2e suite still passes.

## Tests

- **Jest (full suite): 110 suites passed, 5 skipped, 0 failed (2227 tests passed, 17 skipped).** New co-located tests: audio-state reducer + media-event/mute/placeholder behavior, fuzzy-filter ranking, tab-search popover interaction (open/filter/keyboard/backdrop), insert-index logic (incl. pinned clamp + opener grouping + settings round trip), MRU list ops + held-Ctrl switcher flows (cancel/commit/blur/placeholder), close-left/copy-URL/reopen-closed incl. disabled states.
- **Playwright (harness project): 28 passed, 2 skipped (pre-existing macOS-conditional skips in address-bar-clipboard), 0 failed.** New spec `test-e2e/tab-strip.spec.js`: tab search open/filter/activate + Esc, next-to-active ordering, MRU held-Ctrl switcher commit, mute toggle via context menu + indicator click, close-left w/ pinned protection, copy-URL via real clipboard, reopen-closed.
- `npm run lint` clean; prettier clean on all new/touched JS/CSS files.

## Honest notes / caveats

- **Mute e2e uses no audio fixture**: autoplaying audible media in the harness is flaky, so the e2e asserts the mute state machine + indicator via the context menu (muted state shows without sound); the audible-detection path (`isCurrentlyAudible` sampling, fallback, delayed re-sample) is unit-tested only.
- **`src/renderer/index.html` and `README.md` are not prettier-clean at the base commit** (pre-existing, whole-file); new markup matches the files' existing style rather than reformatting ~1600 unrelated lines into this diff.
- One e2e flake was found and fixed in `8f9b98f`: a stray window blur during sequential Electron runs can close the tab context menu between right-click and item click; those interactions now retry as a unit.
- Audio indicator is sampled on media events, not continuously — a page that changes audibility without a media element edge (rare) updates on the next event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)