### PR TITLE
chore(build): update bundled Ant to v0.5.41

### DIFF
--- a/scripts/fetch-ant.js
+++ b/scripts/fetch-ant.js
@@ -15,7 +15,7 @@ const ANT_REPO = process.env.ANT_REPO || 'solardev-xyz/ant';
 // could ship a different Ant than CI validated. Override via ANT_RELEASE_TAG
 // for local testing of newer releases; set it to `latest` to resolve the
 // repo's most recent published release.
-const PINNED_RELEASE_TAG = 'v0.5.36';
+const PINNED_RELEASE_TAG = 'v0.5.41';
 // In-repo trust root for the pinned release: the sha256 of its SHA256SUMS
 // asset, recorded at pin time (trust-on-first-use by the author). The release
 // downloads its SHA256SUMS from the same GitHub release as the binaries, so
@@ -24,7 +24,7 @@ const PINNED_RELEASE_TAG = 'v0.5.36';
 // that tampering detectable. Update alongside PINNED_RELEASE_TAG on every
 // deliberate bump: `shasum -a 256` the freshly downloaded SHA256SUMS.
 const PINNED_SHA256SUMS_DIGEST =
-  'a551283ab539d59bcf5fa2cd40fab20488feb9169fa1293814879e757eff3ff0';
+  'c5138937118f0c728f3fbf52629bd021264a730323ea67d257a80fc042cd2198';
 const ANT_RELEASE_TAG = process.env.ANT_RELEASE_TAG || PINNED_RELEASE_TAG;
 
 function fetchReleaseOnce() {


### PR DESCRIPTION
## What changed

- update the pinned bundled Ant release from `v0.5.36` to `v0.5.41`
- pin the SHA-256 digest of the v0.5.41 `SHA256SUMS` release asset

## Why

Ant v0.5.41 fixes phantom postage batches: expired, foreign-chain, or nonexistent batches are detected and surfaced as unusable instead of repeatedly causing generic upload failures.

## Impact

Freedom packages and CI now use the exact v0.5.41 Ant binaries for every supported target while retaining the repository's release-asset tamper check.

## Validation

- `npm run lint`
- `npm test` — 106 suites passed, 2,143 tests passed
- `npm run ant:download` — all published targets downloaded and checksum-verified
- `npm run check-binaries`
- `npx jest --runInBand src/main/identity/__tests__/integration/bee-to-ant-migration.test.js` — 2 tests passed against the real v0.5.41 daemon
