### PR TITLE
Update colibri-stateless to version 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@adraffy/ens-normalize": "^1.11.1",
-        "@corpus-core/colibri-stateless": "^1.1.30",
+        "@corpus-core/colibri-stateless": "^2.0.0",
         "@ensdomains/content-hash": "^3.0.0",
         "@ethersphere/bee-js": "^12.2.1",
         "@metamask/browser-passworder": "^6.0.0",
@@ -1522,9 +1522,9 @@
       "license": "MIT"
     },
     "node_modules/@corpus-core/colibri-stateless": {
-      "version": "1.1.30",
-      "resolved": "https://registry.npmjs.org/@corpus-core/colibri-stateless/-/colibri-stateless-1.1.30.tgz",
-      "integrity": "sha512-U/oFj14tKfGZUESGxEegJt1d8B0OZYGclXUQl8HIN5ttTUS0QQML//DPvR9k0PsVU9xz7ZWFt3B4pk0Ij6P/Kg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@corpus-core/colibri-stateless/-/colibri-stateless-2.0.0.tgz",
+      "integrity": "sha512-l+hYO+fu1J655iBLfStehm066wD1EgBshSoumP6hlCkFTIcWRMpJPCpyxjqnqUG/Qe4r+m/nvCbr5RWEIrxHZw==",
       "license": "MIT"
     },
     "node_modules/@electron-internal/extract-zip": {

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
   },
   "dependencies": {
     "@adraffy/ens-normalize": "^1.11.1",
-    "@corpus-core/colibri-stateless": "^1.1.30",
+    "@corpus-core/colibri-stateless": "^2.0.0",
     "@ensdomains/content-hash": "^3.0.0",
     "@ethersphere/bee-js": "^12.2.1",
     "@metamask/browser-passworder": "^6.0.0",


### PR DESCRIPTION
This uses the 64bit SP1 v6 zk-proof and once every one has updated, we can stop generating the old v5 proofs.