### PR TITLE
feat(wallet): add Vaughan local signer backend

### DIFF
--- a/scripts/add-vaughan-wallet.js
+++ b/scripts/add-vaughan-wallet.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Add the unlocked Vaughan account to Freedom's wallet list (no DevTools needed).
+ *
+ * Prerequisites:
+ *   1. Freedom has a vault (sidebar → Create New Wallet / unlock once)
+ *   2. Vaughan unlocked with:
+ *        VAUGHAN_PROVIDER_TRUSTED_ORIGINS=https://freedom.browser
+ *      and listening on ws://127.0.0.1:8745
+ *   3. Quit Freedom before running this script, then reopen after
+ *
+ * Usage:
+ *   node scripts/add-vaughan-wallet.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { rpcRequest } = require('../src/main/wallet/vaughan/transport');
+
+const HARDWARE_INDEX_BASE = 1_000_000;
+
+function findVaultMeta() {
+  const root = path.join(os.homedir(), '.config', 'Freedom Dev');
+  if (!fs.existsSync(root)) {
+    return null;
+  }
+  const hits = [];
+  const walk = (dir) => {
+    for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, ent.name);
+      if (ent.isDirectory()) walk(p);
+      else if (ent.name === 'vault-meta.json') hits.push(p);
+    }
+  };
+  walk(root);
+  return hits.sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs)[0] || null;
+}
+
+function nextHardwareIndex(wallets, meta) {
+  const fromMeta = Number(meta.nextHardwareWalletIndex);
+  const maxExisting = wallets.reduce((m, w) => Math.max(m, Number(w.index) || 0), 0);
+  const floor = Math.max(HARDWARE_INDEX_BASE, maxExisting + 1, fromMeta || HARDWARE_INDEX_BASE);
+  return floor;
+}
+
+async function main() {
+  console.log('Asking Vaughan for accounts…');
+  let accounts;
+  try {
+    accounts = await rpcRequest('eth_requestAccounts', []);
+  } catch (err) {
+    console.error('FAIL: cannot reach Vaughan at ws://127.0.0.1:8745');
+    console.error('  → Start/unlock Vaughan with VAUGHAN_PROVIDER_TRUSTED_ORIGINS=https://freedom.browser');
+    console.error('  → Detail:', err.message || err);
+    process.exit(1);
+  }
+  if (!Array.isArray(accounts) || !accounts[0]) {
+    console.error('FAIL: Vaughan returned no accounts (is the wallet unlocked?)');
+    process.exit(1);
+  }
+  const address = accounts[0];
+  console.log('Vaughan address:', address);
+
+  const metaPath = findVaultMeta();
+  if (!metaPath) {
+    console.error('FAIL: no Freedom vault-meta.json found');
+    console.error('  → In Freedom: Create New Wallet (or unlock) once, quit Freedom, then re-run this script');
+    process.exit(1);
+  }
+  console.log('Freedom vault:', metaPath);
+
+  const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+  const wallets = Array.isArray(meta.derivedWallets) ? meta.derivedWallets.slice() : [];
+  const dup = wallets.find((w) => (w.address || '').toLowerCase() === address.toLowerCase());
+  if (dup) {
+    meta.activeWalletIndex = dup.index;
+    fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2) + '\n');
+    console.log(`Already present as "${dup.name}" (index ${dup.index}). Set active. Reopen Freedom.`);
+    return;
+  }
+
+  const index = nextHardwareIndex(wallets, meta);
+  const entry = {
+    index,
+    name: 'Vaughan',
+    address,
+    type: 'vaughan',
+  };
+  wallets.push(entry);
+  meta.derivedWallets = wallets;
+  meta.nextHardwareWalletIndex = index + 1;
+  meta.activeWalletIndex = index;
+  fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2) + '\n');
+  console.log('Added Vaughan wallet and set it active.');
+  console.log('Reopen Freedom, then click Connect on the dApp.');
+}
+
+main().catch((err) => {
+  console.error('FAIL:', err);
+  process.exit(1);
+});

--- a/scripts/smoke-vaughan-bridge.js
+++ b/scripts/smoke-vaughan-bridge.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Manual smoke: Freedom's real Vaughan transport against a running Vaughan provider.
+ *
+ * Prerequisites:
+ *   1. Unlock Vaughan with:
+ *        VAUGHAN_PROVIDER_TRUSTED_ORIGINS=https://freedom.browser
+ *   2. Provider listening on ws://127.0.0.1:8745
+ *   3. Approve any personal_sign / sign prompts that appear in the TUI
+ *
+ * Usage:
+ *   node scripts/smoke-vaughan-bridge.js
+ *   FREEDOM_VAUGHAN_WS_URL=ws://127.0.0.1:8745 node scripts/smoke-vaughan-bridge.js
+ */
+
+const path = require('path');
+const { rpcRequest, DEFAULT_URL, DEFAULT_ORIGIN } = require(
+  path.join(__dirname, '..', 'src', 'main', 'wallet', 'vaughan', 'transport')
+);
+const { createVaughanBackend } = require(
+  path.join(__dirname, '..', 'src', 'main', 'wallet', 'vaughan', 'signer')
+);
+
+async function main() {
+  const url = process.env.FREEDOM_VAUGHAN_WS_URL || DEFAULT_URL;
+  console.log(`Connecting as Origin=${DEFAULT_ORIGIN} → ${url}`);
+
+  const accounts = await rpcRequest('eth_requestAccounts', [], { url });
+  if (!Array.isArray(accounts) || !accounts[0]) {
+    throw new Error(`eth_requestAccounts returned no accounts: ${JSON.stringify(accounts)}`);
+  }
+  const address = accounts[0];
+  console.log(`accounts: ${address}`);
+
+  const backend = createVaughanBackend({ address, type: 'vaughan' });
+  const got = await backend.getAddress();
+  console.log(`getAddress: ${got}`);
+
+  const sig = await backend.signMessage(Buffer.from('freedom-manual-smoke', 'utf8'));
+  console.log(`signMessage: ${sig.slice(0, 18)}… (${sig.length} chars)`);
+
+  console.log('OK — Freedom transport ↔ Vaughan provider smoke passed');
+}
+
+main().catch((err) => {
+  console.error('FAIL:', err && err.message ? err.message : err);
+  if (err && err.code) console.error('code:', err.code);
+  process.exit(1);
+});

--- a/scripts/smoke-vaughan-bridge.js
+++ b/scripts/smoke-vaughan-bridge.js
@@ -3,10 +3,11 @@
  * Manual smoke: Freedom's real Vaughan transport against a running Vaughan provider.
  *
  * Prerequisites:
- *   1. Unlock Vaughan with:
- *        VAUGHAN_PROVIDER_TRUSTED_ORIGINS=https://freedom.browser
+ *   1. Vaughan running with the wallet unlocked (the TUI trusts the Freedom
+ *      origin by default and writes provider.session, which the transport
+ *      picks up automatically).
  *   2. Provider listening on ws://127.0.0.1:8745
- *   3. Approve any personal_sign / sign prompts that appear in the TUI
+ *   3. Approve any connect / sign prompts that appear in the TUI
  *
  * Usage:
  *   node scripts/smoke-vaughan-bridge.js
@@ -17,7 +18,7 @@ const path = require('path');
 const { rpcRequest, DEFAULT_URL, DEFAULT_ORIGIN } = require(
   path.join(__dirname, '..', 'src', 'main', 'wallet', 'vaughan', 'transport')
 );
-const { createVaughanBackend } = require(
+const { createVaughanBackend, SIGN_TIMEOUT_MS } = require(
   path.join(__dirname, '..', 'src', 'main', 'wallet', 'vaughan', 'signer')
 );
 
@@ -25,7 +26,8 @@ async function main() {
   const url = process.env.FREEDOM_VAUGHAN_WS_URL || DEFAULT_URL;
   console.log(`Connecting as Origin=${DEFAULT_ORIGIN} → ${url}`);
 
-  const accounts = await rpcRequest('eth_requestAccounts', [], { url });
+  // Connect gesture waits on interactive TUI approval — signing-grade timeout.
+  const accounts = await rpcRequest('eth_requestAccounts', [], { url, timeoutMs: SIGN_TIMEOUT_MS });
   if (!Array.isArray(accounts) || !accounts[0]) {
     throw new Error(`eth_requestAccounts returned no accounts: ${JSON.stringify(accounts)}`);
   }

--- a/src/main/identity-manager.js
+++ b/src/main/identity-manager.js
@@ -794,12 +794,14 @@ const WALLET_TYPES = {
   MNEMONIC: 'mnemonic',
   LEDGER: 'ledger',
   REMOTE: 'remote', // phone / other device signing over openlv
+  VAUGHAN: 'vaughan', // local Vaughan-CLI EIP-1193 signer
 };
 
 /** User-facing labels for device account types (auto-names, error text). */
 const DEVICE_LABELS = {
   [WALLET_TYPES.LEDGER]: 'Ledger',
   [WALLET_TYPES.REMOTE]: 'Phone',
+  [WALLET_TYPES.VAUGHAN]: 'Vaughan',
 };
 
 /**
@@ -1045,6 +1047,20 @@ async function addLedgerWallet(name, address, path) {
  */
 async function addRemoteWallet(name, address) {
   return addDeviceWallet(WALLET_TYPES.REMOTE, name, address);
+}
+
+/**
+ * Add a Vaughan account record to the wallet list.
+ *
+ * The address is discovered from the local Vaughan provider and persisted; it
+ * is not derivable from this vault.
+ *
+ * @param {string} name - Display name ('' → auto "Vaughan N")
+ * @param {string} address - Checksummed address reported by Vaughan
+ * @returns {Promise<{index: number, name: string, address: string, type: string}>}
+ */
+async function addVaughanWallet(name, address) {
+  return addDeviceWallet(WALLET_TYPES.VAUGHAN, name, address);
 }
 
 /**
@@ -1530,6 +1546,17 @@ function registerIdentityIpc() {
     }
   });
 
+  // Add a Vaughan account (address read from the local Vaughan provider)
+  ipcMain.handle('wallet:add-vaughan-wallet', async (_event, name, address) => {
+    try {
+      const wallet = await addVaughanWallet(name, address);
+      return { success: true, wallet };
+    } catch (error) {
+      console.error('Failed to add Vaughan wallet:', error);
+      return { success: false, error: error.message };
+    }
+  });
+
   // Rename wallet
   ipcMain.handle('wallet:rename-wallet', async (_event, index, newName) => {
     try {
@@ -1595,6 +1622,7 @@ module.exports = {
   createDerivedWallet,
   addLedgerWallet,
   addRemoteWallet,
+  addVaughanWallet,
   renameDerivedWallet,
   deleteDerivedWallet,
   getActiveWalletAddress,

--- a/src/main/identity-manager.test.js
+++ b/src/main/identity-manager.test.js
@@ -449,6 +449,74 @@ describe('identity-manager ledger accounts', () => {
   });
 });
 
+describe('identity-manager vaughan accounts', () => {
+  let tmpDir;
+  let envSnapshot;
+  let identityManager;
+
+  const VAUGHAN_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+  const HARDWARE_INDEX_BASE = 1000000;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'identity-manager-vaughan-'));
+    envSnapshot = snapshotEnv();
+    process.env.FREEDOM_IDENTITY_DATA = tmpDir;
+    identityManager = loadMainModule(require.resolve('./identity-manager'), {
+      userDataDir: tmpDir,
+      extraMocks: {
+        [require.resolve('./identity')]: () => ({
+          getMnemonic: jest.fn(() => null),
+          isUnlocked: jest.fn(() => false),
+        }),
+      },
+    }).mod;
+  });
+
+  afterEach(() => {
+    restoreEnv(envSnapshot);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeVaultMeta(meta) {
+    fs.writeFileSync(path.join(tmpDir, 'vault-meta.json'), JSON.stringify(meta, null, 2), 'utf-8');
+  }
+
+  function readVaultMeta() {
+    return JSON.parse(fs.readFileSync(path.join(tmpDir, 'vault-meta.json'), 'utf-8'));
+  }
+
+  function seedMainWallet() {
+    writeVaultMeta({
+      activeWalletIndex: 0,
+      addresses: { userWallet: '0x0000000000000000000000000000000000000001' },
+      derivedWallets: [
+        { index: 0, name: 'Main Wallet', address: '0x0000000000000000000000000000000000000001' },
+      ],
+    });
+  }
+
+  test('addVaughanWallet appends a typed record and auto-names', async () => {
+    seedMainWallet();
+    const wallet = await identityManager.addVaughanWallet('', VAUGHAN_ADDRESS);
+    expect(wallet).toEqual({
+      index: HARDWARE_INDEX_BASE,
+      name: 'Vaughan 1',
+      address: VAUGHAN_ADDRESS,
+      type: 'vaughan',
+    });
+    expect(readVaultMeta().derivedWallets[1]).toMatchObject({ type: 'vaughan', address: VAUGHAN_ADDRESS });
+  });
+
+  test('addVaughanWallet rejects duplicates and bad addresses', async () => {
+    seedMainWallet();
+    await identityManager.addVaughanWallet('Primary Vaughan', VAUGHAN_ADDRESS);
+    await expect(identityManager.addVaughanWallet('Again', VAUGHAN_ADDRESS.toLowerCase()))
+      .rejects.toThrow(/already in your wallet list/);
+    await expect(identityManager.addVaughanWallet('Bad', '0x123'))
+      .rejects.toThrow('Invalid Vaughan account address');
+  });
+});
+
 /**
  * A wallet's `index` is both the account id every persisted reference
  * stores (dApp permissions, Swarm publisher identities, activeWalletIndex)

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -219,6 +219,7 @@ const { registerQuickUnlockIpc } = require('./quick-unlock');
 const { registerWalletIpc } = require('./wallet/wallet-ipc');
 const { registerLedgerIpc } = require('./wallet/ledger/ipc');
 const { registerRemoteSignerIpc } = require('./wallet/remote/bridge');
+const { registerVaughanIpc } = require('./wallet/vaughan/ipc');
 const { registerTokenRegistryIpc } = require('./token-registry');
 const { registerRpcManagerIpc } = require('./wallet/rpc-manager');
 const { registerNetworkConfigIpc } = require('./networks/network-ipc');
@@ -313,6 +314,7 @@ async function bootstrap() {
   registerWalletIpc();
   registerLedgerIpc();
   registerRemoteSignerIpc();
+  registerVaughanIpc();
 
   // Let identity (re)injection stop the Bee node before wiping its statestore
   // (which it holds a LevelDB lock on) and restart it with the new key. Without

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -508,6 +508,11 @@ contextBridge.exposeInMainWorld('remoteSigner', {
   addAccount: (name, address) => ipcRenderer.invoke('wallet:add-remote-wallet', name, address),
 });
 
+contextBridge.exposeInMainWorld('vaughan', {
+  getAccounts: () => ipcRenderer.invoke('vaughan:get-accounts'),
+  addAccount: (name, address) => ipcRenderer.invoke('wallet:add-vaughan-wallet', name, address),
+});
+
 contextBridge.exposeInMainWorld('swarmNode', {
   getStamps: () => ipcRenderer.invoke('swarm:get-stamps'),
   getStorageCost: (sizeGB, durationDays) =>

--- a/src/main/wallet/signers.js
+++ b/src/main/wallet/signers.js
@@ -5,7 +5,8 @@
  * private keys. The account's `type` (from vault-meta, see
  * identity-manager's WALLET_TYPES) picks the backend: vault-backed
  * mnemonic accounts sign locally with a borrowed key, Ledger accounts
- * sign on the device.
+ * sign on the device, Vaughan accounts sign through the local Vaughan
+ * provider bridge.
  *
  * Input normalization (0x-hex personal messages → raw bytes, JSON-string
  * typed data → object) happens once in the factory, so backends always
@@ -25,6 +26,7 @@ const { withVaultPrivateKey, isValidWalletIndex } = require('./vault-access');
 const { getWalletRecord, isHardwareWalletIndex, WALLET_TYPES } = require('../identity-manager');
 const { createLedgerBackend } = require('./ledger/signer');
 const { createRemoteBackend } = require('./remote/signer');
+const { createVaughanBackend } = require('./vaughan/signer');
 const { withoutDomainType } = require('./signing-utils');
 
 /**
@@ -120,6 +122,8 @@ function getSigner(walletIndex) {
     backend = createLedgerBackend(record);
   } else if (record && record.type === WALLET_TYPES.REMOTE) {
     backend = createRemoteBackend(record);
+  } else if (record && record.type === WALLET_TYPES.VAUGHAN) {
+    backend = createVaughanBackend(record);
   } else {
     backend = createVaultBackend(walletIndex);
   }

--- a/src/main/wallet/signers.test.js
+++ b/src/main/wallet/signers.test.js
@@ -26,6 +26,13 @@ const mockRemoteBackend = {
   sendTransaction: jest.fn(),
 };
 const mockCreateRemoteBackend = jest.fn(() => mockRemoteBackend);
+const mockVaughanBackend = {
+  getAddress: jest.fn(),
+  signTransaction: jest.fn(),
+  signMessage: jest.fn(),
+  signTypedData: jest.fn(),
+};
+const mockCreateVaughanBackend = jest.fn(() => mockVaughanBackend);
 
 jest.mock('../identity-manager', () => ({
   loadIdentityModule: jest.fn(async () => mockIdentity),
@@ -33,7 +40,12 @@ jest.mock('../identity-manager', () => ({
   // Mirrors identity-manager's HARDWARE_INDEX_BASE (inlined: jest.mock
   // factories may not close over out-of-scope constants).
   isHardwareWalletIndex: (index) => Number.isInteger(index) && index >= 1000000,
-  WALLET_TYPES: { MNEMONIC: 'mnemonic', LEDGER: 'ledger', REMOTE: 'remote' },
+  WALLET_TYPES: {
+    MNEMONIC: 'mnemonic',
+    LEDGER: 'ledger',
+    REMOTE: 'remote',
+    VAUGHAN: 'vaughan',
+  },
 }));
 jest.mock('../vault-timer', () => ({
   resetVaultAutoLockTimer: mockResetVaultAutoLockTimer,
@@ -43,6 +55,9 @@ jest.mock('./ledger/signer', () => ({
 }));
 jest.mock('./remote/signer', () => ({
   createRemoteBackend: (...args) => mockCreateRemoteBackend(...args),
+}));
+jest.mock('./vaughan/signer', () => ({
+  createVaughanBackend: (...args) => mockCreateVaughanBackend(...args),
 }));
 
 const { getSigner } = require('./signers');
@@ -245,5 +260,38 @@ describe('getSigner (remote-backed dispatch)', () => {
     const signer = getSigner(4);
     await signer.signMessage('0x48656c6c6f');
     expect(mockRemoteBackend.signMessage).toHaveBeenCalledWith(Buffer.from('Hello', 'utf8'));
+  });
+});
+
+describe('getSigner (vaughan-backed dispatch)', () => {
+  const VAUGHAN_RECORD = {
+    index: 1000005,
+    name: 'Vaughan Wallet',
+    address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    type: 'vaughan',
+  };
+
+  beforeEach(() => {
+    mockGetWalletRecord.mockReturnValue(VAUGHAN_RECORD);
+    mockVaughanBackend.getAddress.mockReset().mockResolvedValue(VAUGHAN_RECORD.address);
+    mockVaughanBackend.signMessage.mockReset().mockResolvedValue('0xvsig');
+    mockVaughanBackend.signTransaction.mockReset().mockResolvedValue('0xvtx');
+    mockVaughanBackend.signTypedData.mockReset().mockResolvedValue('0xv712');
+    mockCreateVaughanBackend.mockClear();
+  });
+
+  test('routes to the vaughan backend and never touches the vault', async () => {
+    const signer = getSigner(VAUGHAN_RECORD.index);
+    await expect(signer.getAddress()).resolves.toBe(VAUGHAN_RECORD.address);
+    await expect(signer.signMessage('hello')).resolves.toBe('0xvsig');
+    expect(mockCreateVaughanBackend).toHaveBeenCalledWith(VAUGHAN_RECORD);
+    expect(mockIdentity.isUnlocked).not.toHaveBeenCalled();
+    expect(mockIdentity.exportPrivateKey).not.toHaveBeenCalled();
+  });
+
+  test('factory normalization applies to vaughan messages', async () => {
+    const signer = getSigner(VAUGHAN_RECORD.index);
+    await signer.signMessage('0x48656c6c6f');
+    expect(mockVaughanBackend.signMessage).toHaveBeenCalledWith(Buffer.from('Hello', 'utf8'));
   });
 });

--- a/src/main/wallet/vaughan/errors.js
+++ b/src/main/wallet/vaughan/errors.js
@@ -8,6 +8,7 @@
 const VAUGHAN_ERROR_CODES = {
   USER_REJECTED: 'VAUGHAN_USER_REJECTED',
   UNAUTHORIZED: 'VAUGHAN_UNAUTHORIZED',
+  NOT_CONNECTED: 'VAUGHAN_NOT_CONNECTED',
   DISCONNECTED: 'VAUGHAN_DISCONNECTED',
   UNSUPPORTED_METHOD: 'VAUGHAN_UNSUPPORTED_METHOD',
   INVALID_PARAMS: 'VAUGHAN_INVALID_PARAMS',
@@ -25,25 +26,36 @@ const EIP1193_TO_VAUGHAN = {
 const MESSAGES = {
   [VAUGHAN_ERROR_CODES.USER_REJECTED]: 'Request rejected in Vaughan.',
   [VAUGHAN_ERROR_CODES.UNAUTHORIZED]: 'Vaughan rejected this account or origin.',
+  [VAUGHAN_ERROR_CODES.NOT_CONNECTED]:
+    'Vaughan is locked or this site was disconnected. Unlock Vaughan and reconnect from the dApp.',
   [VAUGHAN_ERROR_CODES.DISCONNECTED]: 'Cannot connect to Vaughan. Start the wallet and try again.',
   [VAUGHAN_ERROR_CODES.UNSUPPORTED_METHOD]: 'Vaughan does not support this request.',
   [VAUGHAN_ERROR_CODES.INVALID_PARAMS]: 'Invalid request for Vaughan signer.',
   [VAUGHAN_ERROR_CODES.INTERNAL]: 'Vaughan request failed. Try again.',
 };
 
-function createVaughanError(code, cause) {
-  const err = new Error(MESSAGES[code] || MESSAGES[VAUGHAN_ERROR_CODES.INTERNAL], { cause });
+function createVaughanError(code, cause, message) {
+  const text = message || MESSAGES[code] || MESSAGES[VAUGHAN_ERROR_CODES.INTERNAL];
+  const err = new Error(text, { cause });
   err.code = code;
   return err;
 }
 
 function mapVaughanError(err) {
-  if (err && typeof err === 'object' && typeof err.code === 'string' && err.code.startsWith('VAUGHAN_')) {
+  if (
+    err &&
+    typeof err === 'object' &&
+    typeof err.code === 'string' &&
+    err.code.startsWith('VAUGHAN_')
+  ) {
     return err;
   }
   if (err && typeof err === 'object' && typeof err.eip1193Code === 'number') {
     const code = EIP1193_TO_VAUGHAN[err.eip1193Code] || VAUGHAN_ERROR_CODES.INTERNAL;
-    return createVaughanError(code, err);
+    // Prefer the server's detail ("wallet is locked; unlock it first", …)
+    // over the generic mapping — Vaughan never puts secrets in messages.
+    const detail = typeof err.message === 'string' && err.message ? err.message : undefined;
+    return createVaughanError(code, err, detail);
   }
   if (err && typeof err === 'object' && typeof err.code === 'string') {
     if (['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EPIPE'].includes(err.code)) {

--- a/src/main/wallet/vaughan/errors.js
+++ b/src/main/wallet/vaughan/errors.js
@@ -1,0 +1,56 @@
+/**
+ * Vaughan bridge error mapping.
+ *
+ * Vaughan speaks EIP-1193 codes over JSON-RPC; map them to stable app-level
+ * codes so callers can distinguish user rejection from transport failures.
+ */
+
+const VAUGHAN_ERROR_CODES = {
+  USER_REJECTED: 'VAUGHAN_USER_REJECTED',
+  UNAUTHORIZED: 'VAUGHAN_UNAUTHORIZED',
+  DISCONNECTED: 'VAUGHAN_DISCONNECTED',
+  UNSUPPORTED_METHOD: 'VAUGHAN_UNSUPPORTED_METHOD',
+  INVALID_PARAMS: 'VAUGHAN_INVALID_PARAMS',
+  INTERNAL: 'VAUGHAN_INTERNAL',
+};
+
+const EIP1193_TO_VAUGHAN = {
+  4001: VAUGHAN_ERROR_CODES.USER_REJECTED,
+  4100: VAUGHAN_ERROR_CODES.UNAUTHORIZED,
+  4200: VAUGHAN_ERROR_CODES.UNSUPPORTED_METHOD,
+  4900: VAUGHAN_ERROR_CODES.DISCONNECTED,
+  '-32602': VAUGHAN_ERROR_CODES.INVALID_PARAMS,
+};
+
+const MESSAGES = {
+  [VAUGHAN_ERROR_CODES.USER_REJECTED]: 'Request rejected in Vaughan.',
+  [VAUGHAN_ERROR_CODES.UNAUTHORIZED]: 'Vaughan rejected this account or origin.',
+  [VAUGHAN_ERROR_CODES.DISCONNECTED]: 'Cannot connect to Vaughan. Start the wallet and try again.',
+  [VAUGHAN_ERROR_CODES.UNSUPPORTED_METHOD]: 'Vaughan does not support this request.',
+  [VAUGHAN_ERROR_CODES.INVALID_PARAMS]: 'Invalid request for Vaughan signer.',
+  [VAUGHAN_ERROR_CODES.INTERNAL]: 'Vaughan request failed. Try again.',
+};
+
+function createVaughanError(code, cause) {
+  const err = new Error(MESSAGES[code] || MESSAGES[VAUGHAN_ERROR_CODES.INTERNAL], { cause });
+  err.code = code;
+  return err;
+}
+
+function mapVaughanError(err) {
+  if (err && typeof err === 'object' && typeof err.code === 'string' && err.code.startsWith('VAUGHAN_')) {
+    return err;
+  }
+  if (err && typeof err === 'object' && typeof err.eip1193Code === 'number') {
+    const code = EIP1193_TO_VAUGHAN[err.eip1193Code] || VAUGHAN_ERROR_CODES.INTERNAL;
+    return createVaughanError(code, err);
+  }
+  if (err && typeof err === 'object' && typeof err.code === 'string') {
+    if (['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EPIPE'].includes(err.code)) {
+      return createVaughanError(VAUGHAN_ERROR_CODES.DISCONNECTED, err);
+    }
+  }
+  return createVaughanError(VAUGHAN_ERROR_CODES.INTERNAL, err);
+}
+
+module.exports = { VAUGHAN_ERROR_CODES, createVaughanError, mapVaughanError };

--- a/src/main/wallet/vaughan/ipc.js
+++ b/src/main/wallet/vaughan/ipc.js
@@ -9,6 +9,7 @@
 const { ipcMain } = require('electron');
 const { rpcRequest } = require('./transport');
 const { mapVaughanError } = require('./errors');
+const { SIGN_TIMEOUT_MS } = require('./signer');
 
 function registerVaughanIpc() {
   // Requires a running Vaughan provider on loopback with the wallet unlocked;
@@ -17,9 +18,12 @@ function registerVaughanIpc() {
   ipcMain.handle('vaughan:get-accounts', async () => {
     try {
       // Prefer the connect gesture so Vaughan may surface an unlock/connect UX.
+      // It can sit on Vaughan's interactive approval (60s auto-deny), so use
+      // the signing-grade timeout; the read-only eth_accounts fallback keeps
+      // the short probe default.
       let accounts;
       try {
-        accounts = await rpcRequest('eth_requestAccounts', []);
+        accounts = await rpcRequest('eth_requestAccounts', [], { timeoutMs: SIGN_TIMEOUT_MS });
       } catch (err) {
         // Fall back to a read-only probe when the connect method is unavailable.
         if (err && err.eip1193Code === 4200) {

--- a/src/main/wallet/vaughan/ipc.js
+++ b/src/main/wallet/vaughan/ipc.js
@@ -1,0 +1,43 @@
+/**
+ * Vaughan IPC handlers.
+ *
+ * Account discovery for the "Connect Vaughan wallet" flow. Adding the chosen
+ * account to the wallet list goes through identity-manager's
+ * `wallet:add-vaughan-wallet` handler, next to the other wallet-list mutations.
+ */
+
+const { ipcMain } = require('electron');
+const { rpcRequest } = require('./transport');
+const { mapVaughanError } = require('./errors');
+
+function registerVaughanIpc() {
+  // Requires a running Vaughan provider on loopback with the wallet unlocked;
+  // errors carry a stable VAUGHAN_* code the renderer turns into instructions
+  // ("start Vaughan", "unlock the wallet", …).
+  ipcMain.handle('vaughan:get-accounts', async () => {
+    try {
+      // Prefer the connect gesture so Vaughan may surface an unlock/connect UX.
+      let accounts;
+      try {
+        accounts = await rpcRequest('eth_requestAccounts', []);
+      } catch (err) {
+        // Fall back to a read-only probe when the connect method is unavailable.
+        if (err && err.eip1193Code === 4200) {
+          accounts = await rpcRequest('eth_accounts', []);
+        } else {
+          throw err;
+        }
+      }
+      const normalized = Array.isArray(accounts)
+        ? accounts.filter((a) => typeof a === 'string' && a.length > 0)
+        : [];
+      return { success: true, accounts: normalized };
+    } catch (err) {
+      const mapped = mapVaughanError(err);
+      console.error('[VaughanIPC] Account discovery failed:', mapped.message);
+      return { success: false, error: mapped.message, code: mapped.code };
+    }
+  });
+}
+
+module.exports = { registerVaughanIpc };

--- a/src/main/wallet/vaughan/ipc.test.js
+++ b/src/main/wallet/vaughan/ipc.test.js
@@ -1,0 +1,49 @@
+const { registerVaughanIpc } = require('./ipc');
+
+const mockRpcRequest = jest.fn();
+const mockHandlers = new Map();
+
+jest.mock('./transport', () => ({
+  rpcRequest: (...args) => mockRpcRequest(...args),
+}));
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel, fn) => {
+      mockHandlers.set(channel, fn);
+    },
+  },
+}));
+
+describe('registerVaughanIpc', () => {
+  beforeEach(() => {
+    mockHandlers.clear();
+    mockRpcRequest.mockReset();
+    registerVaughanIpc();
+  });
+
+  test('vaughan:get-accounts returns eth_requestAccounts results', async () => {
+    mockRpcRequest.mockResolvedValueOnce(['0xAbc']);
+    const handler = mockHandlers.get('vaughan:get-accounts');
+    await expect(handler()).resolves.toEqual({ success: true, accounts: ['0xAbc'] });
+    expect(mockRpcRequest).toHaveBeenCalledWith('eth_requestAccounts', []);
+  });
+
+  test('falls back to eth_accounts when eth_requestAccounts is unsupported', async () => {
+    const unsupported = Object.assign(new Error('unsupported'), { eip1193Code: 4200 });
+    mockRpcRequest.mockRejectedValueOnce(unsupported).mockResolvedValueOnce(['0xDef']);
+    const handler = mockHandlers.get('vaughan:get-accounts');
+    await expect(handler()).resolves.toEqual({ success: true, accounts: ['0xDef'] });
+    expect(mockRpcRequest).toHaveBeenNthCalledWith(1, 'eth_requestAccounts', []);
+    expect(mockRpcRequest).toHaveBeenNthCalledWith(2, 'eth_accounts', []);
+  });
+
+  test('maps transport failures to VAUGHAN_* codes', async () => {
+    mockRpcRequest.mockRejectedValueOnce(Object.assign(new Error('refused'), { code: 'ECONNREFUSED' }));
+    const handler = mockHandlers.get('vaughan:get-accounts');
+    await expect(handler()).resolves.toMatchObject({
+      success: false,
+      code: 'VAUGHAN_DISCONNECTED',
+    });
+  });
+});

--- a/src/main/wallet/vaughan/ipc.test.js
+++ b/src/main/wallet/vaughan/ipc.test.js
@@ -1,4 +1,5 @@
 const { registerVaughanIpc } = require('./ipc');
+const { SIGN_TIMEOUT_MS } = require('./signer');
 
 const mockRpcRequest = jest.fn();
 const mockHandlers = new Map();
@@ -26,7 +27,7 @@ describe('registerVaughanIpc', () => {
     mockRpcRequest.mockResolvedValueOnce(['0xAbc']);
     const handler = mockHandlers.get('vaughan:get-accounts');
     await expect(handler()).resolves.toEqual({ success: true, accounts: ['0xAbc'] });
-    expect(mockRpcRequest).toHaveBeenCalledWith('eth_requestAccounts', []);
+    expect(mockRpcRequest).toHaveBeenCalledWith('eth_requestAccounts', [], { timeoutMs: SIGN_TIMEOUT_MS });
   });
 
   test('falls back to eth_accounts when eth_requestAccounts is unsupported', async () => {
@@ -34,7 +35,7 @@ describe('registerVaughanIpc', () => {
     mockRpcRequest.mockRejectedValueOnce(unsupported).mockResolvedValueOnce(['0xDef']);
     const handler = mockHandlers.get('vaughan:get-accounts');
     await expect(handler()).resolves.toEqual({ success: true, accounts: ['0xDef'] });
-    expect(mockRpcRequest).toHaveBeenNthCalledWith(1, 'eth_requestAccounts', []);
+    expect(mockRpcRequest).toHaveBeenNthCalledWith(1, 'eth_requestAccounts', [], { timeoutMs: SIGN_TIMEOUT_MS });
     expect(mockRpcRequest).toHaveBeenNthCalledWith(2, 'eth_accounts', []);
   });
 

--- a/src/main/wallet/vaughan/session-token.js
+++ b/src/main/wallet/vaughan/session-token.js
@@ -1,0 +1,89 @@
+/**
+ * Vaughan provider session-token resolution.
+ *
+ * The Vaughan provider (ws://127.0.0.1:8745) writes a per-run bearer token to
+ * `<dataDir>/vaughan-cli/provider.session` (mode 0600) and requires it from
+ * clients it cannot otherwise attest — the same model Vaughan's own dApp
+ * browser launcher uses. Named wallet profiles keep their token at
+ * `<dataDir>/vaughan-cli/profiles/<name>/provider.session`.
+ *
+ * The token is read at call time and never cached or logged: restarting
+ * Vaughan rotates the token and Freedom picks the new one up on the next
+ * request. VAUGHAN_PROVIDER_SESSION_TOKEN overrides file lookup, matching the
+ * env var Vaughan's launcher honors. Returns null when no token exists yet —
+ * older Vaughan builds accept tokenless loopback clients, so absence is not
+ * an error here.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ENV_TOKEN = 'VAUGHAN_PROVIDER_SESSION_TOKEN';
+const APP_DIR = 'vaughan-cli';
+const TOKEN_FILE = 'provider.session';
+
+function dataDir() {
+  if (process.platform === 'win32') {
+    return process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+  }
+  if (process.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Application Support');
+  }
+  return process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
+}
+
+function readTokenFile(file) {
+  try {
+    const token = fs.readFileSync(file, 'utf8').trim();
+    return token.length > 0 ? token : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function resolveSessionToken() {
+  const fromEnv = (process.env[ENV_TOKEN] || '').trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  const base = path.join(dataDir(), APP_DIR);
+  const fromDefault = readTokenFile(path.join(base, TOKEN_FILE));
+  if (fromDefault) {
+    return fromDefault;
+  }
+
+  // Named profiles: newest token wins — the running provider is most likely
+  // the one whose session file was written most recently.
+  const profilesDir = path.join(base, 'profiles');
+  let entries;
+  try {
+    entries = fs.readdirSync(profilesDir, { withFileTypes: true });
+  } catch (_) {
+    return null;
+  }
+  let best = null;
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const file = path.join(profilesDir, entry.name, TOKEN_FILE);
+    let stat;
+    try {
+      stat = fs.statSync(file);
+    } catch (_) {
+      continue;
+    }
+    if (best && stat.mtimeMs <= best.mtimeMs) {
+      continue;
+    }
+    const token = readTokenFile(file);
+    if (token) {
+      best = { token, mtimeMs: stat.mtimeMs };
+    }
+  }
+  return best ? best.token : null;
+}
+
+module.exports = { resolveSessionToken, ENV_TOKEN };

--- a/src/main/wallet/vaughan/session-token.test.js
+++ b/src/main/wallet/vaughan/session-token.test.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+let mockHome;
+
+jest.mock('os', () => {
+  const real = jest.requireActual('os');
+  return {
+    ...real,
+    homedir: () => mockHome,
+  };
+});
+
+const { resolveSessionToken, ENV_TOKEN } = require('./session-token');
+
+function platformDataDir(home) {
+  if (process.platform === 'win32') {
+    return path.join(home, 'AppData', 'Roaming');
+  }
+  if (process.platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support');
+  }
+  return path.join(home, '.local', 'share');
+}
+
+describe('resolveSessionToken', () => {
+  let savedEnv;
+
+  beforeEach(() => {
+    mockHome = fs.mkdtempSync(path.join(os.tmpdir(), 'vaughan-session-'));
+    savedEnv = {
+      token: process.env[ENV_TOKEN],
+      xdg: process.env.XDG_DATA_HOME,
+      appdata: process.env.APPDATA,
+    };
+    delete process.env[ENV_TOKEN];
+    delete process.env.XDG_DATA_HOME;
+    delete process.env.APPDATA;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries({
+      [ENV_TOKEN]: savedEnv.token,
+      XDG_DATA_HOME: savedEnv.xdg,
+      APPDATA: savedEnv.appdata,
+    })) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    fs.rmSync(mockHome, { recursive: true, force: true });
+  });
+
+  function writeToken(rel, token) {
+    const file = path.join(platformDataDir(mockHome), 'vaughan-cli', rel);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, token);
+    return file;
+  }
+
+  test('returns null when no token exists anywhere', () => {
+    expect(resolveSessionToken()).toBeNull();
+  });
+
+  test('env override wins over files', () => {
+    writeToken('provider.session', 'file-token');
+    process.env[ENV_TOKEN] = ' env-token ';
+    expect(resolveSessionToken()).toBe('env-token');
+  });
+
+  test('reads and trims the default profile token', () => {
+    writeToken('provider.session', '  default-token\n');
+    expect(resolveSessionToken()).toBe('default-token');
+  });
+
+  test('default profile beats named profiles', () => {
+    writeToken('provider.session', 'default-token');
+    writeToken(path.join('profiles', 'work', 'provider.session'), 'profile-token');
+    expect(resolveSessionToken()).toBe('default-token');
+  });
+
+  test('newest named profile wins when there is no default token', () => {
+    const older = writeToken(path.join('profiles', 'old', 'provider.session'), 'old-token');
+    writeToken(path.join('profiles', 'new', 'provider.session'), 'new-token');
+    // Backdate the older profile so mtime ordering is deterministic.
+    const past = new Date(Date.now() - 60_000);
+    fs.utimesSync(older, past, past);
+    expect(resolveSessionToken()).toBe('new-token');
+  });
+
+  test('skips empty token files', () => {
+    writeToken('provider.session', '   \n');
+    writeToken(path.join('profiles', 'work', 'provider.session'), 'profile-token');
+    expect(resolveSessionToken()).toBe('profile-token');
+  });
+});

--- a/src/main/wallet/vaughan/signer.js
+++ b/src/main/wallet/vaughan/signer.js
@@ -78,8 +78,18 @@ function assertAccountMatches(record, accounts) {
     throw createVaughanError(VAUGHAN_ERROR_CODES.UNAUTHORIZED);
   }
   const actual = Array.isArray(accounts) && accounts[0] ? String(accounts[0]).toLowerCase() : '';
+  if (!actual) {
+    // eth_accounts answered empty: Vaughan is locked or the site grant is
+    // gone (lock/restart). Distinct from an account mismatch — the fix is
+    // reconnecting, not switching accounts.
+    throw createVaughanError(VAUGHAN_ERROR_CODES.NOT_CONNECTED);
+  }
   if (actual !== expected) {
-    throw createVaughanError(VAUGHAN_ERROR_CODES.UNAUTHORIZED);
+    throw createVaughanError(
+      VAUGHAN_ERROR_CODES.UNAUTHORIZED,
+      undefined,
+      "Vaughan's active account differs from the paired account. Switch accounts in Vaughan or re-pair."
+    );
   }
 }
 

--- a/src/main/wallet/vaughan/signer.js
+++ b/src/main/wallet/vaughan/signer.js
@@ -1,0 +1,132 @@
+/**
+ * Vaughan signing backend for the wallet signer factory.
+ *
+ * Mirrors the Ledger backend contract: verify the connected Vaughan account
+ * still matches the persisted record before every signing call, then forward
+ * to the local EIP-1193 WebSocket server. Approval UX lives in Vaughan (TUI);
+ * this process never sees private keys.
+ *
+ * `signTransaction` uses `vaughan_signTransaction` (sign-and-return raw tx)
+ * so Freedom Browser can broadcast via its own RPC pool — matching the
+ * existing `Signer.signTransaction` contract.
+ */
+
+const { rpcRequest } = require('./transport');
+const { createVaughanError, VAUGHAN_ERROR_CODES } = require('./errors');
+
+/** Signing needs human approval in Vaughan; allow several minutes. */
+const SIGN_TIMEOUT_MS = 5 * 60 * 1000;
+
+function asPersonalSignMessage(message) {
+  if (Buffer.isBuffer(message)) {
+    return '0x' + message.toString('hex');
+  }
+  if (message instanceof Uint8Array) {
+    return '0x' + Buffer.from(message).toString('hex');
+  }
+  return String(message);
+}
+
+/** EIP-1193 quantities are hex strings; ethers may hand us bigint/number. */
+function toHexQuantity(value) {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    if (value.startsWith('0x') || value.startsWith('0X')) {
+      return value;
+    }
+    if (/^\d+$/.test(value)) {
+      return '0x' + BigInt(value).toString(16);
+    }
+    return value;
+  }
+  if (typeof value === 'bigint' || typeof value === 'number') {
+    return '0x' + BigInt(value).toString(16);
+  }
+  return undefined;
+}
+
+/**
+ * Map an ethers-style unsigned tx object into EIP-1193 `TxParams`.
+ *
+ * @param {object} tx
+ * @param {string} fromAddress
+ */
+function toEip1193Tx(tx, fromAddress) {
+  const to = tx.to === null || tx.to === undefined ? undefined : String(tx.to);
+  const data = tx.data !== undefined && tx.data !== null ? String(tx.data) : undefined;
+  const params = {
+    from: fromAddress,
+    to,
+    data,
+    value: toHexQuantity(tx.value),
+    gas: toHexQuantity(tx.gasLimit ?? tx.gas),
+    gasPrice: toHexQuantity(tx.gasPrice),
+    maxFeePerGas: toHexQuantity(tx.maxFeePerGas),
+    maxPriorityFeePerGas: toHexQuantity(tx.maxPriorityFeePerGas),
+    nonce: toHexQuantity(tx.nonce),
+    chainId: toHexQuantity(tx.chainId),
+  };
+  // Drop undefined keys so Vaughan does not see explicit nulls.
+  return Object.fromEntries(Object.entries(params).filter(([, v]) => v !== undefined));
+}
+
+function assertAccountMatches(record, accounts) {
+  const expected = (record.address || '').toLowerCase();
+  if (!expected) {
+    throw createVaughanError(VAUGHAN_ERROR_CODES.UNAUTHORIZED);
+  }
+  const actual = Array.isArray(accounts) && accounts[0] ? String(accounts[0]).toLowerCase() : '';
+  if (actual !== expected) {
+    throw createVaughanError(VAUGHAN_ERROR_CODES.UNAUTHORIZED);
+  }
+}
+
+async function withVerifiedAccount(record, task) {
+  const accounts = await rpcRequest('eth_accounts', []);
+  assertAccountMatches(record, accounts);
+  return task();
+}
+
+/**
+ * @param {{address: string, type?: string}} record - Vaughan wallet record from vault-meta
+ * @returns {import('../signers').Signer}
+ */
+function createVaughanBackend(record) {
+  return {
+    getAddress: async () => {
+      const accounts = await rpcRequest('eth_accounts', []);
+      assertAccountMatches(record, accounts);
+      return record.address;
+    },
+
+    signMessage: async (message) =>
+      withVerifiedAccount(record, () =>
+        rpcRequest('personal_sign', [asPersonalSignMessage(message), record.address], {
+          timeoutMs: SIGN_TIMEOUT_MS,
+        })
+      ),
+
+    signTransaction: async (tx) =>
+      withVerifiedAccount(record, () =>
+        rpcRequest('vaughan_signTransaction', [toEip1193Tx(tx, record.address)], {
+          timeoutMs: SIGN_TIMEOUT_MS,
+        })
+      ),
+
+    signTypedData: async (typedData) =>
+      withVerifiedAccount(record, () =>
+        rpcRequest('eth_signTypedData_v4', [record.address, typedData], {
+          timeoutMs: SIGN_TIMEOUT_MS,
+        })
+      ),
+  };
+}
+
+module.exports = {
+  createVaughanBackend,
+  toEip1193Tx,
+  toHexQuantity,
+  SIGN_TIMEOUT_MS,
+};

--- a/src/main/wallet/vaughan/signer.test.js
+++ b/src/main/wallet/vaughan/signer.test.js
@@ -1,0 +1,123 @@
+const { createVaughanBackend, toEip1193Tx } = require('./signer');
+
+const mockRpcRequest = jest.fn();
+
+jest.mock('./transport', () => ({
+  rpcRequest: (...args) => mockRpcRequest(...args),
+}));
+
+describe('createVaughanBackend', () => {
+  const record = {
+    index: 1000001,
+    name: 'Vaughan 1',
+    address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    type: 'vaughan',
+  };
+
+  beforeEach(() => {
+    mockRpcRequest.mockReset();
+  });
+
+  test('getAddress verifies the connected account matches the record', async () => {
+    mockRpcRequest.mockResolvedValueOnce([record.address]);
+    const backend = createVaughanBackend(record);
+    await expect(backend.getAddress()).resolves.toBe(record.address);
+    expect(mockRpcRequest).toHaveBeenCalledWith('eth_accounts', []);
+  });
+
+  test('signMessage requests personal_sign with normalized hex when input is bytes', async () => {
+    mockRpcRequest
+      .mockResolvedValueOnce([record.address]) // eth_accounts
+      .mockResolvedValueOnce('0xsig'); // personal_sign
+    const backend = createVaughanBackend(record);
+    await expect(backend.signMessage(Buffer.from('Hello', 'utf8'))).resolves.toBe('0xsig');
+    expect(mockRpcRequest).toHaveBeenNthCalledWith(1, 'eth_accounts', []);
+    expect(mockRpcRequest).toHaveBeenNthCalledWith(
+      2,
+      'personal_sign',
+      ['0x48656c6c6f', record.address],
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    );
+  });
+
+  test('signTransaction maps ethers fields and calls vaughan_signTransaction', async () => {
+    mockRpcRequest
+      .mockResolvedValueOnce([record.address])
+      .mockResolvedValueOnce('0xsignedtx');
+    const backend = createVaughanBackend(record);
+    const raw = await backend.signTransaction({
+      to: '0x0000000000000000000000000000000000000001',
+      value: 1n,
+      gasLimit: 21000n,
+      maxFeePerGas: 2n,
+      maxPriorityFeePerGas: 1n,
+      nonce: 7,
+      chainId: 943,
+      data: '0x',
+    });
+    expect(raw).toBe('0xsignedtx');
+    expect(mockRpcRequest).toHaveBeenNthCalledWith(
+      2,
+      'vaughan_signTransaction',
+      [
+        {
+          from: record.address,
+          to: '0x0000000000000000000000000000000000000001',
+          data: '0x',
+          value: '0x1',
+          gas: '0x5208',
+          maxFeePerGas: '0x2',
+          maxPriorityFeePerGas: '0x1',
+          nonce: '0x7',
+          chainId: '0x3af',
+        },
+      ],
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    );
+  });
+
+  test('signTypedData forwards eth_signTypedData_v4 with full payload', async () => {
+    const typedData = {
+      domain: { name: 'Test', version: '1', chainId: 1 },
+      types: { EIP712Domain: [], Mail: [{ name: 'contents', type: 'string' }] },
+      primaryType: 'Mail',
+      message: { contents: 'hi' },
+    };
+    mockRpcRequest
+      .mockResolvedValueOnce([record.address])
+      .mockResolvedValueOnce('0x712sig');
+    const backend = createVaughanBackend(record);
+    await expect(backend.signTypedData(typedData)).resolves.toBe('0x712sig');
+    expect(mockRpcRequest).toHaveBeenNthCalledWith(
+      2,
+      'eth_signTypedData_v4',
+      [record.address, typedData],
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    );
+  });
+
+  test('rejects when provider account does not match record address', async () => {
+    mockRpcRequest.mockResolvedValueOnce(['0x0000000000000000000000000000000000000000']);
+    const backend = createVaughanBackend(record);
+    await expect(backend.signMessage('hello')).rejects.toMatchObject({ code: 'VAUGHAN_UNAUTHORIZED' });
+  });
+});
+
+describe('toEip1193Tx', () => {
+  test('omits null to (contract creation) and undefined quantities', () => {
+    expect(
+      toEip1193Tx(
+        {
+          to: null,
+          data: '0x60806040',
+          value: 0n,
+        },
+        '0xabc'
+      )
+    ).toEqual({
+      from: '0xabc',
+      data: '0x60806040',
+      value: '0x0',
+    });
+  });
+});

--- a/src/main/wallet/vaughan/signer.test.js
+++ b/src/main/wallet/vaughan/signer.test.js
@@ -41,9 +41,7 @@ describe('createVaughanBackend', () => {
   });
 
   test('signTransaction maps ethers fields and calls vaughan_signTransaction', async () => {
-    mockRpcRequest
-      .mockResolvedValueOnce([record.address])
-      .mockResolvedValueOnce('0xsignedtx');
+    mockRpcRequest.mockResolvedValueOnce([record.address]).mockResolvedValueOnce('0xsignedtx');
     const backend = createVaughanBackend(record);
     const raw = await backend.signTransaction({
       to: '0x0000000000000000000000000000000000000001',
@@ -83,9 +81,7 @@ describe('createVaughanBackend', () => {
       primaryType: 'Mail',
       message: { contents: 'hi' },
     };
-    mockRpcRequest
-      .mockResolvedValueOnce([record.address])
-      .mockResolvedValueOnce('0x712sig');
+    mockRpcRequest.mockResolvedValueOnce([record.address]).mockResolvedValueOnce('0x712sig');
     const backend = createVaughanBackend(record);
     await expect(backend.signTypedData(typedData)).resolves.toBe('0x712sig');
     expect(mockRpcRequest).toHaveBeenNthCalledWith(
@@ -99,7 +95,47 @@ describe('createVaughanBackend', () => {
   test('rejects when provider account does not match record address', async () => {
     mockRpcRequest.mockResolvedValueOnce(['0x0000000000000000000000000000000000000000']);
     const backend = createVaughanBackend(record);
-    await expect(backend.signMessage('hello')).rejects.toMatchObject({ code: 'VAUGHAN_UNAUTHORIZED' });
+    await expect(backend.signMessage('hello')).rejects.toMatchObject({
+      code: 'VAUGHAN_UNAUTHORIZED',
+    });
+  });
+
+  test('mismatch message points at account switching, not origin rejection', async () => {
+    mockRpcRequest.mockResolvedValueOnce(['0x0000000000000000000000000000000000000000']);
+    const backend = createVaughanBackend(record);
+    await expect(backend.getAddress()).rejects.toMatchObject({
+      code: 'VAUGHAN_UNAUTHORIZED',
+      message: expect.stringContaining('active account differs'),
+    });
+  });
+
+  test('empty eth_accounts maps to NOT_CONNECTED (locked or grant expired)', async () => {
+    mockRpcRequest.mockResolvedValueOnce([]);
+    const backend = createVaughanBackend(record);
+    await expect(backend.getAddress()).rejects.toMatchObject({
+      code: 'VAUGHAN_NOT_CONNECTED',
+      message: expect.stringContaining('locked or this site was disconnected'),
+    });
+  });
+});
+
+describe('mapVaughanError', () => {
+  const { mapVaughanError } = require('./errors');
+
+  test('keeps the server detail for EIP-1193 errors', () => {
+    const err = new Error('wallet is locked; unlock it first');
+    err.eip1193Code = 4100;
+    const mapped = mapVaughanError(err);
+    expect(mapped.code).toBe('VAUGHAN_UNAUTHORIZED');
+    expect(mapped.message).toBe('wallet is locked; unlock it first');
+  });
+
+  test('falls back to the generic message when the server sent none', () => {
+    const err = new Error('');
+    err.eip1193Code = 4100;
+    const mapped = mapVaughanError(err);
+    expect(mapped.code).toBe('VAUGHAN_UNAUTHORIZED');
+    expect(mapped.message).toBe('Vaughan rejected this account or origin.');
   });
 });
 

--- a/src/main/wallet/vaughan/transport.js
+++ b/src/main/wallet/vaughan/transport.js
@@ -61,6 +61,17 @@ function rpcRequest(method, params = [], opts = {}) {
     });
 
     ws.once('error', fail);
+    ws.once('close', (code) => {
+      // The provider drops gated-out clients without a close frame (observed
+      // as 1006): no response is coming, so fail fast instead of waiting out
+      // the full timeout. After a normal finish() this is a no-op — the
+      // promise is already settled.
+      fail(
+        Object.assign(new Error(`Vaughan closed the connection before responding (code ${code})`), {
+          code: 'EPIPE',
+        })
+      );
+    });
     ws.on('message', (raw) => {
       let msg;
       try {

--- a/src/main/wallet/vaughan/transport.js
+++ b/src/main/wallet/vaughan/transport.js
@@ -1,0 +1,78 @@
+/**
+ * Vaughan JSON-RPC transport over local WebSocket.
+ *
+ * Per-operation connect/close (mirrors Ledger transport lifetime). Sends an
+ * Origin header so Vaughan's trusted-host gate can accept Freedom Browser
+ * and reject arbitrary loopback clients.
+ */
+
+const WebSocket = require('ws');
+
+const { mapVaughanError } = require('./errors');
+
+const DEFAULT_URL = process.env.FREEDOM_VAUGHAN_WS_URL || 'ws://127.0.0.1:8745';
+const DEFAULT_ORIGIN = process.env.FREEDOM_VAUGHAN_WS_ORIGIN || 'https://freedom.browser';
+const REQUEST_TIMEOUT_MS = 10_000;
+
+let nextId = 1;
+
+function rpcRequest(method, params = [], opts = {}) {
+  const url = opts.url || DEFAULT_URL;
+  const origin = opts.origin || DEFAULT_ORIGIN;
+  const timeoutMs = Number.isInteger(opts.timeoutMs) ? opts.timeoutMs : REQUEST_TIMEOUT_MS;
+
+  return new Promise((resolve, reject) => {
+    const id = nextId++;
+    const ws = new WebSocket(url, { headers: { Origin: origin } });
+    const timer = setTimeout(() => {
+      ws.terminate();
+      reject(mapVaughanError(Object.assign(new Error('Vaughan request timed out'), { code: 'ETIMEDOUT' })));
+    }, timeoutMs);
+    const finish = (fn) => (value) => {
+      clearTimeout(timer);
+      try {
+        ws.close();
+      } catch (_) {
+        // no-op
+      }
+      fn(value);
+    };
+    const ok = finish(resolve);
+    const fail = finish((err) => reject(mapVaughanError(err)));
+
+    ws.once('open', () => {
+      ws.send(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id,
+          method,
+          params,
+        })
+      );
+    });
+
+    ws.once('error', fail);
+    ws.on('message', (raw) => {
+      let msg;
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch (err) {
+        fail(err);
+        return;
+      }
+      if (msg.id !== id) {
+        return;
+      }
+      if (msg.error) {
+        const err = new Error(msg.error.message || 'Vaughan RPC error');
+        err.eip1193Code = msg.error.code;
+        err.data = msg.error.data;
+        fail(err);
+        return;
+      }
+      ok(msg.result);
+    });
+  });
+}
+
+module.exports = { rpcRequest, DEFAULT_URL, DEFAULT_ORIGIN };

--- a/src/main/wallet/vaughan/transport.js
+++ b/src/main/wallet/vaughan/transport.js
@@ -2,13 +2,17 @@
  * Vaughan JSON-RPC transport over local WebSocket.
  *
  * Per-operation connect/close (mirrors Ledger transport lifetime). Sends an
- * Origin header so Vaughan's trusted-host gate can accept Freedom Browser
- * and reject arbitrary loopback clients.
+ * Origin header so Vaughan's trusted-host gate can accept Freedom Browser,
+ * plus the provider.session bearer token when one is available — the provider
+ * requires it once token enforcement is on and rejects arbitrary loopback
+ * clients either way. The token travels as an Authorization header, never in
+ * the URL, so it cannot leak through URL logging.
  */
 
 const WebSocket = require('ws');
 
 const { mapVaughanError } = require('./errors');
+const { resolveSessionToken } = require('./session-token');
 
 const DEFAULT_URL = process.env.FREEDOM_VAUGHAN_WS_URL || 'ws://127.0.0.1:8745';
 const DEFAULT_ORIGIN = process.env.FREEDOM_VAUGHAN_WS_ORIGIN || 'https://freedom.browser';
@@ -23,7 +27,12 @@ function rpcRequest(method, params = [], opts = {}) {
 
   return new Promise((resolve, reject) => {
     const id = nextId++;
-    const ws = new WebSocket(url, { headers: { Origin: origin } });
+    const headers = { Origin: origin };
+    const token = resolveSessionToken();
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+    const ws = new WebSocket(url, { headers });
     const timer = setTimeout(() => {
       ws.terminate();
       reject(mapVaughanError(Object.assign(new Error('Vaughan request timed out'), { code: 'ETIMEDOUT' })));

--- a/src/main/wallet/vaughan/transport.test.js
+++ b/src/main/wallet/vaughan/transport.test.js
@@ -1,0 +1,105 @@
+const mockResolveSessionToken = jest.fn();
+
+class MockWebSocket {
+  constructor(url, opts) {
+    this.url = url;
+    this.opts = opts;
+    this.onceListeners = {};
+    this.onListeners = {};
+    this.closed = false;
+    MockWebSocket.instances.push(this);
+  }
+
+  once(event, cb) {
+    if (event === 'open') {
+      setImmediate(cb);
+      return;
+    }
+    this.onceListeners[event] = cb;
+  }
+
+  on(event, cb) {
+    this.onListeners[event] = cb;
+  }
+
+  send(payload) {
+    const req = JSON.parse(payload);
+    this.lastRequest = req;
+    if (!MockWebSocket.replyEnabled) {
+      return;
+    }
+    setImmediate(() => {
+      const onMessage = this.onListeners.message;
+      if (onMessage) {
+        onMessage(Buffer.from(JSON.stringify({ jsonrpc: '2.0', id: req.id, result: ['0xAbc'] })));
+      }
+    });
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+}
+MockWebSocket.instances = [];
+MockWebSocket.replyEnabled = true;
+
+jest.mock('ws', () => MockWebSocket);
+jest.mock('./session-token', () => ({
+  resolveSessionToken: () => mockResolveSessionToken(),
+}));
+
+const { rpcRequest } = require('./transport');
+
+beforeEach(() => {
+  MockWebSocket.instances.length = 0;
+  MockWebSocket.replyEnabled = true;
+  mockResolveSessionToken.mockReset().mockReturnValue(null);
+});
+
+describe('rpcRequest', () => {
+  test('sends the Freedom Origin header derived from the WS URL', async () => {
+    await expect(rpcRequest('eth_accounts', [])).resolves.toEqual(['0xAbc']);
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].opts.headers.Origin).toBe('https://freedom.browser');
+  });
+
+  test('attaches the session token as a Bearer header when available', async () => {
+    mockResolveSessionToken.mockReturnValue('tok-123');
+    await expect(rpcRequest('eth_accounts', [])).resolves.toEqual(['0xAbc']);
+    const { headers } = MockWebSocket.instances[0].opts;
+    expect(headers.Authorization).toBe('Bearer tok-123');
+  });
+
+  test('omits the Authorization header when no token exists', async () => {
+    await expect(rpcRequest('eth_accounts', [])).resolves.toEqual(['0xAbc']);
+    expect(MockWebSocket.instances[0].opts.headers).not.toHaveProperty('Authorization');
+  });
+
+  test('never puts the token in the request URL', async () => {
+    mockResolveSessionToken.mockReturnValue('tok-123');
+    await rpcRequest('eth_accounts', []);
+    expect(MockWebSocket.instances[0].url).not.toContain('tok-123');
+  });
+
+  test('times out and terminates the socket when no response arrives', async () => {
+    MockWebSocket.replyEnabled = false;
+    jest.useFakeTimers();
+    try {
+      const pending = rpcRequest('eth_accounts', [], { timeoutMs: 50 });
+      // Attach the rejection handler before advancing timers so the timeout
+      // rejection is not "handled asynchronously".
+      const assertion = expect(pending).rejects.toMatchObject({ code: 'VAUGHAN_DISCONNECTED' });
+      // Flush the mocked 'open' event, then let the timeout fire.
+      await jest.advanceTimersByTimeAsync(0);
+      await jest.advanceTimersByTimeAsync(60);
+      await assertion;
+      expect(MockWebSocket.instances[0].terminated).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/main/wallet/vaughan/transport.test.js
+++ b/src/main/wallet/vaughan/transport.test.js
@@ -12,7 +12,16 @@ class MockWebSocket {
 
   once(event, cb) {
     if (event === 'open') {
-      setImmediate(cb);
+      setImmediate(() => {
+        cb();
+        if (MockWebSocket.closeAfterOpen) {
+          setImmediate(() => {
+            if (this.onceListeners.close) {
+              this.onceListeners.close(1006);
+            }
+          });
+        }
+      });
       return;
     }
     this.onceListeners[event] = cb;
@@ -46,6 +55,7 @@ class MockWebSocket {
 }
 MockWebSocket.instances = [];
 MockWebSocket.replyEnabled = true;
+MockWebSocket.closeAfterOpen = false;
 
 jest.mock('ws', () => MockWebSocket);
 jest.mock('./session-token', () => ({
@@ -57,6 +67,7 @@ const { rpcRequest } = require('./transport');
 beforeEach(() => {
   MockWebSocket.instances.length = 0;
   MockWebSocket.replyEnabled = true;
+  MockWebSocket.closeAfterOpen = false;
   mockResolveSessionToken.mockReset().mockReturnValue(null);
 });
 
@@ -83,6 +94,16 @@ describe('rpcRequest', () => {
     mockResolveSessionToken.mockReturnValue('tok-123');
     await rpcRequest('eth_accounts', []);
     expect(MockWebSocket.instances[0].url).not.toContain('tok-123');
+  });
+
+  test('rejects promptly when the server closes without a response', async () => {
+    MockWebSocket.closeAfterOpen = true;
+    MockWebSocket.replyEnabled = false;
+    // A long timeout proves the close path fails fast: if the close handler
+    // regresses, this rejects with a timeout error instead.
+    await expect(rpcRequest('eth_accounts', [], { timeoutMs: 60_000 })).rejects.toMatchObject({
+      code: 'VAUGHAN_DISCONNECTED',
+    });
   });
 
   test('times out and terminates the socket when no response arrives', async () => {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1258,6 +1258,13 @@
                         </svg>
                         <span>Connect Phone / Other Device</span>
                       </button>
+                      <button type="button" class="wallet-selector-action" id="wallet-connect-vaughan-btn">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                          <rect x="3" y="4" width="18" height="16" rx="2"/>
+                          <path d="M7 8h10M7 12h6M7 16h8"/>
+                        </svg>
+                        <span>Connect Vaughan Wallet</span>
+                      </button>
                     </div>
                   </div>
 
@@ -1985,6 +1992,80 @@
                 </p>
 
                 <button type="button" id="connect-phone-done" class="create-wallet-done-btn">
+                  Done
+                </button>
+              </div>
+            </div>
+
+            <!-- Connect Vaughan sub-screen -->
+            <div id="sidebar-connect-vaughan" class="sidebar-subscreen hidden">
+              <div class="subscreen-header">
+                <button type="button" class="subscreen-back-btn" id="connect-vaughan-back">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <polyline points="15 18 9 12 15 6"/>
+                  </svg>
+                  <span>Back</span>
+                </button>
+                <h3 class="subscreen-title">Connect Vaughan</h3>
+              </div>
+
+              <!-- Step 1: Detect local Vaughan provider -->
+              <div id="connect-vaughan-detect" class="subscreen-content hidden">
+                <div class="connect-ledger-illustration">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <rect x="3" y="4" width="18" height="16" rx="2"/>
+                    <path d="M7 8h10M7 12h6M7 16h8"/>
+                  </svg>
+                </div>
+                <p class="create-wallet-message">
+                  Start <strong>Vaughan</strong> on this machine and unlock your wallet.
+                  Freedom connects to Vaughan over the local bridge (<code>ws://127.0.0.1:8745</code>).
+                </p>
+                <div id="connect-vaughan-status" class="connect-ledger-status">
+                  <span class="connect-ledger-status-spinner"></span>
+                  <span id="connect-vaughan-status-text">Looking for Vaughan…</span>
+                </div>
+              </div>
+
+              <!-- Step 2: Pick account -->
+              <div id="connect-vaughan-accounts-step" class="subscreen-content hidden">
+                <p class="create-wallet-message">Choose the Vaughan account to add.</p>
+
+                <div id="connect-vaughan-account-list" class="connect-ledger-account-list"></div>
+
+                <input type="text" id="connect-vaughan-name-input"
+                       class="create-wallet-input"
+                       placeholder="Name (e.g. Vaughan Pulse)"
+                       maxlength="32"
+                       autocomplete="off">
+
+                <button type="button" id="connect-vaughan-submit" class="create-wallet-submit-btn" disabled>
+                  Add Account
+                </button>
+
+                <div id="connect-vaughan-error" class="unlock-error hidden"></div>
+              </div>
+
+              <!-- Step 3: Success -->
+              <div id="connect-vaughan-success" class="subscreen-content hidden">
+                <div class="create-wallet-success-icon">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                    <circle cx="12" cy="12" r="10"/>
+                    <polyline points="8 12 11 15 16 9"/>
+                  </svg>
+                </div>
+                <h4 class="create-wallet-success-title">Vaughan Account Added!</h4>
+
+                <div class="create-wallet-result">
+                  <span class="create-wallet-result-name" id="connect-vaughan-result-name"></span>
+                  <code class="create-wallet-result-address" id="connect-vaughan-result-address"></code>
+                </div>
+
+                <p class="create-wallet-message">
+                  Signing requests are approved in the Vaughan TUI — keys never leave Vaughan.
+                </p>
+
+                <button type="button" id="connect-vaughan-done" class="create-wallet-done-btn">
                   Done
                 </button>
               </div>

--- a/src/renderer/lib/wallet-ui.js
+++ b/src/renderer/lib/wallet-ui.js
@@ -29,6 +29,7 @@ import { initWalletSettings, closeWalletSettings } from './wallet/wallet-setting
 import { initCreateWallet, openCreateWallet, closeCreateWallet } from './wallet/create-wallet.js';
 import { initConnectLedger, openConnectLedger, closeConnectLedger } from './wallet/connect-ledger.js';
 import { initConnectPhone, openConnectPhone, closeConnectPhone } from './wallet/connect-phone.js';
+import { initConnectVaughan, openConnectVaughan, closeConnectVaughan } from './wallet/connect-vaughan.js';
 import { initRemoteSession } from './wallet/remote-session.js';
 import { initRemoteSigningPanel } from './wallet/remote-signing-panel.js';
 import { initPublishSetup, openPublishSetup, closePublishSetup } from './wallet/publish-setup.js';
@@ -93,13 +94,14 @@ export function initWalletUi() {
   initDappSign();
   initSend();
   initExportMnemonic(switchTab);
-  initWalletSelector(openCreateWallet, openConnectLedger, openConnectPhone);
+  initWalletSelector(openCreateWallet, openConnectLedger, openConnectPhone, openConnectVaughan);
   initChainSwitcher();
   initReceive();
   initWalletSettings(switchTab);
   initCreateWallet();
   initConnectLedger();
   initConnectPhone();
+  initConnectVaughan();
   initRemoteSession();
   initRemoteSigningPanel(); // after initRemoteSession — subscribes to its broker
   initPublishSetup();
@@ -435,6 +437,7 @@ function closeAllSubscreens() {
   closeCreateWallet();
   closeConnectLedger();
   closeConnectPhone();
+  closeConnectVaughan();
   closeReceive();
   closeWalletSettings();
   closeSend();

--- a/src/renderer/lib/wallet/connect-vaughan.js
+++ b/src/renderer/lib/wallet/connect-vaughan.js
@@ -1,0 +1,259 @@
+/**
+ * Connect Vaughan Module
+ *
+ * "Connect Vaughan wallet" subscreen: polls the local Vaughan EIP-1193
+ * provider for unlocked accounts, lets the user pick one, and adds it to
+ * Freedom's wallet list. Keys stay in Vaughan — Freedom only stores the
+ * address + type=vaughan record (mirrors the Ledger external-signer path).
+ */
+
+import { walletState, registerScreenHider } from './wallet-state.js';
+import { refuseSubscreenWhileInFlight } from './signature-flight.js';
+import { loadDerivedWallets, updateWalletSelectorDisplay } from './wallet-selector.js';
+import { refreshBalances } from './balance-display.js';
+import { escapeHtml, truncateAddress } from './wallet-utils.js';
+
+const DETECT_POLL_MS = 1500;
+
+// DOM references
+let screen;
+let backBtn;
+let detectView;
+let statusText;
+let accountsView;
+let accountList;
+let nameInput;
+let submitBtn;
+let errorEl;
+let successView;
+let resultName;
+let resultAddress;
+let doneBtn;
+
+// Flow state
+let detectTimer = null;
+let discoveredAccounts = [];
+let selectedAccount = null;
+let accountAdded = false;
+
+export function initConnectVaughan() {
+  screen = document.getElementById('sidebar-connect-vaughan');
+  backBtn = document.getElementById('connect-vaughan-back');
+  detectView = document.getElementById('connect-vaughan-detect');
+  statusText = document.getElementById('connect-vaughan-status-text');
+  accountsView = document.getElementById('connect-vaughan-accounts-step');
+  accountList = document.getElementById('connect-vaughan-account-list');
+  nameInput = document.getElementById('connect-vaughan-name-input');
+  submitBtn = document.getElementById('connect-vaughan-submit');
+  errorEl = document.getElementById('connect-vaughan-error');
+  successView = document.getElementById('connect-vaughan-success');
+  resultName = document.getElementById('connect-vaughan-result-name');
+  resultAddress = document.getElementById('connect-vaughan-result-address');
+  doneBtn = document.getElementById('connect-vaughan-done');
+
+  registerScreenHider(() => {
+    stopDetectLoop();
+    screen?.classList.add('hidden');
+  });
+
+  backBtn?.addEventListener('click', closeConnectVaughan);
+  doneBtn?.addEventListener('click', closeConnectVaughan);
+  submitBtn?.addEventListener('click', handleAddAccount);
+}
+
+export async function openConnectVaughan() {
+  if (refuseSubscreenWhileInFlight('Connect Vaughan screen')) return;
+
+  walletState.identityView?.classList.add('hidden');
+  screen?.classList.remove('hidden');
+
+  resetFlowState();
+  showStep('detect');
+  detectTick();
+}
+
+export async function closeConnectVaughan() {
+  if (!screen || screen.classList.contains('hidden')) return;
+
+  stopDetectLoop();
+  screen.classList.add('hidden');
+  walletState.identityView?.classList.remove('hidden');
+
+  if (accountAdded) {
+    await loadDerivedWallets();
+    if (walletState.fullAddresses.wallet) {
+      refreshBalances();
+    }
+  }
+}
+
+function resetFlowState() {
+  discoveredAccounts = [];
+  selectedAccount = null;
+  accountAdded = false;
+  if (nameInput) nameInput.value = '';
+  if (accountList) accountList.innerHTML = '';
+  if (submitBtn) {
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Add Account';
+  }
+  hideError();
+  setStatus('Looking for Vaughan…');
+}
+
+function showStep(step) {
+  detectView?.classList.toggle('hidden', step !== 'detect');
+  accountsView?.classList.toggle('hidden', step !== 'accounts');
+  successView?.classList.toggle('hidden', step !== 'success');
+}
+
+function stopDetectLoop() {
+  if (detectTimer) {
+    clearTimeout(detectTimer);
+    detectTimer = null;
+  }
+}
+
+async function detectTick() {
+  if (!screen || screen.classList.contains('hidden')) return;
+
+  const loaded = await loadAccounts(setStatus);
+  if (loaded) {
+    showStep('accounts');
+  } else {
+    detectTimer = setTimeout(detectTick, DETECT_POLL_MS);
+  }
+}
+
+function setStatus(message) {
+  if (statusText) statusText.textContent = message;
+}
+
+/**
+ * Fetch accounts from the local Vaughan provider.
+ *
+ * @param {(message: string) => void} [onFailure]
+ * @returns {Promise<boolean>}
+ */
+async function loadAccounts(onFailure = showError) {
+  try {
+    if (!window.vaughan?.getAccounts) {
+      onFailure('Vaughan bridge is unavailable in this build.');
+      return false;
+    }
+    const result = await window.vaughan.getAccounts();
+    if (!result.success) {
+      onFailure(result.error || 'Cannot reach Vaughan. Start and unlock the wallet.');
+      return false;
+    }
+    const accounts = Array.isArray(result.accounts) ? result.accounts : [];
+    if (accounts.length === 0) {
+      onFailure('Vaughan is connected but returned no accounts. Unlock the wallet and try again.');
+      return false;
+    }
+    discoveredAccounts = accounts.map((address) => ({ address }));
+    selectedAccount = null;
+    if (submitBtn) submitBtn.disabled = true;
+    renderAccountList();
+    return true;
+  } catch (err) {
+    console.error('[ConnectVaughan] Account load failed:', err);
+    onFailure(err.message || 'Cannot reach Vaughan.');
+    return false;
+  }
+}
+
+function renderAccountList() {
+  if (!accountList) return;
+  accountList.innerHTML = '';
+
+  const existingAddresses = new Set(
+    walletState.derivedWallets
+      .filter((wallet) => wallet.address)
+      .map((wallet) => wallet.address.toLowerCase())
+  );
+
+  discoveredAccounts.forEach((account) => {
+    const alreadyAdded = existingAddresses.has(account.address.toLowerCase());
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'connect-ledger-account';
+    if (alreadyAdded) item.classList.add('added');
+    if (selectedAccount?.address === account.address) item.classList.add('selected');
+    item.disabled = alreadyAdded;
+
+    item.innerHTML = `
+      <div class="connect-ledger-account-info">
+        <code class="connect-ledger-account-address">${escapeHtml(truncateAddress(account.address))}</code>
+        <span class="connect-ledger-account-path">Vaughan</span>
+      </div>
+      ${alreadyAdded ? '<span class="connect-ledger-account-added">Added</span>' : ''}
+    `;
+
+    if (!alreadyAdded) {
+      item.addEventListener('click', () => {
+        selectedAccount = account;
+        if (submitBtn) submitBtn.disabled = false;
+        renderAccountList();
+      });
+    }
+
+    accountList.appendChild(item);
+  });
+}
+
+async function handleAddAccount() {
+  if (!selectedAccount) return;
+
+  if (submitBtn) {
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Adding…';
+  }
+  hideError();
+
+  try {
+    const result = await window.vaughan.addAccount(
+      nameInput?.value?.trim() || '',
+      selectedAccount.address
+    );
+    if (!result.success) {
+      throw new Error(result.error);
+    }
+
+    accountAdded = true;
+    walletState.derivedWallets.push(result.wallet);
+
+    if (resultName) resultName.textContent = result.wallet.name;
+    if (resultAddress) resultAddress.textContent = result.wallet.address;
+
+    const activated = await window.wallet.setActiveWallet(result.wallet.index);
+    if (activated.success) {
+      walletState.activeWalletIndex = result.wallet.index;
+      updateWalletSelectorDisplay(result.wallet);
+      walletState.fullAddresses.wallet = result.wallet.address || '';
+    }
+
+    showStep('success');
+  } catch (err) {
+    console.error('[ConnectVaughan] Failed to add account:', err);
+    showError(err.message || 'Failed to add the Vaughan account');
+    if (submitBtn) {
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Add Account';
+    }
+  }
+}
+
+function showError(message) {
+  if (errorEl) {
+    errorEl.textContent = message;
+    errorEl.classList.remove('hidden');
+  }
+}
+
+function hideError() {
+  if (errorEl) {
+    errorEl.classList.add('hidden');
+    errorEl.textContent = '';
+  }
+}

--- a/src/renderer/lib/wallet/connect-vaughan.js
+++ b/src/renderer/lib/wallet/connect-vaughan.js
@@ -9,7 +9,7 @@
 
 import { walletState, registerScreenHider } from './wallet-state.js';
 import { refuseSubscreenWhileInFlight } from './signature-flight.js';
-import { loadDerivedWallets, updateWalletSelectorDisplay } from './wallet-selector.js';
+import { loadDerivedWallets, activateAddedWallet } from './wallet-selector.js';
 import { refreshBalances } from './balance-display.js';
 import { escapeHtml, truncateAddress } from './wallet-utils.js';
 
@@ -221,17 +221,10 @@ async function handleAddAccount() {
     }
 
     accountAdded = true;
-    walletState.derivedWallets.push(result.wallet);
-
     if (resultName) resultName.textContent = result.wallet.name;
     if (resultAddress) resultAddress.textContent = result.wallet.address;
 
-    const activated = await window.wallet.setActiveWallet(result.wallet.index);
-    if (activated.success) {
-      walletState.activeWalletIndex = result.wallet.index;
-      updateWalletSelectorDisplay(result.wallet);
-      walletState.fullAddresses.wallet = result.wallet.address || '';
-    }
+    await activateAddedWallet(result.wallet);
 
     showStep('success');
   } catch (err) {

--- a/src/renderer/lib/wallet/connect-vaughan.test.js
+++ b/src/renderer/lib/wallet/connect-vaughan.test.js
@@ -1,0 +1,125 @@
+const { createDocument, createElement } = require('../../../../test/helpers/fake-dom.js');
+
+const originalWindow = global.window;
+const originalDocument = global.document;
+
+const ELEMENT_IDS = [
+  'sidebar-identity',
+  'sidebar-connect-vaughan',
+  'connect-vaughan-back',
+  'connect-vaughan-detect',
+  'connect-vaughan-status-text',
+  'connect-vaughan-accounts-step',
+  'connect-vaughan-account-list',
+  'connect-vaughan-name-input',
+  'connect-vaughan-submit',
+  'connect-vaughan-error',
+  'connect-vaughan-success',
+  'connect-vaughan-result-name',
+  'connect-vaughan-result-address',
+  'connect-vaughan-done',
+];
+
+function flush() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function loadConnectVaughan({ getAccounts }) {
+  jest.resetModules();
+
+  const elementsById = Object.fromEntries(
+    ELEMENT_IDS.map((id) => {
+      const tag =
+        id.includes('input') ? 'input' : id.includes('list') || id.includes('error') ? 'div' : 'button';
+      return [id, createElement(tag)];
+    })
+  );
+  elementsById['sidebar-connect-vaughan'].classList.add('hidden');
+  elementsById['connect-vaughan-detect'].classList.add('hidden');
+  elementsById['connect-vaughan-accounts-step'].classList.add('hidden');
+  elementsById['connect-vaughan-success'].classList.add('hidden');
+  elementsById['connect-vaughan-error'].classList.add('hidden');
+  elementsById['connect-vaughan-submit'].disabled = true;
+  elementsById['connect-vaughan-submit'].textContent = 'Add Account';
+
+  global.document = createDocument({ elementsById });
+  global.window = {
+    vaughan: {
+      getAccounts,
+      addAccount: jest.fn(),
+    },
+    wallet: {
+      setActiveWallet: jest.fn(async () => ({ success: true })),
+    },
+  };
+
+  jest.doMock('./wallet-state.js', () => ({
+    walletState: {
+      identityView: elementsById['sidebar-identity'],
+      derivedWallets: [],
+      activeWalletIndex: 0,
+      fullAddresses: { wallet: '' },
+    },
+    registerScreenHider: jest.fn(),
+  }));
+  jest.doMock('./signature-flight.js', () => ({
+    refuseSubscreenWhileInFlight: jest.fn(() => false),
+  }));
+  jest.doMock('./wallet-selector.js', () => ({
+    loadDerivedWallets: jest.fn(async () => {}),
+    updateWalletSelectorDisplay: jest.fn(),
+  }));
+  jest.doMock('./balance-display.js', () => ({
+    refreshBalances: jest.fn(),
+  }));
+  jest.doMock('./wallet-utils.js', () => ({
+    escapeHtml: (text) => String(text ?? ''),
+    truncateAddress: (address) => address,
+  }));
+
+  const mod = await import('./connect-vaughan.js');
+  mod.initConnectVaughan();
+  return { mod, elementsById };
+}
+
+afterEach(() => {
+  global.window = originalWindow;
+  global.document = originalDocument;
+  jest.useRealTimers();
+});
+
+describe('connect-vaughan', () => {
+  test('openConnectVaughan lists accounts from Vaughan getAccounts', async () => {
+    const getAccounts = jest.fn(async () => ({
+      success: true,
+      accounts: ['0x1111111111111111111111111111111111111111'],
+    }));
+    const { mod, elementsById } = await loadConnectVaughan({ getAccounts });
+
+    await mod.openConnectVaughan();
+    await flush();
+
+    expect(getAccounts).toHaveBeenCalled();
+    expect(elementsById['connect-vaughan-accounts-step'].classList.contains('hidden')).toBe(false);
+    expect(elementsById['connect-vaughan-account-list'].children).toHaveLength(1);
+    expect(elementsById['connect-vaughan-account-list'].children[0].innerHTML).toMatch(/0x1111/i);
+  });
+
+  test('shows disconnect guidance when Vaughan is unreachable', async () => {
+    const getAccounts = jest.fn(async () => ({
+      success: false,
+      error: 'Cannot connect to Vaughan. Start the wallet and try again.',
+      code: 'VAUGHAN_DISCONNECTED',
+    }));
+    const { mod, elementsById } = await loadConnectVaughan({ getAccounts });
+
+    await mod.openConnectVaughan();
+    await flush();
+
+    expect(elementsById['connect-vaughan-detect'].classList.contains('hidden')).toBe(false);
+    expect(elementsById['connect-vaughan-status-text'].textContent).toMatch(/Cannot connect/i);
+    expect(getAccounts).toHaveBeenCalled();
+
+    await mod.closeConnectVaughan();
+  });
+});

--- a/src/renderer/lib/wallet/dapp-sign.test.js
+++ b/src/renderer/lib/wallet/dapp-sign.test.js
@@ -60,6 +60,10 @@ async function loadDappSign() {
   jest.doMock('../dapp-provider.js', () => ({ executeSign }));
   // The Ledger account bypasses the vault-unlock gate, the same as in the app.
   jest.doMock('./wallet-utils.js', () => ({
+    bypassUnlockGateForDevice: jest.fn((_index, _unlockEl, confirmBtn) => {
+      if (confirmBtn) confirmBtn.disabled = false;
+      return true;
+    }),
     bypassUnlockGateForHardware: jest.fn((_index, _unlockEl, confirmBtn) => {
       if (confirmBtn) confirmBtn.disabled = false;
       return true;

--- a/src/renderer/lib/wallet/dapp-tx.test.js
+++ b/src/renderer/lib/wallet/dapp-tx.test.js
@@ -117,6 +117,10 @@ async function loadDappTx() {
 
   // The Ledger account bypasses the vault-unlock gate, the same as in the app.
   jest.doMock('./wallet-utils.js', () => ({
+    bypassUnlockGateForDevice: jest.fn((_index, _unlockEl, confirmBtn) => {
+      if (confirmBtn) confirmBtn.disabled = false;
+      return true;
+    }),
     bypassUnlockGateForHardware: jest.fn((_index, _unlockEl, confirmBtn) => {
       if (confirmBtn) confirmBtn.disabled = false;
       return true;

--- a/src/renderer/lib/wallet/wallet-selector.js
+++ b/src/renderer/lib/wallet/wallet-selector.js
@@ -17,14 +17,16 @@ let walletSelectorList;
 let walletCreateBtn;
 let walletConnectLedgerBtn;
 let walletConnectPhoneBtn;
+let walletConnectVaughanBtn;
 let walletHeadlineName;
 
 // Callbacks for opening subscreens (set by coordinator)
 let openCreateWalletFn = null;
 let openConnectLedgerFn = null;
 let openConnectPhoneFn = null;
+let openConnectVaughanFn = null;
 
-export function initWalletSelector(openCreateWallet, openConnectLedger, openConnectPhone) {
+export function initWalletSelector(openCreateWallet, openConnectLedger, openConnectPhone, openConnectVaughan) {
   walletSelectorBtn = document.getElementById('wallet-selector-btn');
   walletSelectorName = document.getElementById('wallet-selector-name');
   walletSelectorAddress = document.getElementById('wallet-selector-address');
@@ -33,11 +35,13 @@ export function initWalletSelector(openCreateWallet, openConnectLedger, openConn
   walletCreateBtn = document.getElementById('wallet-create-btn');
   walletConnectLedgerBtn = document.getElementById('wallet-connect-ledger-btn');
   walletConnectPhoneBtn = document.getElementById('wallet-connect-phone-btn');
+  walletConnectVaughanBtn = document.getElementById('wallet-connect-vaughan-btn');
   walletHeadlineName = document.getElementById('wallet-headline-name');
 
   openCreateWalletFn = openCreateWallet;
   openConnectLedgerFn = openConnectLedger;
   openConnectPhoneFn = openConnectPhone;
+  openConnectVaughanFn = openConnectVaughan;
 
   setupWalletSelector();
 }
@@ -74,6 +78,13 @@ function setupWalletSelector() {
       if (openConnectPhoneFn) openConnectPhoneFn();
     });
   }
+
+  if (walletConnectVaughanBtn) {
+    walletConnectVaughanBtn.addEventListener('click', () => {
+      closeWalletDropdown();
+      if (openConnectVaughanFn) openConnectVaughanFn();
+    });
+  }
 }
 
 function toggleWalletDropdown() {
@@ -103,7 +114,7 @@ function closeWalletDropdown() {
 
 /** Badge label for device account types (mnemonic accounts get none). */
 function walletTypeBadge(type) {
-  const label = { ledger: 'Ledger', remote: 'Phone' }[type];
+  const label = { ledger: 'Ledger', remote: 'Phone', vaughan: 'Vaughan' }[type];
   return label ? `<span class="wallet-selector-item-badge">${label}</span>` : '';
 }
 

--- a/src/renderer/lib/wallet/wallet-utils.js
+++ b/src/renderer/lib/wallet/wallet-utils.js
@@ -50,11 +50,16 @@ export function isExternalSignerAccount(walletIndex) {
  * build their copy from.
  */
 export function deviceLabel(walletIndex) {
-  return { ledger: 'your Ledger', remote: 'your phone', vaughan: 'Vaughan' }[accountType(walletIndex)] || null;
+  return {
+    ledger: 'your Ledger',
+    remote: 'your phone',
+    vaughan: 'Vaughan',
+  }[accountType(walletIndex)] || null;
 }
 
 /** Pending label for approve buttons while a signature is in flight. */
 export function signingButtonLabel(walletIndex) {
+  if (isVaughanAccount(walletIndex)) return 'Confirm in Vaughan…';
   const label = deviceLabel(walletIndex);
   return label ? `Confirm on ${label}…` : 'Signing…';
 }

--- a/src/renderer/lib/wallet/wallet-utils.js
+++ b/src/renderer/lib/wallet/wallet-utils.js
@@ -11,7 +11,7 @@ export function truncateAddress(address, startChars = 6, endChars = 4) {
   return `${address.slice(0, startChars)}...${address.slice(-endChars)}`;
 }
 
-/** Account type ('mnemonic' | 'ledger' | 'remote') for a wallet index. */
+/** Account type ('mnemonic' | 'ledger' | 'remote' | 'vaughan') for a wallet index. */
 export function accountType(walletIndex) {
   return walletState.derivedWallets?.find((wallet) => wallet.index === walletIndex)?.type;
 }
@@ -31,7 +31,17 @@ export function isLedgerAccount(walletIndex) {
  */
 export function isDeviceAccount(walletIndex) {
   const type = accountType(walletIndex);
-  return type === 'ledger' || type === 'remote';
+  return type === 'ledger' || type === 'remote' || type === 'vaughan';
+}
+
+/** Whether a wallet index is a Vaughan external signer (keys stay in Vaughan). */
+export function isVaughanAccount(walletIndex) {
+  return accountType(walletIndex) === 'vaughan';
+}
+
+/** External signers (Ledger / Vaughan / phone) never use Freedom's vault key material. */
+export function isExternalSignerAccount(walletIndex) {
+  return isDeviceAccount(walletIndex);
 }
 
 /**
@@ -40,7 +50,7 @@ export function isDeviceAccount(walletIndex) {
  * build their copy from.
  */
 export function deviceLabel(walletIndex) {
-  return { ledger: 'your Ledger', remote: 'your phone' }[accountType(walletIndex)] || null;
+  return { ledger: 'your Ledger', remote: 'your phone', vaughan: 'Vaughan' }[accountType(walletIndex)] || null;
 }
 
 /** Pending label for approve buttons while a signature is in flight. */
@@ -70,6 +80,10 @@ export function generateScannableQr(text) {
  * @param {HTMLButtonElement|null} confirmBtn - the approve/confirm button
  * @returns {boolean}
  */
+export function bypassUnlockGateForHardware(walletIndex, unlockEl, confirmBtn) {
+  return bypassUnlockGateForDevice(walletIndex, unlockEl, confirmBtn);
+}
+
 export function bypassUnlockGateForDevice(walletIndex, unlockEl, confirmBtn) {
   if (!isDeviceAccount(walletIndex)) return false;
   unlockEl?.classList.add('hidden');


### PR DESCRIPTION
## Summary
- Adds a Vaughan signer backend (`src/main/wallet/vaughan/`) that talks to Vaughan’s loopback EIP-1193 WebSocket (`ws://127.0.0.1:8745`) with Origin `https://freedom.browser`
- Wires `WALLET_TYPES.VAUGHAN`, `addVaughanWallet`, preload `window.vaughan`, and signer factory dispatch (mirrors Ledger)
- **UI:** wallet selector **Connect Vaughan Wallet** → detect / list / add (mirrors Connect Ledger; keys stay in Vaughan; approve in the Vaughan TUI)
- Implements `getAddress`, `signMessage` (`personal_sign`), `signTransaction` (`vaughan_signTransaction`), `signTypedData` (`eth_signTypedData_v4`) with account-match checks and long approval timeouts
- Account discovery IPC: `vaughan:get-accounts` → `eth_requestAccounts` (fallback `eth_accounts`)
- Helpers: `scripts/smoke-vaughan-bridge.js`, `scripts/add-vaughan-wallet.js`

## Test plan
- [x] `npx jest --testPathPatterns='wallet/vaughan|wallet/signers.test|identity-manager.test|connect-vaughan'` (backend + Connect Vaughan UI unit tests)
- [x] Vaughan bridge smoke (Vaughan-CLI): `cargo test -p vaughan-tui --test freedom_bridge_smoke` (Freedom Origin + RPC methods)
- [ ] Manual: start Vaughan TUI unlocked with `VAUGHAN_PROVIDER_TRUSTED_ORIGINS=https://freedom.browser`
- [ ] Manual: Freedom wallet dropdown → **Connect Vaughan Wallet** → pick account → Add
- [ ] Manual: `node scripts/smoke-vaughan-bridge.js` (approve `personal_sign` in Vaughan TUI)
- [ ] Manual: dApp `personal_sign` / send tx → Vaughan approval prompt → signed result in Freedom Browser

## Reviewer notes
- Vaughan is a separate local wallet; Freedom only stores `type: 'vaughan'` + address (same external-signer pattern as Ledger).
- Signing never uses Freedom’s vault key — UI shows “Confirm in Vaughan…” and bypasses the unlock gate for Vaughan accounts.
- **Fee source of truth:** Freedom’s confirm dialog shows its own fee estimate, but the Vaughan TUI approval prompt is authoritative — the user can adjust fee speed / custom gas there, and the signed transaction carries exactly what was approved in Vaughan (which may differ from Freedom’s estimate).
- **Error UX:** empty `eth_accounts` (Vaughan locked or site grant cleared) maps to `VAUGHAN_NOT_CONNECTED` with a reconnect hint; account mismatches keep `VAUGHAN_UNAUTHORIZED` with a switch-or-repair message; EIP-1193 errors prefer Vaughan’s server detail over generic fallback text.