### PR TITLE
Fix ant download: follow upstream repo rename and redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ All notable changes to Freedom will be documented in this file.
 
 ### Changed
 
-- Updated bundled [Ant](https://github.com/solardev-xyz/ant) to 0.5.36: fixes the ~250 MiB upload stall, adds upload-side Reed-Solomon encoding, end-to-end Swarm content encryption, local pinning, and ACT access control
+- Updated bundled [Ant](https://github.com/freedom-hq/ant) to 0.5.36: fixes the ~250 MiB upload stall, adds upload-side Reed-Solomon encoding, end-to-end Swarm content encryption, local pinning, and ACT access control
 - The Swarm node's API now comes up instantly on start, so the node menu shows peers counting up live instead of sitting at 0 during startup
 
 ## [0.8.0] - 2026-07-02
@@ -43,7 +43,7 @@ All notable changes to Freedom will be documented in this file.
 
 - In-house Rust implementations of the bundled Swarm and IPFS nodes, built for the upcoming mobile apps:
   - Reasoning: mobile needs small binaries and bounded memory; every platform gains speed and room for specialised node features
-- [Ant](https://github.com/solardev-xyz/ant) 0.5.33, a lean Swarm light node, replaces bundled Bee:
+- [Ant](https://github.com/freedom-hq/ant) 0.5.33, a lean Swarm light node, replaces bundled Bee:
   - Full Bee parity: retrieval, feeds, stamp purchase, publishing, and chequebook payments
   - Instant publishing setup (no more lengthy Gnosis chain-state download)
   - Node data and Swarm identity migrate in place on first launch

--- a/LICENSE_AUDIT.md
+++ b/LICENSE_AUDIT.md
@@ -91,7 +91,7 @@ Freedom Browser is distributed as:
 
 ### Ant (antd, Swarm Node)
 
-- **Source:** https://github.com/solardev-xyz/ant
+- **Source:** https://github.com/freedom-hq/ant
 - **License:** MIT OR Apache-2.0 (upstream ships `LICENSE-MIT` and `LICENSE-APACHE`)
 - **Risk:** Green
 - **Integration:** Separate process via IPC

--- a/NOTICES
+++ b/NOTICES
@@ -5,7 +5,7 @@ This software includes the following third-party components:
 Ant (antd, Swarm node)
   License: MIT OR Apache-2.0
   Copyright (c) solardev-xyz contributors
-  https://github.com/solardev-xyz/ant
+  https://github.com/freedom-hq/ant
 
 freedom-ipfs
   License: MIT OR Apache-2.0

--- a/docs/agent-playbooks/release-process.md
+++ b/docs/agent-playbooks/release-process.md
@@ -83,7 +83,7 @@ The other fetch scripts resolve the latest from a **vendor-specific** upstream â
 
 | Binary                                                | Authoritative source the fetch script reads                                                                                |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Ant (`scripts/fetch-ant.js`)                          | `https://api.github.com/repos/solardev-xyz/ant/releases/tags/<PINNED_RELEASE_TAG>` (pinned in the script; `ANT_RELEASE_TAG` overrides) |
+| Ant (`scripts/fetch-ant.js`)                          | `https://api.github.com/repos/freedom-hq/ant/releases/tags/<PINNED_RELEASE_TAG>` (pinned in the script; `ANT_RELEASE_TAG` overrides) |
 | freedom-ipfs (`scripts/fetch-freedom-ipfs-native.js`) | pinned GitHub release in the fetch script                                                                                  |
 | Radicle main (`scripts/fetch-radicle.js`)             | `https://files.radicle.xyz/releases/latest`                                                                                |
 | Radicle httpd (same script)                           | `https://files.radicle.xyz/releases/radicle-httpd/latest`                                                                  |
@@ -142,7 +142,7 @@ npm test
 npm run check-binaries
 ```
 
-**License check.** `NOTICES`, `LICENSE_AUDIT.md`, and `licenses-audit.json` attribute the bundled Ant binary as MIT OR Apache-2.0, matching the `LICENSE-MIT` / `LICENSE-APACHE` that `https://github.com/solardev-xyz/ant` now publishes. Before building release artifacts, confirm the upstream license is unchanged and update those three files if it differs.
+**License check.** `NOTICES`, `LICENSE_AUDIT.md`, and `licenses-audit.json` attribute the bundled Ant binary as MIT OR Apache-2.0, matching the `LICENSE-MIT` / `LICENSE-APACHE` that `https://github.com/freedom-hq/ant` now publishes. Before building release artifacts, confirm the upstream license is unchanged and update those three files if it differs.
 
 Spot-check the app once (`npm start`) and confirm the About/version surface reflects the new number.
 

--- a/licenses-audit.json
+++ b/licenses-audit.json
@@ -341,7 +341,7 @@
       "scope": "runtime",
       "source": {
         "ecosystem": "github",
-        "url": "https://github.com/solardev-xyz/ant"
+        "url": "https://github.com/freedom-hq/ant"
       },
       "license": {
         "spdx": ["MIT", "Apache-2.0"],

--- a/scripts/fetch-ant.js
+++ b/scripts/fetch-ant.js
@@ -5,11 +5,12 @@ const crypto = require('crypto');
 const { execFileSync } = require('child_process');
 
 // Fetches the Ant (`antd`) Swarm light node. Ant is a bee-compatible drop-in
-// published at solardev-xyz/ant; its release assets follow a bee-style os/arch
-// keyword scheme, which the per-target matcher below relies on. The binary
-// shipped is `antd` (not `bee`) and it installs into `ant-bin/<os>-<arch>/`.
+// published at freedom-hq/ant (formerly solardev-xyz/ant); its release assets
+// follow a bee-style os/arch keyword scheme, which the per-target matcher below
+// relies on. The binary shipped is `antd` (not `bee`) and it installs into
+// `ant-bin/<os>-<arch>/`.
 const OUTPUT_DIR = path.join(__dirname, '..', 'ant-bin');
-const ANT_REPO = process.env.ANT_REPO || 'solardev-xyz/ant';
+const ANT_REPO = process.env.ANT_REPO || 'freedom-hq/ant';
 // The known-good Ant release this app version is built and CI-tested against.
 // Bump deliberately (with a CI run) — do NOT float on `latest`, or releases
 // could ship a different Ant than CI validated. Override via ANT_RELEASE_TAG
@@ -27,37 +28,85 @@ const PINNED_SHA256SUMS_DIGEST =
   'ba9d97564a0e8631371bf036bdb33e0a9c7986493a7dca2406907f30e9bb900d';
 const ANT_RELEASE_TAG = process.env.ANT_RELEASE_TAG || PINNED_RELEASE_TAG;
 
-function fetchReleaseOnce() {
+const API_HOST = 'api.github.com';
+// GitHub answers an API request for a *renamed* repo with a 301 to the new
+// canonical location rather than serving it, so a fetch that treats anything
+// other than 200 as fatal turns an upstream rename into a hard CI failure
+// (solardev-xyz/ant → freedom-hq/ant broke every job that downloads antd).
+// Following redirects makes the next rename degrade to an extra hop.
+const REDIRECT_STATUS_CODES = [301, 302, 303, 307, 308];
+const MAX_REDIRECTS = 5;
+
+function releaseUrl() {
+  const releasePath =
+    ANT_RELEASE_TAG === 'latest'
+      ? `/repos/${ANT_REPO}/releases/latest`
+      : `/repos/${ANT_REPO}/releases/tags/${ANT_RELEASE_TAG}`;
+  return `https://${API_HOST}${releasePath}`;
+}
+
+function fetchReleaseOnce(url = releaseUrl(), redirectCount = 0) {
   return new Promise((resolve, reject) => {
     const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
     const headers = {
       'User-Agent': 'Freedom-Updater',
       Accept: 'application/vnd.github+json',
     };
-    if (token) {
+    // Only ever send the token to GitHub's own API host. A redirect can point
+    // anywhere, and forwarding Authorization off-host would leak CI's
+    // GITHUB_TOKEN to a third party.
+    if (token && new URL(url).host === API_HOST) {
       headers.Authorization = `Bearer ${token}`;
     }
 
-    const releasePath =
-      ANT_RELEASE_TAG === 'latest'
-        ? `/repos/${ANT_REPO}/releases/latest`
-        : `/repos/${ANT_REPO}/releases/tags/${ANT_RELEASE_TAG}`;
-
-    const options = {
-      hostname: 'api.github.com',
-      path: releasePath,
-      headers,
-    };
-
     https
-      .get(options, (res) => {
+      .get(url, { headers }, (res) => {
+        if (REDIRECT_STATUS_CODES.includes(res.statusCode)) {
+          // Drain the redirect body so the socket can be reused, and let the
+          // redirected request own completion from here.
+          res.resume();
+          if (redirectCount >= MAX_REDIRECTS) {
+            reject(new Error(`Too many redirects fetching release (${url})`));
+            return;
+          }
+          // Guard the missing header explicitly: `new URL(undefined, base)`
+          // resolves to `<base origin>/undefined` rather than throwing, which
+          // would send the next hop somewhere meaningless.
+          if (!res.headers.location) {
+            reject(new Error(`Redirect ${res.statusCode} with no Location header (${url})`));
+            return;
+          }
+          let location;
+          try {
+            location = new URL(res.headers.location, url);
+          } catch {
+            reject(
+              new Error(`Invalid redirect fetching release (${url}): ${res.headers.location}`)
+            );
+            return;
+          }
+          if (location.protocol !== 'https:') {
+            reject(new Error(`Refusing non-HTTPS redirect fetching release (${url})`));
+            return;
+          }
+          console.warn(
+            `Release fetch redirected to ${location.href} — upstream repo may have moved`
+          );
+          fetchReleaseOnce(location.href, redirectCount + 1).then(resolve, reject);
+          return;
+        }
         let data = '';
+        res.on('error', reject);
         res.on('data', (chunk) => (data += chunk));
         res.on('end', () => {
-          if (res.statusCode === 200) {
+          if (res.statusCode !== 200) {
+            reject(new Error(`Failed to fetch release (${url}): ${res.statusCode}`));
+            return;
+          }
+          try {
             resolve(JSON.parse(data));
-          } else {
-            reject(new Error(`Failed to fetch release (${releasePath}): ${res.statusCode}`));
+          } catch (err) {
+            reject(new Error(`Invalid JSON from release fetch (${url}): ${err.message}`));
           }
         });
       })
@@ -89,19 +138,48 @@ async function fetchRelease() {
 // timeout (a hung binary download can otherwise burn a whole e2e job).
 const REQUEST_TIMEOUT_MS = 60000;
 
-function downloadFileOnce(url, dest) {
+function downloadFileOnce(url, dest, redirectCount = 0) {
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(dest);
+    let settled = false;
     const fail = (err) => {
+      if (settled) return;
+      settled = true;
       file.close();
       fs.unlink(dest, () => reject(err));
     };
     const req = https
       .get(url, { headers: { 'User-Agent': 'Freedom-Updater' } }, (response) => {
-        if (response.statusCode === 302 || response.statusCode === 301) {
+        response.on('error', fail);
+        if (REDIRECT_STATUS_CODES.includes(response.statusCode)) {
+          if (redirectCount >= MAX_REDIRECTS) {
+            fail(new Error(`Too many redirects while downloading ${url}`));
+            return;
+          }
+          if (!response.headers.location) {
+            fail(new Error(`Redirect ${response.statusCode} with no Location header for ${url}`));
+            return;
+          }
+          let location;
+          try {
+            location = new URL(response.headers.location, url);
+          } catch {
+            fail(new Error(`Invalid redirect while downloading ${url}`));
+            return;
+          }
+          if (location.protocol !== 'https:') {
+            fail(new Error(`Refusing non-HTTPS redirect while downloading ${url}`));
+            return;
+          }
+          // The redirected request owns completion from here. Ignore any late
+          // error emitted by the response we are deliberately draining.
+          settled = true;
+          response.resume();
           file.close();
           fs.unlink(dest, () => {
-            downloadFileOnce(response.headers.location, dest).then(resolve).catch(reject);
+            downloadFileOnce(location.href, dest, redirectCount + 1)
+              .then(resolve)
+              .catch(reject);
           });
           return;
         }
@@ -110,9 +188,13 @@ function downloadFileOnce(url, dest) {
           return;
         }
         response.pipe(file);
-        file.on('finish', () => {
-          file.close(resolve);
-        });
+        file.on('finish', () =>
+          file.close(() => {
+            if (settled) return;
+            settled = true;
+            resolve();
+          })
+        );
         file.on('error', fail);
       })
       .on('error', fail);
@@ -317,4 +399,9 @@ async function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+// Exported for unit tests; `npm run ant:download` still runs main() above.
+module.exports = { fetchReleaseOnce, releaseUrl, parseChecksums, ANT_REPO };

--- a/scripts/fetch-ant.test.js
+++ b/scripts/fetch-ant.test.js
@@ -1,0 +1,165 @@
+/**
+ * Redirect handling for the Ant release lookup.
+ *
+ * GitHub answers an API request for a renamed repo with a 301 to the new
+ * canonical location. Before this was handled, the solardev-xyz/ant →
+ * freedom-hq/ant rename turned every `npm run ant:download` into a hard
+ * failure and took out the e2e-ant and e2e-onboarding-identity CI jobs on
+ * every branch, main included.
+ *
+ * `https` is mocked rather than served for real: the code under test hardcodes
+ * https:// (deliberately — it refuses to downgrade across a redirect), so a
+ * plain local listener can't stand in for it.
+ */
+
+const https = require('https');
+const { EventEmitter } = require('events');
+
+jest.mock('https');
+
+const { fetchReleaseOnce, releaseUrl, ANT_REPO } = require('./fetch-ant');
+
+// Build a fake `https.get` that replays scripted responses in order and
+// records the (url, options) each call was made with.
+function mockResponses(responses) {
+  const calls = [];
+  https.get.mockImplementation((url, options, callback) => {
+    calls.push({ url, headers: options.headers });
+    const scripted = responses[calls.length - 1];
+    if (!scripted) throw new Error(`Unexpected request #${calls.length} to ${url}`);
+
+    const req = new EventEmitter();
+    req.setTimeout = jest.fn();
+    req.destroy = jest.fn();
+
+    const res = new EventEmitter();
+    res.statusCode = scripted.statusCode;
+    res.headers = scripted.headers || {};
+    res.resume = jest.fn();
+
+    process.nextTick(() => {
+      callback(res);
+      process.nextTick(() => {
+        if (scripted.body !== undefined) res.emit('data', scripted.body);
+        res.emit('end');
+      });
+    });
+    return req;
+  });
+  return calls;
+}
+
+const RELEASE = { tag_name: 'v0.5.43', assets: [] };
+
+afterEach(() => {
+  jest.resetAllMocks();
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.GH_TOKEN;
+});
+
+describe('fetch-ant release lookup', () => {
+  test('points at the current upstream repo, freedom-hq/ant', () => {
+    expect(ANT_REPO).toBe('freedom-hq/ant');
+    expect(releaseUrl()).toMatch('https://api.github.com/repos/freedom-hq/ant/releases/');
+  });
+
+  test('resolves a 200 without redirecting', async () => {
+    const calls = mockResponses([{ statusCode: 200, body: JSON.stringify(RELEASE) }]);
+    await expect(fetchReleaseOnce()).resolves.toEqual(RELEASE);
+    expect(calls).toHaveLength(1);
+  });
+
+  // The regression this PR fixes: a renamed repo must not be fatal.
+  test('follows a 301 from a renamed repo to the new location', async () => {
+    const calls = mockResponses([
+      {
+        statusCode: 301,
+        headers: {
+          location: 'https://api.github.com/repositories/1220484552/releases/tags/v0.5.43',
+        },
+      },
+      { statusCode: 200, body: JSON.stringify(RELEASE) },
+    ]);
+
+    await expect(
+      fetchReleaseOnce('https://api.github.com/repos/solardev-xyz/ant/releases/tags/v0.5.43')
+    ).resolves.toEqual(RELEASE);
+
+    expect(calls.map((c) => c.url)).toEqual([
+      'https://api.github.com/repos/solardev-xyz/ant/releases/tags/v0.5.43',
+      'https://api.github.com/repositories/1220484552/releases/tags/v0.5.43',
+    ]);
+  });
+
+  test.each([302, 303, 307, 308])('follows a %i redirect', async (statusCode) => {
+    mockResponses([
+      { statusCode, headers: { location: '/repos/freedom-hq/ant/releases/tags/v0.5.43' } },
+      { statusCode: 200, body: JSON.stringify(RELEASE) },
+    ]);
+    await expect(fetchReleaseOnce()).resolves.toEqual(RELEASE);
+  });
+
+  test('resolves a relative Location against the current URL', async () => {
+    const calls = mockResponses([
+      { statusCode: 301, headers: { location: '/repositories/1220484552/releases/latest' } },
+      { statusCode: 200, body: JSON.stringify(RELEASE) },
+    ]);
+    await expect(fetchReleaseOnce()).resolves.toEqual(RELEASE);
+    expect(calls[1].url).toBe('https://api.github.com/repositories/1220484552/releases/latest');
+  });
+
+  test('sends the GitHub token to api.github.com', async () => {
+    process.env.GITHUB_TOKEN = 'ci-token';
+    const calls = mockResponses([{ statusCode: 200, body: JSON.stringify(RELEASE) }]);
+    await fetchReleaseOnce();
+    expect(calls[0].headers.Authorization).toBe('Bearer ci-token');
+  });
+
+  // A redirect can point anywhere; forwarding Authorization off-host would
+  // leak CI's GITHUB_TOKEN to a third party.
+  test('drops the GitHub token when a redirect leaves api.github.com', async () => {
+    process.env.GITHUB_TOKEN = 'ci-token';
+    const calls = mockResponses([
+      { statusCode: 301, headers: { location: 'https://evil.example.com/releases' } },
+      { statusCode: 200, body: JSON.stringify(RELEASE) },
+    ]);
+    await fetchReleaseOnce();
+    expect(calls[0].headers.Authorization).toBe('Bearer ci-token');
+    expect(calls[1].url).toBe('https://evil.example.com/releases');
+    expect(calls[1].headers.Authorization).toBeUndefined();
+  });
+
+  // `new URL(undefined, base)` resolves to `<base>/undefined` instead of
+  // throwing, so a missing Location must be rejected explicitly or the next
+  // hop goes somewhere meaningless.
+  test('rejects a redirect with no Location header', async () => {
+    const calls = mockResponses([{ statusCode: 301, headers: {} }]);
+    await expect(fetchReleaseOnce()).rejects.toThrow(/no Location header/);
+    expect(calls).toHaveLength(1);
+  });
+
+  test('refuses a redirect that downgrades to plain HTTP', async () => {
+    mockResponses([{ statusCode: 301, headers: { location: 'http://api.github.com/x' } }]);
+    await expect(fetchReleaseOnce()).rejects.toThrow(/non-HTTPS redirect/);
+  });
+
+  test('gives up after too many redirects instead of looping forever', async () => {
+    mockResponses(
+      Array.from({ length: 7 }, () => ({
+        statusCode: 301,
+        headers: { location: 'https://api.github.com/loop' },
+      }))
+    );
+    await expect(fetchReleaseOnce()).rejects.toThrow(/Too many redirects/);
+  });
+
+  test('still surfaces a non-redirect failure status', async () => {
+    mockResponses([{ statusCode: 404, body: '{"message":"Not Found"}' }]);
+    await expect(fetchReleaseOnce()).rejects.toThrow(/Failed to fetch release .*: 404/);
+  });
+
+  test('rejects rather than throwing on a malformed JSON body', async () => {
+    mockResponses([{ statusCode: 200, body: 'not json' }]);
+    await expect(fetchReleaseOnce()).rejects.toThrow(/Invalid JSON/);
+  });
+});


### PR DESCRIPTION
## What broke

The Ant upstream repo was renamed `solardev-xyz/ant` → `freedom-hq/ant`. GitHub answers an API request for a renamed repo with a **301** to the new canonical location rather than serving it:

```
$ curl -sI https://api.github.com/repos/solardev-xyz/ant/releases/tags/v0.5.43
HTTP/2 301
location: https://api.github.com/repositories/1220484552/releases/tags/v0.5.43
```

`scripts/fetch-ant.js` treated anything other than 200 as fatal, so every `npm run ant:download` failed — taking out the `e2e-ant` job and all three `e2e-onboarding-identity` jobs on **every branch, `main` included** (seen on PR #188 head f5431a46 and on PR #197).

## What changed

Pointing at the new name alone would just break again on the next rename, so this is two parts:

**1. `ANT_REPO` now defaults to `freedom-hq/ant`.**

**2. The release lookup follows redirects**, so the next rename degrades to an extra hop instead of a red CI board:

- `301/302/303/307/308`, capped at 5 hops, `https`-only (refuses a downgrade to plain HTTP).
- Relative `Location` headers resolve against the current URL.
- **The `Authorization` header is only sent to `api.github.com`.** A redirect can point anywhere; forwarding it off-host would leak CI's `GITHUB_TOKEN` to a third party.
- A redirect with **no** `Location` header is rejected explicitly — `new URL(undefined, base)` resolves to `<base>/undefined` rather than throwing, so without this guard the next hop would silently go somewhere meaningless.

**3. Sibling parity on the asset-download path.** `downloadFileOnce` had the same weakness in milder form (301/302 only, no hop cap, no protocol check, no double-settle guard). It's brought up to the semantics its sibling `scripts/fetch-myotis.js` already had, so the two read identically.

**4. Every remaining `solardev-xyz/ant` reference updated** — `docs/agent-playbooks/release-process.md` (the pinned-URL table at :86 *and* the license-check note at :145), `NOTICES`, `LICENSE_AUDIT.md`, `licenses-audit.json`, and the two `CHANGELOG.md` entries that link the upstream repo. `grep -rn "solardev-xyz/ant"` is now clean apart from the deliberate historical mentions in the fix's own comments and tests.

Per the task, alan's own target-repo config was left untouched.

## Verification

**The actual `e2e-ant` job, run locally — passes.** Both setup steps (`ant:download`, `ipfs:download`) succeed, and the live spec they gate passes:

```
✓ 1 [live] › eth-sites.spec.js:182 › cold-start: Bee reaches peers, native IPFS
  starts, ENS, WNS, and GNS sites render (38.4s)
  1 passed (39.9s)
```

**Full download works**, with the in-repo pinned SHA256SUMS digest still matching — the release content is byte-identical across the rename, no re-publish:

```
Fetching Ant release info from freedom-hq/ant @ v0.5.43...
Verified SHA256SUMS against the in-repo pinned digest
Successfully installed Ant for mac-arm64 / mac-x64 / linux-x64 / linux-arm64 / win-x64
All downloads complete.
$ ./ant-bin/linux-x64/antd --version
antd 0.5.43
```

**The graceful-degradation claim, proven against real GitHub** — forcing the *old* repo name now succeeds via the live 301 instead of failing:

```
$ ANT_REPO=solardev-xyz/ant node -e "require('./scripts/fetch-ant.js').fetchReleaseOnce().then(r => console.log(r.html_url))"
Release fetch redirected to https://api.github.com/repositories/1220484552/releases/tags/v0.5.43 — upstream repo may have moved
https://github.com/freedom-hq/ant/releases/tag/v0.5.43
```

**New unit tests** — `scripts/fetch-ant.test.js`, 15 tests covering the 301-from-rename case, each of 302/303/307/308, relative-`Location` resolution, token-sent-to-GitHub, token-dropped-off-host, HTTP-downgrade refusal, missing-`Location`, hop cap, non-redirect failure status, and malformed JSON. The script now only auto-runs under `require.main === module` so it can be required by the test.

**Mutation-tested** so the new tests carry real assertions, not incidental ones:

| Mutation | Result |
| --- | --- |
| `REDIRECT_STATUS_CODES = []` | 9 of 14 fail |
| drop the `host === API_HOST` guard on `Authorization` | the token-leak test fails, alone |
| revert `ANT_REPO` to `solardev-xyz/ant` | the repo-name test fails, alone |

**Suite-wide:** `npm run test:unit` → 168 suites, 3248 passed, 0 failed. `npm run lint` clean. `npm run check-binaries` no longer reports Ant missing.

## Visual acceptance evidence

Screenshots below (captured via a throwaway instrumented copy of the live spec, since deleted) show the freshly-downloaded binary actually working, not just present:

- **Nodes menu** — `Version: Ant v0.5.43`, `Connected Peers: 400`. The binary fetched from `freedom-hq/ant` runs and joins the Swarm network.
- **`bzz://meinhard.eth/`** — a Swarm-hosted site retrieved through that node and rendering in the browser.

## Notes for the reviewer

- `NOTICES` still reads `Copyright (c) solardev-xyz contributors`, which I left alone. Upstream's `LICENSE-MIT` actually says `Copyright (c) 2026 Meinhard Benn and the Ant Authors` — so that line was already wrong before the rename. Correcting a legal attribution felt out of scope for a CI unbreak; happy to do it here or in a follow-up, your call.
- `scripts/fetch-myotis.js`'s `httpsGetJson` has the *same* latent no-redirect-following gap in its API lookup (its download path is already fine — that's the one I mirrored). `biafra23/myotis` hasn't been renamed so nothing is broken today, but it's the identical trap. Deliberately left out to keep this a tight CI fix; say the word and I'll follow up.
- `scripts/fetch-ant.js` had three pre-existing Prettier deviations (lines 27, ~292, ~319). I left them as-is and only formatted the lines this PR touches, so the diff stays reviewable. Note `format:check` isn't wired into CI, and several files including this one and `fetch-myotis.js` already fail it on `main`.