### PR TITLE
ci(release): add signed macOS arm64 release workflow

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -26,7 +26,9 @@ name: Release (macOS arm64)
 # electron-builder imports CSC_LINK into a temporary keychain on CI and
 # `build.mac.notarize: true` in package.json submits + staples the
 # notarization inline, exactly like the maintainer flow in
-# docs/agent-playbooks/release-process.md §5.
+# docs/agent-playbooks/release-process.md §5. That inline pass covers
+# `Freedom.app` only — the disk image dmg-builder wraps around it is
+# notarized and stapled by a separate step below.
 
 on:
   push:
@@ -164,12 +166,77 @@ jobs:
         if: env.SIGNED != 'true'
         run: npm run dist -- --mac --arm64 --unsigned --no-notarize
 
+      # `build.mac.notarize: true` submits and staples `Freedom.app` and stops
+      # there: dmg-builder wraps that already-stapled app in a disk image but
+      # never notarizes the image itself, so the `.dmg` carries no ticket of
+      # its own — Gatekeeper has to check it online when a user opens it, and
+      # `xcrun stapler validate` on it fails outright. Notarize and staple
+      # each disk image here, the same thing `npm run dist:mac:staple-notary`
+      # does in the out-of-band flow (release-process.md §5).
+      - name: Notarize and staple the disk image
+        if: env.SIGNED == 'true'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          shopt -s nullglob
+          dmgs=(dist/*.dmg)
+          if [ ${#dmgs[@]} -eq 0 ]; then
+            echo "No .dmg in dist/ to notarize." >&2
+            exit 1
+          fi
+          for dmg in "${dmgs[@]}"; do
+            echo "Notarizing $(basename "$dmg")"
+            xcrun notarytool submit "$dmg" \
+              --apple-id "$APPLE_ID" \
+              --team-id "$APPLE_TEAM_ID" \
+              --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+              --wait --timeout 30m
+            xcrun stapler staple "$dmg"
+          done
+
+      # Stapling rewrites the disk image, so the sha512/size electron-builder
+      # recorded for it before the ticket was attached no longer describe the
+      # file that gets uploaded. electron-updater only ever reads the `.zip`
+      # entry on macOS, but latest-mac.yml is a checksum manifest: refresh the
+      # `.dmg` entry so every hash it publishes matches the bytes actually
+      # shipped. The `.dmg.blockmap` still describes the pre-staple bytes;
+      # nothing on the macOS update path reads it, and a mismatch there only
+      # costs a full download instead of a differential one.
+      - name: Refresh mac update metadata
+        if: env.SIGNED == 'true'
+        run: |
+          node - <<'NODE'
+          const crypto = require('crypto');
+          const fs = require('fs');
+          const path = require('path');
+
+          const ymlPath = path.join('dist', 'latest-mac.yml');
+          let yml = fs.readFileSync(ymlPath, 'utf8');
+
+          for (const name of fs.readdirSync('dist').filter((f) => f.endsWith('.dmg'))) {
+            const bytes = fs.readFileSync(path.join('dist', name));
+            const sha512 = crypto.createHash('sha512').update(bytes).digest('base64');
+            const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const entry = new RegExp(`(- url: ${escaped}\\n\\s+sha512: )\\S+(\\n\\s+size: )\\d+`);
+            if (!entry.test(yml)) {
+              throw new Error(`No ${name} entry in ${ymlPath} to refresh`);
+            }
+            yml = yml.replace(entry, `$1${sha512}$2${bytes.length}`);
+            console.log(`${name}: sha512 refreshed, size ${bytes.length}`);
+          }
+
+          fs.writeFileSync(ymlPath, yml);
+          NODE
+
       - name: Verify signature, notarization and staple
         if: env.SIGNED == 'true'
         run: |
           set -x
           codesign --verify --deep --strict --verbose=2 dist/mac-arm64/Freedom.app
           spctl --assess --type execute --verbose dist/mac-arm64/Freedom.app
+          xcrun stapler validate dist/mac-arm64/Freedom.app
           for dmg in dist/*.dmg; do xcrun stapler validate "$dmg"; done
 
       - name: List distributables

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -306,7 +306,20 @@ jobs:
           Changelog: ${changelog}"
               ;;
           esac
-          state="$(gh release view "$TAG" --json isDraft --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo missing)"
+          # Look the tag up in the full release list rather than `gh release
+          # view`, whose non-zero exit cannot tell a transient API error from
+          # "no release yet" — and GitHub happily creates a second draft for
+          # the same tag. A failed list call fails the step.
+          if ! found="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+                --jq ".[] | select(.tag_name == \"${TAG}\") | if .draft then \"draft\" else \"published\" end")"; then
+            echo "Could not list releases for ${GITHUB_REPOSITORY}; not touching the release." >&2
+            exit 1
+          fi
+          if [ "$(printf '%s\n' "$found" | grep -c .)" -gt 1 ]; then
+            echo "More than one release exists for $TAG; resolve the duplicates by hand." >&2
+            exit 1
+          fi
+          state="${found:-missing}"
           case "$state" in
             published)
               echo "Release $TAG is already published; refusing to overwrite its assets. Cut a new version instead." >&2

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -1,0 +1,202 @@
+name: Release (macOS arm64)
+
+# Builds the Apple Silicon distributable on a GitHub-hosted macOS runner,
+# signs + notarizes it with the Developer ID secrets, and attaches the result
+# to a draft GitHub Release for the pushed tag.
+#
+# Triggers:
+#   - push of a `v*` tag: signed build, verified, attached to a draft release
+#     (a maintainer publishes the draft after the §6 smoke test in
+#     docs/agent-playbooks/release-process.md).
+#   - workflow_dispatch: signed by default; set `signed: false` for an
+#     unsigned pipeline test. Dispatch runs only upload a workflow artifact,
+#     never a release.
+#
+# Required repository secrets for a signed build (Settings → Secrets and
+# variables → Actions):
+#   CSC_LINK                    Developer ID Application cert, .p12 exported
+#                               from Keychain, base64-encoded
+#   CSC_KEY_PASSWORD            password set on that .p12 export
+#   APPLE_ID                    Apple ID used for notarytool
+#   APPLE_TEAM_ID               team id (46XPHRBLH5 for Solar Dev Ltd)
+#   APPLE_APP_SPECIFIC_PASSWORD app-specific password for that Apple ID
+#
+# electron-builder imports CSC_LINK into a temporary keychain on CI and
+# `build.mac.notarize: true` in package.json submits + staples the
+# notarization inline, exactly like the maintainer flow in
+# docs/agent-playbooks/release-process.md §5.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      signed:
+        description: >-
+          Sign and notarize with the Developer ID secrets. Uncheck for an
+          unsigned pipeline test that needs no secrets.
+        type: boolean
+        default: true
+      bundle_tor:
+        description: >-
+          Build and bundle the Arti (Tor) client. Compiles from crates.io with
+          cargo and adds several minutes.
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-mac-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mac-arm64:
+    runs-on: macos-14
+    timeout-minutes: 120
+    permissions:
+      contents: write
+    env:
+      # Tag pushes are always signed and always bundle Tor; dispatch runs
+      # follow their inputs (`inputs.*` is null on push, hence the OR).
+      SIGNED: ${{ github.event_name == 'push' || inputs.signed }}
+      BUNDLE_TOR: ${{ github.event_name == 'push' || inputs.bundle_tor }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Assert Apple Silicon runner
+        run: |
+          if [ "$(uname -m)" != "arm64" ]; then
+            echo "Expected an arm64 macOS runner, got $(uname -m)" >&2
+            exit 1
+          fi
+
+      - name: Check signing secrets are configured
+        if: env.SIGNED == 'true'
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          missing=""
+          for name in CSC_LINK CSC_KEY_PASSWORD APPLE_ID APPLE_TEAM_ID APPLE_APP_SPECIFIC_PASSWORD; do
+            if [ -z "${!name}" ]; then missing="$missing $name"; fi
+          done
+          if [ -n "$missing" ]; then
+            echo "Signed build requested but these repository secrets are empty:$missing" >&2
+            echo "Add them under Settings → Secrets and variables → Actions, or re-run with signed=false for an unsigned pipeline test." >&2
+            exit 1
+          fi
+
+      - name: Assert package.json version matches the tag
+        if: github.event_name == 'push'
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$version" ]; then
+            echo "Tag v$tag does not match package.json version $version." >&2
+            echo "Promote the dev version on the release branch first (release-process.md §1)." >&2
+            exit 1
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      # Full install (with lifecycle scripts): `electron-builder install-app-deps`
+      # rebuilds the native modules against Electron on the arm64 host.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download adblock filter lists
+        run: npm run adblock:download
+
+      - name: Download Ant binaries
+        run: npm run ant:download
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download IPFS native addon
+        run: npm run ipfs:download
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download libradicle addon
+        run: npm run radicle:download -- --mac --arm64
+
+      - name: Download Myotis addon
+        run: npm run myotis:download
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MYOTIS_DOWNLOAD_TARGET: darwin-arm64
+
+      - name: Build Arti (Tor) client
+        if: env.BUNDLE_TOR == 'true'
+        run: |
+          if ! command -v cargo >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+            export PATH="$HOME/.cargo/bin:$PATH"
+          fi
+          npm run tor:download
+
+      - name: Build, sign and notarize
+        if: env.SIGNED == 'true'
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: npm run dist -- --mac --arm64
+
+      - name: Build unsigned (pipeline test)
+        if: env.SIGNED != 'true'
+        run: npm run dist -- --mac --arm64 --unsigned --no-notarize
+
+      - name: Verify signature, notarization and staple
+        if: env.SIGNED == 'true'
+        run: |
+          set -x
+          codesign --verify --deep --strict --verbose=2 dist/mac-arm64/Freedom.app
+          spctl --assess --type execute --verbose dist/mac-arm64/Freedom.app
+          for dmg in dist/*.dmg; do xcrun stapler validate "$dmg"; done
+
+      - name: List distributables
+        run: ls -la dist
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: freedom-mac-arm64-${{ env.SIGNED == 'true' && 'signed' || 'unsigned' }}
+          path: |
+            dist/*.dmg
+            dist/*.zip
+            dist/*.blockmap
+            dist/latest-mac.yml
+          if-no-files-found: error
+
+      # Draft so a maintainer can run the release-process.md §6 smoke test
+      # before anything becomes visible to end users. Re-runs on the same tag
+      # replace the assets instead of failing.
+      - name: Attach to draft GitHub Release
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          notes="Signed and notarized macOS (Apple Silicon) build of Freedom ${TAG#v}.
+
+          Changelog: https://github.com/${GITHUB_REPOSITORY}/blob/${TAG}/CHANGELOG.md"
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" --draft --verify-tag --title "Freedom ${TAG#v}" --notes "$notes"
+          fi
+          gh release upload "$TAG" --clobber dist/*.dmg dist/*.zip dist/*.blockmap dist/latest-mac.yml

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -5,9 +5,11 @@ name: Release (macOS arm64)
 # to a draft GitHub Release for the pushed tag.
 #
 # Triggers:
-#   - push of a `v*` tag: signed build, verified, attached to a draft release
-#     (a maintainer publishes the draft after the §6 smoke test in
-#     docs/agent-playbooks/release-process.md).
+#   - push of a `v*` tag: signed build, verified, attached to a GitHub
+#     Release. A pre-release tag (`v0.8.1-rc.1`, anything with a hyphen) is
+#     published immediately, flagged "Pre-release", so testers can download
+#     it. A final tag (`v0.8.1`) becomes a draft that a maintainer publishes
+#     after the §6 smoke test in docs/agent-playbooks/release-process.md.
 #   - workflow_dispatch: signed by default; set `signed: false` for an
 #     unsigned pipeline test. Dispatch runs only upload a workflow artifact,
 #     never a release.
@@ -184,19 +186,37 @@ jobs:
             dist/latest-mac.yml
           if-no-files-found: error
 
-      # Draft so a maintainer can run the release-process.md §6 smoke test
+      # Pre-release tags (semver with a hyphen: v0.8.1-alpha.1, v0.8.1-rc.2)
+      # are published at once and flagged "Pre-release" so testers can grab
+      # them; GitHub keeps them out of "Latest release". Final tags become a
+      # draft so a maintainer can run the release-process.md §6 smoke test
       # before anything becomes visible to end users. Re-runs on the same tag
       # replace the assets instead of failing.
-      - name: Attach to draft GitHub Release
+      - name: Attach to GitHub Release
         if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: |
-          notes="Signed and notarized macOS (Apple Silicon) build of Freedom ${TAG#v}.
+          version="${TAG#v}"
+          changelog="https://github.com/${GITHUB_REPOSITORY}/blob/${TAG}/CHANGELOG.md"
+          case "$version" in
+            *-*)
+              flag="--prerelease"
+              title="Freedom ${version} (pre-release)"
+              notes="Pre-release build of Freedom ${version} for macOS (Apple Silicon), signed and notarized. Not for general use: test it against a separate profile (FREEDOM_TEST_USER_DATA) and report problems on the release branch.
 
-          Changelog: https://github.com/${GITHUB_REPOSITORY}/blob/${TAG}/CHANGELOG.md"
+          Changelog so far: ${changelog}"
+              ;;
+            *)
+              flag="--draft"
+              title="Freedom ${version}"
+              notes="Signed and notarized macOS (Apple Silicon) build of Freedom ${version}.
+
+          Changelog: ${changelog}"
+              ;;
+          esac
           if ! gh release view "$TAG" >/dev/null 2>&1; then
-            gh release create "$TAG" --draft --verify-tag --title "Freedom ${TAG#v}" --notes "$notes"
+            gh release create "$TAG" "$flag" --verify-tag --title "$title" --notes "$notes"
           fi
           gh release upload "$TAG" --clobber dist/*.dmg dist/*.zip dist/*.blockmap dist/latest-mac.yml

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -98,6 +98,12 @@ jobs:
             exit 1
           fi
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
       - name: Assert package.json version matches the tag
         if: github.event_name == 'push'
         run: |
@@ -108,12 +114,6 @@ jobs:
             echo "Promote the dev version on the release branch first (release-process.md §1)." >&2
             exit 1
           fi
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: npm
 
       # Full install (with lifecycle scripts): `electron-builder install-app-deps`
       # rebuilds the native modules against Electron on the arm64 host.
@@ -128,10 +128,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+      # fetch-freedom-ipfs-native.js downloads release assets directly and
+      # makes no API calls, so it needs no token.
       - name: Download IPFS native addon
         run: npm run ipfs:download
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Download libradicle addon
         run: npm run radicle:download -- --mac --arm64
@@ -142,11 +142,26 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           MYOTIS_DOWNLOAD_TARGET: darwin-arm64
 
+      # The runner image normally ships cargo. If it does not, install a
+      # pinned, checksummed rustup-init rather than piping sh.rustup.rs into
+      # a shell: this job later holds the signing credentials, so nothing
+      # unpinned should run on it. Same convention as the fetch-* scripts.
       - name: Build Arti (Tor) client
         if: env.BUNDLE_TOR == 'true'
+        env:
+          RUSTUP_VERSION: 1.28.2
+          RUSTUP_SHA256: 20ef5516c31b1ac2290084199ba77dbbcaa1406c45c1d978ca68558ef5964ef5
         run: |
           if ! command -v cargo >/dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+            (
+              cd "$RUNNER_TEMP"
+              curl --proto '=https' --tlsv1.2 -sSfo rustup-init \
+                "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/aarch64-apple-darwin/rustup-init"
+              echo "${RUSTUP_SHA256}  rustup-init" | shasum -a 256 -c -
+              chmod +x rustup-init
+              ./rustup-init -y --profile minimal --no-modify-path
+              rm rustup-init
+            )
             echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
             export PATH="$HOME/.cargo/bin:$PATH"
           fi
@@ -252,13 +267,21 @@ jobs:
             dist/*.blockmap
             dist/latest-mac.yml
           if-no-files-found: error
+          # "Re-run failed jobs" keeps the previous attempt's artifact; without
+          # this the upload 409s and the run never reaches the release step.
+          overwrite: true
 
-      # Pre-release tags (semver with a hyphen: v0.8.1-alpha.1, v0.8.1-rc.2)
-      # are published at once and flagged "Pre-release" so testers can grab
-      # them; GitHub keeps them out of "Latest release". Final tags become a
-      # draft so a maintainer can run the release-process.md §6 smoke test
-      # before anything becomes visible to end users. Re-runs on the same tag
-      # replace the assets instead of failing.
+      # The release is always created as a draft first and only flipped to
+      # public once every asset is uploaded, so watchers never see an empty
+      # release. Pre-release tags (semver with a hyphen: v0.8.1-alpha.1,
+      # v0.8.1-rc.2) are then published flagged "Pre-release" so testers can
+      # grab them; GitHub keeps them out of "Latest release". Final tags stay
+      # a draft so a maintainer can run the release-process.md §6 smoke test
+      # before anything becomes visible to end users. Re-running the job on a
+      # tag whose release is still a draft replaces the assets; re-running on
+      # an already published release fails instead of overwriting files users
+      # may have downloaded and checksummed. Tags are never moved, so a bad
+      # published build means a new version, not a rebuild.
       - name: Attach to GitHub Release
         if: github.event_name == 'push'
         env:
@@ -269,21 +292,31 @@ jobs:
           changelog="https://github.com/${GITHUB_REPOSITORY}/blob/${TAG}/CHANGELOG.md"
           case "$version" in
             *-*)
-              flag="--prerelease"
+              prerelease=true
               title="Freedom ${version} (pre-release)"
               notes="Pre-release build of Freedom ${version} for macOS (Apple Silicon), signed and notarized. Not for general use: test it against a separate profile (FREEDOM_TEST_USER_DATA) and report problems on the release branch.
 
           Changelog so far: ${changelog}"
               ;;
             *)
-              flag="--draft"
+              prerelease=false
               title="Freedom ${version}"
               notes="Signed and notarized macOS (Apple Silicon) build of Freedom ${version}.
 
           Changelog: ${changelog}"
               ;;
           esac
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            gh release create "$TAG" "$flag" --verify-tag --title "$title" --notes "$notes"
-          fi
+          state="$(gh release view "$TAG" --json isDraft --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo missing)"
+          case "$state" in
+            published)
+              echo "Release $TAG is already published; refusing to overwrite its assets. Cut a new version instead." >&2
+              exit 1
+              ;;
+            missing)
+              gh release create "$TAG" --draft --verify-tag --title "$title" --notes "$notes"
+              ;;
+          esac
           gh release upload "$TAG" --clobber dist/*.dmg dist/*.zip dist/*.blockmap dist/latest-mac.yml
+          if [ "$prerelease" = true ]; then
+            gh release edit "$TAG" --draft=false --prerelease
+          fi

--- a/docs/agent-playbooks/release-process.md
+++ b/docs/agent-playbooks/release-process.md
@@ -170,6 +170,15 @@ npm run dist:mac:staple-notary      # staple once accepted
 
 These require `.env` credentials via `dotenv-cli` and are implemented in `scripts/macos-notary.js`.
 
+### macOS (Apple Silicon) via GitHub Actions
+
+`.github/workflows/release-mac.yml` produces the same signed + notarized arm64 `.dmg` / `.zip` on a GitHub-hosted `macos-14` runner, so a release does not depend on one maintainer's Mac.
+
+- **Tag push (`v*`)** — signed build, verified with `codesign` / `spctl` / `stapler`, and attached to a **draft** GitHub Release for that tag together with `latest-mac.yml` and the `.blockmap`. The job fails fast if `package.json` does not match the tag (step 1) or if any signing secret is missing. Publish the draft only after the §6 smoke test passes; `freedom.baby/downloads` (§7) remains the updater channel, so still upload the artifacts there.
+- **Manual run** (Actions → "Release (macOS arm64)" → Run workflow) — builds from any branch and uploads a workflow artifact only, no release. Untick `signed` for an unsigned pipeline test that needs no secrets; untick `bundle_tor` to skip the cargo build of Arti.
+
+Signed runs need these repository secrets (Settings → Secrets and variables → Actions): `CSC_LINK` (the Developer ID Application certificate exported from Keychain as a password-protected `.p12`, then base64-encoded), `CSC_KEY_PASSWORD`, and the same `APPLE_ID` / `APPLE_TEAM_ID` / `APPLE_APP_SPECIFIC_PASSWORD` as `.env.example`. `electron-builder` imports the certificate into a temporary keychain for the run.
+
 ### Linux
 
 ```

--- a/docs/agent-playbooks/release-process.md
+++ b/docs/agent-playbooks/release-process.md
@@ -185,7 +185,7 @@ These require `.env` credentials via `dotenv-cli` and are implemented in `script
 
 `.github/workflows/release-mac.yml` produces the same signed + notarized arm64 `.dmg` / `.zip` on a GitHub-hosted `macos-14` runner, so a release does not depend on one maintainer's Mac.
 
-- **Tag push (`v*`)** — signed build, then the `.dmg` is notarized and stapled in its own step (electron-builder's inline pass covers the `.app` only, see above) and `latest-mac.yml`'s `.dmg` entry is refreshed to the stapled bytes. The result is verified with `codesign` / `spctl` / `stapler` — the staple check now covers both `Freedom.app` and every `.dmg` — and attached to a GitHub Release for that tag together with `latest-mac.yml` and the `.blockmap`. A final tag (`v0.8.1`) produces a **draft**; publish it only after the §6 smoke test passes. A pre-release tag (`v0.8.1-rc.1`, anything with a hyphen) is published immediately and flagged **Pre-release** — see "Release candidates" below. The job fails fast if `package.json` does not match the tag (step 1) or if any signing secret is missing. `freedom.baby/downloads` (§7) remains the updater channel, so still upload final artifacts there.
+- **Tag push (`v*`)** — signed build, then the `.dmg` is notarized and stapled in its own step (electron-builder's inline pass covers the `.app` only, see above) and `latest-mac.yml`'s `.dmg` entry is refreshed to the stapled bytes. The result is verified with `codesign` / `spctl` / `stapler` — the staple check now covers both `Freedom.app` and every `.dmg` — and attached to a GitHub Release for that tag together with `latest-mac.yml` and the `.blockmap`. A final tag (`v0.8.1`) produces a **draft**; publish it only after the §6 smoke test passes. A pre-release tag (`v0.8.1-rc.1`, anything with a hyphen) is published as soon as its assets are uploaded and flagged **Pre-release** — see "Release candidates" below. Re-running the job on a tag whose release is already published fails rather than overwriting the live files; tags are never moved, so a bad published build means a new version. With the Actions build, the tag is the build trigger — push it before §6 (see §8 for the reordered flow). The job fails fast if `package.json` does not match the tag (step 1) or if any signing secret is missing. `freedom.baby/downloads` (§7) remains the updater channel, so still upload final artifacts there.
 - **Manual run** (Actions → "Release (macOS arm64)" → Run workflow) — builds from any branch and uploads a workflow artifact only, no release. Untick `signed` for an unsigned pipeline test that needs no secrets; untick `bundle_tor` to skip the cargo build of Arti.
 
 Signed runs need these repository secrets (Settings → Secrets and variables → Actions): `CSC_LINK` (the Developer ID Application certificate exported from Keychain as a password-protected `.p12`, then base64-encoded), `CSC_KEY_PASSWORD`, and the same `APPLE_ID` / `APPLE_TEAM_ID` / `APPLE_APP_SPECIFIC_PASSWORD` as `.env.example`. `electron-builder` imports the certificate into a temporary keychain for the run.
@@ -346,7 +346,12 @@ On the release branch, from the commit you actually built and shipped:
 git tag -a v<version> -m "Release <version>"
 ```
 
-Tag format is `v<version>` (lowercase `v`), matching `v0.6.2`. Do not push the tag yet — push it together with the merge in the next step so `main` and the tag move as one.
+Tag format is `v<version>` (lowercase `v`), matching `v0.6.2`.
+
+When to push the tag depends on which build is the release build:
+
+- **GitHub Actions build (default).** The tag is the build trigger, so push it from the release branch as soon as the release commit (version bump + changelog) is final — before §6. Wait for the "Release (macOS arm64)" run, download the assets from the draft release it creates, and use _those_ files for the §6 smoke test and the §7 upload to `freedom.baby`, so GitHub and `freedom.baby` serve byte-identical binaries and a single `latest-mac.yml`. Publish the draft in §10. A tag is never moved: a final that fails §6 becomes the next patch version, not a retag — which is why a final should only be tagged after an `rc.N` from the same workflow has already passed §6 ("Release candidates" above).
+- **Local build (fallback).** If you built on your own Mac (§5, inline or async flow), keep the original order: do not push the tag until the §9 merge, so `main` and the tag move as one. The Actions run that tag triggers produces a _second_ signed build whose hashes differ from what you uploaded; delete that draft instead of publishing it, so GitHub never advertises files that do not match `freedom.baby`.
 
 ## 9. Merge the release branch into main
 
@@ -357,14 +362,14 @@ git checkout main
 git pull --ff-only
 git merge --no-ff release/<version>
 git push origin main
-git push origin v<version>
+git push origin v<version>   # no-op if the tag was already pushed for the Actions build (§8)
 ```
 
 The `--no-ff` is deliberate — it preserves the release branch as a visible bubble in `main`'s history, which matches how earlier releases landed.
 
 ## 10. Post-release housekeeping
 
-- Confirm the GitHub release page lists the correct artifacts and release notes.
+- Publish the draft GitHub Release created by the Actions build (or delete it if the release was built locally, see §8), and confirm the release page lists the correct artifacts and release notes.
 - Keep the `release/<version>` branch around (do not delete) — it matches the historical pattern and is the natural base for a `hotfix/<version>.<patch>` branch later if needed.
 - Any build-only fixes that land after the version bump should be committed on the release branch with `fix(build): ...` messages, same as the `0.6.2` cycle did.
 

--- a/docs/agent-playbooks/release-process.md
+++ b/docs/agent-playbooks/release-process.md
@@ -174,7 +174,7 @@ These require `.env` credentials via `dotenv-cli` and are implemented in `script
 
 `.github/workflows/release-mac.yml` produces the same signed + notarized arm64 `.dmg` / `.zip` on a GitHub-hosted `macos-14` runner, so a release does not depend on one maintainer's Mac.
 
-- **Tag push (`v*`)** — signed build, verified with `codesign` / `spctl` / `stapler`, and attached to a **draft** GitHub Release for that tag together with `latest-mac.yml` and the `.blockmap`. The job fails fast if `package.json` does not match the tag (step 1) or if any signing secret is missing. Publish the draft only after the §6 smoke test passes; `freedom.baby/downloads` (§7) remains the updater channel, so still upload the artifacts there.
+- **Tag push (`v*`)** — signed build, verified with `codesign` / `spctl` / `stapler`, and attached to a GitHub Release for that tag together with `latest-mac.yml` and the `.blockmap`. A final tag (`v0.8.1`) produces a **draft**; publish it only after the §6 smoke test passes. A pre-release tag (`v0.8.1-rc.1`, anything with a hyphen) is published immediately and flagged **Pre-release** — see "Release candidates" below. The job fails fast if `package.json` does not match the tag (step 1) or if any signing secret is missing. `freedom.baby/downloads` (§7) remains the updater channel, so still upload final artifacts there.
 - **Manual run** (Actions → "Release (macOS arm64)" → Run workflow) — builds from any branch and uploads a workflow artifact only, no release. Untick `signed` for an unsigned pipeline test that needs no secrets; untick `bundle_tor` to skip the cargo build of Arti.
 
 Signed runs need these repository secrets (Settings → Secrets and variables → Actions): `CSC_LINK` (the Developer ID Application certificate exported from Keychain as a password-protected `.p12`, then base64-encoded), `CSC_KEY_PASSWORD`, and the same `APPLE_ID` / `APPLE_TEAM_ID` / `APPLE_APP_SPECIFIC_PASSWORD` as `.env.example`. `electron-builder` imports the certificate into a temporary keychain for the run.
@@ -291,6 +291,23 @@ If any platform fails:
 - Proceed to §7 only when every platform you intend to ship passes.
 
 This step is intentionally separate from §4 — §4 verifies the source tree (`npm test`, `npm start` from source); §6 verifies the **packaged artifact** that end users will install. They catch different classes of bugs.
+
+## Release candidates (optional loop between §5 and §7)
+
+When a release needs testing on machines or by people who do not build from source, cut pre-release builds from the release branch instead of sharing ad-hoc artifacts. The version string is the marker: use semver pre-release identifiers, never a separate branch or tag scheme.
+
+1. On `release/<version>`, set the version in `package.json` and `package-lock.json` (same two files as §1) to `<version>-alpha.1` for early builds or `<version>-rc.1` once you believe it is shippable.
+2. Commit (`chore(release): cut <version>-rc.1`), tag `v<version>-rc.1`, and push both. The GitHub Actions job (§5) builds, signs, and publishes it as a **Pre-release** on GitHub — visible to testers, excluded from "Latest release".
+3. Fix issues with normal PRs against the release branch (or land them on `main` and cherry-pick). When a fix set is in, bump to `rc.2` and tag again. Never move or reuse a tag; the number always goes up. The final release is the bare `<version>` with no suffix, which sorts higher than every candidate.
+4. Do **not** upload candidate artifacts or manifests to `freedom.baby/downloads`. The in-app updater auto-downloads whatever that manifest advertises, so only finals go there. A tester on `rc.N` is upgraded to the final automatically once it is published, because `<version>` is newer than `<version>-rc.N`.
+
+Testing a candidate: it shares the app id and profile directory with the installed release, so launch the binary directly (`open -a` does not forward shell environment variables) against a separate profile to keep migrations and node data from touching your real one:
+
+```
+FREEDOM_TEST_USER_DATA="$HOME/freedom-rc-test" /Applications/Freedom.app/Contents/MacOS/Freedom
+```
+
+Run the §6 checklist twice per candidate — as a fresh install and as an upgrade from the last final (copy a real profile into the test directory first). For quick private iteration between tagged candidates, trigger the workflow manually on the PR branch; the artifact needs a GitHub login to download and expires, so it is for your own testing, not for handing out.
 
 ## 7. Upload binaries and update the website
 

--- a/docs/agent-playbooks/release-process.md
+++ b/docs/agent-playbooks/release-process.md
@@ -158,6 +158,17 @@ npm run dist -- --mac
 
 `build.mac.notarize: true` in `package.json` makes `electron-builder` submit and staple the notarization in the same invocation. The command blocks until Apple finishes notarizing — expect several minutes. This is the default mac release flow.
 
+That inline pass notarizes and staples **`Freedom.app` only**. `dmg-builder` then wraps the already-stapled app in a disk image but never notarizes the image itself, so the `.dmg` this command produces has no ticket of its own (`xcrun stapler validate` on it fails, and Gatekeeper has to check it online when a user opens it). If you hand out that disk image, notarize and staple it too:
+
+```
+xcrun notarytool submit dist/Freedom-<version>-arm64.dmg \
+  --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" \
+  --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait
+xcrun stapler staple dist/Freedom-<version>-arm64.dmg
+```
+
+Stapling rewrites the image, so the `.dmg` entry in `dist/latest-mac.yml` no longer matches the file you upload — refresh its `sha512`/`size` (the release workflow below does this automatically). The macOS updater only reads the `.zip` entry, so this affects the checksum manifest, not updates. The async fallback below already submits and staples the `.dmg` for you.
+
 **Fallback — async notarization.** If notarization is slow or flaky and you need to do it out-of-band (for example to retry or to free the terminal), use the split scripts instead:
 
 ```
@@ -174,7 +185,7 @@ These require `.env` credentials via `dotenv-cli` and are implemented in `script
 
 `.github/workflows/release-mac.yml` produces the same signed + notarized arm64 `.dmg` / `.zip` on a GitHub-hosted `macos-14` runner, so a release does not depend on one maintainer's Mac.
 
-- **Tag push (`v*`)** — signed build, verified with `codesign` / `spctl` / `stapler`, and attached to a GitHub Release for that tag together with `latest-mac.yml` and the `.blockmap`. A final tag (`v0.8.1`) produces a **draft**; publish it only after the §6 smoke test passes. A pre-release tag (`v0.8.1-rc.1`, anything with a hyphen) is published immediately and flagged **Pre-release** — see "Release candidates" below. The job fails fast if `package.json` does not match the tag (step 1) or if any signing secret is missing. `freedom.baby/downloads` (§7) remains the updater channel, so still upload final artifacts there.
+- **Tag push (`v*`)** — signed build, then the `.dmg` is notarized and stapled in its own step (electron-builder's inline pass covers the `.app` only, see above) and `latest-mac.yml`'s `.dmg` entry is refreshed to the stapled bytes. The result is verified with `codesign` / `spctl` / `stapler` — the staple check now covers both `Freedom.app` and every `.dmg` — and attached to a GitHub Release for that tag together with `latest-mac.yml` and the `.blockmap`. A final tag (`v0.8.1`) produces a **draft**; publish it only after the §6 smoke test passes. A pre-release tag (`v0.8.1-rc.1`, anything with a hyphen) is published immediately and flagged **Pre-release** — see "Release candidates" below. The job fails fast if `package.json` does not match the tag (step 1) or if any signing secret is missing. `freedom.baby/downloads` (§7) remains the updater channel, so still upload final artifacts there.
 - **Manual run** (Actions → "Release (macOS arm64)" → Run workflow) — builds from any branch and uploads a workflow artifact only, no release. Untick `signed` for an unsigned pipeline test that needs no secrets; untick `bundle_tor` to skip the cargo build of Arti.
 
 Signed runs need these repository secrets (Settings → Secrets and variables → Actions): `CSC_LINK` (the Developer ID Application certificate exported from Keychain as a password-protected `.p12`, then base64-encoded), `CSC_KEY_PASSWORD`, and the same `APPLE_ID` / `APPLE_TEAM_ID` / `APPLE_APP_SPECIFIC_PASSWORD` as `.env.example`. `electron-builder` imports the certificate into a temporary keychain for the run.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release-mac.yml`: a GitHub-hosted `macos-14` (Apple Silicon) job that builds Freedom with `npm run dist -- --mac --arm64`, signs and notarizes the app through electron-builder, then notarizes and staples the `.dmg` itself (electron-builder's inline pass only covers the `.app`) and refreshes the `.dmg` hash in `latest-mac.yml`. It verifies the result (`codesign`, `spctl`, `stapler` on both app and dmg) and attaches the `.dmg`, `.zip`, `.blockmap` and `latest-mac.yml` to a GitHub Release for the pushed `v*` tag:

- **Final tag** (`v0.8.1`): the release stays a **draft** for a maintainer to publish after the smoke test.
- **Pre-release tag** (`v0.8.1-rc.1`, anything with a hyphen): created as a draft, assets uploaded, then flipped to a **published Pre-release** so testers can download it. GitHub keeps it out of "Latest release".
- Re-running onto an already published release fails instead of overwriting live files; a failed release lookup fails the step rather than creating a duplicate draft.

A manual run builds from any branch and uploads a workflow artifact only; untick `signed` for an unsigned pipeline test that needs no secrets, untick `bundle_tor` to skip the cargo build of Arti (installed from a pinned, sha256-checked rustup-init if the runner lacks cargo).

Until now every release has been built on one maintainer's Mac and uploaded to `freedom.baby` by hand; this makes a downloadable signed Apple Silicon build reproducible from GitHub. `freedom.baby/downloads` stays the updater channel. The playbook now makes the Actions build canonical for finals (tag before the smoke test, test and upload the draft's assets, publish last), documents the local build as fallback, and gains a "Release candidates" section for the `-rc.N` loop.

Guards: the job fails fast if `package.json` does not match the tag, or if a signed build is requested while any of `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_TEAM_ID`, `APPLE_APP_SPECIFIC_PASSWORD` is missing.

**Before this can produce a signed build**, a maintainer must add those five repository secrets (Settings → Secrets and variables → Actions). `CSC_LINK` is the Developer ID Application certificate exported from Keychain as a password-protected `.p12`, base64-encoded. Until then, run the workflow manually with `signed` unticked to exercise the pipeline.

## Related issue

None.

## Verification

- [x] `npx prettier --check` on changed files
- [x] `git diff --check`
- [x] Workflow YAML parses (`js-yaml`), 20 steps, triggers `push` (tags `v*`) and `workflow_dispatch`; `bash -n` on the release-attach script
- [x] Two alan review loops (5 rounds total): 1 blocking finding confirmed and fixed (`8b3da0fd`, bot commit), 9 minors landed; `alan:clean`
- [ ] `npm run lint` – not applicable, no JS changed
- [ ] Relevant unit tests – not applicable
- [ ] Relevant Playwright or live smoke tests – not applicable
- [ ] **The workflow itself has not been executed yet.** It cannot run on a PR trigger by design; after merge, trigger it manually with `signed` unticked to validate the unsigned path, then add the secrets and re-run signed. Expect the first runs to surface runner-specific issues (for example the Arti cargo build time).

## Visual changes

Not applicable.

## Security and privacy

Signing credentials live only in GitHub Actions secrets and are passed as env vars to the two steps that need them; nothing is written to the repo. The job has `contents: write` only to create the draft release. `CSC_LINK` is imported by electron-builder into a temporary keychain that is discarded with the runner.

## AI assistance

Drafted with Claude Code; reviewed and submitted by the maintainer, who is responsible for verifying the first workflow runs.

