### PR TITLE
ci: centralize Linux native dependencies

### DIFF
--- a/.github/actions/install-linux-native-deps/action.yml
+++ b/.github/actions/install-linux-native-deps/action.yml
@@ -1,0 +1,13 @@
+name: Install Linux native dependencies
+description: Install system libraries required to build Ledger USB dependencies on Linux
+
+runs:
+  using: composite
+  steps:
+    - name: Install native USB build dependencies
+      shell: bash
+      run: |
+        # Refresh the image's package index first; cached entries can point to
+        # package builds that Ubuntu mirrors have already rotated out.
+        sudo apt-get update
+        sudo apt-get install -y libudev-dev libusb-1.0-0-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,12 +158,7 @@ jobs:
 
       - name: Install Linux native USB build dependency
         if: runner.os == 'Linux'
-        # node-hid builds against libudev (hidraw) and libusb; install both.
-        # `apt-get update` first — the image's pre-seeded index can name a
-        # build the mirrors already rotated out (install 404s).
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libudev-dev libusb-1.0-0-dev
+        uses: ./.github/actions/install-linux-native-deps
 
       - name: Install dependencies
         run: npm ci
@@ -233,12 +228,7 @@ jobs:
 
       - name: Install Linux native USB build dependency
         if: runner.os == 'Linux'
-        # node-hid builds against libudev (hidraw) and libusb; install both.
-        # `apt-get update` first — the image's pre-seeded index can name a
-        # build the mirrors already rotated out (install 404s).
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libudev-dev libusb-1.0-0-dev
+        uses: ./.github/actions/install-linux-native-deps
 
       - name: Install dependencies
         run: npm ci
@@ -292,12 +282,7 @@ jobs:
 
       - name: Install Linux native USB build dependency
         if: runner.os == 'Linux'
-        # node-hid builds against libudev (hidraw) and libusb; install both.
-        # `apt-get update` first — the image's pre-seeded index can name a
-        # build the mirrors already rotated out (install 404s).
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libudev-dev libusb-1.0-0-dev
+        uses: ./.github/actions/install-linux-native-deps
 
       - name: Install dependencies
         run: npm ci
@@ -349,12 +334,7 @@ jobs:
 
       - name: Install Linux native USB build dependency
         if: runner.os == 'Linux'
-        # node-hid builds against libudev (hidraw) and libusb; install both.
-        # `apt-get update` first — the image's pre-seeded index can name a
-        # build the mirrors already rotated out (install 404s).
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libudev-dev libusb-1.0-0-dev
+        uses: ./.github/actions/install-linux-native-deps
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## What changed

- add a reusable local action that installs `libudev-dev` and `libusb-1.0-0-dev`
- use that action in every existing Linux Electron E2E job
- keep the package-index refresh and native dependency list in one place

## Why

Ledger support introduces native USB modules that compile during `npm ci`. Linux E2E jobs without these system headers fail before their tests start. A shared action prevents new Electron jobs from silently omitting the prerequisites.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file(...)"` for the action and workflow
- `npm run lint`
- `git diff --check`
