### PR TITLE
test(renderer): gate settings navigation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,46 @@ jobs:
           FREEDOM_IPFS_NATIVE_SMOKE_LIVE: '0'
           FREEDOM_IPFS_NATIVE_SMOKE_ISSUE_102: '1'
 
+  # Settings navigation and persistence are shipped control surfaces. Exercise
+  # their real renderer/webview integration so malformed sidebar markup and
+  # broken section transitions cannot pass unit-only CI.
+  e2e-settings:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Linux native USB build dependency
+        uses: ./.github/actions/install-linux-native-deps
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps
+
+      - name: Run settings E2E
+        run: xvfb-run -a npm run test:e2e -- test-e2e/settings.spec.js test-e2e/settings-adblock.spec.js
+
+      - name: Upload Playwright traces and screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-settings-traces
+          path: |
+            test-results/
+            playwright-report/
+          if-no-files-found: ignore
+          retention-days: 14
+
   # Onboarding wizard must create node identities while a real Swarm node (now
   # antd) is running. Drives the full password wizard end-to-end against a real
   # antd spawn across all three desktop platforms — the cross-platform proof

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,9 @@ jobs:
       - name: Install Playwright system dependencies
         run: npx playwright install-deps
 
+      - name: Download adblock filter lists
+        run: npm run adblock:download
+
       - name: Run settings E2E
         run: xvfb-run -a npm run test:e2e -- test-e2e/settings.spec.js test-e2e/settings-adblock.spec.js
 


### PR DESCRIPTION
## What changed

- add a dedicated Settings E2E job to ordinary CI
- run both the general Settings suite and Ad Blocking/Site Permissions suite
- use the shared Linux native-dependency setup before `npm ci`
- retain Playwright traces and screenshots on failure

## Why

Malformed nested sidebar buttons on `main` made Ad Blocking unselectable and visually combined it with Site Permissions. The renderer repair now has an end-to-end gate that clicks both entries and verifies the corresponding active and hidden sections.

## Validation

- `npm run test:e2e -- test-e2e/settings.spec.js test-e2e/settings-adblock.spec.js` — 5 passed
- `npm run lint`
- workflow YAML parse
- `git diff --check`
