### PR TITLE
fix(build): extract the IPFS native addon on Windows with bsdtar

### DIFF
--- a/scripts/fetch-freedom-ipfs-native.js
+++ b/scripts/fetch-freedom-ipfs-native.js
@@ -246,8 +246,18 @@ async function installPrebuilt() {
     const prebuildDir = prebuildDirForTarget(target);
     fs.rmSync(prebuildDir, { recursive: true, force: true });
     fs.mkdirSync(prebuildDir, { recursive: true });
-    run('tar', ['-xzf', archive, '-C', prebuildDir, ADDON_FILENAME]);
+    // Extract next to the archive with a bare file name, then copy: on
+    // Windows an absolute `D:\\...` argument makes GNU tar (first on PATH in
+    // Git Bash) treat `D` as a remote host, and a relative -C target can
+    // still cross drives (temp dir vs. workspace). Windows' own bsdtar is
+    // used there so the result does not depend on which tar wins on PATH.
+    const tarBin =
+      process.platform === 'win32'
+        ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'tar.exe')
+        : 'tar';
+    run(tarBin, ['-xzf', path.basename(archive), ADDON_FILENAME], { cwd: tmpDir });
     const prebuildAddon = path.join(prebuildDir, ADDON_FILENAME);
+    fs.copyFileSync(path.join(tmpDir, ADDON_FILENAME), prebuildAddon);
     console.log(`[freedom-ipfs-native] installed packaged addon ${prebuildAddon}`);
     if (platformKey === currentPlatformKey()) {
       copyAddon(prebuildAddon, addonPath);


### PR DESCRIPTION
## Summary

Second Windows-only extraction failure in the `Release` workflow ([run 33881297082](https://github.com/solardev-xyz/freedom-browser/actions/runs/33881297082), step "Download IPFS native addon"), same class as #211: the Windows job runs in Git Bash, where GNU tar is first on PATH and reads the absolute archive path `D:\a\...` as `host:file`. CI's own `freedom-ipfs-native-addon` job on `windows-latest` never hit this because it runs under the default pwsh, where Windows' bsdtar wins.

`scripts/fetch-freedom-ipfs-native.js` now extracts next to the archive with a bare file name (using `%SystemRoot%\System32\tar.exe` on Windows) and copies the addon into the prebuild directory. A relative `-C` target was not an option: the temp dir and the workspace can be on different drives, and `path.relative` across drives yields an absolute path again. Linux/macOS behaviour is unchanged apart from the extract-then-copy.

`fetch-myotis.js` and `fetch-radicle-addon.js` download bare files and use no archive tool, so the Windows leg should get through the remaining downloads.

## Related issue

Follows #211.

## Verification

- [x] `npx eslint`, `npx prettier --check`, `git diff --check`
- [x] Ran `node scripts/fetch-freedom-ipfs-native.js` on Linux: downloads, extracts and installs the linux-x64 addon (46 MB) into `native/freedom-ipfs-node/prebuilds/linux-x64/` and the dev build dir as before
- [ ] Not run on Windows locally; the next `Release` dispatch after merge is the real test
- [ ] Unit / Playwright tests – not applicable

## Visual changes

Not applicable.

## Security and privacy

No change; same pinned release, same checksum path, no shell interpolation of asset names.

## AI assistance

Prepared by Claude Code after diagnosing the failed run; the maintainer reviews and merges.