### PR TITLE
chore(release): rename the dev cycle to 0.8.5-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freedom-browser",
-  "version": "0.8.1-dev",
+  "version": "0.8.5-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freedom-browser",
-      "version": "0.8.1-dev",
+      "version": "0.8.5-dev",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "freedom-browser",
-  "version": "0.8.1-dev",
+  "version": "0.8.5-dev",
   "license": "MPL-2.0",
-  "description": "Freedom \u2013 A browser for the decentralized web, with Swarm, IPFS, onchain apps, and ENS as first-class protocols.",
+  "description": "Freedom – A browser for the decentralized web, with Swarm, IPFS, onchain apps, and ENS as first-class protocols.",
   "author": {
     "name": "Freedom Team",
     "email": "browser@freedom.baby"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "freedom-browser",
   "version": "0.8.5-dev",
   "license": "MPL-2.0",
-  "description": "Freedom – A browser for the decentralized web, with Swarm, IPFS, onchain apps, and ENS as first-class protocols.",
+  "description": "Freedom \u2013 A browser for the decentralized web, with Swarm, IPFS, onchain apps, and ENS as first-class protocols.",
   "author": {
     "name": "Freedom Team",
     "email": "browser@freedom.baby"


### PR DESCRIPTION
## Summary

The next release is **0.8.5**, not 0.8.1. This bumps `package.json` and the two matching `package-lock.json` entries from `0.8.1-dev` to `0.8.5-dev` via `npm version 0.8.5-dev --no-git-tag-version`. No other file hard-codes the version. GitHub milestones v0.8.1 → v0.8.5 and v0.8.2 → v0.8.6 are renamed alongside (issues stay attached).

## Related issue

None.

## Verification

- [x] `git diff --check`
- [x] Only the version fields changed (`git diff --stat`)
- [ ] `npm run lint` – not applicable
- [ ] Unit / Playwright tests – not applicable
- [ ] `npx prettier --check` – package-lock.json is prettier-ignored; package.json untouched apart from the version field

## Visual changes

Not applicable.

## Security and privacy

No change.

## AI assistance

Prepared by Claude Code at the maintainer's request; the maintainer reviews and merges.