### PR TITLE
feat(shortcuts): central shortcut registry + remappable shortcuts settings page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 native/freedom-ipfs-node/build/
 native/freedom-ipfs-node/prebuilds/
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Freedom will be documented in this file.
 
 ### Added
 
+- Remappable keyboard shortcuts under Settings > Shortcuts:
+  - Searchable list grouped by category; click a binding and press the new combination
+  - Conflict warning with a one-click swap when a combination is already taken
+  - Per-shortcut reset and a Restore defaults button; changes apply without a restart
+- Find in page (`Cmd+F` / `Ctrl+F`, also under Edit in the menu): overlay bar over the page with a live match counter, `Enter` / `Shift+Enter` to cycle matches, `Esc` to close
+- Download manager covering every download source, including `bzz://` and `ipfs://` content:
+  - Shelf card with live progress and cancel; Open / Show in Folder on completion
+  - `freedom://downloads` page (Cmd/Ctrl+Shift+J) with search, pause/resume, and Clear All
+  - "Ask where to save each file" toggle under Settings > Downloads
 - Per-site permission prompts for camera, microphone, notifications, clipboard reading, location, and MIDI, replacing the previous silent denial:
   - Prompt under the address bar with Allow / Block and "Remember for this site"
   - Remembered decisions per profile under Settings > Site Permissions, with per-site and remove-all revocation

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ The address bar also provides **autocomplete suggestions** from browsing history
 - **Reload**: Refresh the current page (ignores cache). On error pages, retries the original URL.
 - **Stop**: Cancel page loading mid-request.
 - **Home**: Return to the welcome page.
-- **Keyboard Shortcuts**:
+- **Keyboard Shortcuts** (defaults; remap them under Settings > Shortcuts — click a binding, press the new combination, changes apply immediately; `Cmd+Q`, the standard Cut/Copy/Paste/Select-All/Undo set, and `F12` stay reserved):
   - `Cmd+N` / `Ctrl+N`: New window
   - `Cmd+T` / `Ctrl+T`: New tab
   - `Cmd+W` / `Ctrl+W` / `Ctrl+F4`: Close tab

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -172,6 +172,7 @@ protocol.registerSchemesAsPrivileged([
   },
 ]);
 const { registerSettingsIpc, loadSettings } = require('./settings-store');
+const { registerShortcutsIpc } = require('./shortcuts-ipc');
 const { registerBookmarksIpc } = require('./bookmarks-store');
 const { registerHistoryIpc, closeDb: closeHistoryDb } = require('./history');
 const {
@@ -270,6 +271,7 @@ async function bootstrap() {
     onNewWindow: createMainWindow,
   });
   registerSettingsIpc();
+  registerShortcutsIpc();
   registerBookmarksIpc();
   registerHistoryIpc();
   registerDownloadsIpc();

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -10,14 +10,35 @@ const {
 const { getActiveProfile, listProfilesForActiveApp } = require('./profile-resolver');
 const { openOrFocusProfile } = require('./profile-launcher');
 const IPC = require('../shared/ipc-channels');
-const { getDefaultAccelerator, getAliasAccelerators } = require('../shared/shortcuts');
+const { getEffectiveAccelerator, getAliasAccelerators } = require('../shared/shortcuts');
+const { loadSettings, onSettingsChanged } = require('./settings-store');
 
 // Every menu accelerator comes from the shared shortcut registry
 // (src/shared/shortcuts.js) — menu.test.js rejects accelerator literals in
-// this file so new shortcuts land in the registry first.
-const acc = (id, platform = process.platform) => getDefaultAccelerator(id, platform);
+// this file so new shortcuts land in the registry first. `acc` resolves the
+// per-profile override (Settings > Shortcuts) over the registry default;
+// aliases are fixed and never remapped.
+const currentOverrides = () => {
+  try {
+    return loadSettings()?.shortcutOverrides || {};
+  } catch {
+    return {};
+  }
+};
+const acc = (id, platform = process.platform) =>
+  getEffectiveAccelerator(id, currentOverrides(), platform);
 const aliasAcc = (id, index, platform = process.platform) =>
   getAliasAccelerators(id, platform)[index];
+
+// Rebuild the application menu when the user remaps shortcuts so the new
+// accelerators take effect without a restart.
+onSettingsChanged((merged, previous) => {
+  const before = JSON.stringify(previous?.shortcutOverrides || {});
+  const after = JSON.stringify(merged?.shortcutOverrides || {});
+  if (before !== after) {
+    setupApplicationMenu();
+  }
+});
 
 // Helper to get the best target window for tab operations
 // Only returns main browser windows we created (not DevTools or other system windows)

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -10,6 +10,14 @@ const {
 const { getActiveProfile, listProfilesForActiveApp } = require('./profile-resolver');
 const { openOrFocusProfile } = require('./profile-launcher');
 const IPC = require('../shared/ipc-channels');
+const { getDefaultAccelerator, getAliasAccelerators } = require('../shared/shortcuts');
+
+// Every menu accelerator comes from the shared shortcut registry
+// (src/shared/shortcuts.js) — menu.test.js rejects accelerator literals in
+// this file so new shortcuts land in the registry first.
+const acc = (id, platform = process.platform) => getDefaultAccelerator(id, platform);
+const aliasAcc = (id, index, platform = process.platform) =>
+  getAliasAccelerators(id, platform)[index];
 
 // Helper to get the best target window for tab operations
 // Only returns main browser windows we created (not DevTools or other system windows)
@@ -153,7 +161,7 @@ function buildFileSubmenu(isMac) {
     {
       id: 'new-tab',
       label: 'New Tab',
-      accelerator: 'CmdOrCtrl+T',
+      accelerator: acc('tab.new'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -164,7 +172,7 @@ function buildFileSubmenu(isMac) {
     {
       id: 'close-tab',
       label: 'Close Tab',
-      accelerator: 'CmdOrCtrl+W',
+      accelerator: acc('tab.close'),
       click: () => {
         const mainWindows = getMainWindows();
         const focusedMainWindow = mainWindows.find((win) => win.isFocused());
@@ -181,7 +189,8 @@ function buildFileSubmenu(isMac) {
   if (!isMac) {
     submenu.push({
       label: 'Close Tab',
-      accelerator: 'Ctrl+F4',
+      // Fixed Ctrl+F4 alias from the registry (win/linux only).
+      accelerator: aliasAcc('tab.close', 0),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -195,7 +204,7 @@ function buildFileSubmenu(isMac) {
     {
       id: 'reopen-closed-tab',
       label: 'Reopen Closed Tab',
-      accelerator: 'CmdOrCtrl+Shift+T',
+      accelerator: acc('tab.reopenClosed'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -207,7 +216,7 @@ function buildFileSubmenu(isMac) {
     {
       id: 'downloads',
       label: 'Downloads',
-      accelerator: 'CmdOrCtrl+Shift+J',
+      accelerator: acc('downloads.show'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -220,7 +229,7 @@ function buildFileSubmenu(isMac) {
     { type: 'separator' },
     {
       label: 'New Window',
-      accelerator: 'CmdOrCtrl+N',
+      accelerator: acc('window.new'),
       click: () => {
         log.info('[menu] New Window clicked');
         createMainWindow();
@@ -242,7 +251,7 @@ function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
     {
       id: 'reload',
       label: 'Reload This Page',
-      accelerator: 'CmdOrCtrl+R',
+      accelerator: acc('page.reload'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -252,7 +261,7 @@ function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
     },
     {
       label: 'Force Reload This Page',
-      accelerator: 'CmdOrCtrl+Shift+R',
+      accelerator: acc('page.hardReload'),
       visible: false,
       click: () => {
         const win = getTargetWindow();
@@ -264,7 +273,7 @@ function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
     { type: 'separator' },
     {
       label: 'Focus Address Bar',
-      accelerator: 'CmdOrCtrl+L',
+      accelerator: acc('view.focusAddressBar'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -277,7 +286,7 @@ function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
     {
       id: 'fullscreen',
       label: fullScreen ? 'Exit Full Screen' : 'Enter Full Screen',
-      accelerator: 'F11',
+      accelerator: acc('view.fullscreen'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -289,7 +298,7 @@ function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
     {
       id: 'next-tab',
       label: 'Next Tab',
-      accelerator: 'Ctrl+PageDown',
+      accelerator: acc('tab.next'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -300,7 +309,7 @@ function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
     {
       id: 'prev-tab',
       label: 'Previous Tab',
-      accelerator: 'Ctrl+PageUp',
+      accelerator: acc('tab.previous'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -311,7 +320,7 @@ function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
     {
       id: 'move-tab-right',
       label: 'Move Tab Right',
-      accelerator: 'Ctrl+Shift+PageDown',
+      accelerator: acc('tab.moveRight'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -322,7 +331,7 @@ function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
     {
       id: 'move-tab-left',
       label: 'Move Tab Left',
-      accelerator: 'Ctrl+Shift+PageUp',
+      accelerator: acc('tab.moveLeft'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -336,7 +345,7 @@ function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
       label: 'Always Show Bookmarks Bar',
       type: 'checkbox',
       checked: false,
-      accelerator: 'CmdOrCtrl+Shift+B',
+      accelerator: acc('view.toggleBookmarksBar'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -348,7 +357,7 @@ function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
     {
       id: 'toggle-devtools',
       label: 'Developer Tools',
-      accelerator: 'CmdOrCtrl+Alt+I',
+      accelerator: acc('devtools.toggle'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -362,7 +371,7 @@ function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
     submenu.push({
       id: 'toggle-app-devtools',
       label: 'App Developer Tools',
-      accelerator: 'CmdOrCtrl+Shift+Alt+I',
+      accelerator: acc('devtools.toggleApp'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -375,11 +384,11 @@ function buildViewSubmenu({ isFullScreen: fullScreen, showAppDevtools }) {
   return submenu;
 }
 
-function buildHistorySubmenu(isMac) {
+function buildHistorySubmenu() {
   return [
     {
       label: 'Show All History',
-      accelerator: isMac ? 'Cmd+Y' : 'Ctrl+H',
+      accelerator: acc('history.showAll'),
       click: () => {
         const win = getTargetWindow();
         if (win) {
@@ -397,7 +406,7 @@ function buildFindMenuItem() {
   return {
     id: 'find-in-page',
     label: 'Find in Page...',
-    accelerator: 'CmdOrCtrl+F',
+    accelerator: acc('page.findInPage'),
     click: () => {
       const win = getTargetWindow();
       if (win) {
@@ -467,7 +476,7 @@ function buildSharedMenuEntries(ctx) {
         showAppDevtools: !isPackaged,
       }),
     },
-    { label: 'History', submenu: buildHistorySubmenu(isMac) },
+    { label: 'History', submenu: buildHistorySubmenu() },
     { label: 'Profiles', submenu: buildProfilesSubmenu() },
   ];
 }

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -577,10 +577,30 @@ function setupApplicationMenu() {
   closeTabMenuItem = menu.getMenuItemById('close-tab');
   toggleBookmarkBarMenuItem = menu.getMenuItemById('toggle-bookmark-bar');
   updateTabMenuItems();
+  // Restore renderer-pushed state the rebuild just reset.
+  if (lastTabState) applyTabState(lastTabState);
+  if (toggleBookmarkBarMenuItem && lastBookmarkBarEnabled !== null) {
+    toggleBookmarkBarMenuItem.enabled = lastBookmarkBarEnabled;
+  }
+  if (toggleBookmarkBarMenuItem && lastBookmarkBarChecked !== null) {
+    toggleBookmarkBarMenuItem.checked = lastBookmarkBarChecked;
+  }
 }
+
+// Last renderer-pushed dynamic state, re-applied after any menu rebuild
+// (shortcut remap, fullscreen label flip) — rebuilt items otherwise reset
+// to template defaults until the renderer's next push.
+let lastTabState = null;
+let lastBookmarkBarEnabled = null;
+let lastBookmarkBarChecked = null;
 
 // Receive tab state updates from the renderer and apply to menu items immediately
 ipcMain.on('menu:update-tab-state', (_event, state) => {
+  lastTabState = state;
+  applyTabState(state);
+});
+
+function applyTabState(state) {
   const menu = Menu.getApplicationMenu();
   if (!menu) return;
 
@@ -600,7 +620,7 @@ ipcMain.on('menu:update-tab-state', (_event, state) => {
   setEnabled('move-tab-left', hasMultipleTabs && activeIndex > 0);
   setEnabled('reopen-closed-tab', hasClosedTabs);
   setEnabled('toggle-devtools', hasTabs);
-});
+}
 
 // Track fullscreen state changes from any window to update menu label
 app.on('browser-window-created', (_event, win) => {
@@ -610,6 +630,7 @@ app.on('browser-window-created', (_event, win) => {
 
 // Allow renderer to enable/disable the bookmark bar toggle menu item
 ipcMain.on('menu:set-bookmark-bar-toggle-enabled', (_event, enabled) => {
+  lastBookmarkBarEnabled = enabled;
   if (toggleBookmarkBarMenuItem) {
     toggleBookmarkBarMenuItem.enabled = enabled;
   }
@@ -617,6 +638,7 @@ ipcMain.on('menu:set-bookmark-bar-toggle-enabled', (_event, enabled) => {
 
 // Allow renderer to update the bookmark bar checked state
 ipcMain.on('menu:set-bookmark-bar-checked', (_event, checked) => {
+  lastBookmarkBarChecked = checked;
   if (toggleBookmarkBarMenuItem) {
     toggleBookmarkBarMenuItem.checked = checked;
   }

--- a/src/main/menu.test.js
+++ b/src/main/menu.test.js
@@ -1,4 +1,6 @@
+const fs = require('fs');
 const { loadMainModule } = require('../../test/helpers/main-process-test-utils');
+const { SHORTCUTS, getDefaultAccelerator, getAliasAccelerators } = require('../shared/shortcuts');
 
 function loadMenuModule(platform, options = {}) {
   let capturedTemplate = null;
@@ -214,5 +216,62 @@ describe('menu', () => {
     expect(fileIndex).toBeGreaterThanOrEqual(0);
     expect(editIndex).toBe(fileIndex + 1);
     expect(viewIndex).toBeGreaterThan(editIndex);
+  });
+});
+
+describe('menu ↔ shortcut registry', () => {
+  // Collect every explicit accelerator in a built menu template.
+  function collectAccelerators(items, found = []) {
+    for (const item of items || []) {
+      if (item.accelerator !== undefined) {
+        found.push(item.accelerator);
+      }
+      if (Array.isArray(item.submenu)) {
+        collectAccelerators(item.submenu, found);
+      }
+    }
+    return found;
+  }
+
+  test('menu.js carries no accelerator literals — everything resolves through the registry', () => {
+    const source = fs.readFileSync(require.resolve('./menu'), 'utf-8');
+    // Any accelerator assigned from a string (or template/ternary) literal
+    // means a shortcut bypassed src/shared/shortcuts.js. Add the shortcut
+    // to the registry and use acc()/aliasAcc() instead.
+    const literalAccelerator = /accelerator:\s*(['"`]|isMac)/;
+    expect(source).not.toMatch(literalAccelerator);
+    expect(source).toMatch(/require\('\.\.\/shared\/shortcuts'\)/);
+  });
+
+  test('every template accelerator is a registry default or fixed alias', () => {
+    for (const platform of ['darwin', 'win32', 'linux']) {
+      const registryAccelerators = new Set();
+      for (const entry of SHORTCUTS) {
+        registryAccelerators.add(getDefaultAccelerator(entry, platform));
+        for (const alias of getAliasAccelerators(entry, platform)) {
+          registryAccelerators.add(alias);
+        }
+      }
+
+      const { capturedTemplate } = loadMenuModule(platform);
+      const used = collectAccelerators(capturedTemplate);
+      expect(used.length).toBeGreaterThan(0);
+      for (const accelerator of used) {
+        expect(registryAccelerators).toContain(accelerator);
+      }
+    }
+  });
+
+  test('menu-context registry entries all surface in the menu template', () => {
+    // Renderer-only shortcuts (context: 'renderer') have no menu item; every
+    // other entry's default accelerator must appear in the built template on
+    // a platform where the entry applies.
+    const { capturedTemplate } = loadMenuModule('linux');
+    const used = new Set(collectAccelerators(capturedTemplate));
+
+    for (const entry of SHORTCUTS) {
+      if (entry.context === 'renderer') continue;
+      expect(used).toContain(getDefaultAccelerator(entry, 'linux'));
+    }
   });
 });

--- a/src/main/menu.test.js
+++ b/src/main/menu.test.js
@@ -10,6 +10,12 @@ function loadMenuModule(platform, options = {}) {
   };
   const openOrFocusProfile = options.openOrFocusProfile || jest.fn();
 
+  // In-memory settings so menu accelerators resolve overrides without
+  // touching a real settings.json; settingsListeners captures the menu's
+  // rebuild-on-remap subscription.
+  const settings = { shortcutOverrides: options.shortcutOverrides || {} };
+  const settingsListeners = [];
+
   const { mod, dialog } = loadMainModule(require.resolve('./menu'), {
     electronOverrides: {
       Menu: {
@@ -43,19 +49,45 @@ function loadMenuModule(platform, options = {}) {
       [require.resolve('./profile-launcher')]: () => ({
         openOrFocusProfile,
       }),
+      [require.resolve('./settings-store')]: () => ({
+        loadSettings: () => settings,
+        onSettingsChanged: (listener) => {
+          settingsListeners.push(listener);
+          return () => {};
+        },
+      }),
     },
   });
 
   const originalPlatform = process.platform;
   Object.defineProperty(process, 'platform', { value: platform });
 
+  // Keep the mocked platform active for the returned emitter too — the
+  // rebuild path resolves accelerators against process.platform.
+  const restorePlatform = () =>
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+
+  const emitSettingsChanged = (merged, previous) => {
+    settings.shortcutOverrides = merged.shortcutOverrides || {};
+    for (const listener of settingsListeners) listener(merged, previous);
+  };
+
   try {
     mod.setupApplicationMenu();
   } finally {
-    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    if (!options.keepPlatform) restorePlatform();
   }
 
-  return { capturedTemplate, mod, dialog, openOrFocusProfile };
+  return {
+    get capturedTemplate() {
+      return capturedTemplate;
+    },
+    mod,
+    dialog,
+    openOrFocusProfile,
+    emitSettingsChanged,
+    restorePlatform,
+  };
 }
 
 function findTopLabel(template, label) {
@@ -259,6 +291,42 @@ describe('menu ↔ shortcut registry', () => {
       for (const accelerator of used) {
         expect(registryAccelerators).toContain(accelerator);
       }
+    }
+  });
+
+  test('user overrides replace default accelerators in the built menu', () => {
+    const ctx = loadMenuModule('linux', {
+      shortcutOverrides: { 'tab.new': 'Ctrl+Shift+U' },
+    });
+
+    const file = ctx.capturedTemplate.find((item) => item.label === 'File');
+    const newTab = file.submenu.find((item) => item.id === 'new-tab');
+    expect(newTab.accelerator).toBe('Ctrl+Shift+U');
+
+    // Untouched shortcuts keep their registry defaults.
+    const closeTab = file.submenu.find((item) => item.id === 'close-tab');
+    expect(closeTab.accelerator).toBe('CmdOrCtrl+W');
+  });
+
+  test('the menu rebuilds when shortcut overrides change and not otherwise', () => {
+    const ctx = loadMenuModule('linux', { keepPlatform: true });
+    try {
+      const before = ctx.capturedTemplate;
+
+      // Unrelated settings change → no rebuild.
+      ctx.emitSettingsChanged({ theme: 'dark', shortcutOverrides: {} }, { shortcutOverrides: {} });
+      expect(ctx.capturedTemplate).toBe(before);
+
+      // Shortcut remap → rebuild with the new accelerator.
+      ctx.emitSettingsChanged(
+        { shortcutOverrides: { 'tab.new': 'Ctrl+Shift+U' } },
+        { shortcutOverrides: {} }
+      );
+      expect(ctx.capturedTemplate).not.toBe(before);
+      const file = ctx.capturedTemplate.find((item) => item.label === 'File');
+      expect(file.submenu.find((item) => item.id === 'new-tab').accelerator).toBe('Ctrl+Shift+U');
+    } finally {
+      ctx.restorePlatform();
     }
   });
 

--- a/src/main/settings-store.js
+++ b/src/main/settings-store.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const IPC = require('../shared/ipc-channels');
 const { broadcastToAllWebContents } = require('./lib/broadcast-to-all-webcontents');
+const { sanitizeOverrides } = require('../shared/shortcuts');
 
 // Apply theme to nativeTheme so webviews get correct prefers-color-scheme
 function applyNativeTheme(theme) {
@@ -61,6 +62,11 @@ const DEFAULT_SETTINGS = {
   // Linux only: render the tab strip as the window titlebar (frameless window).
   // Off by default so Linux users get the native OS frame; opt in via Settings.
   tabsInTitlebar: false,
+  // Keyboard-shortcut remaps: shortcut id → accelerator string. Only ids
+  // from the shared registry (src/shared/shortcuts.js) with valid, non-
+  // reserved accelerators survive sanitization. The one non-primitive
+  // settings value — saveSettings compares it by JSON, not ===.
+  shortcutOverrides: {},
 };
 
 let cachedSettings = null;
@@ -173,6 +179,13 @@ function loadSettings() {
     cachedSettings = { ...DEFAULT_SETTINGS };
   }
 
+  // Defense against hand-edited or stale files: only registry-known,
+  // editable, valid shortcut remaps survive into the live settings.
+  cachedSettings.shortcutOverrides = sanitizeOverrides(
+    cachedSettings.shortcutOverrides,
+    process.platform
+  );
+
   // Apply theme to nativeTheme
   applyNativeTheme(cachedSettings.theme);
 
@@ -183,10 +196,33 @@ function broadcastSettingsUpdated(merged) {
   broadcastToAllWebContents(IPC.SETTINGS_UPDATED, merged);
 }
 
+// Main-process subscribers to committed settings changes (e.g. the
+// application menu rebuilding on shortcut remaps). Renderers keep using
+// the SETTINGS_UPDATED broadcast instead.
+const changeListeners = new Set();
+
+function onSettingsChanged(listener) {
+  changeListeners.add(listener);
+  return () => changeListeners.delete(listener);
+}
+
+function notifySettingsChanged(merged, previous) {
+  for (const listener of changeListeners) {
+    try {
+      listener(merged, previous);
+    } catch (err) {
+      log.error('Settings change listener failed:', err);
+    }
+  }
+}
+
 // Walks DEFAULT_SETTINGS keys in one pass: drops unknown input keys (defense
 // against a buggy or compromised internal page persisting junk to disk) and
-// detects no-op saves at the same time. customSearchProviders is the one
-// structured setting and is normalized before it reaches disk or a renderer.
+// detects no-op saves at the same time. Two structured settings get special
+// handling: customSearchProviders is normalized before it reaches disk or a
+// renderer, and shortcutOverrides is sanitized against the shortcut registry;
+// both compare by JSON, everything else is primitive-valued and compares
+// by === .
 function saveSettings(newSettings) {
   try {
     const previous = loadSettings();
@@ -196,6 +232,15 @@ function saveSettings(newSettings) {
     if (newSettings && typeof newSettings === 'object') {
       for (const key of Object.keys(DEFAULT_SETTINGS)) {
         if (!Object.prototype.hasOwnProperty.call(newSettings, key)) continue;
+
+        if (key === 'shortcutOverrides') {
+          const sanitized = sanitizeOverrides(newSettings[key], process.platform);
+          if (JSON.stringify(sanitized) !== JSON.stringify(previous[key] || {})) {
+            merged[key] = sanitized;
+            changed = true;
+          }
+          continue;
+        }
 
         const nextValue =
           key === 'customSearchProviders'
@@ -224,6 +269,7 @@ function saveSettings(newSettings) {
     }
 
     broadcastSettingsUpdated(merged);
+    notifySettingsChanged(merged, previous);
 
     return true;
   } catch (err) {
@@ -248,4 +294,5 @@ module.exports = {
   registerSettingsIpc,
   // Exported for the parity test against the renderer copy in search-utils.js.
   normalizeSearchUrlTemplate,
+  onSettingsChanged,
 };

--- a/src/main/settings-store.test.js
+++ b/src/main/settings-store.test.js
@@ -310,6 +310,55 @@ describe('settings-store', () => {
     expect(mod.saveSettings({ theme: 'dark' })).toBe(true);
   });
 
+  test('persists sanitized shortcut overrides and notifies main-process listeners', () => {
+    const { mod } = loadSettingsStore({ userDataDir });
+    const listener = jest.fn();
+    mod.onSettingsChanged(listener);
+
+    expect(
+      mod.saveSettings({
+        shortcutOverrides: {
+          'tab.new': 'Shift+Ctrl+u', // valid → normalized
+          'devtools.toggle': 'Ctrl+U', // non-editable → dropped
+          bogus: 'Ctrl+U', // unknown id → dropped
+          'page.reload': 'F12', // reserved → dropped
+        },
+      })
+    ).toBe(true);
+
+    const persisted = JSON.parse(
+      fs.readFileSync(path.join(userDataDir, 'settings.json'), 'utf-8')
+    );
+    expect(persisted.shortcutOverrides).toEqual({ 'tab.new': 'Ctrl+Shift+U' });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const [merged, previous] = listener.mock.calls[0];
+    expect(merged.shortcutOverrides).toEqual({ 'tab.new': 'Ctrl+Shift+U' });
+    expect(previous.shortcutOverrides).toEqual({});
+
+    // Saving the identical overrides again is a no-op — no second notify.
+    expect(mod.saveSettings({ shortcutOverrides: { 'tab.new': 'Ctrl+Shift+U' } })).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  test('sanitizes shortcut overrides already on disk at load time', () => {
+    fs.writeFileSync(
+      path.join(userDataDir, 'settings.json'),
+      JSON.stringify({
+        shortcutOverrides: {
+          'tab.new': 'Ctrl+Shift+U',
+          'devtools.toggle': 'Ctrl+U',
+          garbage: true,
+        },
+      }),
+      'utf-8'
+    );
+
+    const { mod } = loadSettingsStore({ userDataDir });
+
+    expect(mod.loadSettings().shortcutOverrides).toEqual({ 'tab.new': 'Ctrl+Shift+U' });
+  });
+
   test('registers IPC handlers for loading and saving settings', async () => {
     const ipcMain = createIpcMainMock();
     const { mod, nativeTheme } = loadSettingsStore({ userDataDir, ipcMain });

--- a/src/main/shortcuts-ipc.js
+++ b/src/main/shortcuts-ipc.js
@@ -1,0 +1,149 @@
+/**
+ * Shortcuts IPC — backs the Settings > Shortcuts page.
+ *
+ * All shortcut logic (registry, accelerator parsing, validation, conflict
+ * detection, formatting) lives in src/shared/shortcuts.js and runs here in
+ * the main process; the settings page only renders the state it gets back.
+ * Overrides persist in the per-profile settings store, whose save path
+ * sanitizes them again (defense in depth) and broadcasts SETTINGS_UPDATED —
+ * which rebuilds the application menu (menu.js) and refreshes the renderer
+ * keydown matcher live.
+ */
+
+const { ipcMain } = require('electron');
+const IPC = require('../shared/ipc-channels');
+const {
+  SHORTCUTS,
+  getShortcutById,
+  getDefaultAccelerator,
+  getAliasAccelerators,
+  getEffectiveAccelerator,
+  normalizeAccelerator,
+  acceleratorFromEvent,
+  validateBinding,
+  findConflict,
+  formatAccelerator,
+} = require('../shared/shortcuts');
+const { loadSettings, saveSettings } = require('./settings-store');
+
+const getOverrides = () => loadSettings()?.shortcutOverrides || {};
+
+// Full render model for the settings page.
+function getShortcutState(platform = process.platform) {
+  const overrides = getOverrides();
+  const entries = SHORTCUTS.map((entry) => {
+    const defaultAccelerator = getDefaultAccelerator(entry, platform);
+    const accelerator = getEffectiveAccelerator(entry, overrides, platform);
+    return {
+      id: entry.id,
+      description: entry.description,
+      category: entry.category,
+      context: entry.context,
+      editable: entry.editable !== false,
+      warnOnEdit: entry.warnOnEdit === true,
+      accelerator,
+      formatted: formatAccelerator(accelerator, platform),
+      defaultAccelerator,
+      defaultFormatted: formatAccelerator(defaultAccelerator, platform),
+      isOverridden:
+        normalizeAccelerator(accelerator, platform) !==
+        normalizeAccelerator(defaultAccelerator, platform),
+      aliases: getAliasAccelerators(entry, platform).map((alias) =>
+        formatAccelerator(alias, platform)
+      ),
+    };
+  });
+  return { platform, entries };
+}
+
+// Turn a captured keydown (recording mode) into a validated candidate
+// binding, including conflict info so the UI can offer a swap.
+function previewBinding({ id, event } = {}, platform = process.platform) {
+  const entry = getShortcutById(id);
+  if (!entry) return { ok: false, reason: 'unknown-shortcut' };
+
+  const accelerator = acceleratorFromEvent(event, platform);
+  // Only modifiers held so far — the UI keeps listening.
+  if (!accelerator) return { ok: false, reason: 'incomplete' };
+
+  const validity = validateBinding(entry, accelerator, platform);
+  if (!validity.ok) return { ok: false, reason: validity.reason, accelerator };
+
+  const overrides = getOverrides();
+  const conflict = findConflict(entry, accelerator, overrides, platform);
+  return {
+    ok: true,
+    accelerator,
+    formatted: formatAccelerator(accelerator, platform),
+    conflict: conflict
+      ? {
+          ...conflict,
+          // What the swap would hand the conflicting shortcut: this
+          // shortcut's current (pre-remap) binding.
+          swapFormatted: formatAccelerator(
+            getEffectiveAccelerator(entry, overrides, platform),
+            platform
+          ),
+        }
+      : null,
+  };
+}
+
+// Persist a remap. `swapWithConflict` gives the conflicting shortcut this
+// shortcut's previous binding instead of refusing.
+function setOverride(
+  { id, accelerator, swapWithConflict = false } = {},
+  platform = process.platform
+) {
+  const entry = getShortcutById(id);
+  if (!entry) return { ok: false, reason: 'unknown-shortcut' };
+
+  const validity = validateBinding(entry, accelerator, platform);
+  if (!validity.ok) return { ok: false, reason: validity.reason };
+
+  const overrides = { ...getOverrides() };
+  const normalized = normalizeAccelerator(accelerator, platform);
+  const conflict = findConflict(entry, normalized, overrides, platform);
+
+  if (conflict) {
+    if (conflict.fixed || !swapWithConflict) {
+      return { ok: false, reason: 'conflict', conflict };
+    }
+    // Swap: the conflicting shortcut inherits this shortcut's previous
+    // binding. sanitizeOverrides drops it again if that equals its default.
+    const previous = getEffectiveAccelerator(entry, overrides, platform);
+    overrides[conflict.id] = normalizeAccelerator(previous, platform);
+  }
+
+  overrides[id] = normalized;
+  const saved = saveSettings({ shortcutOverrides: overrides });
+  return saved ? { ok: true } : { ok: false, reason: 'save-failed' };
+}
+
+// Reset one shortcut (id given) or all of them (no id) to defaults.
+function resetOverride({ id } = {}) {
+  const overrides = { ...getOverrides() };
+  if (id === undefined || id === null) {
+    const saved = saveSettings({ shortcutOverrides: {} });
+    return saved ? { ok: true } : { ok: false, reason: 'save-failed' };
+  }
+  if (!getShortcutById(id)) return { ok: false, reason: 'unknown-shortcut' };
+  delete overrides[id];
+  const saved = saveSettings({ shortcutOverrides: overrides });
+  return saved ? { ok: true } : { ok: false, reason: 'save-failed' };
+}
+
+function registerShortcutsIpc() {
+  ipcMain.handle(IPC.SHORTCUTS_GET_STATE, () => getShortcutState());
+  ipcMain.handle(IPC.SHORTCUTS_PREVIEW_BINDING, (_event, payload) => previewBinding(payload));
+  ipcMain.handle(IPC.SHORTCUTS_SET_OVERRIDE, (_event, payload) => setOverride(payload));
+  ipcMain.handle(IPC.SHORTCUTS_RESET, (_event, payload) => resetOverride(payload));
+}
+
+module.exports = {
+  getShortcutState,
+  previewBinding,
+  setOverride,
+  resetOverride,
+  registerShortcutsIpc,
+};

--- a/src/main/shortcuts-ipc.js
+++ b/src/main/shortcuts-ipc.js
@@ -10,7 +10,7 @@
  * keydown matcher live.
  */
 
-const { ipcMain } = require('electron');
+const { app, ipcMain } = require('electron');
 const IPC = require('../shared/ipc-channels');
 const {
   SHORTCUTS,
@@ -41,6 +41,9 @@ function getShortcutState(platform = process.platform) {
       context: entry.context,
       editable: entry.editable !== false,
       warnOnEdit: entry.warnOnEdit === true,
+      // Dev-only entries (App Developer Tools) have no menu item in
+      // packaged builds — don't list a shortcut that doesn't exist.
+      hidden: entry.devOnly === true && app.isPackaged === true,
       accelerator,
       formatted: formatAccelerator(accelerator, platform),
       defaultAccelerator,

--- a/src/main/shortcuts-ipc.test.js
+++ b/src/main/shortcuts-ipc.test.js
@@ -109,6 +109,20 @@ describe('shortcuts IPC', () => {
     });
     expect(bare.reason).toBe('needs-modifier');
 
+    // Bare character on a renderer-only shortcut — it listens globally too.
+    const bareRenderer = await ctx.ipcMain.invoke(IPC.SHORTCUTS_PREVIEW_BINDING, {
+      id: 'view.toggleSidebar',
+      event: recordedKey('w', 'KeyW'),
+    });
+    expect(bareRenderer.reason).toBe('needs-modifier');
+
+    // Bare editing key (Enter would fire while typing anywhere).
+    const bareEnter = await ctx.ipcMain.invoke(IPC.SHORTCUTS_PREVIEW_BINDING, {
+      id: 'tab.new',
+      event: recordedKey('Enter', 'Enter'),
+    });
+    expect(bareEnter.reason).toBe('needs-modifier');
+
     // Conflict with another shortcut's default.
     const conflicted = await ctx.ipcMain.invoke(IPC.SHORTCUTS_PREVIEW_BINDING, {
       id: 'tab.new',

--- a/src/main/shortcuts-ipc.test.js
+++ b/src/main/shortcuts-ipc.test.js
@@ -1,0 +1,192 @@
+const { loadMainModule } = require('../../test/helpers/main-process-test-utils');
+const IPC = require('../shared/ipc-channels');
+
+// In-memory settings store standing in for src/main/settings-store.js —
+// mirrors its contract: saveSettings merges shortcutOverrides (already
+// sanitized upstream in the real store; these tests exercise the IPC
+// module's own validation).
+function loadShortcutsIpc({ platform = 'linux', initialOverrides = {} } = {}) {
+  let settings = { shortcutOverrides: { ...initialOverrides } };
+  const saveSettings = jest.fn((patch) => {
+    settings = { ...settings, ...patch };
+    return true;
+  });
+
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform });
+
+  const loaded = loadMainModule(require.resolve('./shortcuts-ipc'), {
+    extraMocks: {
+      [require.resolve('./settings-store')]: () => ({
+        loadSettings: () => settings,
+        saveSettings,
+        onSettingsChanged: jest.fn(),
+      }),
+    },
+  });
+
+  loaded.mod.registerShortcutsIpc();
+
+  return {
+    ...loaded,
+    saveSettings,
+    getSettings: () => settings,
+    restorePlatform: () => Object.defineProperty(process, 'platform', { value: originalPlatform }),
+  };
+}
+
+const recordedKey = (key, code, mods = {}) => ({
+  key,
+  code,
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  metaKey: false,
+  ...mods,
+});
+
+describe('shortcuts IPC', () => {
+  let ctx;
+
+  afterEach(() => {
+    ctx?.restorePlatform();
+    ctx = null;
+  });
+
+  test('get-state returns every registry entry with effective + formatted bindings', async () => {
+    ctx = loadShortcutsIpc({ initialOverrides: { 'tab.new': 'Ctrl+Shift+U' } });
+    const state = await ctx.ipcMain.invoke(IPC.SHORTCUTS_GET_STATE);
+
+    expect(state.platform).toBe('linux');
+    const byId = Object.fromEntries(state.entries.map((entry) => [entry.id, entry]));
+
+    expect(byId['tab.new']).toMatchObject({
+      accelerator: 'Ctrl+Shift+U',
+      formatted: 'Ctrl+Shift+U',
+      defaultAccelerator: 'CmdOrCtrl+T',
+      defaultFormatted: 'Ctrl+T',
+      isOverridden: true,
+      editable: true,
+    });
+    expect(byId['tab.close']).toMatchObject({
+      accelerator: 'CmdOrCtrl+W',
+      isOverridden: false,
+      warnOnEdit: true,
+    });
+    expect(byId['tab.next'].aliases).toEqual(['Ctrl+Tab']);
+    expect(byId['devtools.toggle'].editable).toBe(false);
+  });
+
+  test('preview validates recorded keydowns and reports conflicts', async () => {
+    ctx = loadShortcutsIpc();
+
+    // Free combo — ok, no conflict.
+    const free = await ctx.ipcMain.invoke(IPC.SHORTCUTS_PREVIEW_BINDING, {
+      id: 'tab.new',
+      event: recordedKey('u', 'KeyU', { ctrlKey: true, shiftKey: true }),
+    });
+    expect(free).toMatchObject({ ok: true, accelerator: 'Ctrl+Shift+U', conflict: null });
+
+    // Modifier-only — keep recording.
+    const incomplete = await ctx.ipcMain.invoke(IPC.SHORTCUTS_PREVIEW_BINDING, {
+      id: 'tab.new',
+      event: recordedKey('Shift', 'ShiftLeft', { shiftKey: true }),
+    });
+    expect(incomplete).toEqual({ ok: false, reason: 'incomplete' });
+
+    // Reserved combo.
+    const reserved = await ctx.ipcMain.invoke(IPC.SHORTCUTS_PREVIEW_BINDING, {
+      id: 'tab.new',
+      event: recordedKey('q', 'KeyQ', { ctrlKey: true }),
+    });
+    expect(reserved.ok).toBe(false);
+    expect(reserved.reason).toBe('reserved');
+
+    // Bare character on a menu-context shortcut.
+    const bare = await ctx.ipcMain.invoke(IPC.SHORTCUTS_PREVIEW_BINDING, {
+      id: 'tab.new',
+      event: recordedKey('k', 'KeyK'),
+    });
+    expect(bare.reason).toBe('needs-modifier');
+
+    // Conflict with another shortcut's default.
+    const conflicted = await ctx.ipcMain.invoke(IPC.SHORTCUTS_PREVIEW_BINDING, {
+      id: 'tab.new',
+      event: recordedKey('w', 'KeyW', { ctrlKey: true }),
+    });
+    expect(conflicted.ok).toBe(true);
+    expect(conflicted.conflict).toMatchObject({ id: 'tab.close', fixed: false });
+    expect(conflicted.conflict.swapFormatted).toBe('Ctrl+T');
+  });
+
+  test('set-override persists a valid remap through the settings store', async () => {
+    ctx = loadShortcutsIpc();
+    const result = await ctx.ipcMain.invoke(IPC.SHORTCUTS_SET_OVERRIDE, {
+      id: 'tab.new',
+      accelerator: 'Ctrl+Shift+U',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(ctx.saveSettings).toHaveBeenCalledWith({
+      shortcutOverrides: { 'tab.new': 'Ctrl+Shift+U' },
+    });
+  });
+
+  test('set-override refuses conflicts unless the caller asks for a swap', async () => {
+    ctx = loadShortcutsIpc();
+
+    const refused = await ctx.ipcMain.invoke(IPC.SHORTCUTS_SET_OVERRIDE, {
+      id: 'tab.new',
+      accelerator: 'Ctrl+W',
+    });
+    expect(refused.ok).toBe(false);
+    expect(refused.reason).toBe('conflict');
+    expect(refused.conflict.id).toBe('tab.close');
+    expect(ctx.saveSettings).not.toHaveBeenCalled();
+
+    const swapped = await ctx.ipcMain.invoke(IPC.SHORTCUTS_SET_OVERRIDE, {
+      id: 'tab.new',
+      accelerator: 'Ctrl+W',
+      swapWithConflict: true,
+    });
+    expect(swapped).toEqual({ ok: true });
+    // tab.new takes Ctrl+W; tab.close inherits tab.new's previous Ctrl+T.
+    expect(ctx.getSettings().shortcutOverrides).toEqual({
+      'tab.new': 'Ctrl+W',
+      'tab.close': 'Ctrl+T',
+    });
+  });
+
+  test('set-override never swaps against fixed aliases or reserved targets', async () => {
+    ctx = loadShortcutsIpc();
+
+    const fixedAlias = await ctx.ipcMain.invoke(IPC.SHORTCUTS_SET_OVERRIDE, {
+      id: 'tab.new',
+      accelerator: 'Ctrl+Tab',
+      swapWithConflict: true,
+    });
+    expect(fixedAlias.ok).toBe(false);
+    expect(fixedAlias.reason).toBe('conflict');
+    expect(fixedAlias.conflict).toMatchObject({ id: 'tab.next', fixed: true });
+
+    const notEditable = await ctx.ipcMain.invoke(IPC.SHORTCUTS_SET_OVERRIDE, {
+      id: 'devtools.toggle',
+      accelerator: 'Ctrl+Shift+U',
+    });
+    expect(notEditable.reason).toBe('not-editable');
+
+    expect(ctx.saveSettings).not.toHaveBeenCalled();
+  });
+
+  test('reset clears one override or all of them', async () => {
+    ctx = loadShortcutsIpc({
+      initialOverrides: { 'tab.new': 'Ctrl+Shift+U', 'page.reload': 'Ctrl+Shift+Y' },
+    });
+
+    await ctx.ipcMain.invoke(IPC.SHORTCUTS_RESET, { id: 'tab.new' });
+    expect(ctx.getSettings().shortcutOverrides).toEqual({ 'page.reload': 'Ctrl+Shift+Y' });
+
+    await ctx.ipcMain.invoke(IPC.SHORTCUTS_RESET, {});
+    expect(ctx.getSettings().shortcutOverrides).toEqual({});
+  });
+});

--- a/src/main/webview-preload.js
+++ b/src/main/webview-preload.js
@@ -291,6 +291,25 @@ contextBridge.exposeInMainWorld('freedomAPI', {
   ),
   relaunchApp: guardInternal('relaunchApp', () => ipcRenderer.send('app:relaunch')),
 
+  // Keyboard shortcuts (Settings > Shortcuts). Reads are internal-page
+  // wide; anything that changes bindings is settings-only, matching the
+  // profile-write guards. previewShortcutBinding is a pure computation
+  // (validation + conflict lookup for a captured keydown) but only the
+  // settings page has any business calling it.
+  getShortcuts: guardInternal('getShortcuts', () => ipcRenderer.invoke('shortcuts:get-state')),
+  previewShortcutBinding: guardSettingsPage('previewShortcutBinding', (payload) =>
+    ipcRenderer.invoke('shortcuts:preview-binding', payload)
+  ),
+  setShortcutOverride: guardSettingsPage('setShortcutOverride', (payload) =>
+    ipcRenderer.invoke('shortcuts:set-override', payload)
+  ),
+  resetShortcut: guardSettingsPage('resetShortcut', (id) =>
+    ipcRenderer.invoke('shortcuts:reset', { id })
+  ),
+  resetAllShortcuts: guardSettingsPage('resetAllShortcuts', () =>
+    ipcRenderer.invoke('shortcuts:reset', {})
+  ),
+
   // Platform / environment info needed by settings page
   getPlatform: guardInternal('getPlatform', () => ipcRenderer.invoke('window:get-platform')),
   getActiveProfile: guardInternal('getActiveProfile', () =>

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -70,6 +70,7 @@ import { initRadicleAlias } from './lib/radicle-alias.js';
 import { initWalletUi, openPublishSetupFlow } from './lib/wallet-ui.js';
 import { attachSubmenuHover } from './lib/submenu-hover.js';
 import { bindHoverTooltip } from './lib/hover-tooltip.js';
+import { initShortcuts } from './lib/shortcuts.js';
 
 const electronAPI = window.electronAPI;
 
@@ -720,6 +721,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     applySettingsToState(event.detail);
   });
 
+  initShortcuts(); // Live shortcut bindings — before any keydown consumers
   initMenuBackdrop(closeAllOverlays);
   initMenus();
   initAntUi();

--- a/src/renderer/lib/find-bar.js
+++ b/src/renderer/lib/find-bar.js
@@ -13,6 +13,7 @@
 // its tab-switch and did-navigate paths.
 
 import { pushDebug } from './debug.js';
+import { matchesShortcut } from './shortcuts.js';
 
 // Debounce for find-as-you-type. Exported so the unit tests advance fake
 // timers by the real value instead of a magic number.
@@ -311,12 +312,7 @@ export const initFindBar = ({ getActiveWebview: getWebview } = {}) => {
   // page itself focused the keystroke lands inside the webview and reaches
   // us via the Edit-menu accelerator instead (main → find:open → below).
   window.addEventListener('keydown', (event) => {
-    if (
-      (event.metaKey || event.ctrlKey) &&
-      !event.shiftKey &&
-      !event.altKey &&
-      event.key.toLowerCase() === 'f'
-    ) {
+    if (matchesShortcut(event, 'page.findInPage')) {
       event.preventDefault();
       openFindBar();
     }

--- a/src/renderer/lib/find-bar.test.js
+++ b/src/renderer/lib/find-bar.test.js
@@ -64,6 +64,11 @@ const loadFindBarModule = async ({ webview = createFakeWebview(), initOptions } 
     },
   };
 
+  // Pin the shortcut matcher to macOS semantics (the Cmd-based events these
+  // tests dispatch) so assertions don't depend on the host platform.
+  const shortcuts = await import('./shortcuts.js');
+  shortcuts.configureShortcuts({ platform: 'darwin', overrides: {} });
+
   const mod = await import('./find-bar.js');
   mod.initFindBar(initOptions ?? { getActiveWebview: () => webview });
 

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -62,6 +62,7 @@ import { walletState } from './wallet/wallet-state.js';
 import { formatWeiToDecimal } from './wallet/send.js';
 import { startIpfsProgressStatus, stopIpfsProgressStatus } from './ipfs-progress-status.js';
 import { TOOLTIP_HOVER_DELAY_MS } from './hover-tooltip.js';
+import { matchesShortcut } from './shortcuts.js';
 
 // Helper to get active tab's navigation state (with fallback to empty object)
 const getNavState = () => getActiveTabState() || {};
@@ -2435,27 +2436,17 @@ export const initNavigation = () => {
     toggleBookmarkBar();
   });
 
-  // Keyboard shortcuts
+  // Keyboard shortcuts — resolved through the shared shortcut registry so
+  // user remaps apply live. (Escape stays hardcoded: it's contextual
+  // stop-loading behavior, not a remappable shortcut.)
   window.addEventListener('keydown', (event) => {
-    // Cmd+Shift+R / Ctrl+Shift+R - Hard Reload (check first, before soft reload)
-    if (
-      (event.metaKey || event.ctrlKey) &&
-      event.shiftKey &&
-      event.key &&
-      event.key.toLowerCase() === 'r' &&
-      !event.altKey
-    ) {
+    // Hard reload (check first, before soft reload)
+    if (matchesShortcut(event, 'page.hardReload')) {
       event.preventDefault();
       hardReloadPage();
     }
-    // Cmd+R / Ctrl+R - Reload (soft, uses cache)
-    else if (
-      (event.metaKey || event.ctrlKey) &&
-      !event.shiftKey &&
-      event.key &&
-      event.key.toLowerCase() === 'r' &&
-      !event.altKey
-    ) {
+    // Reload (soft, uses cache)
+    else if (matchesShortcut(event, 'page.reload')) {
       event.preventDefault();
       reloadPage();
     } else if (event.key === 'Escape') {

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -409,6 +409,11 @@ const loadNavigationModule = async (options = {}) => {
   jest.doMock('./page-urls.js', () => pageUrlsMocks);
   jest.doMock('./ipfs-progress-status.js', () => ipfsProgressMocks);
 
+  // Pin the shortcut matcher to Linux semantics (Ctrl-based combos) so the
+  // keyboard-shortcut assertions below don't depend on the host platform.
+  const shortcuts = await import('./shortcuts.js');
+  shortcuts.configureShortcuts({ platform: 'linux', overrides: {} });
+
   const mod = await import('./navigation.js');
 
   return {

--- a/src/renderer/lib/shortcuts.js
+++ b/src/renderer/lib/shortcuts.js
@@ -326,6 +326,27 @@ export function eventMatchesAccelerator(event, accelerator, platform) {
   return eventKeyCandidates(event).has(parsed.key);
 }
 
+// The only keys safe to bind without a real modifier: function keys never
+// type or edit text, so a bare binding cannot fire mid-typing. Everything
+// else — printable characters and named editing/navigation keys (Enter,
+// Space, Backspace, Delete, Tab, arrows, Home/End/Page keys, …) — needs
+// Ctrl/Alt/Cmd. Escape is deliberately not allowlisted: it is the
+// universal cancel/dismiss gesture inside dialogs and text fields.
+const SAFE_BARE_KEY_RE = /^F([1-9]|1\d|2[0-4])$/;
+
+/**
+ * True when `accelerator` would fire while the user is typing if bound
+ * as-is: no real modifier (Ctrl/Alt/Cmd — Shift alone does not count) and
+ * a key outside the safe-bare allowlist. Applies to every action scope;
+ * renderer-only shortcuts listen globally too.
+ */
+export function acceleratorNeedsModifier(accelerator, platform) {
+  const parsed = parseAccelerator(accelerator, platform);
+  if (!parsed) return false;
+  if (parsed.ctrl || parsed.alt || parsed.meta) return false;
+  return !SAFE_BARE_KEY_RE.test(parsed.key);
+}
+
 export function getShortcutById(id) {
   return SHORTCUTS.find((entry) => entry.id === id) || null;
 }
@@ -405,16 +426,32 @@ export const getEffectiveAccelerator = (id) => {
   return getDefaultAccelerator(id, getPlatform());
 };
 
+// True for events originating in editable UI — inputs, textareas, selects,
+// contenteditable regions — where modifier-less bindings must never fire.
+const isEditableEventTarget = (target) => {
+  if (!target || typeof target !== 'object') return false;
+  if (target.isContentEditable === true) return true;
+  const tag = typeof target.tagName === 'string' ? target.tagName.toLowerCase() : '';
+  return tag === 'input' || tag === 'textarea' || tag === 'select';
+};
+
 /**
  * True when a keydown event matches the shortcut's effective primary
  * accelerator or one of its fixed aliases. Keydown handlers resolve every
  * shortcut through this so user remaps apply without a restart.
+ *
+ * Defense in depth: validation and sanitizeOverrides already reject
+ * modifier-less typing/editing keys, but should one still reach the
+ * renderer (stale store, out-of-band settings edit), it is ignored while
+ * the user is typing in an editable target.
  */
 export const matchesShortcut = (event, id) => {
   const platform = getPlatform();
-  const primary = getEffectiveAccelerator(id);
-  if (primary && eventMatchesAccelerator(event, primary, platform)) return true;
-  return getAliasAccelerators(id, platform).some((alias) =>
-    eventMatchesAccelerator(event, alias, platform)
-  );
+  const editable = isEditableEventTarget(event?.target);
+  const matches = (accelerator) =>
+    Boolean(accelerator) &&
+    eventMatchesAccelerator(event, accelerator, platform) &&
+    !(editable && acceleratorNeedsModifier(accelerator, platform));
+  if (matches(getEffectiveAccelerator(id))) return true;
+  return getAliasAccelerators(id, platform).some(matches);
 };

--- a/src/renderer/lib/shortcuts.js
+++ b/src/renderer/lib/shortcuts.js
@@ -191,8 +191,10 @@ export const SHORTCUTS = [
     defaultAccelerator: 'CmdOrCtrl+Shift+Alt+I',
     context: 'menu',
     category: 'Developer',
-    // Dev-build-only menu entry; never shown as remappable.
+    // Dev-build-only menu entry; never shown as remappable and hidden
+    // from the Shortcuts settings page in packaged builds.
     editable: false,
+    devOnly: true,
   },
 ];
 

--- a/src/renderer/lib/shortcuts.js
+++ b/src/renderer/lib/shortcuts.js
@@ -1,0 +1,418 @@
+/**
+ * Keyboard Shortcut Registry + matcher (Renderer)
+ *
+ * ESM mirror of src/shared/shortcuts.js plus the renderer-side state that
+ * keydown handlers resolve through. The shared file is CommonJS and cannot
+ * be imported directly by the renderer (script type="module" context with
+ * no Node require). Both implementations MUST stay in sync; drift is
+ * guarded against by src/renderer/lib/shortcuts.test.js which asserts the
+ * registries are identical and the matchers agree across a battery of
+ * accelerator/event/platform combinations.
+ *
+ * Renderer usage:
+ *   initShortcuts();                      // once, at chrome startup
+ *   matchesShortcut(event, 'tab.new');    // inside keydown handlers
+ *
+ * matchesShortcut checks the shortcut's effective primary accelerator
+ * (user override, else registry default — kept live via settings:updated)
+ * plus its fixed aliases.
+ */
+
+// ── Registry (mirror of src/shared/shortcuts.js — keep in sync) ─────────
+
+export const SHORTCUTS = [
+  // Tabs
+  {
+    id: 'tab.new',
+    description: 'New Tab',
+    defaultAccelerator: 'CmdOrCtrl+T',
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+  },
+  {
+    id: 'tab.close',
+    description: 'Close Tab',
+    defaultAccelerator: 'CmdOrCtrl+W',
+    aliases: [{ accelerator: 'Ctrl+F4', platforms: ['win32', 'linux'] }],
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+    // Cmd/Ctrl+W is deep muscle memory and doubles as the close-window
+    // gesture elsewhere in the OS — rebinding deserves a caution.
+    warnOnEdit: true,
+  },
+  {
+    id: 'tab.reopenClosed',
+    description: 'Reopen Closed Tab',
+    defaultAccelerator: 'CmdOrCtrl+Shift+T',
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+  },
+  {
+    id: 'tab.next',
+    description: 'Next Tab',
+    defaultAccelerator: 'Ctrl+PageDown',
+    aliases: [{ accelerator: 'Ctrl+Tab' }, { accelerator: 'Cmd+Shift+]', platforms: ['darwin'] }],
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+  },
+  {
+    id: 'tab.previous',
+    description: 'Previous Tab',
+    defaultAccelerator: 'Ctrl+PageUp',
+    aliases: [
+      { accelerator: 'Ctrl+Shift+Tab' },
+      { accelerator: 'Cmd+Shift+[', platforms: ['darwin'] },
+    ],
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+  },
+  {
+    id: 'tab.moveRight',
+    description: 'Move Tab Right',
+    defaultAccelerator: 'Ctrl+Shift+PageDown',
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+  },
+  {
+    id: 'tab.moveLeft',
+    description: 'Move Tab Left',
+    defaultAccelerator: 'Ctrl+Shift+PageUp',
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+  },
+
+  // Page
+  {
+    id: 'page.reload',
+    description: 'Reload This Page',
+    defaultAccelerator: 'CmdOrCtrl+R',
+    context: 'both',
+    category: 'Page',
+    editable: true,
+  },
+  {
+    id: 'page.hardReload',
+    description: 'Force Reload This Page',
+    defaultAccelerator: 'CmdOrCtrl+Shift+R',
+    context: 'both',
+    category: 'Page',
+    editable: true,
+  },
+  {
+    id: 'page.findInPage',
+    description: 'Find in Page',
+    defaultAccelerator: 'CmdOrCtrl+F',
+    context: 'both',
+    category: 'Page',
+    editable: true,
+  },
+
+  // Navigation
+  {
+    id: 'view.focusAddressBar',
+    description: 'Focus Address Bar',
+    defaultAccelerator: 'CmdOrCtrl+L',
+    context: 'both',
+    category: 'Navigation',
+    editable: true,
+  },
+  {
+    id: 'history.showAll',
+    description: 'Show All History',
+    defaultAccelerator: { darwin: 'Cmd+Y', other: 'Ctrl+H' },
+    context: 'menu',
+    category: 'Navigation',
+    editable: true,
+  },
+  {
+    id: 'downloads.show',
+    description: 'Downloads',
+    defaultAccelerator: 'CmdOrCtrl+Shift+J',
+    context: 'menu',
+    category: 'Navigation',
+    editable: true,
+  },
+
+  // Window
+  {
+    id: 'window.new',
+    description: 'New Window',
+    defaultAccelerator: 'CmdOrCtrl+N',
+    context: 'menu',
+    category: 'Window',
+    editable: true,
+  },
+  {
+    id: 'view.fullscreen',
+    description: 'Toggle Full Screen',
+    defaultAccelerator: 'F11',
+    context: 'both',
+    category: 'Window',
+    editable: true,
+  },
+  {
+    id: 'view.toggleBookmarksBar',
+    description: 'Toggle Bookmarks Bar',
+    defaultAccelerator: 'CmdOrCtrl+Shift+B',
+    context: 'menu',
+    category: 'Window',
+    editable: true,
+  },
+  {
+    id: 'view.toggleSidebar',
+    description: 'Toggle Wallet Sidebar',
+    defaultAccelerator: 'CmdOrCtrl+Shift+W',
+    context: 'renderer',
+    category: 'Window',
+    editable: true,
+  },
+
+  // Developer
+  {
+    id: 'devtools.toggle',
+    description: 'Developer Tools',
+    defaultAccelerator: 'CmdOrCtrl+Alt+I',
+    aliases: [{ accelerator: 'Ctrl+Shift+I' }, { accelerator: 'F12' }],
+    context: 'both',
+    category: 'Developer',
+    // F12 / DevTools bindings are part of the reserved set — not remappable.
+    editable: false,
+  },
+  {
+    id: 'devtools.toggleApp',
+    description: 'App Developer Tools',
+    defaultAccelerator: 'CmdOrCtrl+Shift+Alt+I',
+    context: 'menu',
+    category: 'Developer',
+    // Dev-build-only menu entry; never shown as remappable.
+    editable: false,
+  },
+];
+
+// ── Accelerator parsing / matching (mirror — keep in sync) ──────────────
+
+const MODIFIER_TOKENS = {
+  ctrl: 'ctrl',
+  control: 'ctrl',
+  alt: 'alt',
+  option: 'alt',
+  shift: 'shift',
+  cmd: 'meta',
+  command: 'meta',
+  meta: 'meta',
+  super: 'meta',
+};
+
+const KEY_ALIASES = {
+  esc: 'Escape',
+  escape: 'Escape',
+  return: 'Enter',
+  enter: 'Enter',
+  space: 'Space',
+  spacebar: 'Space',
+  tab: 'Tab',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  del: 'Delete',
+  insert: 'Insert',
+  home: 'Home',
+  end: 'End',
+  pageup: 'PageUp',
+  pagedown: 'PageDown',
+  up: 'Up',
+  arrowup: 'Up',
+  down: 'Down',
+  arrowdown: 'Down',
+  left: 'Left',
+  arrowleft: 'Left',
+  right: 'Right',
+  arrowright: 'Right',
+  plus: 'Plus',
+};
+
+const CODE_BASE_KEYS = {
+  Minus: '-',
+  Equal: '=',
+  BracketLeft: '[',
+  BracketRight: ']',
+  Semicolon: ';',
+  Quote: "'",
+  Backquote: '`',
+  Backslash: '\\',
+  Comma: ',',
+  Period: '.',
+  Slash: '/',
+  Space: 'Space',
+};
+
+export function canonicalKey(rawKey) {
+  if (rawKey === undefined || rawKey === null || rawKey === '') return null;
+  const raw = String(rawKey);
+  if (raw.length === 1) {
+    if (raw === ' ') return 'Space';
+    if (raw === '+') return 'Plus';
+    return raw.toLowerCase();
+  }
+  const lower = raw.toLowerCase();
+  if (KEY_ALIASES[lower]) return KEY_ALIASES[lower];
+  if (/^f([1-9]|1\d|2[0-4])$/.test(lower)) return lower.toUpperCase();
+  // Unknown named key (media keys, etc.) — keep as-is so it still compares
+  // consistently between accelerator strings and KeyboardEvent.key.
+  return raw;
+}
+
+export function parseAccelerator(accelerator, platform) {
+  if (typeof accelerator !== 'string' || accelerator.length === 0) return null;
+  const parts = accelerator.split('+');
+  const parsed = { key: null, ctrl: false, alt: false, shift: false, meta: false };
+
+  for (const part of parts) {
+    if (part === '') return null;
+    const token = part.toLowerCase();
+    if (token === 'cmdorctrl' || token === 'commandorcontrol') {
+      if (platform === 'darwin') parsed.meta = true;
+      else parsed.ctrl = true;
+      continue;
+    }
+    if (MODIFIER_TOKENS[token]) {
+      parsed[MODIFIER_TOKENS[token]] = true;
+      continue;
+    }
+    if (parsed.key !== null) return null; // two non-modifier keys
+    parsed.key = canonicalKey(part);
+  }
+
+  if (!parsed.key) return null;
+  return parsed;
+}
+
+export function eventKeyCandidates(event) {
+  const candidates = new Set();
+  const fromKey = canonicalKey(event?.key);
+  if (fromKey && !['Shift', 'Control', 'Alt', 'Meta', 'AltGraph'].includes(String(event.key))) {
+    candidates.add(fromKey);
+  }
+  const code = event?.code;
+  if (typeof code === 'string') {
+    if (CODE_BASE_KEYS[code]) {
+      candidates.add(CODE_BASE_KEYS[code]);
+    } else if (/^Key[A-Z]$/.test(code)) {
+      candidates.add(code.slice(3).toLowerCase());
+    } else if (/^Digit\d$/.test(code)) {
+      candidates.add(code.slice(5));
+    }
+  }
+  return candidates;
+}
+
+export function eventMatchesAccelerator(event, accelerator, platform) {
+  const parsed = parseAccelerator(accelerator, platform);
+  if (!parsed || !event) return false;
+
+  if (Boolean(event.ctrlKey) !== parsed.ctrl) return false;
+  if (Boolean(event.altKey) !== parsed.alt) return false;
+  if (Boolean(event.shiftKey) !== parsed.shift) return false;
+  if (Boolean(event.metaKey) !== parsed.meta) return false;
+
+  return eventKeyCandidates(event).has(parsed.key);
+}
+
+export function getShortcutById(id) {
+  return SHORTCUTS.find((entry) => entry.id === id) || null;
+}
+
+export function getDefaultAccelerator(entryOrId, platform) {
+  const entry = typeof entryOrId === 'string' ? getShortcutById(entryOrId) : entryOrId;
+  if (!entry) return null;
+  const def = entry.defaultAccelerator;
+  if (typeof def === 'string') return def;
+  if (def && typeof def === 'object') return def[platform] || def.other || null;
+  return null;
+}
+
+export function getAliasAccelerators(entryOrId, platform) {
+  const entry = typeof entryOrId === 'string' ? getShortcutById(entryOrId) : entryOrId;
+  if (!entry || !Array.isArray(entry.aliases)) return [];
+  return entry.aliases
+    .filter((alias) => !alias.platforms || alias.platforms.includes(platform))
+    .map((alias) => alias.accelerator);
+}
+
+// ── Renderer-side state ─────────────────────────────────────────────────
+
+const detectPlatform = () => {
+  const nav = globalThis.navigator;
+  const probe = `${nav?.platform || ''} ${nav?.userAgent || ''}`.toLowerCase();
+  if (probe.includes('mac')) return 'darwin';
+  if (probe.includes('win')) return 'win32';
+  return 'linux';
+};
+
+const state = {
+  platform: null, // resolved lazily so tests can configure before first use
+  overrides: {}, // shortcut id → accelerator string (user remaps)
+};
+
+const getPlatform = () => {
+  if (!state.platform) state.platform = detectPlatform();
+  return state.platform;
+};
+
+const applySettings = (settings) => {
+  const raw = settings?.shortcutOverrides;
+  state.overrides = raw && typeof raw === 'object' && !Array.isArray(raw) ? { ...raw } : {};
+};
+
+/**
+ * Configure the module explicitly (unit tests, or callers that already
+ * know the platform). Any field may be omitted.
+ */
+export const configureShortcuts = ({ platform, overrides } = {}) => {
+  if (platform) state.platform = platform;
+  if (overrides !== undefined) applySettings({ shortcutOverrides: overrides });
+};
+
+/**
+ * Load the current overrides and keep them live. Safe to call in
+ * environments without electronAPI (overrides simply stay empty).
+ */
+export const initShortcuts = () => {
+  window.electronAPI
+    ?.getSettings?.()
+    .then((settings) => applySettings(settings))
+    .catch(() => {});
+  // Preload re-dispatches main's settings:updated broadcast as a window
+  // CustomEvent — remaps apply live, no restart needed.
+  window.addEventListener?.('settings:updated', (event) => applySettings(event.detail));
+};
+
+/**
+ * Effective primary accelerator for a shortcut: user override, else the
+ * registry default for this platform.
+ */
+export const getEffectiveAccelerator = (id) => {
+  const override = state.overrides[id];
+  if (typeof override === 'string' && override) return override;
+  return getDefaultAccelerator(id, getPlatform());
+};
+
+/**
+ * True when a keydown event matches the shortcut's effective primary
+ * accelerator or one of its fixed aliases. Keydown handlers resolve every
+ * shortcut through this so user remaps apply without a restart.
+ */
+export const matchesShortcut = (event, id) => {
+  const platform = getPlatform();
+  const primary = getEffectiveAccelerator(id);
+  if (primary && eventMatchesAccelerator(event, primary, platform)) return true;
+  return getAliasAccelerators(id, platform).some((alias) =>
+    eventMatchesAccelerator(event, alias, platform)
+  );
+};

--- a/src/renderer/lib/shortcuts.test.js
+++ b/src/renderer/lib/shortcuts.test.js
@@ -86,6 +86,37 @@ describe('shared ↔ renderer mirror equivalence', () => {
     }
   });
 
+  test('acceleratorNeedsModifier agrees across a battery of accelerators', async () => {
+    const mirror = await loadMirror();
+    const accelerators = [
+      'W',
+      'Shift+W',
+      'Ctrl+W',
+      'CmdOrCtrl+Shift+W',
+      'Enter',
+      'Shift+Enter',
+      'Alt+Enter',
+      'Space',
+      'Backspace',
+      'Delete',
+      'Tab',
+      'Escape',
+      'Left',
+      'Home',
+      'PageUp',
+      'F5',
+      'F11',
+      'Shift+F5',
+    ];
+    for (const accelerator of accelerators) {
+      for (const platform of PLATFORMS) {
+        expect(mirror.acceleratorNeedsModifier(accelerator, platform)).toBe(
+          shared.acceleratorNeedsModifier(accelerator, platform)
+        );
+      }
+    }
+  });
+
   test('default and alias lookups agree', async () => {
     const mirror = await loadMirror();
     for (const entry of shared.SHORTCUTS) {
@@ -157,6 +188,54 @@ describe('renderer live bindings', () => {
 
     expect(mirror.getEffectiveAccelerator('tab.new')).toBe('Ctrl+Shift+U');
     expect(mirror.getEffectiveAccelerator('tab.close')).toBe('CmdOrCtrl+W');
+  });
+
+  test('bare-key bindings are ignored while typing in editable targets', async () => {
+    const mirror = await loadMirror();
+    // A modifier-less override should never reach the renderer (validation
+    // and sanitizeOverrides both reject it) — but if one does (stale store,
+    // out-of-band settings edit), it must not fire mid-typing.
+    mirror.configureShortcuts({ platform: 'linux', overrides: { 'view.toggleSidebar': 'W' } });
+
+    const bareW = keyEvent({ key: 'w', code: 'KeyW' });
+    const page = { tagName: 'BODY', isContentEditable: false };
+    const input = { tagName: 'INPUT', isContentEditable: false };
+    const textarea = { tagName: 'TEXTAREA', isContentEditable: false };
+    const select = { tagName: 'SELECT', isContentEditable: false };
+    const editableDiv = { tagName: 'DIV', isContentEditable: true };
+
+    expect(mirror.matchesShortcut({ ...bareW, target: page }, 'view.toggleSidebar')).toBe(true);
+    for (const target of [input, textarea, select, editableDiv]) {
+      expect(mirror.matchesShortcut({ ...bareW, target }, 'view.toggleSidebar')).toBe(false);
+    }
+
+    // Shift alone is not a real modifier — Shift+Enter must not fire either.
+    mirror.configureShortcuts({ overrides: { 'view.toggleSidebar': 'Shift+Enter' } });
+    expect(
+      mirror.matchesShortcut(
+        { ...keyEvent({ key: 'Enter', code: 'Enter', shiftKey: true }), target: textarea },
+        'view.toggleSidebar'
+      )
+    ).toBe(false);
+  });
+
+  test('modifier combos and bare function keys still fire in editable targets', async () => {
+    const mirror = await loadMirror();
+    mirror.configureShortcuts({ platform: 'linux', overrides: {} });
+    const input = { tagName: 'INPUT', isContentEditable: false };
+
+    expect(
+      mirror.matchesShortcut(
+        { ...keyEvent({ key: 'W', code: 'KeyW', ctrlKey: true, shiftKey: true }), target: input },
+        'view.toggleSidebar'
+      )
+    ).toBe(true);
+    expect(
+      mirror.matchesShortcut(
+        { ...keyEvent({ key: 'F11', code: 'F11' }), target: input },
+        'view.fullscreen'
+      )
+    ).toBe(true);
   });
 
   test('initShortcuts loads settings and applies live settings:updated payloads', async () => {

--- a/src/renderer/lib/shortcuts.test.js
+++ b/src/renderer/lib/shortcuts.test.js
@@ -1,0 +1,191 @@
+/**
+ * Equivalence guard for the ESM mirror (src/renderer/lib/shortcuts.js) vs
+ * the canonical CommonJS module (src/shared/shortcuts.js), plus tests for
+ * the renderer-only live-binding state.
+ */
+
+const shared = require('../../shared/shortcuts.js');
+
+const PLATFORMS = ['darwin', 'win32', 'linux'];
+
+const loadMirror = async () => {
+  jest.resetModules();
+  return import('./shortcuts.js');
+};
+
+const keyEvent = (overrides = {}) => ({
+  key: 'a',
+  code: 'KeyA',
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  metaKey: false,
+  ...overrides,
+});
+
+describe('shared ↔ renderer mirror equivalence', () => {
+  test('registries are identical', async () => {
+    const mirror = await loadMirror();
+    expect(mirror.SHORTCUTS).toEqual(shared.SHORTCUTS);
+  });
+
+  test('parseAccelerator agrees across registry defaults and aliases', async () => {
+    const mirror = await loadMirror();
+    for (const entry of shared.SHORTCUTS) {
+      for (const platform of PLATFORMS) {
+        const accelerators = [
+          shared.getDefaultAccelerator(entry, platform),
+          ...shared.getAliasAccelerators(entry, platform),
+        ];
+        for (const accelerator of accelerators) {
+          expect(mirror.parseAccelerator(accelerator, platform)).toEqual(
+            shared.parseAccelerator(accelerator, platform)
+          );
+        }
+      }
+    }
+  });
+
+  test('event matching agrees across a battery of events', async () => {
+    const mirror = await loadMirror();
+    const events = [
+      keyEvent({ key: 't', code: 'KeyT', metaKey: true }),
+      keyEvent({ key: 't', code: 'KeyT', ctrlKey: true }),
+      keyEvent({ key: 'T', code: 'KeyT', ctrlKey: true, shiftKey: true }),
+      keyEvent({ key: 'W', code: 'KeyW', metaKey: true, shiftKey: true }),
+      keyEvent({ key: 'w', code: 'KeyW', metaKey: true }),
+      keyEvent({ key: 'Tab', code: 'Tab', ctrlKey: true }),
+      keyEvent({ key: 'Tab', code: 'Tab', ctrlKey: true, shiftKey: true }),
+      keyEvent({ key: '}', code: 'BracketRight', metaKey: true, shiftKey: true }),
+      keyEvent({ key: '[', code: 'BracketLeft', metaKey: true, shiftKey: true }),
+      keyEvent({ key: 'F11', code: 'F11' }),
+      keyEvent({ key: 'F12', code: 'F12' }),
+      keyEvent({ key: 'F4', code: 'F4', ctrlKey: true }),
+      keyEvent({ key: 'PageDown', code: 'PageDown', ctrlKey: true }),
+      keyEvent({ key: 'PageUp', code: 'PageUp', ctrlKey: true, shiftKey: true }),
+      keyEvent({ key: 'i', code: 'KeyI', metaKey: true, altKey: true }),
+      keyEvent({ key: 'I', code: 'KeyI', ctrlKey: true, shiftKey: true }),
+      keyEvent({ key: 'Shift', code: 'ShiftLeft', shiftKey: true }),
+      { key: 'f', metaKey: true, ctrlKey: false, altKey: false, shiftKey: false },
+    ];
+
+    for (const entry of shared.SHORTCUTS) {
+      for (const platform of PLATFORMS) {
+        const accelerators = [
+          shared.getDefaultAccelerator(entry, platform),
+          ...shared.getAliasAccelerators(entry, platform),
+        ];
+        for (const accelerator of accelerators) {
+          for (const event of events) {
+            expect(mirror.eventMatchesAccelerator(event, accelerator, platform)).toBe(
+              shared.eventMatchesAccelerator(event, accelerator, platform)
+            );
+          }
+        }
+      }
+    }
+  });
+
+  test('default and alias lookups agree', async () => {
+    const mirror = await loadMirror();
+    for (const entry of shared.SHORTCUTS) {
+      for (const platform of PLATFORMS) {
+        expect(mirror.getDefaultAccelerator(entry.id, platform)).toBe(
+          shared.getDefaultAccelerator(entry.id, platform)
+        );
+        expect(mirror.getAliasAccelerators(entry.id, platform)).toEqual(
+          shared.getAliasAccelerators(entry.id, platform)
+        );
+      }
+    }
+  });
+});
+
+describe('renderer live bindings', () => {
+  const originalWindow = global.window;
+
+  afterEach(() => {
+    global.window = originalWindow;
+  });
+
+  test('matchesShortcut uses the platform default when no override exists', async () => {
+    const mirror = await loadMirror();
+    mirror.configureShortcuts({ platform: 'darwin', overrides: {} });
+
+    expect(
+      mirror.matchesShortcut(keyEvent({ key: 't', code: 'KeyT', metaKey: true }), 'tab.new')
+    ).toBe(true);
+    expect(
+      mirror.matchesShortcut(keyEvent({ key: 't', code: 'KeyT', ctrlKey: true }), 'tab.new')
+    ).toBe(false);
+
+    mirror.configureShortcuts({ platform: 'linux' });
+    expect(
+      mirror.matchesShortcut(keyEvent({ key: 't', code: 'KeyT', ctrlKey: true }), 'tab.new')
+    ).toBe(true);
+  });
+
+  test('an override replaces the primary binding but keeps fixed aliases', async () => {
+    const mirror = await loadMirror();
+    mirror.configureShortcuts({
+      platform: 'linux',
+      overrides: { 'tab.next': 'Ctrl+Shift+U' },
+    });
+
+    // New binding works, old primary does not…
+    expect(
+      mirror.matchesShortcut(
+        keyEvent({ key: 'U', code: 'KeyU', ctrlKey: true, shiftKey: true }),
+        'tab.next'
+      )
+    ).toBe(true);
+    expect(
+      mirror.matchesShortcut(
+        keyEvent({ key: 'PageDown', code: 'PageDown', ctrlKey: true }),
+        'tab.next'
+      )
+    ).toBe(false);
+    // …while the fixed Ctrl+Tab alias stays active.
+    expect(
+      mirror.matchesShortcut(keyEvent({ key: 'Tab', code: 'Tab', ctrlKey: true }), 'tab.next')
+    ).toBe(true);
+  });
+
+  test('getEffectiveAccelerator resolves override ?? default', async () => {
+    const mirror = await loadMirror();
+    mirror.configureShortcuts({ platform: 'linux', overrides: { 'tab.new': 'Ctrl+Shift+U' } });
+
+    expect(mirror.getEffectiveAccelerator('tab.new')).toBe('Ctrl+Shift+U');
+    expect(mirror.getEffectiveAccelerator('tab.close')).toBe('CmdOrCtrl+W');
+  });
+
+  test('initShortcuts loads settings and applies live settings:updated payloads', async () => {
+    const listeners = {};
+    global.window = {
+      electronAPI: {
+        getSettings: jest.fn().mockResolvedValue({
+          shortcutOverrides: { 'tab.new': 'Ctrl+Shift+U' },
+        }),
+      },
+      addEventListener: jest.fn((name, handler) => {
+        listeners[name] = handler;
+      }),
+    };
+
+    const mirror = await loadMirror();
+    mirror.configureShortcuts({ platform: 'linux' });
+    mirror.initShortcuts();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mirror.getEffectiveAccelerator('tab.new')).toBe('Ctrl+Shift+U');
+
+    // Live update: override removed again.
+    listeners['settings:updated']({ detail: { shortcutOverrides: {} } });
+    expect(mirror.getEffectiveAccelerator('tab.new')).toBe('CmdOrCtrl+T');
+
+    // Malformed payloads reset to defaults instead of throwing.
+    listeners['settings:updated']({ detail: { shortcutOverrides: null } });
+    expect(mirror.getEffectiveAccelerator('tab.new')).toBe('CmdOrCtrl+T');
+  });
+});

--- a/src/renderer/lib/sidebar.js
+++ b/src/renderer/lib/sidebar.js
@@ -5,6 +5,8 @@
  * Fixed width (320px), toggle open/closed.
  */
 
+import { matchesShortcut } from './shortcuts.js';
+
 // State
 let isOpen = false;
 let featureEnabled = false;
@@ -67,9 +69,9 @@ export function initSidebar() {
     closeBtn.addEventListener('click', close);
   }
 
-  // Keyboard shortcut: Cmd/Ctrl+Shift+W
+  // Keyboard shortcut (default Cmd/Ctrl+Shift+W, remappable)
   document.addEventListener('keydown', (e) => {
-    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'W') {
+    if (matchesShortcut(e, 'view.toggleSidebar')) {
       if (!featureEnabled) return;
       e.preventDefault();
       toggle();

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -9,6 +9,7 @@ import { setupWebviewProvider, setActiveWebview } from './dapp-provider.js';
 import { setupSwarmProvider } from './swarm-provider.js';
 import { setupRadicleProvider } from './radicle-provider.js';
 import { closeFindBar, notifyFindBarNavigated } from './find-bar.js';
+import { matchesShortcut } from './shortcuts.js';
 import {
   clearLinkStatus,
   clearHoverStatus,
@@ -1745,15 +1746,18 @@ export const initTabs = async () => {
     reopenLastClosedTab();
   });
 
-  // Keyboard shortcuts (fallback for when menu doesn't handle it)
+  // Keyboard shortcuts (fallback for when menu doesn't handle it).
+  // Every binding resolves through the shared shortcut registry — including
+  // fixed aliases (Ctrl+Tab, Ctrl+F4, F12, …) and any user remaps, which
+  // apply live via settings:updated.
   window.addEventListener('keydown', (event) => {
-    // Cmd+T - New tab (exclude Shift to avoid conflict with Cmd+Shift+T)
-    if (event.metaKey && !event.shiftKey && event.key.toLowerCase() === 't') {
+    // New tab
+    if (matchesShortcut(event, 'tab.new')) {
       event.preventDefault();
       createTab(homeUrl);
     }
-    // Cmd+W - Close tab (skip pinned tabs)
-    if (event.metaKey && event.key.toLowerCase() === 'w') {
+    // Close tab (skip pinned tabs)
+    if (matchesShortcut(event, 'tab.close')) {
       event.preventDefault();
       if (tabState.activeTabId) {
         const activeTab = tabState.tabs.find((t) => t.id === tabState.activeTabId);
@@ -1762,16 +1766,13 @@ export const initTabs = async () => {
         }
       }
     }
-    // Cmd+Option+I (Mac) or Ctrl+Shift+I (Win/Linux) - Toggle DevTools
-    if (
-      (event.metaKey && event.altKey && event.key.toLowerCase() === 'i') ||
-      (event.ctrlKey && event.shiftKey && event.key.toLowerCase() === 'i')
-    ) {
+    // Toggle DevTools (Cmd/Ctrl+Alt+I, Ctrl+Shift+I, F12)
+    if (matchesShortcut(event, 'devtools.toggle')) {
       event.preventDefault();
       toggleDevTools();
     }
-    // Cmd+L (Mac) or Ctrl+L (Win/Linux) - Focus address bar
-    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'l') {
+    // Focus address bar
+    if (matchesShortcut(event, 'view.focusAddressBar')) {
       event.preventDefault();
       const addressInput = document.getElementById('address-input');
       if (addressInput) {
@@ -1779,60 +1780,35 @@ export const initTabs = async () => {
         addressInput.select();
       }
     }
-    // Ctrl+Tab / Ctrl+PageDown - Next tab (all platforms)
-    // Cmd+Shift+] - Next tab (macOS alternative)
-    if (
-      (event.ctrlKey && event.key === 'Tab' && !event.shiftKey) ||
-      (event.ctrlKey && event.key === 'PageDown' && !event.shiftKey) ||
-      (event.metaKey && event.shiftKey && event.key === ']')
-    ) {
+    // Next tab (Ctrl+PageDown; aliases Ctrl+Tab, Cmd+Shift+])
+    if (matchesShortcut(event, 'tab.next')) {
       event.preventDefault();
       switchToNextTab();
     }
-    // Ctrl+Shift+Tab / Ctrl+PageUp - Previous tab (all platforms)
-    // Cmd+Shift+[ - Previous tab (macOS alternative)
-    if (
-      (event.ctrlKey && event.key === 'Tab' && event.shiftKey) ||
-      (event.ctrlKey && event.key === 'PageUp' && !event.shiftKey) ||
-      (event.metaKey && event.shiftKey && event.key === '[')
-    ) {
+    // Previous tab (Ctrl+PageUp; aliases Ctrl+Shift+Tab, Cmd+Shift+[)
+    if (matchesShortcut(event, 'tab.previous')) {
       event.preventDefault();
       switchToPrevTab();
     }
-    // Ctrl+Shift+PageDown - Move tab right
-    if (event.ctrlKey && event.shiftKey && event.key === 'PageDown') {
+    // Move tab right
+    if (matchesShortcut(event, 'tab.moveRight')) {
       event.preventDefault();
       moveTab('right');
     }
-    // Ctrl+Shift+PageUp - Move tab left
-    if (event.ctrlKey && event.shiftKey && event.key === 'PageUp') {
+    // Move tab left
+    if (matchesShortcut(event, 'tab.moveLeft')) {
       event.preventDefault();
       moveTab('left');
     }
-    // Ctrl+F4 - Close tab (Windows/Linux)
-    if (event.ctrlKey && event.key === 'F4') {
-      event.preventDefault();
-      if (tabState.activeTabId) {
-        const activeTab = tabState.tabs.find((t) => t.id === tabState.activeTabId);
-        if (activeTab && !activeTab.pinned) {
-          closeTab(tabState.activeTabId);
-        }
-      }
-    }
-    // Cmd+Shift+T / Ctrl+Shift+T - Reopen closed tab
-    if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === 't') {
+    // Reopen closed tab
+    if (matchesShortcut(event, 'tab.reopenClosed')) {
       event.preventDefault();
       reopenLastClosedTab();
     }
-    // F11 - Toggle fullscreen
-    if (event.key === 'F11') {
+    // Toggle fullscreen
+    if (matchesShortcut(event, 'view.fullscreen')) {
       event.preventDefault();
       electronAPI?.toggleFullscreen?.();
-    }
-    // F12 - Toggle DevTools
-    if (event.key === 'F12') {
-      event.preventDefault();
-      toggleDevTools();
     }
   });
 

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -1116,8 +1116,8 @@
         <section class="section" id="shortcuts">
           <h2 class="section-title">Shortcuts</h2>
           <p class="row-help" style="margin-bottom: 16px">
-            Click a binding, press the new key combination, done — changes apply immediately.
-            Press Esc while recording to cancel.
+            Click a binding, press the new key combination, done — changes apply immediately. Press
+            Esc while recording to cancel.
           </p>
           <div class="shortcut-toolbar">
             <input
@@ -1151,9 +1151,9 @@
         <section class="section" id="ens">
           <h2 class="section-title">Ethereum Name Resolution</h2>
           <p class="row-help" style="margin-bottom: 16px">
-            How Freedom resolves <code>.eth</code>, <code>.box</code>, <code>.wei</code>,
-            and <code>.gwei</code> names. These records live on Ethereum — manage RPC
-            endpoints under <a href="#chains">Chains settings</a>.
+            How Freedom resolves <code>.eth</code>, <code>.box</code>, <code>.wei</code>, and
+            <code>.gwei</code> names. These records live on Ethereum — manage RPC endpoints under
+            <a href="#chains">Chains settings</a>.
           </p>
           <div class="card">
             <div class="row">
@@ -1191,9 +1191,9 @@
               <div class="row-body">
                 <p class="row-label">Block unverified name navigation</p>
                 <p class="row-help">
-                  Show a warning page before navigating to a name that resolved without
-                  verification (for example, when only one RPC answered). Turn off to navigate
-                  straight through with only the amber shield indicator.
+                  Show a warning page before navigating to a name that resolved without verification
+                  (for example, when only one RPC answered). Turn off to navigate straight through
+                  with only the amber shield indicator.
                 </p>
               </div>
               <div class="row-control">
@@ -2153,7 +2153,8 @@
 
         const REASON_MESSAGES = {
           reserved: 'That combination is reserved and cannot be assigned.',
-          'needs-modifier': 'Combine letters or digits with Ctrl, Alt or Cmd.',
+          'needs-modifier':
+            'Combine that key with Ctrl, Alt or Cmd. Only function keys work on their own.',
           invalid: 'That key cannot be used as a shortcut.',
           'not-editable': 'This shortcut cannot be changed.',
           conflict: 'That combination is already in use.',
@@ -2323,7 +2324,10 @@
 
             stopRecording();
             if (!preview.ok) {
-              rowNotice = { id, message: REASON_MESSAGES[preview.reason] || REASON_MESSAGES.invalid };
+              rowNotice = {
+                id,
+                message: REASON_MESSAGES[preview.reason] || REASON_MESSAGES.invalid,
+              };
               render();
               return;
             }
@@ -2357,7 +2361,10 @@
               conflictState = null;
               rowNotice = null;
               const result = await freedomAPI.resetShortcut(id).catch(() => null);
-              setStatus(result?.ok ? 'Shortcut reset to default.' : 'Could not reset.', result?.ok ? 'success' : 'error');
+              setStatus(
+                result?.ok ? 'Shortcut reset to default.' : 'Could not reset.',
+                result?.ok ? 'success' : 'error'
+              );
               await load();
               break;
             }

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -537,6 +537,81 @@
       }
 
       .search-provider-actions {
+      /* Shortcuts */
+      .shortcut-toolbar {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 12px;
+      }
+
+      .shortcut-toolbar input {
+        flex: 1;
+        font-family: inherit;
+      }
+
+      .shortcut-category {
+        margin: 20px 0 8px 0;
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.4px;
+        text-transform: uppercase;
+        color: var(--text-muted);
+      }
+
+      .shortcut-category:first-child {
+        margin-top: 0;
+      }
+
+      .shortcut-kbd {
+        display: inline-block;
+        padding: 3px 8px;
+        background: var(--bg-elev);
+        border: 1px solid var(--border);
+        border-bottom-width: 2px;
+        border-radius: 6px;
+        color: var(--text);
+        font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+        font-size: 12px;
+        line-height: 1.4;
+        white-space: nowrap;
+      }
+
+      .shortcut-controls {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .shortcut-binding {
+        padding: 5px 8px;
+      }
+
+      .shortcut-binding.recording {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+
+      .shortcut-locked {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--text-subtle);
+        font-size: 12px;
+      }
+
+      .shortcut-note {
+        margin: 6px 0 0 0;
+        font-size: 12px;
+        color: var(--warn);
+      }
+
+      .row.shortcut-conflict {
+        justify-content: space-between;
+        background: rgba(210, 153, 34, 0.08);
+        font-size: 13px;
+      }
+
+      .shortcut-conflict-actions {
         display: flex;
         flex-shrink: 0;
         gap: 8px;
@@ -718,6 +793,26 @@
               <line x1="12" y1="15" x2="12" y2="3"></line>
             </svg>
             Downloads
+          </button>
+          <button type="button" class="nav-item" data-target="shortcuts">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="2" y="6" width="20" height="12" rx="2"></rect>
+              <line x1="6" y1="10" x2="6" y2="10"></line>
+              <line x1="10" y1="10" x2="10" y2="10"></line>
+              <line x1="14" y1="10" x2="14" y2="10"></line>
+              <line x1="18" y1="10" x2="18" y2="10"></line>
+              <line x1="7" y1="14" x2="17" y2="14"></line>
+            </svg>
+            Shortcuts
           </button>
           <button type="button" class="nav-item" data-target="chains">
             <svg
@@ -1015,6 +1110,29 @@
               </div>
             </div>
           </div>
+        </section>
+
+        <!-- Shortcuts -->
+        <section class="section" id="shortcuts">
+          <h2 class="section-title">Shortcuts</h2>
+          <p class="row-help" style="margin-bottom: 16px">
+            Click a binding, press the new key combination, done — changes apply immediately.
+            Press Esc while recording to cancel.
+          </p>
+          <div class="shortcut-toolbar">
+            <input
+              type="search"
+              id="shortcut-search"
+              class="rpc-input"
+              placeholder="Search shortcuts"
+              spellcheck="false"
+            />
+            <button type="button" class="btn" id="shortcuts-restore-defaults">
+              Restore defaults
+            </button>
+          </div>
+          <div id="shortcuts-view"></div>
+          <p id="shortcuts-status" class="rpc-status"></p>
         </section>
 
         <!-- Chains -->
@@ -2011,6 +2129,276 @@
         } catch {
           console.error('[settings] failed to load settings');
         }
+      })();
+
+      // ── Shortcuts settings page ─────────────────────────────────────
+      // Render-only controller: the registry state, validation, conflict
+      // detection, and persistence all live in the main process behind
+      // freedomAPI.getShortcuts / previewShortcutBinding /
+      // setShortcutOverride / resetShortcut(s). This page captures
+      // keydowns in recording mode and paints whatever main answers.
+      (() => {
+        const view = $('shortcuts-view');
+        const searchInput = $('shortcut-search');
+        const restoreBtn = $('shortcuts-restore-defaults');
+        const statusEl = $('shortcuts-status');
+        if (!view) return;
+
+        let entries = [];
+        let query = '';
+        let recordingId = null; // shortcut currently capturing a new combo
+        let conflictState = null; // { id, accelerator, formatted, conflict }
+        let rowNotice = null; // { id, message } transient validation notice
+        let recordingHandler = null;
+
+        const REASON_MESSAGES = {
+          reserved: 'That combination is reserved and cannot be assigned.',
+          'needs-modifier': 'Combine letters or digits with Ctrl, Alt or Cmd.',
+          invalid: 'That key cannot be used as a shortcut.',
+          'not-editable': 'This shortcut cannot be changed.',
+          conflict: 'That combination is already in use.',
+          'save-failed': 'Could not save the shortcut. Try again.',
+        };
+
+        const setStatus = (message, kind) => {
+          if (!statusEl) return;
+          statusEl.textContent = message || '';
+          statusEl.className = 'rpc-status' + (kind ? ' ' + kind : '');
+        };
+
+        const matchesQuery = (entry) => {
+          const q = query.trim().toLowerCase();
+          if (!q) return true;
+          return [entry.description, entry.category, entry.formatted, entry.accelerator]
+            .concat(entry.aliases)
+            .join(' ')
+            .toLowerCase()
+            .includes(q);
+        };
+
+        const kbd = (text) => `<kbd class="shortcut-kbd">${esc(text)}</kbd>`;
+
+        const renderConflict = (state) => {
+          const { conflict } = state;
+          const message = conflict.fixed
+            ? `${esc(state.formatted)} is already used by “${esc(conflict.description)}” and cannot be reassigned. Pick a different combination.`
+            : `${esc(state.formatted)} is already used by “${esc(conflict.description)}”. Swap the bindings so “${esc(conflict.description)}” becomes ${kbd(conflict.swapFormatted)}?`;
+          return `
+            <div class="row shortcut-conflict" data-shortcut-id="${esc(state.id)}">
+              <div class="row-body"><p class="row-label">${message}</p></div>
+              <span class="shortcut-conflict-actions">
+                ${conflict.fixed ? '' : '<button type="button" class="btn" data-action="swap">Swap</button>'}
+                <button type="button" class="btn" data-action="cancel-conflict">Cancel</button>
+              </span>
+            </div>`;
+        };
+
+        const renderRow = (entry) => {
+          const isRecording = recordingId === entry.id;
+          const notice = rowNotice?.id === entry.id ? rowNotice.message : null;
+          const aliasLine = entry.aliases.length
+            ? `<p class="row-help">Also ${entry.aliases.map(kbd).join(' ')}</p>`
+            : '';
+          const warnLine =
+            isRecording && entry.warnOnEdit
+              ? '<p class="shortcut-note">Heads up: this is a common close gesture across apps — remapping it changes deep muscle memory.</p>'
+              : '';
+          const control = !entry.editable
+            ? `<span class="shortcut-locked">${kbd(entry.formatted)} Locked</span>`
+            : `<button type="button" class="btn shortcut-binding${isRecording ? ' recording' : ''}" data-action="record">
+                 ${isRecording ? 'Press new shortcut… (Esc cancels)' : kbd(entry.formatted)}
+               </button>`;
+          const resetBtn =
+            entry.editable && entry.isOverridden && !isRecording
+              ? `<button type="button" class="btn" data-action="reset" title="Reset to ${esc(entry.defaultFormatted)}">Reset</button>`
+              : '';
+          const conflictRow =
+            conflictState && conflictState.id === entry.id ? renderConflict(conflictState) : '';
+          return `
+            <div class="row" data-shortcut-id="${esc(entry.id)}">
+              <div class="row-body">
+                <p class="row-label">${esc(entry.description)}</p>
+                ${aliasLine}
+                ${warnLine}
+                ${notice ? `<p class="shortcut-note">${esc(notice)}</p>` : ''}
+              </div>
+              <div class="row-control shortcut-controls">${resetBtn}${control}</div>
+            </div>
+            ${conflictRow}`;
+        };
+
+        const render = () => {
+          const visible = entries.filter(matchesQuery);
+          if (!visible.length) {
+            view.innerHTML =
+              '<div class="card"><div class="profile-node-empty">No shortcuts match your search.</div></div>';
+            return;
+          }
+          const categories = [];
+          for (const entry of visible) {
+            if (!categories.includes(entry.category)) categories.push(entry.category);
+          }
+          view.innerHTML = categories
+            .map(
+              (category) => `
+                <h3 class="shortcut-category">${esc(category)}</h3>
+                <div class="card">
+                  ${visible
+                    .filter((entry) => entry.category === category)
+                    .map(renderRow)
+                    .join('')}
+                </div>`
+            )
+            .join('');
+        };
+
+        const load = async () => {
+          try {
+            const state = await freedomAPI.getShortcuts();
+            entries = (state?.entries || []).filter((entry) => !entry.hidden);
+          } catch {
+            entries = [];
+            setStatus('Could not load shortcuts.', 'error');
+          }
+          render();
+        };
+
+        const stopRecording = () => {
+          if (recordingHandler) {
+            window.removeEventListener('keydown', recordingHandler, true);
+            recordingHandler = null;
+          }
+          recordingId = null;
+        };
+
+        const applyBinding = async (id, accelerator, swapWithConflict = false) => {
+          let result;
+          try {
+            result = await freedomAPI.setShortcutOverride({ id, accelerator, swapWithConflict });
+          } catch {
+            result = { ok: false, reason: 'save-failed' };
+          }
+          if (!result?.ok) {
+            rowNotice = { id, message: REASON_MESSAGES[result?.reason] || REASON_MESSAGES.invalid };
+          } else {
+            setStatus('Shortcut updated.', 'success');
+          }
+          await load();
+        };
+
+        const startRecording = (id) => {
+          const entry = entries.find((item) => item.id === id);
+          if (!entry?.editable || recordingId === id) return;
+          stopRecording();
+          conflictState = null;
+          rowNotice = null;
+          setStatus('');
+          recordingId = id;
+          render();
+
+          recordingHandler = async (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            if (event.key === 'Escape') {
+              stopRecording();
+              render();
+              return;
+            }
+            const captured = {
+              key: event.key,
+              code: event.code,
+              ctrlKey: event.ctrlKey,
+              altKey: event.altKey,
+              shiftKey: event.shiftKey,
+              metaKey: event.metaKey,
+            };
+            let preview;
+            try {
+              preview = await freedomAPI.previewShortcutBinding({ id, event: captured });
+            } catch {
+              preview = { ok: false, reason: 'invalid' };
+            }
+            // Only modifiers held so far — keep listening.
+            if (!preview.ok && preview.reason === 'incomplete') return;
+
+            stopRecording();
+            if (!preview.ok) {
+              rowNotice = { id, message: REASON_MESSAGES[preview.reason] || REASON_MESSAGES.invalid };
+              render();
+              return;
+            }
+            if (preview.conflict) {
+              conflictState = {
+                id,
+                accelerator: preview.accelerator,
+                formatted: preview.formatted,
+                conflict: preview.conflict,
+              };
+              render();
+              return;
+            }
+            await applyBinding(id, preview.accelerator);
+          };
+          window.addEventListener('keydown', recordingHandler, true);
+        };
+
+        view.addEventListener('click', async (event) => {
+          const button = event.target.closest('[data-action]');
+          if (!button) return;
+          const id = event.target.closest('[data-shortcut-id]')?.dataset.shortcutId;
+          if (!id) return;
+
+          switch (button.dataset.action) {
+            case 'record':
+              startRecording(id);
+              break;
+            case 'reset': {
+              stopRecording();
+              conflictState = null;
+              rowNotice = null;
+              const result = await freedomAPI.resetShortcut(id).catch(() => null);
+              setStatus(result?.ok ? 'Shortcut reset to default.' : 'Could not reset.', result?.ok ? 'success' : 'error');
+              await load();
+              break;
+            }
+            case 'swap': {
+              const pending = conflictState;
+              conflictState = null;
+              if (pending) await applyBinding(pending.id, pending.accelerator, true);
+              break;
+            }
+            case 'cancel-conflict':
+              conflictState = null;
+              render();
+              break;
+          }
+        });
+
+        searchInput?.addEventListener('input', () => {
+          query = searchInput.value || '';
+          render();
+        });
+
+        restoreBtn?.addEventListener('click', async () => {
+          stopRecording();
+          conflictState = null;
+          rowNotice = null;
+          const result = await freedomAPI.resetAllShortcuts().catch(() => null);
+          setStatus(
+            result?.ok ? 'All shortcuts restored to defaults.' : 'Could not restore defaults.',
+            result?.ok ? 'success' : 'error'
+          );
+          await load();
+        });
+
+        // Keep a second open settings tab (or a remap made elsewhere) in
+        // sync — but never clobber an in-progress recording or conflict
+        // prompt.
+        freedomAPI.onSettingsUpdated?.(() => {
+          if (!recordingId && !conflictState) load();
+        });
+
+        load();
       })();
 
       // ── Chains settings page ────────────────────────────────────────

--- a/src/shared/ipc-channels.js
+++ b/src/shared/ipc-channels.js
@@ -49,6 +49,15 @@ module.exports = {
   SETTINGS_SAVE: 'settings:save',
   SETTINGS_UPDATED: 'settings:updated',
 
+  // Keyboard shortcuts (Settings > Shortcuts page ↔ main). State/preview
+  // are reads; set/reset persist overrides into the settings store, whose
+  // SETTINGS_UPDATED broadcast then rebuilds the menu and refreshes the
+  // renderer keydown matcher.
+  SHORTCUTS_GET_STATE: 'shortcuts:get-state',
+  SHORTCUTS_PREVIEW_BINDING: 'shortcuts:preview-binding',
+  SHORTCUTS_SET_OVERRIDE: 'shortcuts:set-override',
+  SHORTCUTS_RESET: 'shortcuts:reset',
+
   // Bzz routing (Swarm)
   BZZ_SET_BASE: 'bzz:set-base',
   BZZ_CLEAR_BASE: 'bzz:clear-base',

--- a/src/shared/shortcuts.js
+++ b/src/shared/shortcuts.js
@@ -1,0 +1,396 @@
+/**
+ * Keyboard Shortcut Registry
+ *
+ * Canonical source of truth for every keyboard shortcut the app implements,
+ * plus the pure helpers that turn Electron accelerator strings into
+ * per-platform KeyboardEvent matchers.
+ *
+ * Consumers:
+ *   - src/main/menu.js builds all menu accelerators from this registry
+ *     (a menu.test.js guard asserts menu.js carries no accelerator literals).
+ *   - The renderer keydown handlers resolve through the ESM mirror in
+ *     src/renderer/lib/shortcuts.js (ES modules cannot require() this file;
+ *     keep both in sync — the mirror's test asserts equivalence).
+ *
+ * Entry shape:
+ *   id                 stable identifier, also the key for user overrides
+ *   description        user-facing label (Settings > Shortcuts)
+ *   defaultAccelerator Electron accelerator string, or a per-platform map
+ *                      ({ darwin, win32, linux, other }) when platforms
+ *                      genuinely differ (e.g. Show All History)
+ *   aliases            fixed secondary bindings that always stay active and
+ *                      are never remapped ([{ accelerator, platforms? }])
+ *   context            'menu' | 'renderer' | 'both' — where the binding is
+ *                      enforced today (menu accelerator, renderer keydown
+ *                      fallback, or both)
+ *   category           Settings > Shortcuts group header
+ *   editable           false for reserved bindings (DevTools F12 contract,
+ *                      dev-only entries)
+ *   warnOnEdit         show a caution when the user rebinds (Close Tab)
+ */
+
+// ── Registry ────────────────────────────────────────────────────────────
+
+const SHORTCUTS = [
+  // Tabs
+  {
+    id: 'tab.new',
+    description: 'New Tab',
+    defaultAccelerator: 'CmdOrCtrl+T',
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+  },
+  {
+    id: 'tab.close',
+    description: 'Close Tab',
+    defaultAccelerator: 'CmdOrCtrl+W',
+    aliases: [{ accelerator: 'Ctrl+F4', platforms: ['win32', 'linux'] }],
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+    // Cmd/Ctrl+W is deep muscle memory and doubles as the close-window
+    // gesture elsewhere in the OS — rebinding deserves a caution.
+    warnOnEdit: true,
+  },
+  {
+    id: 'tab.reopenClosed',
+    description: 'Reopen Closed Tab',
+    defaultAccelerator: 'CmdOrCtrl+Shift+T',
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+  },
+  {
+    id: 'tab.next',
+    description: 'Next Tab',
+    defaultAccelerator: 'Ctrl+PageDown',
+    aliases: [{ accelerator: 'Ctrl+Tab' }, { accelerator: 'Cmd+Shift+]', platforms: ['darwin'] }],
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+  },
+  {
+    id: 'tab.previous',
+    description: 'Previous Tab',
+    defaultAccelerator: 'Ctrl+PageUp',
+    aliases: [
+      { accelerator: 'Ctrl+Shift+Tab' },
+      { accelerator: 'Cmd+Shift+[', platforms: ['darwin'] },
+    ],
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+  },
+  {
+    id: 'tab.moveRight',
+    description: 'Move Tab Right',
+    defaultAccelerator: 'Ctrl+Shift+PageDown',
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+  },
+  {
+    id: 'tab.moveLeft',
+    description: 'Move Tab Left',
+    defaultAccelerator: 'Ctrl+Shift+PageUp',
+    context: 'both',
+    category: 'Tabs',
+    editable: true,
+  },
+
+  // Page
+  {
+    id: 'page.reload',
+    description: 'Reload This Page',
+    defaultAccelerator: 'CmdOrCtrl+R',
+    context: 'both',
+    category: 'Page',
+    editable: true,
+  },
+  {
+    id: 'page.hardReload',
+    description: 'Force Reload This Page',
+    defaultAccelerator: 'CmdOrCtrl+Shift+R',
+    context: 'both',
+    category: 'Page',
+    editable: true,
+  },
+  {
+    id: 'page.findInPage',
+    description: 'Find in Page',
+    defaultAccelerator: 'CmdOrCtrl+F',
+    context: 'both',
+    category: 'Page',
+    editable: true,
+  },
+
+  // Navigation
+  {
+    id: 'view.focusAddressBar',
+    description: 'Focus Address Bar',
+    defaultAccelerator: 'CmdOrCtrl+L',
+    context: 'both',
+    category: 'Navigation',
+    editable: true,
+  },
+  {
+    id: 'history.showAll',
+    description: 'Show All History',
+    defaultAccelerator: { darwin: 'Cmd+Y', other: 'Ctrl+H' },
+    context: 'menu',
+    category: 'Navigation',
+    editable: true,
+  },
+  {
+    id: 'downloads.show',
+    description: 'Downloads',
+    defaultAccelerator: 'CmdOrCtrl+Shift+J',
+    context: 'menu',
+    category: 'Navigation',
+    editable: true,
+  },
+
+  // Window
+  {
+    id: 'window.new',
+    description: 'New Window',
+    defaultAccelerator: 'CmdOrCtrl+N',
+    context: 'menu',
+    category: 'Window',
+    editable: true,
+  },
+  {
+    id: 'view.fullscreen',
+    description: 'Toggle Full Screen',
+    defaultAccelerator: 'F11',
+    context: 'both',
+    category: 'Window',
+    editable: true,
+  },
+  {
+    id: 'view.toggleBookmarksBar',
+    description: 'Toggle Bookmarks Bar',
+    defaultAccelerator: 'CmdOrCtrl+Shift+B',
+    context: 'menu',
+    category: 'Window',
+    editable: true,
+  },
+  {
+    id: 'view.toggleSidebar',
+    description: 'Toggle Wallet Sidebar',
+    defaultAccelerator: 'CmdOrCtrl+Shift+W',
+    context: 'renderer',
+    category: 'Window',
+    editable: true,
+  },
+
+  // Developer
+  {
+    id: 'devtools.toggle',
+    description: 'Developer Tools',
+    defaultAccelerator: 'CmdOrCtrl+Alt+I',
+    aliases: [{ accelerator: 'Ctrl+Shift+I' }, { accelerator: 'F12' }],
+    context: 'both',
+    category: 'Developer',
+    // F12 / DevTools bindings are part of the reserved set — not remappable.
+    editable: false,
+  },
+  {
+    id: 'devtools.toggleApp',
+    description: 'App Developer Tools',
+    defaultAccelerator: 'CmdOrCtrl+Shift+Alt+I',
+    context: 'menu',
+    category: 'Developer',
+    // Dev-build-only menu entry; never shown as remappable.
+    editable: false,
+  },
+];
+
+// ── Accelerator parsing / matching ──────────────────────────────────────
+
+// Electron modifier tokens → the KeyboardEvent modifier they assert.
+// 'cmdorctrl' is resolved per platform in parseAccelerator.
+const MODIFIER_TOKENS = {
+  ctrl: 'ctrl',
+  control: 'ctrl',
+  alt: 'alt',
+  option: 'alt',
+  shift: 'shift',
+  cmd: 'meta',
+  command: 'meta',
+  meta: 'meta',
+  super: 'meta',
+};
+
+// Electron/legacy key spellings → canonical names used for comparison.
+const KEY_ALIASES = {
+  esc: 'Escape',
+  escape: 'Escape',
+  return: 'Enter',
+  enter: 'Enter',
+  space: 'Space',
+  spacebar: 'Space',
+  tab: 'Tab',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  del: 'Delete',
+  insert: 'Insert',
+  home: 'Home',
+  end: 'End',
+  pageup: 'PageUp',
+  pagedown: 'PageDown',
+  up: 'Up',
+  arrowup: 'Up',
+  down: 'Down',
+  arrowdown: 'Down',
+  left: 'Left',
+  arrowleft: 'Left',
+  right: 'Right',
+  arrowright: 'Right',
+  plus: 'Plus',
+};
+
+// KeyboardEvent.code → the base (unshifted, US-layout) character. Used both
+// to match shifted punctuation (Cmd+Shift+] arrives as key '}' on some
+// layouts) and to record layout-stable overrides.
+const CODE_BASE_KEYS = {
+  Minus: '-',
+  Equal: '=',
+  BracketLeft: '[',
+  BracketRight: ']',
+  Semicolon: ';',
+  Quote: "'",
+  Backquote: '`',
+  Backslash: '\\',
+  Comma: ',',
+  Period: '.',
+  Slash: '/',
+  Space: 'Space',
+};
+
+function canonicalKey(rawKey) {
+  if (rawKey === undefined || rawKey === null || rawKey === '') return null;
+  const raw = String(rawKey);
+  if (raw.length === 1) {
+    if (raw === ' ') return 'Space';
+    if (raw === '+') return 'Plus';
+    return raw.toLowerCase();
+  }
+  const lower = raw.toLowerCase();
+  if (KEY_ALIASES[lower]) return KEY_ALIASES[lower];
+  if (/^f([1-9]|1\d|2[0-4])$/.test(lower)) return lower.toUpperCase();
+  // Unknown named key (media keys, etc.) — keep as-is so it still compares
+  // consistently between accelerator strings and KeyboardEvent.key.
+  return raw;
+}
+
+/**
+ * Parse an Electron accelerator string into { key, ctrl, alt, shift, meta }.
+ * CmdOrCtrl resolves per `platform` ('darwin' → meta, otherwise ctrl).
+ * Returns null when the string is not a usable accelerator (no key, more
+ * than one key, unknown modifier arrangement).
+ */
+function parseAccelerator(accelerator, platform) {
+  if (typeof accelerator !== 'string' || accelerator.length === 0) return null;
+  const parts = accelerator.split('+');
+  const parsed = { key: null, ctrl: false, alt: false, shift: false, meta: false };
+
+  for (const part of parts) {
+    if (part === '') return null;
+    const token = part.toLowerCase();
+    if (token === 'cmdorctrl' || token === 'commandorcontrol') {
+      if (platform === 'darwin') parsed.meta = true;
+      else parsed.ctrl = true;
+      continue;
+    }
+    if (MODIFIER_TOKENS[token]) {
+      parsed[MODIFIER_TOKENS[token]] = true;
+      continue;
+    }
+    if (parsed.key !== null) return null; // two non-modifier keys
+    parsed.key = canonicalKey(part);
+  }
+
+  if (!parsed.key) return null;
+  return parsed;
+}
+
+// Candidate canonical keys for a KeyboardEvent: the layout-produced key plus
+// the physical-code base character (so Shift'ed punctuation still matches).
+function eventKeyCandidates(event) {
+  const candidates = new Set();
+  const fromKey = canonicalKey(event?.key);
+  if (fromKey && !['Shift', 'Control', 'Alt', 'Meta', 'AltGraph'].includes(String(event.key))) {
+    candidates.add(fromKey);
+  }
+  const code = event?.code;
+  if (typeof code === 'string') {
+    if (CODE_BASE_KEYS[code]) {
+      candidates.add(CODE_BASE_KEYS[code]);
+    } else if (/^Key[A-Z]$/.test(code)) {
+      candidates.add(code.slice(3).toLowerCase());
+    } else if (/^Digit\d$/.test(code)) {
+      candidates.add(code.slice(5));
+    }
+  }
+  return candidates;
+}
+
+/**
+ * Strict accelerator ↔ KeyboardEvent match: every modifier must agree
+ * (Cmd+W does not match Cmd+Shift+W) and the key must match either the
+ * event's produced key or its physical base key.
+ */
+function eventMatchesAccelerator(event, accelerator, platform) {
+  const parsed = parseAccelerator(accelerator, platform);
+  if (!parsed || !event) return false;
+
+  if (Boolean(event.ctrlKey) !== parsed.ctrl) return false;
+  if (Boolean(event.altKey) !== parsed.alt) return false;
+  if (Boolean(event.shiftKey) !== parsed.shift) return false;
+  if (Boolean(event.metaKey) !== parsed.meta) return false;
+
+  return eventKeyCandidates(event).has(parsed.key);
+}
+
+// ── Registry lookups ────────────────────────────────────────────────────
+
+function getShortcutById(id) {
+  return SHORTCUTS.find((entry) => entry.id === id) || null;
+}
+
+/**
+ * Default accelerator for an entry on `platform`. Accepts an entry object
+ * or an id. Platform-map defaults fall back to `other`.
+ */
+function getDefaultAccelerator(entryOrId, platform) {
+  const entry = typeof entryOrId === 'string' ? getShortcutById(entryOrId) : entryOrId;
+  if (!entry) return null;
+  const def = entry.defaultAccelerator;
+  if (typeof def === 'string') return def;
+  if (def && typeof def === 'object') return def[platform] || def.other || null;
+  return null;
+}
+
+/**
+ * Fixed (non-remappable) secondary accelerators for an entry on `platform`.
+ */
+function getAliasAccelerators(entryOrId, platform) {
+  const entry = typeof entryOrId === 'string' ? getShortcutById(entryOrId) : entryOrId;
+  if (!entry || !Array.isArray(entry.aliases)) return [];
+  return entry.aliases
+    .filter((alias) => !alias.platforms || alias.platforms.includes(platform))
+    .map((alias) => alias.accelerator);
+}
+
+module.exports = {
+  SHORTCUTS,
+  canonicalKey,
+  parseAccelerator,
+  eventKeyCandidates,
+  eventMatchesAccelerator,
+  getShortcutById,
+  getDefaultAccelerator,
+  getAliasAccelerators,
+};

--- a/src/shared/shortcuts.js
+++ b/src/shared/shortcuts.js
@@ -202,8 +202,10 @@ const SHORTCUTS = [
     defaultAccelerator: 'CmdOrCtrl+Shift+Alt+I',
     context: 'menu',
     category: 'Developer',
-    // Dev-build-only menu entry; never shown as remappable.
+    // Dev-build-only menu entry; never shown as remappable and hidden
+    // from the Shortcuts settings page in packaged builds.
     editable: false,
+    devOnly: true,
   },
 ];
 

--- a/src/shared/shortcuts.js
+++ b/src/shared/shortcuts.js
@@ -384,6 +384,211 @@ function getAliasAccelerators(entryOrId, platform) {
     .map((alias) => alias.accelerator);
 }
 
+// ── Overrides / validation / conflicts ──────────────────────────────────
+
+// Bindings that may never be reassigned to a shortcut: quit, the standard
+// edit-role clipboard set (they come from Electron menu roles, not this
+// registry), and the F12 DevTools contract.
+const RESERVED_ACCELERATORS = [
+  'CmdOrCtrl+Q',
+  'CmdOrCtrl+C',
+  'CmdOrCtrl+V',
+  'CmdOrCtrl+X',
+  'CmdOrCtrl+A',
+  'CmdOrCtrl+Z',
+  'CmdOrCtrl+Shift+Z',
+  'F12',
+];
+
+/**
+ * Canonical string form of an accelerator on `platform`, for storage and
+ * equality comparison: modifiers in fixed order (Ctrl, Alt, Shift, then
+ * Cmd/Super), single-character keys uppercased. Returns null when the
+ * accelerator does not parse.
+ */
+function normalizeAccelerator(accelerator, platform) {
+  const parsed = parseAccelerator(accelerator, platform);
+  if (!parsed) return null;
+  const parts = [];
+  if (parsed.ctrl) parts.push('Ctrl');
+  if (parsed.alt) parts.push('Alt');
+  if (parsed.shift) parts.push('Shift');
+  if (parsed.meta) parts.push(platform === 'darwin' ? 'Cmd' : 'Super');
+  parts.push(parsed.key.length === 1 ? parsed.key.toUpperCase() : parsed.key);
+  return parts.join('+');
+}
+
+function isReservedAccelerator(accelerator, platform) {
+  const normalized = normalizeAccelerator(accelerator, platform);
+  if (!normalized) return false;
+  return RESERVED_ACCELERATORS.some(
+    (reserved) => normalizeAccelerator(reserved, platform) === normalized
+  );
+}
+
+const isModifierEventKey = (key) =>
+  ['Shift', 'Control', 'Alt', 'Meta', 'AltGraph'].includes(String(key));
+
+/**
+ * Build a normalized accelerator from a keydown event (Settings recording
+ * mode). Prefers the physical key code so the stored binding is stable
+ * across keyboard layouts. Returns null while only modifiers are held.
+ */
+function acceleratorFromEvent(event, platform) {
+  if (!event || isModifierEventKey(event.key)) return null;
+
+  // Prefer the code-derived base key (layout-stable), fall back to key.
+  const candidates = eventKeyCandidates(event);
+  let key = null;
+  const code = event.code;
+  if (typeof code === 'string') {
+    if (CODE_BASE_KEYS[code]) key = CODE_BASE_KEYS[code];
+    else if (/^Key[A-Z]$/.test(code)) key = code.slice(3).toLowerCase();
+    else if (/^Digit\d$/.test(code)) key = code.slice(5);
+  }
+  if (!key) key = candidates.values().next().value || null;
+  if (!key) return null;
+
+  const parts = [];
+  if (event.ctrlKey) parts.push('Ctrl');
+  if (event.altKey) parts.push('Alt');
+  if (event.shiftKey) parts.push('Shift');
+  if (event.metaKey) parts.push(platform === 'darwin' ? 'Cmd' : 'Super');
+  parts.push(key.length === 1 ? key.toUpperCase() : key);
+  return parts.join('+');
+}
+
+/**
+ * Whether `accelerator` is assignable to `entry` on `platform`.
+ * Returns { ok: true } or { ok: false, reason }, with reason one of
+ * 'unknown-shortcut', 'not-editable', 'invalid', 'reserved',
+ * 'needs-modifier'. Conflicts with other shortcuts are a separate check
+ * (findConflict) so the UI can offer a swap.
+ */
+function validateBinding(entryOrId, accelerator, platform) {
+  const entry = typeof entryOrId === 'string' ? getShortcutById(entryOrId) : entryOrId;
+  if (!entry) return { ok: false, reason: 'unknown-shortcut' };
+  if (entry.editable === false) return { ok: false, reason: 'not-editable' };
+
+  const parsed = parseAccelerator(accelerator, platform);
+  if (!parsed) return { ok: false, reason: 'invalid' };
+  if (isReservedAccelerator(accelerator, platform)) return { ok: false, reason: 'reserved' };
+
+  // Menu-context shortcuts must carry a real modifier: a bare (or
+  // shift-only) character would fire while typing in any text field.
+  const hasRealModifier = parsed.ctrl || parsed.alt || parsed.meta;
+  const isBareCharacter = parsed.key.length === 1;
+  if (entry.context !== 'renderer' && isBareCharacter && !hasRealModifier) {
+    return { ok: false, reason: 'needs-modifier' };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Effective primary accelerator: user override ?? registry default.
+ */
+function getEffectiveAccelerator(entryOrId, overrides, platform) {
+  const entry = typeof entryOrId === 'string' ? getShortcutById(entryOrId) : entryOrId;
+  if (!entry) return null;
+  const override = overrides ? overrides[entry.id] : undefined;
+  if (typeof override === 'string' && parseAccelerator(override, platform)) return override;
+  return getDefaultAccelerator(entry, platform);
+}
+
+/**
+ * First shortcut whose effective binding collides with `accelerator`,
+ * excluding `entryOrId` itself. Returns null or
+ * { id, description, fixed } — `fixed: true` means the collision is with
+ * a fixed alias (or a non-editable entry) and cannot be swapped away.
+ */
+function findConflict(entryOrId, accelerator, overrides, platform) {
+  const self = typeof entryOrId === 'string' ? entryOrId : entryOrId?.id;
+  const normalized = normalizeAccelerator(accelerator, platform);
+  if (!normalized) return null;
+
+  for (const entry of SHORTCUTS) {
+    if (entry.id === self) continue;
+    const effective = getEffectiveAccelerator(entry, overrides, platform);
+    if (effective && normalizeAccelerator(effective, platform) === normalized) {
+      return { id: entry.id, description: entry.description, fixed: entry.editable === false };
+    }
+    for (const alias of getAliasAccelerators(entry, platform)) {
+      if (normalizeAccelerator(alias, platform) === normalized) {
+        return { id: entry.id, description: entry.description, fixed: true };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Defensive cleanup for a stored/incoming overrides map: drops unknown or
+ * non-editable ids, non-string and unparsable values, reserved combos, and
+ * no-op overrides equal to the default. Values are normalized. Never
+ * throws — malformed input yields {}.
+ */
+function sanitizeOverrides(raw, platform) {
+  const clean = {};
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return clean;
+  for (const [id, value] of Object.entries(raw)) {
+    const entry = getShortcutById(id);
+    if (!entry || entry.editable === false) continue;
+    if (typeof value !== 'string') continue;
+    const normalized = normalizeAccelerator(value, platform);
+    if (!normalized) continue;
+    if (isReservedAccelerator(normalized, platform)) continue;
+    if (normalized === normalizeAccelerator(getDefaultAccelerator(entry, platform), platform)) {
+      continue;
+    }
+    clean[id] = normalized;
+  }
+  return clean;
+}
+
+// ── Display formatting ──────────────────────────────────────────────────
+
+const MAC_MODIFIER_GLYPHS = { ctrl: '⌃', alt: '⌥', shift: '⇧', meta: '⌘' };
+const MAC_KEY_GLYPHS = {
+  Left: '←',
+  Right: '→',
+  Up: '↑',
+  Down: '↓',
+  Enter: '↩',
+  Backspace: '⌫',
+  Delete: '⌦',
+  Escape: '⎋',
+  Tab: '⇥',
+  Plus: '+',
+};
+
+/**
+ * Human-readable binding: mac-style glyph run ('⌘⇧K') on darwin,
+ * 'Ctrl+Shift+K' elsewhere. Returns '' for unparsable input.
+ */
+function formatAccelerator(accelerator, platform) {
+  const parsed = parseAccelerator(accelerator, platform);
+  if (!parsed) return '';
+  const key = parsed.key.length === 1 ? parsed.key.toUpperCase() : parsed.key;
+
+  if (platform === 'darwin') {
+    let out = '';
+    if (parsed.ctrl) out += MAC_MODIFIER_GLYPHS.ctrl;
+    if (parsed.alt) out += MAC_MODIFIER_GLYPHS.alt;
+    if (parsed.shift) out += MAC_MODIFIER_GLYPHS.shift;
+    if (parsed.meta) out += MAC_MODIFIER_GLYPHS.meta;
+    return out + (MAC_KEY_GLYPHS[key] || key);
+  }
+
+  const parts = [];
+  if (parsed.ctrl) parts.push('Ctrl');
+  if (parsed.alt) parts.push('Alt');
+  if (parsed.shift) parts.push('Shift');
+  if (parsed.meta) parts.push('Super');
+  parts.push(key === 'Plus' ? '+' : key);
+  return parts.join('+');
+}
+
 module.exports = {
   SHORTCUTS,
   canonicalKey,
@@ -393,4 +598,12 @@ module.exports = {
   getShortcutById,
   getDefaultAccelerator,
   getAliasAccelerators,
+  normalizeAccelerator,
+  isReservedAccelerator,
+  acceleratorFromEvent,
+  validateBinding,
+  getEffectiveAccelerator,
+  findConflict,
+  sanitizeOverrides,
+  formatAccelerator,
 };

--- a/src/shared/shortcuts.js
+++ b/src/shared/shortcuts.js
@@ -481,6 +481,23 @@ function acceleratorFromEvent(event, platform) {
   return parts.join('+');
 }
 
+// Named keys Electron's accelerator parser actually accepts. canonicalKey
+// passes unknown names through untouched (media keys, 'Dead' from intl
+// dead-key layouts) and Menu silently ignores accelerators built from them
+// — the binding would look bound in settings but never fire. Reject those
+// at validation instead. Escape is excluded here on purpose: the recorder
+// cancels on Escape (with or without modifiers), so accepting it from any
+// other path would create bindings the recorder can never produce.
+const KNOWN_NAMED_KEYS = new Set(
+  Object.values(KEY_ALIASES).filter((key) => key !== 'Escape')
+);
+function isRecognizedKey(key) {
+  if (typeof key !== 'string' || key.length === 0) return false;
+  if (key.length === 1) return true;
+  if (/^F([1-9]|1\d|2[0-4])$/.test(key)) return true;
+  return KNOWN_NAMED_KEYS.has(key);
+}
+
 /**
  * Whether `accelerator` is assignable to `entry` on `platform`.
  * Returns { ok: true } or { ok: false, reason }, with reason one of
@@ -495,6 +512,7 @@ function validateBinding(entryOrId, accelerator, platform) {
 
   const parsed = parseAccelerator(accelerator, platform);
   if (!parsed) return { ok: false, reason: 'invalid' };
+  if (!isRecognizedKey(parsed.key)) return { ok: false, reason: 'invalid' };
   if (isReservedAccelerator(accelerator, platform)) return { ok: false, reason: 'reserved' };
 
   // Every scope must carry a real modifier for typing/editing keys: a bare

--- a/src/shared/shortcuts.js
+++ b/src/shared/shortcuts.js
@@ -431,6 +431,27 @@ function isReservedAccelerator(accelerator, platform) {
 const isModifierEventKey = (key) =>
   ['Shift', 'Control', 'Alt', 'Meta', 'AltGraph'].includes(String(key));
 
+// The only keys safe to bind without a real modifier: function keys never
+// type or edit text, so a bare binding cannot fire mid-typing. Everything
+// else — printable characters and named editing/navigation keys (Enter,
+// Space, Backspace, Delete, Tab, arrows, Home/End/Page keys, …) — needs
+// Ctrl/Alt/Cmd. Escape is deliberately not allowlisted: it is the
+// universal cancel/dismiss gesture inside dialogs and text fields.
+const SAFE_BARE_KEY_RE = /^F([1-9]|1\d|2[0-4])$/;
+
+/**
+ * True when `accelerator` would fire while the user is typing if bound
+ * as-is: no real modifier (Ctrl/Alt/Cmd — Shift alone does not count) and
+ * a key outside the safe-bare allowlist. Applies to every action scope;
+ * renderer-only shortcuts listen globally too.
+ */
+function acceleratorNeedsModifier(accelerator, platform) {
+  const parsed = parseAccelerator(accelerator, platform);
+  if (!parsed) return false;
+  if (parsed.ctrl || parsed.alt || parsed.meta) return false;
+  return !SAFE_BARE_KEY_RE.test(parsed.key);
+}
+
 /**
  * Build a normalized accelerator from a keydown event (Settings recording
  * mode). Prefers the physical key code so the stored binding is stable
@@ -476,11 +497,11 @@ function validateBinding(entryOrId, accelerator, platform) {
   if (!parsed) return { ok: false, reason: 'invalid' };
   if (isReservedAccelerator(accelerator, platform)) return { ok: false, reason: 'reserved' };
 
-  // Menu-context shortcuts must carry a real modifier: a bare (or
-  // shift-only) character would fire while typing in any text field.
-  const hasRealModifier = parsed.ctrl || parsed.alt || parsed.meta;
-  const isBareCharacter = parsed.key.length === 1;
-  if (entry.context !== 'renderer' && isBareCharacter && !hasRealModifier) {
+  // Every scope must carry a real modifier for typing/editing keys: a bare
+  // (or shift-only) character, Enter, Space, Backspace, Delete, … would
+  // fire while typing in any text field — renderer-only actions included.
+  // Only function keys are safe bare (see SAFE_BARE_KEY_RE).
+  if (acceleratorNeedsModifier(accelerator, platform)) {
     return { ok: false, reason: 'needs-modifier' };
   }
 
@@ -526,9 +547,10 @@ function findConflict(entryOrId, accelerator, overrides, platform) {
 
 /**
  * Defensive cleanup for a stored/incoming overrides map: drops unknown or
- * non-editable ids, non-string and unparsable values, reserved combos, and
- * no-op overrides equal to the default. Values are normalized. Never
- * throws — malformed input yields {}.
+ * non-editable ids, non-string and unparsable values, reserved combos,
+ * modifier-less typing/editing keys, and no-op overrides equal to the
+ * default. Values are normalized. Never throws — malformed input
+ * yields {}.
  */
 function sanitizeOverrides(raw, platform) {
   const clean = {};
@@ -540,6 +562,7 @@ function sanitizeOverrides(raw, platform) {
     const normalized = normalizeAccelerator(value, platform);
     if (!normalized) continue;
     if (isReservedAccelerator(normalized, platform)) continue;
+    if (acceleratorNeedsModifier(normalized, platform)) continue;
     if (normalized === normalizeAccelerator(getDefaultAccelerator(entry, platform), platform)) {
       continue;
     }
@@ -602,6 +625,7 @@ module.exports = {
   getAliasAccelerators,
   normalizeAccelerator,
   isReservedAccelerator,
+  acceleratorNeedsModifier,
   acceleratorFromEvent,
   validateBinding,
   getEffectiveAccelerator,

--- a/src/shared/shortcuts.test.js
+++ b/src/shared/shortcuts.test.js
@@ -266,6 +266,29 @@ describe('acceleratorFromEvent (recording)', () => {
 });
 
 describe('validateBinding', () => {
+  test('rejects key names Electron accelerators silently ignore', () => {
+    // Dead keys / media keys / unmapped codes pass through canonicalKey
+    // unchanged; Menu accepts and silently ignores such accelerators, so a
+    // stored binding would look bound but never fire.
+    for (const accel of ['Ctrl+Dead', 'Ctrl+AudioVolumeUp', 'Ctrl+IntlBackslash']) {
+      expect(validateBinding('tab.new', accel, 'linux')).toEqual({
+        ok: false,
+        reason: 'invalid',
+      });
+    }
+    // Known named keys and function keys stay bindable.
+    expect(validateBinding('tab.new', 'Ctrl+PageDown', 'linux').ok).toBe(true);
+    expect(validateBinding('tab.new', 'Ctrl+Up', 'linux').ok).toBe(true);
+  });
+
+  test('rejects Escape with or without modifiers, matching the recorder', () => {
+    // The recorder cancels on Escape regardless of held modifiers, so no
+    // Escape combo may validate through any other path either.
+    for (const accel of ['Escape', 'Ctrl+Escape', 'Alt+Escape']) {
+      expect(validateBinding('tab.new', accel, 'linux').ok).toBe(false);
+    }
+  });
+
   test('rejects reserved combos (quit, edit roles, F12)', () => {
     expect(validateBinding('tab.new', 'CmdOrCtrl+Q', 'darwin')).toEqual({
       ok: false,
@@ -327,8 +350,9 @@ describe('validateBinding', () => {
     expect(validateBinding('view.toggleSidebar', 'Shift+Enter', 'linux').reason).toBe(
       'needs-modifier'
     );
-    // …Escape is the universal cancel/dismiss key, also not bindable bare…
-    expect(validateBinding('tab.new', 'Escape', 'linux').reason).toBe('needs-modifier');
+    // …Escape is the universal cancel/dismiss key, not bindable at all now
+    // (the recorder cancels on it, so validation rejects it outright)…
+    expect(validateBinding('tab.new', 'Escape', 'linux').reason).toBe('invalid');
     // …but a real modifier makes named keys fine.
     expect(validateBinding('tab.new', 'Ctrl+Enter', 'linux').ok).toBe(true);
     expect(validateBinding('view.toggleSidebar', 'Alt+Delete', 'darwin').ok).toBe(true);

--- a/src/shared/shortcuts.test.js
+++ b/src/shared/shortcuts.test.js
@@ -276,16 +276,62 @@ describe('validateBinding', () => {
     expect(validateBinding('tab.new', 'F12', 'win32').reason).toBe('reserved');
   });
 
-  test('rejects bare characters for menu-context shortcuts', () => {
+  test('rejects bare characters for every scope — renderer-only included', () => {
     expect(validateBinding('tab.new', 'K', 'linux')).toEqual({
       ok: false,
       reason: 'needs-modifier',
     });
     expect(validateBinding('downloads.show', 'Shift+K', 'linux').reason).toBe('needs-modifier');
+    // Renderer-only shortcuts listen globally too — bare W must not pass.
+    expect(validateBinding('view.toggleSidebar', 'W', 'linux')).toEqual({
+      ok: false,
+      reason: 'needs-modifier',
+    });
+    expect(validateBinding('view.toggleSidebar', 'Shift+W', 'darwin').reason).toBe(
+      'needs-modifier'
+    );
     // Function keys are fine without modifiers…
     expect(validateBinding('tab.new', 'F6', 'linux').ok).toBe(true);
+    expect(validateBinding('view.toggleSidebar', 'F5', 'win32').ok).toBe(true);
     // …and real modifiers make characters fine.
     expect(validateBinding('tab.new', 'Alt+K', 'linux').ok).toBe(true);
+    expect(validateBinding('view.toggleSidebar', 'Ctrl+Shift+W', 'linux').ok).toBe(true);
+  });
+
+  test('rejects modifier-less named editing/navigation keys for every scope', () => {
+    const namedKeys = [
+      'Enter',
+      'Space',
+      'Backspace',
+      'Delete',
+      'Tab',
+      'Up',
+      'Down',
+      'Left',
+      'Right',
+      'Home',
+      'End',
+      'PageUp',
+      'PageDown',
+      'Insert',
+    ];
+    for (const id of ['tab.new', 'downloads.show', 'view.toggleSidebar']) {
+      for (const key of namedKeys) {
+        expect(validateBinding(id, key, 'linux')).toEqual({
+          ok: false,
+          reason: 'needs-modifier',
+        });
+      }
+    }
+    // Shift alone is not a real modifier…
+    expect(validateBinding('view.toggleSidebar', 'Shift+Enter', 'linux').reason).toBe(
+      'needs-modifier'
+    );
+    // …Escape is the universal cancel/dismiss key, also not bindable bare…
+    expect(validateBinding('tab.new', 'Escape', 'linux').reason).toBe('needs-modifier');
+    // …but a real modifier makes named keys fine.
+    expect(validateBinding('tab.new', 'Ctrl+Enter', 'linux').ok).toBe(true);
+    expect(validateBinding('view.toggleSidebar', 'Alt+Delete', 'darwin').ok).toBe(true);
   });
 
   test('rejects non-editable and unknown shortcuts', () => {
@@ -316,6 +362,8 @@ describe('override resolution', () => {
         unknown: 'Ctrl+U', // unknown id → dropped
         'page.findInPage': 42, // not a string → dropped
         'tab.next': 'bad+', // unparsable → dropped
+        'view.toggleSidebar': 'W', // bare character → dropped
+        'page.hardReload': 'Enter', // bare editing key → dropped
       },
       'linux'
     );

--- a/src/shared/shortcuts.test.js
+++ b/src/shared/shortcuts.test.js
@@ -1,0 +1,201 @@
+const {
+  SHORTCUTS,
+  parseAccelerator,
+  eventMatchesAccelerator,
+  getShortcutById,
+  getDefaultAccelerator,
+  getAliasAccelerators,
+} = require('./shortcuts');
+
+const PLATFORMS = ['darwin', 'win32', 'linux'];
+
+const keyEvent = (overrides = {}) => ({
+  key: 'a',
+  code: 'KeyA',
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  metaKey: false,
+  ...overrides,
+});
+
+describe('shortcut registry', () => {
+  test('ids are unique and entries carry the required fields', () => {
+    const ids = SHORTCUTS.map((entry) => entry.id);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    for (const entry of SHORTCUTS) {
+      expect(typeof entry.id).toBe('string');
+      expect(entry.description.length).toBeGreaterThan(0);
+      expect(['menu', 'renderer', 'both']).toContain(entry.context);
+      expect(typeof entry.category).toBe('string');
+      expect(typeof entry.editable).toBe('boolean');
+    }
+  });
+
+  test('every default accelerator parses on every platform', () => {
+    for (const entry of SHORTCUTS) {
+      for (const platform of PLATFORMS) {
+        const accelerator = getDefaultAccelerator(entry, platform);
+        expect(accelerator).toBeTruthy();
+        expect(parseAccelerator(accelerator, platform)).not.toBeNull();
+      }
+    }
+  });
+
+  test('every alias accelerator parses on its platforms', () => {
+    for (const entry of SHORTCUTS) {
+      for (const platform of PLATFORMS) {
+        for (const alias of getAliasAccelerators(entry, platform)) {
+          expect(parseAccelerator(alias, platform)).not.toBeNull();
+        }
+      }
+    }
+  });
+
+  test('getShortcutById resolves known ids and rejects unknown ones', () => {
+    expect(getShortcutById('tab.new')?.description).toBe('New Tab');
+    expect(getShortcutById('nope')).toBeNull();
+  });
+
+  test('platform-map defaults resolve per platform with `other` fallback', () => {
+    expect(getDefaultAccelerator('history.showAll', 'darwin')).toBe('Cmd+Y');
+    expect(getDefaultAccelerator('history.showAll', 'win32')).toBe('Ctrl+H');
+    expect(getDefaultAccelerator('history.showAll', 'linux')).toBe('Ctrl+H');
+  });
+
+  test('aliases filter by platform', () => {
+    expect(getAliasAccelerators('tab.close', 'win32')).toEqual(['Ctrl+F4']);
+    expect(getAliasAccelerators('tab.close', 'linux')).toEqual(['Ctrl+F4']);
+    expect(getAliasAccelerators('tab.close', 'darwin')).toEqual([]);
+    expect(getAliasAccelerators('tab.next', 'darwin')).toEqual(['Ctrl+Tab', 'Cmd+Shift+]']);
+    expect(getAliasAccelerators('tab.next', 'linux')).toEqual(['Ctrl+Tab']);
+  });
+});
+
+describe('parseAccelerator', () => {
+  test('resolves CmdOrCtrl to meta on macOS and ctrl elsewhere', () => {
+    expect(parseAccelerator('CmdOrCtrl+T', 'darwin')).toEqual({
+      key: 't',
+      ctrl: false,
+      alt: false,
+      shift: false,
+      meta: true,
+    });
+    expect(parseAccelerator('CmdOrCtrl+T', 'linux')).toEqual({
+      key: 't',
+      ctrl: true,
+      alt: false,
+      shift: false,
+      meta: false,
+    });
+    expect(parseAccelerator('CommandOrControl+T', 'win32').ctrl).toBe(true);
+  });
+
+  test('parses multi-modifier combos and named keys', () => {
+    expect(parseAccelerator('Ctrl+Shift+PageDown', 'linux')).toEqual({
+      key: 'PageDown',
+      ctrl: true,
+      alt: false,
+      shift: true,
+      meta: false,
+    });
+    expect(parseAccelerator('Cmd+Alt+I', 'darwin')).toEqual({
+      key: 'i',
+      ctrl: false,
+      alt: true,
+      shift: false,
+      meta: true,
+    });
+    expect(parseAccelerator('F11', 'win32')).toEqual({
+      key: 'F11',
+      ctrl: false,
+      alt: false,
+      shift: false,
+      meta: false,
+    });
+  });
+
+  test('rejects malformed accelerators', () => {
+    expect(parseAccelerator('', 'linux')).toBeNull();
+    expect(parseAccelerator('Ctrl+', 'linux')).toBeNull();
+    expect(parseAccelerator('Ctrl+K+J', 'linux')).toBeNull();
+    expect(parseAccelerator('Ctrl+Shift', 'linux')).toBeNull();
+    expect(parseAccelerator(null, 'linux')).toBeNull();
+  });
+});
+
+describe('eventMatchesAccelerator', () => {
+  test('maps CmdOrCtrl per platform', () => {
+    const cmdT = keyEvent({ key: 't', code: 'KeyT', metaKey: true });
+    const ctrlT = keyEvent({ key: 't', code: 'KeyT', ctrlKey: true });
+
+    expect(eventMatchesAccelerator(cmdT, 'CmdOrCtrl+T', 'darwin')).toBe(true);
+    expect(eventMatchesAccelerator(ctrlT, 'CmdOrCtrl+T', 'darwin')).toBe(false);
+    expect(eventMatchesAccelerator(ctrlT, 'CmdOrCtrl+T', 'linux')).toBe(true);
+    expect(eventMatchesAccelerator(cmdT, 'CmdOrCtrl+T', 'win32')).toBe(false);
+  });
+
+  test('is strict about extra modifiers (Cmd+Shift+W is not Cmd+W)', () => {
+    const cmdShiftW = keyEvent({ key: 'W', code: 'KeyW', metaKey: true, shiftKey: true });
+    expect(eventMatchesAccelerator(cmdShiftW, 'CmdOrCtrl+W', 'darwin')).toBe(false);
+    expect(eventMatchesAccelerator(cmdShiftW, 'CmdOrCtrl+Shift+W', 'darwin')).toBe(true);
+
+    const ctrlAltT = keyEvent({ key: 't', code: 'KeyT', ctrlKey: true, altKey: true });
+    expect(eventMatchesAccelerator(ctrlAltT, 'CmdOrCtrl+T', 'linux')).toBe(false);
+  });
+
+  test('matches letters case-insensitively (Shift produces uppercase keys)', () => {
+    const upper = keyEvent({ key: 'T', code: 'KeyT', ctrlKey: true, shiftKey: true });
+    expect(eventMatchesAccelerator(upper, 'Ctrl+Shift+T', 'linux')).toBe(true);
+  });
+
+  test('matches named keys and function keys', () => {
+    expect(
+      eventMatchesAccelerator(
+        keyEvent({ key: 'Tab', code: 'Tab', ctrlKey: true }),
+        'Ctrl+Tab',
+        'linux'
+      )
+    ).toBe(true);
+    expect(eventMatchesAccelerator(keyEvent({ key: 'F11', code: 'F11' }), 'F11', 'win32')).toBe(
+      true
+    );
+    expect(
+      eventMatchesAccelerator(
+        keyEvent({ key: 'PageDown', code: 'PageDown', ctrlKey: true, shiftKey: true }),
+        'Ctrl+Shift+PageDown',
+        'darwin'
+      )
+    ).toBe(true);
+  });
+
+  test('matches shifted punctuation via the physical key code', () => {
+    // On layouts where Shift+] produces '}', the physical code still says
+    // BracketRight — Cmd+Shift+] must match either representation.
+    const shifted = keyEvent({
+      key: '}',
+      code: 'BracketRight',
+      metaKey: true,
+      shiftKey: true,
+    });
+    const unshifted = keyEvent({
+      key: ']',
+      code: 'BracketRight',
+      metaKey: true,
+      shiftKey: true,
+    });
+    expect(eventMatchesAccelerator(shifted, 'Cmd+Shift+]', 'darwin')).toBe(true);
+    expect(eventMatchesAccelerator(unshifted, 'Cmd+Shift+]', 'darwin')).toBe(true);
+  });
+
+  test('a bare modifier keydown matches nothing', () => {
+    const bareShift = keyEvent({ key: 'Shift', code: 'ShiftLeft', shiftKey: true });
+    expect(eventMatchesAccelerator(bareShift, 'Shift+T', 'linux')).toBe(false);
+  });
+
+  test('handles missing code gracefully (synthetic events)', () => {
+    const noCode = { key: 'f', metaKey: true, ctrlKey: false, altKey: false, shiftKey: false };
+    expect(eventMatchesAccelerator(noCode, 'CmdOrCtrl+F', 'darwin')).toBe(true);
+  });
+});

--- a/src/shared/shortcuts.test.js
+++ b/src/shared/shortcuts.test.js
@@ -199,3 +199,184 @@ describe('eventMatchesAccelerator', () => {
     expect(eventMatchesAccelerator(noCode, 'CmdOrCtrl+F', 'darwin')).toBe(true);
   });
 });
+
+const {
+  normalizeAccelerator,
+  acceleratorFromEvent,
+  validateBinding,
+  getEffectiveAccelerator,
+  findConflict,
+  sanitizeOverrides,
+  formatAccelerator,
+} = require('./shortcuts');
+
+describe('normalizeAccelerator', () => {
+  test('produces a canonical modifier order and key casing', () => {
+    expect(normalizeAccelerator('Shift+Ctrl+u', 'linux')).toBe('Ctrl+Shift+U');
+    expect(normalizeAccelerator('CmdOrCtrl+T', 'darwin')).toBe('Cmd+T');
+    expect(normalizeAccelerator('CmdOrCtrl+T', 'win32')).toBe('Ctrl+T');
+    expect(normalizeAccelerator('Ctrl+PageDown', 'linux')).toBe('Ctrl+PageDown');
+    expect(normalizeAccelerator('nonsense+', 'linux')).toBeNull();
+  });
+
+  test('equates spellings of the same combo', () => {
+    expect(normalizeAccelerator('Command+Shift+t', 'darwin')).toBe(
+      normalizeAccelerator('CmdOrCtrl+Shift+T', 'darwin')
+    );
+  });
+});
+
+describe('acceleratorFromEvent (recording)', () => {
+  test('builds a normalized accelerator from a keydown', () => {
+    expect(
+      acceleratorFromEvent(
+        { key: 'u', code: 'KeyU', ctrlKey: true, shiftKey: true, altKey: false, metaKey: false },
+        'linux'
+      )
+    ).toBe('Ctrl+Shift+U');
+    expect(
+      acceleratorFromEvent(
+        { key: 'k', code: 'KeyK', metaKey: true, ctrlKey: false, shiftKey: false, altKey: false },
+        'darwin'
+      )
+    ).toBe('Cmd+K');
+  });
+
+  test('waits while only modifiers are held', () => {
+    expect(
+      acceleratorFromEvent({ key: 'Shift', code: 'ShiftLeft', shiftKey: true }, 'linux')
+    ).toBeNull();
+    expect(
+      acceleratorFromEvent({ key: 'Meta', code: 'MetaLeft', metaKey: true }, 'darwin')
+    ).toBeNull();
+  });
+
+  test('prefers the physical key for shifted punctuation', () => {
+    expect(
+      acceleratorFromEvent(
+        { key: '}', code: 'BracketRight', ctrlKey: true, shiftKey: true },
+        'linux'
+      )
+    ).toBe('Ctrl+Shift+]');
+  });
+
+  test('records function keys without modifiers', () => {
+    expect(acceleratorFromEvent({ key: 'F6', code: 'F6' }, 'win32')).toBe('F6');
+  });
+});
+
+describe('validateBinding', () => {
+  test('rejects reserved combos (quit, edit roles, F12)', () => {
+    expect(validateBinding('tab.new', 'CmdOrCtrl+Q', 'darwin')).toEqual({
+      ok: false,
+      reason: 'reserved',
+    });
+    expect(validateBinding('tab.new', 'Cmd+C', 'darwin').reason).toBe('reserved');
+    expect(validateBinding('tab.new', 'Ctrl+V', 'linux').reason).toBe('reserved');
+    expect(validateBinding('tab.new', 'F12', 'win32').reason).toBe('reserved');
+  });
+
+  test('rejects bare characters for menu-context shortcuts', () => {
+    expect(validateBinding('tab.new', 'K', 'linux')).toEqual({
+      ok: false,
+      reason: 'needs-modifier',
+    });
+    expect(validateBinding('downloads.show', 'Shift+K', 'linux').reason).toBe('needs-modifier');
+    // Function keys are fine without modifiers…
+    expect(validateBinding('tab.new', 'F6', 'linux').ok).toBe(true);
+    // …and real modifiers make characters fine.
+    expect(validateBinding('tab.new', 'Alt+K', 'linux').ok).toBe(true);
+  });
+
+  test('rejects non-editable and unknown shortcuts', () => {
+    expect(validateBinding('devtools.toggle', 'Ctrl+Shift+U', 'linux').reason).toBe('not-editable');
+    expect(validateBinding('nope', 'Ctrl+U', 'linux').reason).toBe('unknown-shortcut');
+    expect(validateBinding('tab.new', 'garbage+', 'linux').reason).toBe('invalid');
+  });
+});
+
+describe('override resolution', () => {
+  test('effective accelerator is override ?? default', () => {
+    expect(getEffectiveAccelerator('tab.new', { 'tab.new': 'Ctrl+Shift+U' }, 'linux')).toBe(
+      'Ctrl+Shift+U'
+    );
+    expect(getEffectiveAccelerator('tab.new', {}, 'linux')).toBe('CmdOrCtrl+T');
+    expect(getEffectiveAccelerator('tab.new', null, 'darwin')).toBe('CmdOrCtrl+T');
+    // Unparsable overrides are ignored, not propagated.
+    expect(getEffectiveAccelerator('tab.new', { 'tab.new': '+bad+' }, 'linux')).toBe('CmdOrCtrl+T');
+  });
+
+  test('sanitizeOverrides drops junk and keeps valid remaps normalized', () => {
+    const cleaned = sanitizeOverrides(
+      {
+        'tab.new': 'Shift+Ctrl+u', // valid → normalized
+        'tab.close': 'CmdOrCtrl+W', // no-op (equals default) → dropped
+        'devtools.toggle': 'Ctrl+U', // not editable → dropped
+        'page.reload': 'F12', // reserved → dropped
+        unknown: 'Ctrl+U', // unknown id → dropped
+        'page.findInPage': 42, // not a string → dropped
+        'tab.next': 'bad+', // unparsable → dropped
+      },
+      'linux'
+    );
+    expect(cleaned).toEqual({ 'tab.new': 'Ctrl+Shift+U' });
+
+    expect(sanitizeOverrides(null, 'linux')).toEqual({});
+    expect(sanitizeOverrides([], 'linux')).toEqual({});
+    expect(sanitizeOverrides('junk', 'linux')).toEqual({});
+  });
+});
+
+describe('findConflict', () => {
+  test('detects collisions with effective primaries', () => {
+    expect(findConflict('tab.new', 'CmdOrCtrl+W', {}, 'darwin')).toEqual({
+      id: 'tab.close',
+      description: 'Close Tab',
+      fixed: false,
+    });
+    // Overrides shift what conflicts: tab.close remapped away frees Cmd+W.
+    expect(findConflict('tab.new', 'Cmd+W', { 'tab.close': 'Cmd+Shift+X' }, 'darwin')).toBeNull();
+  });
+
+  test('collisions with fixed aliases and non-editable entries are fixed', () => {
+    expect(findConflict('tab.new', 'Ctrl+Tab', {}, 'linux')).toEqual({
+      id: 'tab.next',
+      description: 'Next Tab',
+      fixed: true,
+    });
+    expect(findConflict('tab.new', 'Ctrl+Alt+I', {}, 'linux')).toEqual({
+      id: 'devtools.toggle',
+      description: 'Developer Tools',
+      fixed: true,
+    });
+    // Ctrl+F4 alias only exists on win/linux.
+    expect(findConflict('tab.new', 'Ctrl+F4', {}, 'darwin')).toBeNull();
+  });
+
+  test('no conflict for a free combo or with itself', () => {
+    expect(findConflict('tab.new', 'Ctrl+Shift+U', {}, 'linux')).toBeNull();
+    expect(findConflict('tab.new', 'CmdOrCtrl+T', {}, 'linux')).toBeNull();
+  });
+
+  test('equates CmdOrCtrl defaults with concrete recorded combos', () => {
+    expect(findConflict('tab.close', 'Cmd+T', {}, 'darwin')?.id).toBe('tab.new');
+    expect(findConflict('tab.close', 'Ctrl+T', {}, 'win32')?.id).toBe('tab.new');
+    expect(findConflict('tab.close', 'Ctrl+T', {}, 'darwin')).toBeNull();
+  });
+});
+
+describe('formatAccelerator', () => {
+  test('renders mac-style glyphs on darwin', () => {
+    expect(formatAccelerator('CmdOrCtrl+Shift+K', 'darwin')).toBe('⇧⌘K');
+    expect(formatAccelerator('Cmd+Alt+I', 'darwin')).toBe('⌥⌘I');
+    expect(formatAccelerator('Ctrl+PageDown', 'darwin')).toBe('⌃PageDown');
+    expect(formatAccelerator('F11', 'darwin')).toBe('F11');
+  });
+
+  test('renders Ctrl-style text elsewhere', () => {
+    expect(formatAccelerator('CmdOrCtrl+Shift+K', 'linux')).toBe('Ctrl+Shift+K');
+    expect(formatAccelerator('Ctrl+Tab', 'win32')).toBe('Ctrl+Tab');
+    expect(formatAccelerator('F11', 'win32')).toBe('F11');
+    expect(formatAccelerator('', 'win32')).toBe('');
+  });
+});

--- a/test-e2e/shortcuts.spec.js
+++ b/test-e2e/shortcuts.spec.js
@@ -1,0 +1,223 @@
+// Shortcuts editor — remap "New Tab" through the Settings > Shortcuts
+// recording flow, assert the new combo opens a tab (and the old one no
+// longer does) without a restart, then restore defaults.
+//
+// The settings page lives inside a webview, so all page interaction goes
+// through executeJavaScript (same pattern as downloads.spec.js). Chrome
+// key presses use the renderer's window-level keydown fallback — synthetic
+// CDP key events don't trigger native menu accelerators.
+
+const { test, expect } = require('./fixtures');
+
+// Run a script inside the active webview and return its result.
+async function inSettingsPage(window, code) {
+  return window.evaluate(async (script) => {
+    const wv = document.querySelector('webview:not(.hidden)');
+    if (!wv || typeof wv.executeJavaScript !== 'function') return null;
+    try {
+      return await wv.executeJavaScript(script);
+    } catch {
+      return null;
+    }
+  }, code);
+}
+
+async function openShortcutsSettings(window) {
+  const address = window.locator('[data-test="address-input"]');
+  await address.click();
+  await address.fill('freedom://settings/shortcuts');
+  await address.press('Enter');
+
+  await expect
+    .poll(
+      () =>
+        inSettingsPage(
+          window,
+          `document.querySelectorAll('#shortcuts-view [data-shortcut-id]').length`
+        ),
+      { message: 'Waiting for the Shortcuts settings list to render', timeout: 10_000 }
+    )
+    .toBeGreaterThan(0);
+}
+
+// Click a shortcut's binding button (recording mode), then synthesize the
+// keydown the recorder should capture. Modifier choice follows the page's
+// platform (Cmd on macOS, Ctrl elsewhere) to mirror a real user.
+async function recordBinding(window, id, key, code) {
+  const clicked = await inSettingsPage(
+    window,
+    `(() => {
+       const row = document.querySelector('[data-shortcut-id="${id}"]');
+       const btn = row && row.querySelector('[data-action="record"]');
+       if (!btn) return false;
+       btn.click();
+       return true;
+     })()`
+  );
+  expect(clicked).toBe(true);
+
+  await inSettingsPage(
+    window,
+    `(() => {
+       const isMac = navigator.platform.toLowerCase().includes('mac');
+       window.dispatchEvent(
+         new KeyboardEvent('keydown', {
+           key: '${key}',
+           code: '${code}',
+           shiftKey: true,
+           ctrlKey: !isMac,
+           metaKey: isMac,
+           bubbles: true,
+           cancelable: true,
+         })
+       );
+       return true;
+     })()`
+  );
+}
+
+const effectiveAccelerator = (window, id) =>
+  inSettingsPage(
+    window,
+    `window.freedomAPI.getShortcuts().then((s) => s.entries.find((e) => e.id === '${id}').accelerator)`
+  );
+
+test('remapping New Tab applies live and restores cleanly', async ({ window }) => {
+  await openShortcutsSettings(window);
+
+  const tabs = window.locator('[data-test="tab"]');
+  const initialTabs = await tabs.count();
+
+  // Record Cmd/Ctrl+Shift+U for New Tab.
+  await recordBinding(window, 'tab.new', 'U', 'KeyU');
+  await expect
+    .poll(() => effectiveAccelerator(window, 'tab.new'), {
+      message: 'Waiting for the override to persist',
+    })
+    .toMatch(/^(Ctrl|Shift)\+.*U$/);
+
+  // The new combo opens a tab (chrome-focused renderer fallback)…
+  await window.locator('[data-test="address-input"]').click();
+  await window.keyboard.press('ControlOrMeta+Shift+U');
+  await expect(tabs).toHaveCount(initialTabs + 1);
+
+  // …and the old default no longer does.
+  await window.keyboard.press('ControlOrMeta+T');
+  await window.waitForTimeout(500);
+  await expect(tabs).toHaveCount(initialTabs + 1);
+
+  // Back to the settings tab — the freshly opened tab is active now and
+  // inSettingsPage talks to the active webview.
+  await window.locator('[data-test="tab"][data-tab-id="1"]').click();
+  await expect
+    .poll(() => inSettingsPage(window, `!!document.getElementById('shortcuts-restore-defaults')`))
+    .toBe(true);
+
+  // Restore defaults re-arms Cmd/Ctrl+T without a restart.
+  const restored = await inSettingsPage(
+    window,
+    `(() => { document.getElementById('shortcuts-restore-defaults').click(); return true; })()`
+  );
+  expect(restored).toBe(true);
+  await expect
+    .poll(() => effectiveAccelerator(window, 'tab.new'), {
+      message: 'Waiting for defaults to be restored',
+    })
+    .toBe('CmdOrCtrl+T');
+
+  await window.locator('[data-test="address-input"]').click();
+  await window.keyboard.press('ControlOrMeta+T');
+  await expect(tabs).toHaveCount(initialTabs + 2);
+});
+
+test('conflicting combos warn with a swap offer instead of silently rebinding', async ({
+  window,
+}) => {
+  await openShortcutsSettings(window);
+
+  // Start recording on New Tab, then press Close Tab's combo
+  // (Cmd/Ctrl+W, no Shift) so the preview reports a swappable conflict.
+  const clicked = await inSettingsPage(
+    window,
+    `(() => {
+       const row = document.querySelector('[data-shortcut-id="tab.new"]');
+       const btn = row && row.querySelector('[data-action="record"]');
+       if (!btn) return false;
+       btn.click();
+       return true;
+     })()`
+  );
+  expect(clicked).toBe(true);
+  await inSettingsPage(
+    window,
+    `(() => {
+       const isMac = navigator.platform.toLowerCase().includes('mac');
+       window.dispatchEvent(
+         new KeyboardEvent('keydown', {
+           key: 'w',
+           code: 'KeyW',
+           ctrlKey: !isMac,
+           metaKey: isMac,
+           bubbles: true,
+           cancelable: true,
+         })
+       );
+       return true;
+     })()`
+  );
+
+  // The conflict prompt names Close Tab and offers a swap.
+  await expect
+    .poll(() =>
+      inSettingsPage(
+        window,
+        `(() => {
+           const conflict = document.querySelector('.shortcut-conflict');
+           if (!conflict) return null;
+           return {
+             text: conflict.textContent,
+             hasSwap: !!conflict.querySelector('[data-action="swap"]'),
+           };
+         })()`
+      )
+    )
+    .toMatchObject({ hasSwap: true });
+
+  // Cancel keeps both bindings unchanged.
+  await inSettingsPage(
+    window,
+    `(() => { document.querySelector('[data-action="cancel-conflict"]').click(); return true; })()`
+  );
+  expect(await effectiveAccelerator(window, 'tab.new')).toBe('CmdOrCtrl+T');
+  expect(await effectiveAccelerator(window, 'tab.close')).toBe('CmdOrCtrl+W');
+});
+
+test('search filters the shortcut list', async ({ window }) => {
+  await openShortcutsSettings(window);
+
+  const count = (code) => inSettingsPage(window, code);
+
+  const total = await count(
+    `document.querySelectorAll('#shortcuts-view .row[data-shortcut-id]').length`
+  );
+  expect(total).toBeGreaterThan(5);
+
+  await inSettingsPage(
+    window,
+    `(() => {
+       const input = document.getElementById('shortcut-search');
+       input.value = 'find in page';
+       input.dispatchEvent(new Event('input', { bubbles: true }));
+       return true;
+     })()`
+  );
+
+  await expect
+    .poll(() => count(`document.querySelectorAll('#shortcuts-view .row[data-shortcut-id]').length`))
+    .toBe(1);
+  expect(
+    await count(
+      `document.querySelector('#shortcuts-view .row[data-shortcut-id]').dataset.shortcutId`
+    )
+  ).toBe('page.findInPage');
+});


### PR DESCRIPTION
**Based on `integration/daily-driver` (= main + #150 + #151 + #152). Will be retargeted to `main` once those merge; only the commits past 98566d2 are this PR.**

Implements roadmap item 7 (keyboard-shortcuts editor). Three reviewable commits:

## 1. Registry refactor — no behavior change

Every shortcut the app implements now lives in one place, `src/shared/shortcuts.js`: `{ id, description, defaultAccelerator, aliases, context: 'menu'|'renderer'|'both', category, editable, warnOnEdit }`.

- `src/main/menu.js` builds all menu accelerators from the registry; a menu.test.js guard **rejects accelerator literals in menu.js** so future shortcuts must land in the registry first.
- Renderer keydown handlers (tabs, find bar, navigation reload, sidebar) resolve events through `matchesShortcut(event, id)` — a unit-tested Electron-accelerator ↔ KeyboardEvent matcher with macOS/Windows/Linux modifier mapping (`CmdOrCtrl` → ⌘ on darwin, Ctrl elsewhere) and physical-key fallback for shifted punctuation (`Cmd+Shift+]`).
- The renderer matcher is an ESM mirror of the CommonJS shared module — same pattern as `origin-utils.js` (the renderer can't `require()` shared CJS) — guarded by an equivalence test over the full registry × platform × event battery.
- Secondary bindings that were previously hardcoded (`Ctrl+Tab`, `Ctrl+Shift+Tab`, `Cmd+Shift+[`/`]`, `Ctrl+F4`, `F12`, `Ctrl+Shift+I`) are modeled as **fixed aliases**: always active, never remapped.

## 2. Per-profile overrides, applied live

- `shortcutOverrides` (id → accelerator) in the existing per-profile settings store; effective binding = override ?? default. Overrides are sanitized against the registry on load *and* save (unknown ids, non-editable entries, reserved combos, unparsable values, and no-op defaults are dropped).
- The application menu rebuilds on remap via a new `onSettingsChanged` hook in the settings store; the renderer matcher picks changes up from the existing `settings:updated` broadcast. No restart anywhere.
- New IPC (`shortcuts:get-state / preview-binding / set-override / reset`) backs the settings page; all logic (validation, conflict detection, formatting) runs in the main process.

## 3. Settings UI

New **Settings > Shortcuts** section (existing settings.html patterns, theme via the page's CSS variables): searchable list grouped by category, bindings rendered mac-style (`⇧⌘K`) or Ctrl-style per platform, click-to-record (Esc cancels), per-shortcut Reset, and Restore defaults.

## Reserved-shortcut policy

- **Never assignable:** `Cmd/Ctrl+Q`, the edit-role clipboard set (`Cmd/Ctrl+C/V/X/A/Z`, `Shift+Z` redo — these come from Electron menu roles, not the registry), and `F12`.
- **Not editable:** the DevTools entries (F12 contract); the dev-only App DevTools entry is additionally hidden from the page in packaged builds.
- **Editable with a warning:** `Cmd/Ctrl+W` (Close Tab) carries a `warnOnEdit` flag; the recorder shows a caution while rebinding it.
- Menu-context shortcuts reject bare/shift-only characters (they'd fire while typing).
- Conflicts warn and offer **swap or cancel**; conflicts against fixed aliases or locked entries can only be cancelled.

## Tests

- Jest: registry completeness (no accelerator literals in menu.js + every template accelerator comes from the registry + all menu-context entries surface in the template), matcher platform cases, mirror equivalence, override resolution, sanitization, conflict/swap semantics, validation reasons, settings-store persistence + change-hook, menu rebuild-on-remap.
- Playwright e2e (`test-e2e/shortcuts.spec.js`): remap New Tab through the real recording UI → new combo opens a tab, old one doesn't → Restore defaults re-arms `Cmd/Ctrl+T`; conflict prompt with swap offer + cancel; search filter.
- Full jest suite: **113→114 suites passed, 2276 passed / 17 skipped, 0 failures.** Full Playwright harness: **30 passed / 2 skipped (pre-existing skips), 0 failures.** `npm run lint` clean; prettier clean on all new files.

## Honest notes / caveats

- The README's `Cmd+=`/`Cmd+-`/`Cmd+0` zoom, `Cmd+P` print, and contextual `Escape`/`Enter` behaviors are **not in the registry**: they aren't implemented as menu accelerators or chrome keydown handlers anywhere in the codebase (zoom/print come from toolbar buttons / Chromium internals), so there is nothing to remap. Out of scope here.
- Strict modifier matching fixes a latent collision: `Cmd/Ctrl+Shift+W` (sidebar toggle) previously *also* closed the tab, because the close-tab handler ignored Shift. Now each combo triggers exactly one action.
- On win/linux the renderer fallback now also matches `Ctrl+T`/`Ctrl+W`/etc. (previously mac-only `metaKey` checks). No double-fire: the renderer `preventDefault`s before the menu accelerator can act, and it performs the same action.
- Overrides are stored normalized per platform (e.g. `Shift+Cmd+U`), which is fine for per-profile, per-machine settings but means a settings file moved across OSes re-sanitizes rather than translates.
- Menu-item enable/disable state (`menu:update-tab-state`) is untouched; menu.js changes are accelerator-plumbing only, so the parallel private-windows branch can still add its File-menu item cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)