### PR TITLE
test(vault): raise auto-lock test timeout to 5000ms

### DIFF
--- a/src/main/identity/vault.test.js
+++ b/src/main/identity/vault.test.js
@@ -245,7 +245,11 @@ describe('vault', () => {
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       expect(isUnlocked()).toBe(false);
-    }, 1000);
+      // Generous outer timeout: the body runs two PBKDF2 key derivations
+      // (importVault + unlockVault, ~800ms each on slower hardware) plus the
+      // 200ms wait, so ~1.8s total. The 100ms auto-lock window above still
+      // carries the assertion; this only stops the test flaking on slow VMs.
+    }, 5000);
 
     test('does not auto-lock when timeout is 0', async () => {
       await importVault(tempDir, 'password123', TEST_MNEMONIC);


### PR DESCRIPTION
## What changed

`src/main/identity/vault.test.js` — the `vault > auto-lock > auto-locks after timeout` test had a hardcoded **1000ms** outer timeout. Raised to **5000ms**, plus a comment explaining why the number is what it is.

Nothing else changed. The auto-lock behavior, the 100ms unlock window, and the 200ms wait are all untouched.

## Why

The test body does two PBKDF2 key derivations before it can even assert anything:

| step | run 0 | run 1 | run 2 |
|---|---|---|---|
| `importVault` | 744ms | 839ms | 815ms |
| `unlockVault` | 841ms | 781ms | 748ms |
| fixed 200ms wait | 200ms | 200ms | 200ms |
| **total** | **1785ms** | **1820ms** | **1763ms** |

So the body needs ~1.8s against a 1000ms budget. This isn't a race — it fails *deterministically* on slower hardware and only passes on CI runners fast enough to do both derivations in under 800ms. Confirmed on this branch's parent commit:

```
● vault › auto-lock › auto-locks after timeout
  thrown: "Exceeded timeout of 1000 ms for a test."
```

5000ms is not an arbitrary bump — it's Jest's default. The repo sets no global `testTimeout`, so every other test in this file already runs at 5000ms, including the sibling `does not auto-lock when timeout is 0`, which does the same two PBKDF2 derivations. The 1000ms override was the outlier; removing it restores consistency. It is the only hardcoded per-test timeout in the file (`grep -n "}, [0-9]\+);"` returns one hit), so there is no structurally-identical sibling left unfixed.

## How it was verified

**1. Reproduced the failure** on the parent commit — fails at 1000ms, as quoted above.

**2. Fixed suite passes, repeatedly.** All 24 tests in the file pass; the target test passes 3/3 on repeat runs. Full `src/main/identity/` suite: 75 passed, 10 skipped, 0 failed. `eslint` clean.

**3. Mutation-tested that the bigger timeout did not weaken the assertion.** This was the main risk, so I verified it rather than reasoned about it. Two mutations of `src/main/identity/vault.js`, both reverted afterward:

- **Auto-lock disabled entirely** (`if (autoLockMs > 0 && unlockedMnemonic)` → `if (false)`) → test **fails**.
- **Auto-lock fires far too late** (`}, autoLockMs)` → `}, 3000)`, i.e. still comfortably inside the new 5000ms outer timeout) → test **fails**.

Both failed on the real assertion, not on a timeout:

```
expect(received).toBe(expected)
  Expected: false
  Received: true
> 247 |       expect(isUnlocked()).toBe(false);
```

That second mutation is the one that matters: a 5000ms outer timeout does **not** let a slow-but-eventually-correct auto-lock slip through, because the 100ms/200ms window is what actually decides the assertion. The test is still sharp; it just no longer runs out of wall clock before reaching its own assertion.

*No UI/visual verification here — this is a unit-test timeout with no user-visible surface.*