### PR TITLE
chore(build): update bundled Ant to v0.5.43

### DIFF
--- a/scripts/fetch-ant.js
+++ b/scripts/fetch-ant.js
@@ -15,7 +15,7 @@ const ANT_REPO = process.env.ANT_REPO || 'solardev-xyz/ant';
 // could ship a different Ant than CI validated. Override via ANT_RELEASE_TAG
 // for local testing of newer releases; set it to `latest` to resolve the
 // repo's most recent published release.
-const PINNED_RELEASE_TAG = 'v0.5.41';
+const PINNED_RELEASE_TAG = 'v0.5.43';
 // In-repo trust root for the pinned release: the sha256 of its SHA256SUMS
 // asset, recorded at pin time (trust-on-first-use by the author). The release
 // downloads its SHA256SUMS from the same GitHub release as the binaries, so
@@ -24,7 +24,7 @@ const PINNED_RELEASE_TAG = 'v0.5.41';
 // that tampering detectable. Update alongside PINNED_RELEASE_TAG on every
 // deliberate bump: `shasum -a 256` the freshly downloaded SHA256SUMS.
 const PINNED_SHA256SUMS_DIGEST =
-  'c5138937118f0c728f3fbf52629bd021264a730323ea67d257a80fc042cd2198';
+  'ba9d97564a0e8631371bf036bdb33e0a9c7986493a7dca2406907f30e9bb900d';
 const ANT_RELEASE_TAG = process.env.ANT_RELEASE_TAG || PINNED_RELEASE_TAG;
 
 function fetchReleaseOnce() {


### PR DESCRIPTION
Bumps the pinned Ant release from v0.5.41 to v0.5.43 (latest upstream release, published 2026-07-19).

- Updates `PINNED_RELEASE_TAG` to `v0.5.43`
- Updates `PINNED_SHA256SUMS_DIGEST` to match — verified locally: sha256 of the v0.5.43 release's SHA256SUMS asset is `ba9d97564a0e8631371bf036bdb33e0a9c7986493a7dca2406907f30e9bb900d`