### PR TITLE
test(e2e): packaged-build smoke suite + Linux x64 release gate (smoke phase 1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,6 +407,110 @@ jobs:
           if-no-files-found: error
           overwrite: true
 
+  # Smoke-test the Linux x64 artifacts the way a user gets them: install the
+  # .deb, run the `packaged` Playwright project against /opt/Freedom/freedom,
+  # then repeat against the binary inside the AppImage. This automates steps 1
+  # (launch), 2 (version) and 6 (persistence) of the manual checklist in
+  # docs/agent-playbooks/release-process.md §6 for this one platform; the other
+  # platforms, navigation, the bundled nodes and the headline feature are still
+  # tested by hand there.
+  smoke-linux-x64:
+    needs: [linux]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      # `--ignore-scripts` on purpose: this job only needs Playwright to drive
+      # an already-built artifact, so there is nothing to rebuild against
+      # Electron and no bundled binary to download.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install Playwright system dependencies
+        uses: ./.github/actions/install-playwright-deps
+
+      - name: Download the linux x64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: freedom-linux-x64
+          path: artifact
+
+      # A tag push must smoke-test the version it claims to be shipping; a
+      # dispatch run has no tag, so the working tree's version is the only
+      # truth available.
+      - name: Resolve the expected version
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = 'push' ]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="$(node -p "require('./package.json').version")"
+          fi
+          echo "Expecting the packaged app to report version $version"
+          echo "FREEDOM_E2E_EXPECTED_VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Install the .deb
+        run: |
+          shopt -s nullglob
+          debs=(artifact/*.deb)
+          if [ ${#debs[@]} -ne 1 ]; then
+            echo "Expected exactly one .deb in the artifact, found ${#debs[@]}" >&2
+            exit 1
+          fi
+          package="$(dpkg-deb -f "${debs[0]}" Package)"
+          # Through the apt wrapper for the same reason every other apt call on
+          # a Linux runner goes through it: bounded, retried, lock-aware.
+          "$GITHUB_WORKSPACE/scripts/ci/apt-hardening.sh" install "$(realpath "${debs[0]}")"
+          dpkg -s "$package" | grep -E '^(Package|Version|Architecture):'
+          test -x /opt/Freedom/freedom
+
+      - name: Smoke-test the installed .deb
+        env:
+          FREEDOM_E2E_EXECUTABLE: /opt/Freedom/freedom
+          FREEDOM_E2E_NO_SANDBOX: '1'
+        run: xvfb-run -a npm run test:e2e:packaged -- --output=test-results/deb
+
+      # No FUSE on the runner, so run the extracted tree rather than the
+      # self-mounting AppImage. `--appimage-extract-and-run` would do the same
+      # thing per launch; extracting once keeps every launch in this leg
+      # pointing at one binary.
+      - name: Extract the AppImage
+        run: |
+          shopt -s nullglob
+          images=(artifact/*.AppImage)
+          if [ ${#images[@]} -ne 1 ]; then
+            echo "Expected exactly one .AppImage in the artifact, found ${#images[@]}" >&2
+            exit 1
+          fi
+          chmod +x "${images[0]}"
+          "$(realpath "${images[0]}")" --appimage-extract >/dev/null
+          test -x squashfs-root/freedom
+
+      - name: Smoke-test the AppImage
+        env:
+          FREEDOM_E2E_EXECUTABLE: ${{ github.workspace }}/squashfs-root/freedom
+          FREEDOM_E2E_NO_SANDBOX: '1'
+        run: xvfb-run -a npm run test:e2e:packaged -- --output=test-results/appimage
+
+      # Traces and screenshots are only written for failures, so this is
+      # usually empty on a green run — hence `ignore` rather than `error`.
+      - name: Upload the smoke-test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-linux-x64-report
+          path: test-results/
+          if-no-files-found: ignore
+          overwrite: true
+
   windows-x64:
     runs-on: windows-latest
     timeout-minutes: 90
@@ -493,11 +597,12 @@ jobs:
           overwrite: true
 
   # One release for all platforms, created only after every build succeeded
-  # so the page never shows a partial set. "Re-run failed jobs" re-runs this
-  # job too and picks the successful jobs' artifacts back up from the run.
+  # and the Linux x64 artifacts passed their packaged smoke test, so the page
+  # never shows a partial or dead-on-arrival set. "Re-run failed jobs" re-runs
+  # this job too and picks the successful jobs' artifacts back up from the run.
   release:
     if: github.event_name == 'push'
-    needs: [mac-arm64, linux, windows-x64]
+    needs: [mac-arm64, linux, windows-x64, smoke-linux-x64]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/docs/agent-playbooks/release-process.md
+++ b/docs/agent-playbooks/release-process.md
@@ -247,6 +247,13 @@ For each platform, run through:
 5. **Bundled nodes**: confirm Ant, native IPFS, and Radicle start cleanly (Radicle ships on macOS, Linux, and Windows). The nodes manager or the relevant `freedom://` settings page surfaces this — a "node failed to start" red badge or a missing native addon/API port is the failure mode
 6. **Persistence**: change one trivial setting (e.g. theme), close the app fully, reopen, confirm the change stuck
 
+**Linux x64 runs steps 1, 2 and 6 automatically.** The `smoke-linux-x64` job in `.github/workflows/release.yml` installs the run's own `.deb`, drives `/opt/Freedom/freedom` with the `packaged` Playwright project (`npm run test:e2e:packaged` — launch, version, persistence), then repeats the suite against the binary inside the AppImage. The `release` job depends on it, so a Linux x64 artifact that cannot launch, reports the wrong version, or loses a setting across a restart never reaches a release page. The job passes the tag version as `FREEDOM_E2E_EXPECTED_VERSION`, which is exactly the step-2 check. Nothing else is automated: steps 3–5 (navigation, headline feature, bundled nodes) on Linux, and the whole checklist on macOS, Windows and Linux arm64, are still done by hand as described above. To run the automated leg yourself against any packaged build:
+
+```bash
+FREEDOM_E2E_EXECUTABLE="$PWD/dist/linux-unpacked/freedom" \
+  FREEDOM_E2E_NO_SANDBOX=1 xvfb-run -a npm run test:e2e:packaged
+```
+
 If any platform fails: fix on the release branch (PR), bump to the next `rc.N`, tag, push, and re-test that candidate. Do not proceed to §7 until every platform you intend to ship passes on the **same** candidate — one green build, not a patchwork of legs from different runs.
 
 This step is intentionally separate from §4 — §4 verifies the source tree; §6 verifies the **packaged artifact** that end users will install. They catch different classes of bugs.
@@ -399,4 +406,5 @@ Each packaged app carries only the prebuild for its own target: the `mac`/`linux
 - **Re-runs**: "Re-run failed jobs" keeps the successful legs' artifacts and re-runs `release`. "Re-run all jobs" rebuilds everything, including a fresh macOS signature and notarization — the bytes and hashes change, which is fine for a draft and forbidden for a published release (the guard above).
 - **Update channel**: `build.publish.channel` is pinned to `latest` in `package.json`; without it electron-builder derives the channel from the version's pre-release suffix and would name the manifest `rc-mac.yml`. `scripts/build.js` pins the Windows channel to `latest-win-x64` on the command line.
 - **Known first-run fixes** worth remembering when a leg breaks: the adblock list download uses a retrying `https` client because the EasyList server drops connections; the Ant and IPFS fetch scripts extract archives with Windows' own bsdtar and relative paths because the Windows job runs in Git Bash, where GNU tar misreads `D:\...` as a remote host.
-- **Cost**: the repo is public, so runner minutes are free. A full run is four parallel jobs of 10–25 minutes.
+- **Smoke gate**: `smoke-linux-x64` runs after the `linux` matrix and before `release` (§6). It needs no secrets and rebuilds nothing — `npm ci --ignore-scripts`, then Playwright against the run's own `.deb` and AppImage. A failure there blocks the release job; its Playwright traces are uploaded as the `smoke-linux-x64-report` artifact.
+- **Cost**: the repo is public, so runner minutes are free. A full run is four parallel jobs of 10–25 minutes, plus a ~5-minute smoke job on the Linux x64 leg.

--- a/docs/development.md
+++ b/docs/development.md
@@ -54,6 +54,7 @@ Protocol and privileged logic belongs in the main process. The renderer talks to
 | `npm run test:coverage`       | Run Jest with coverage                                          |
 | `npm run test:e2e`            | Run the deterministic Playwright harness suite                  |
 | `npm run test:e2e:live`       | Run live node, protocol, and naming integration tests           |
+| `npm run test:e2e:packaged`   | Smoke-test a packaged build (`FREEDOM_E2E_EXECUTABLE`)          |
 | `npm run test:e2e:tor`        | Run the live Tor `.onion` integration test                      |
 | `npm run check-binaries`      | Validate packaged native binary targets                         |
 | `npm run ant:download`        | Download the pinned Ant binary                                  |
@@ -82,14 +83,17 @@ Most source modules have a neighboring `.test.js` file. At minimum, run the corr
 
 ### End-to-end tests
 
-Playwright has two projects:
+Playwright has three projects:
 
-| Suite     | Command                 | Behavior                                                                                 |
-| --------- | ----------------------- | ---------------------------------------------------------------------------------------- |
-| `harness` | `npm run test:e2e`      | Launches Electron with deterministic Ant/IPFS/naming stubs; fast and network-independent |
-| `live`    | `npm run test:e2e:live` | Uses real nodes, protocols, and network resolution; requires downloaded binaries         |
+| Suite      | Command                     | Behavior                                                                                                       |
+| ---------- | --------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `harness`  | `npm run test:e2e`          | Launches Electron with deterministic Ant/IPFS/naming stubs; fast and network-independent                       |
+| `live`     | `npm run test:e2e:live`     | Uses real nodes, protocols, and network resolution; requires downloaded binaries                               |
+| `packaged` | `npm run test:e2e:packaged` | Runs the release smoke checks (launch, version, persistence) against a built binary instead of the source tree |
 
-Both suites use a temporary Electron `userData` directory and run sequentially. The full CI matrix covers the operating-system-specific and native-node checks that most contributors cannot reproduce locally.
+The `packaged` project needs `FREEDOM_E2E_EXECUTABLE` pointing at that binary and refuses to run without it; add `FREEDOM_E2E_NO_SANDBOX=1` on a headless machine. After `npm run build -- --linux --x64`, that is `FREEDOM_E2E_EXECUTABLE="$PWD/dist/linux-unpacked/freedom" FREEDOM_E2E_NO_SANDBOX=1 xvfb-run -a npm run test:e2e:packaged`. The release workflow runs the same suite against the `.deb` and AppImage it just built (see `agent-playbooks/release-process.md` §6).
+
+All three suites use a temporary Electron `userData` directory and run sequentially. The full CI matrix covers the operating-system-specific and native-node checks that most contributors cannot reproduce locally.
 
 ## Logging and debugging
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:migration": "jest --runInBand src/main/migrate-user-data.test.js src/main/__tests__/integration/v08-upgrade.test.js src/main/profile-resolver.test.js src/main/profile-paths.test.js src/main/profile-catalog.test.js src/main/identity/__tests__/integration/postage-publisher-continuity.test.js",
     "test:e2e": "playwright test --project=harness",
     "test:e2e:live": "playwright test --project=live",
+    "test:e2e:packaged": "playwright test --project=packaged",
     "test:e2e:onboarding": "playwright test --project=live test-e2e/live/onboarding-identity.spec.js",
     "test:e2e:tor": "FREEDOM_LIVE_E2E_DISABLE_DEFAULT_NODES=1 playwright test --project=live test-e2e/live/tor-onion.spec.js",
     "lint": "eslint .",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,6 +1,6 @@
 // Playwright config for renderer E2E tests.
 //
-// Two projects:
+// Three projects:
 //   - `harness` (default `npm run test:e2e`): fixture-driven specs that run
 //     against the in-process test harness. No actual Ant, IPFS, ENS, or
 //     network. Fast, deterministic, safe in CI.
@@ -10,10 +10,19 @@
 //     and is slow (Swarm cold-start can take several minutes). Skipped
 //     automatically if the antd binary for the current platform isn't
 //     present.
+//   - `packaged` (`npm run test:e2e:packaged`): the release smoke test.
+//     Same harness stubs, but Electron is launched from a *built* binary
+//     named by `FREEDOM_E2E_EXECUTABLE` instead of from the source tree,
+//     which is what catches packaging-class bugs (see
+//     docs/agent-playbooks/release-process.md §6). Its `packaged-preflight`
+//     setup project fails the run before any spec starts when that variable
+//     is missing or does not name an executable file.
 //
 // Layout:
-//   - `test-e2e/live/**/*.spec.js`  → `live` project
-//   - `test-e2e/*.spec.js`          → `harness` project (everything else)
+//   - `test-e2e/live/**/*.spec.js`         → `live` project
+//   - `test-e2e/packaged/preflight.setup.js` → `packaged-preflight` project
+//   - `test-e2e/packaged/**/*.spec.js`     → `packaged` project
+//   - `test-e2e/*.spec.js`                 → `harness` project (everything else)
 
 const { defineConfig } = require('@playwright/test');
 
@@ -33,7 +42,7 @@ module.exports = defineConfig({
   projects: [
     {
       name: 'harness',
-      testMatch: /^(?!.*[\\/]live[\\/]).*\.spec\.js$/,
+      testMatch: /^(?!.*[\\/](?:live|packaged)[\\/]).*\.spec\.js$/,
       // Bee/IPFS startup is stubbed in test mode, but Electron + first-
       // window ready can still take 10–15s on cold cache. 30s gives
       // headroom without hiding genuine hangs.
@@ -50,6 +59,26 @@ module.exports = defineConfig({
       // single-test work without inviting infinite hangs.
       timeout: 10 * 60_000,
       expect: { timeout: 30_000 },
+    },
+    {
+      // Runs automatically ahead of `packaged` (and only then): a missing or
+      // unusable FREEDOM_E2E_EXECUTABLE fails here, with the fix in the
+      // message, instead of launching Electron from source and reporting a
+      // green smoke test for an artifact nothing ever opened.
+      name: 'packaged-preflight',
+      testMatch: /[\\/]packaged[\\/]preflight\.setup\.js$/,
+      timeout: 10_000,
+    },
+    {
+      name: 'packaged',
+      testMatch: /[\\/]packaged[\\/].*\.spec\.js$/,
+      dependencies: ['packaged-preflight'],
+      // `harness` plus headroom: a just-installed package launches with a
+      // cold asar and cold shared libraries, and the persistence spec pays
+      // that cost twice in a single test (launch, quit, relaunch).
+      timeout: 120_000,
+      expect: { timeout: 10_000 },
+      retries: process.env.CI ? 2 : 0,
     },
   ],
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -26,6 +26,12 @@
 
 const { defineConfig } = require('@playwright/test');
 
+const packagedRequested =
+  Boolean(process.env.FREEDOM_E2E_EXECUTABLE) ||
+  process.argv.some(
+    (a, i, argv) => a === '--project=packaged' || (a === '--project' && argv[i + 1] === 'packaged')
+  );
+
 module.exports = defineConfig({
   testDir: './test-e2e',
   // Sequential runs only — Electron launches multiple processes per app
@@ -60,25 +66,33 @@ module.exports = defineConfig({
       timeout: 10 * 60_000,
       expect: { timeout: 30_000 },
     },
-    {
-      // Runs automatically ahead of `packaged` (and only then): a missing or
-      // unusable FREEDOM_E2E_EXECUTABLE fails here, with the fix in the
-      // message, instead of launching Electron from source and reporting a
-      // green smoke test for an artifact nothing ever opened.
-      name: 'packaged-preflight',
-      testMatch: /[\\/]packaged[\\/]preflight\.setup\.js$/,
-      timeout: 10_000,
-    },
-    {
-      name: 'packaged',
-      testMatch: /[\\/]packaged[\\/].*\.spec\.js$/,
-      dependencies: ['packaged-preflight'],
-      // `harness` plus headroom: a just-installed package launches with a
-      // cold asar and cold shared libraries, and the persistence spec pays
-      // that cost twice in a single test (launch, quit, relaunch).
-      timeout: 120_000,
-      expect: { timeout: 10_000 },
-      retries: process.env.CI ? 2 : 0,
-    },
+    // The two `packaged` projects are registered only when they are wanted:
+    // FREEDOM_E2E_EXECUTABLE set, or `--project packaged` on the command
+    // line. Otherwise a bare `npx playwright test` (no --project) would run
+    // them too and fail in the preflight instead of exercising harness+live.
+    ...(packagedRequested
+      ? [
+          {
+            // Runs automatically ahead of `packaged` (and only then): a missing or
+            // unusable FREEDOM_E2E_EXECUTABLE fails here, with the fix in the
+            // message, instead of launching Electron from source and reporting a
+            // green smoke test for an artifact nothing ever opened.
+            name: 'packaged-preflight',
+            testMatch: /[\\/]packaged[\\/]preflight\.setup\.js$/,
+            timeout: 10_000,
+          },
+          {
+            name: 'packaged',
+            testMatch: /[\\/]packaged[\\/].*\.spec\.js$/,
+            dependencies: ['packaged-preflight'],
+            // `harness` plus headroom: a just-installed package launches with a
+            // cold asar and cold shared libraries, and the persistence spec pays
+            // that cost twice in a single test (launch, quit, relaunch).
+            timeout: 120_000,
+            expect: { timeout: 10_000 },
+            retries: process.env.CI ? 2 : 0,
+          },
+        ]
+      : []),
   ],
 });

--- a/test-e2e/fixtures.js
+++ b/test-e2e/fixtures.js
@@ -5,6 +5,12 @@
 // bookmarks, and history. `window` is the first BrowserWindow page.
 // `harness` exposes ergonomic helpers backed by the main-process test
 // harness (see `src/main/test-harness.js`).
+//
+// Setting `FREEDOM_E2E_EXECUTABLE` points the same fixtures at a *packaged*
+// Freedom binary (`dist/linux-unpacked/freedom`, `/opt/Freedom/freedom`, an
+// extracted AppImage) instead of the source tree — that is how the
+// `packaged` project (`npm run test:e2e:packaged`) smoke-tests a release
+// artifact. Unset, everything below behaves exactly as it did before.
 
 const { test: base, expect, _electron: electron } = require('@playwright/test');
 const path = require('path');
@@ -12,6 +18,61 @@ const fs = require('fs');
 const os = require('os');
 
 const repoRoot = path.resolve(__dirname, '..');
+
+// Trimmed, because shells (and YAML `env:` blocks) capture stray whitespace
+// into a value and `executablePath: '/opt/Freedom/freedom '` would fail with
+// a confusing ENOENT.
+const packagedExecutable = (process.env.FREEDOM_E2E_EXECUTABLE || '').trim();
+
+// Launch options for one app instance against `userDataDir`. Source runs pass
+// `.` so Electron loads the repo as its app directory; a packaged binary
+// already embeds its app, so it gets no positional argument at all.
+function launchOptions(userDataDir) {
+  const args = [];
+  if (!packagedExecutable) {
+    args.push('.');
+  } else if ((process.env.FREEDOM_E2E_NO_SANDBOX || '').trim() === '1') {
+    // Headless CI runners generally cannot use Chromium's setuid/namespace
+    // sandbox. Only ever passed in packaged mode — a source run under
+    // `npm run test:e2e` keeps the sandbox on.
+    args.push('--no-sandbox');
+  }
+
+  return {
+    ...(packagedExecutable ? { executablePath: packagedExecutable } : {}),
+    args,
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      FREEDOM_TEST_MODE: '1',
+      FREEDOM_TEST_USER_DATA: userDataDir,
+      ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+      // Force a deterministic locale so menu accelerators don't drift
+      // by region (CmdOrCtrl resolves to Cmd on darwin regardless).
+      LANG: 'en_US.UTF-8',
+    },
+    // A freshly installed package has a cold asar and cold shared libraries;
+    // give its first launch more room than a warm source run needs.
+    timeout: packagedExecutable ? 45_000 : 20_000,
+  };
+}
+
+// Launch one Freedom instance against `userDataDir`. Exported through the
+// `relaunchApp` fixture rather than directly so every app a spec opens is
+// closed at teardown.
+function launchApp(userDataDir) {
+  return electron.launch(launchOptions(userDataDir));
+}
+
+// First BrowserWindow, waited until the browser chrome has mounted. The
+// address bar is the last toolbar element initialized; presence here implies
+// tab bar, bookmarks bar, and menus are all live.
+async function browserWindow(app) {
+  const win = await app.firstWindow();
+  await win.waitForLoadState('domcontentloaded');
+  await win.waitForSelector('[data-test="address-input"]', { state: 'visible' });
+  return win;
+}
 
 // We want a stable settings shape across runs. The main-process settings
 // store loads JSON from `<userData>/settings.json` and merges over
@@ -35,24 +96,24 @@ const test = base.extend({
   // problem above.
   seedSettings: [null, { option: true }],
 
-  electronApp: async ({ seedSettings: settingsOverride }, use) => {
-    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'freedom-e2e-'));
-    seedSettings(userDataDir, settingsOverride);
+  // The scratch profile this test's app instances run against. Kept separate
+  // from `electronApp` so a spec can shut the app down and start another one
+  // on the same on-disk state (see `relaunchApp`).
+  userDataDir: async ({ seedSettings: settingsOverride }, use) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'freedom-e2e-'));
+    seedSettings(dir, settingsOverride);
 
-    const app = await electron.launch({
-      args: ['.'],
-      cwd: repoRoot,
-      env: {
-        ...process.env,
-        FREEDOM_TEST_MODE: '1',
-        FREEDOM_TEST_USER_DATA: userDataDir,
-        ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
-        // Force a deterministic locale so menu accelerators don't drift
-        // by region (CmdOrCtrl resolves to Cmd on darwin regardless).
-        LANG: 'en_US.UTF-8',
-      },
-      timeout: 20_000,
-    });
+    await use(dir);
+
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup — leftover dirs in /tmp are harmless.
+    }
+  },
+
+  electronApp: async ({ userDataDir }, use) => {
+    const app = await launchApp(userDataDir);
 
     await use(app);
 
@@ -61,21 +122,33 @@ const test = base.extend({
     } catch {
       // Window may already have been closed by the spec.
     }
-    try {
-      fs.rmSync(userDataDir, { recursive: true, force: true });
-    } catch {
-      // Best-effort cleanup — leftover dirs in /tmp are harmless.
+  },
+
+  // Start another instance of the same executable against the same scratch
+  // profile, for specs that need state to survive a real process restart.
+  // Close the running instance first (`await electronApp.close()`): Freedom
+  // holds a per-profile lock, so a second instance on a live profile just
+  // asks the first one to focus itself and exits.
+  relaunchApp: async ({ userDataDir }, use) => {
+    const started = [];
+
+    await use(async () => {
+      const app = await launchApp(userDataDir);
+      started.push(app);
+      return app;
+    });
+
+    for (const app of started) {
+      try {
+        await app.close();
+      } catch {
+        // Already closed by the spec.
+      }
     }
   },
 
   window: async ({ electronApp }, use) => {
-    const win = await electronApp.firstWindow();
-    await win.waitForLoadState('domcontentloaded');
-    // Wait for chrome to mount before any spec interacts with it. The
-    // address bar is the last toolbar element initialized; presence here
-    // implies tab bar, bookmarks bar, and menus are all live.
-    await win.waitForSelector('[data-test="address-input"]', { state: 'visible' });
-    await use(win);
+    await use(await browserWindow(electronApp));
   },
 
   // High-level helpers backed by the main-process test harness. Each
@@ -83,21 +156,30 @@ const test = base.extend({
   // main process where the harness state lives.
   harness: async ({ electronApp }, use) => {
     const setContentFixture = async (url, fixture) => {
-      await electronApp.evaluate(({ ipcMain: _ipcMain }, { url: u, fixture: f }) => {
-        globalThis.__FREEDOM_TEST_HARNESS__.setContentFixture(u, f);
-      }, { url, fixture });
+      await electronApp.evaluate(
+        ({ ipcMain: _ipcMain }, { url: u, fixture: f }) => {
+          globalThis.__FREEDOM_TEST_HARNESS__.setContentFixture(u, f);
+        },
+        { url, fixture }
+      );
     };
 
     const setEnsFixture = async (name, result) => {
-      await electronApp.evaluate(({ ipcMain: _ipcMain }, { name: n, result: r }) => {
-        globalThis.__FREEDOM_TEST_HARNESS__.setEnsFixture(n, r);
-      }, { name, result });
+      await electronApp.evaluate(
+        ({ ipcMain: _ipcMain }, { name: n, result: r }) => {
+          globalThis.__FREEDOM_TEST_HARNESS__.setEnsFixture(n, r);
+        },
+        { name, result }
+      );
     };
 
     const setProbeFixture = async (hash, outcome) => {
-      await electronApp.evaluate(({ ipcMain: _ipcMain }, { hash: h, outcome: o }) => {
-        globalThis.__FREEDOM_TEST_HARNESS__.setProbeFixture(h, o);
-      }, { hash, outcome });
+      await electronApp.evaluate(
+        ({ ipcMain: _ipcMain }, { hash: h, outcome: o }) => {
+          globalThis.__FREEDOM_TEST_HARNESS__.setProbeFixture(h, o);
+        },
+        { hash, outcome }
+      );
     };
 
     const reset = async () => {
@@ -122,6 +204,7 @@ const SAMPLE_IPFS_CID = 'bafybeib' + 'a'.repeat(51);
 module.exports = {
   test,
   expect,
+  browserWindow,
   SAMPLE_BZZ_HASH,
   SAMPLE_IPFS_CID,
 };

--- a/test-e2e/packaged/launch.spec.js
+++ b/test-e2e/packaged/launch.spec.js
@@ -1,0 +1,53 @@
+// Packaged smoke — step 1 of the release-process.md §6 checklist:
+// "the app opens cleanly — no crash dialog, main window appears".
+//
+// Runs against the binary named by FREEDOM_E2E_EXECUTABLE (see
+// playwright.config.js). The failure this guards against is a package that
+// cannot start at all: a missing asar entry, a native module built for the
+// wrong ABI, an extraResources path that only resolves in a source tree.
+
+const { test, expect } = require('../fixtures');
+
+test('the packaged app launches with its browser chrome', async ({ window, electronApp }) => {
+  await expect(window.locator('[data-test="address-input"]')).toBeVisible();
+  await expect(window.locator('[data-test="tab-bar"]')).toBeVisible();
+  await expect(window.locator('[data-test="new-tab-btn"]')).toBeVisible();
+  expect(await window.title()).toContain('Freedom');
+
+  // Exactly one BrowserWindow: the main window, with no crash/error dialog
+  // window alongside it. (`electronApp.windows()` also counts the home page's
+  // webview, so count real windows in the main process instead.)
+  const windows = await electronApp.evaluate(({ BrowserWindow }) =>
+    BrowserWindow.getAllWindows().map((win) => ({
+      title: win.getTitle(),
+      destroyed: win.isDestroyed(),
+    }))
+  );
+  expect(windows).toHaveLength(1);
+  expect(windows[0].destroyed).toBe(false);
+  expect(windows[0].title).toContain('Freedom');
+});
+
+test('the binary under test really is a packaged Electron build', async ({
+  window,
+  electronApp,
+}) => {
+  const build = await electronApp.evaluate(({ app }) => ({
+    electron: process.versions.electron,
+    chrome: process.versions.chrome,
+    packaged: app.isPackaged,
+    // Trips if the suite were pointed at a source checkout by mistake.
+    executable: process.execPath,
+  }));
+
+  expect(build.electron).toMatch(/^\d+\.\d+/);
+  expect(build.chrome).toMatch(/^\d+\./);
+  expect(build.packaged).toBe(true);
+  expect(build.executable).toBe((process.env.FREEDOM_E2E_EXECUTABLE || '').trim());
+
+  // The renderer has to be running on that same Electron; anything else would
+  // mean the window we are driving did not come from this package.
+  const userAgent = await window.evaluate(() => navigator.userAgent);
+  expect(userAgent).toContain(`Electron/${build.electron}`);
+  expect(userAgent).toContain(`Chrome/${build.chrome}`);
+});

--- a/test-e2e/packaged/launch.spec.js
+++ b/test-e2e/packaged/launch.spec.js
@@ -6,6 +6,8 @@
 // cannot start at all: a missing asar entry, a native module built for the
 // wrong ABI, an extraResources path that only resolves in a source tree.
 
+const fs = require('fs');
+const path = require('path');
 const { test, expect } = require('../fixtures');
 
 test('the packaged app launches with its browser chrome', async ({ window, electronApp }) => {
@@ -43,7 +45,12 @@ test('the binary under test really is a packaged Electron build', async ({
   expect(build.electron).toMatch(/^\d+\.\d+/);
   expect(build.chrome).toMatch(/^\d+\./);
   expect(build.packaged).toBe(true);
-  expect(build.executable).toBe((process.env.FREEDOM_E2E_EXECUTABLE || '').trim());
+  // process.execPath is symlink-resolved (/proc/self/exe), so compare real
+  // paths: the .deb installs /usr/bin/freedom -> /etc/alternatives/freedom ->
+  // /opt/Freedom/freedom, and a relative dist/linux-unpacked/freedom is fine too.
+  expect(fs.realpathSync(build.executable)).toBe(
+    fs.realpathSync(path.resolve((process.env.FREEDOM_E2E_EXECUTABLE || '').trim()))
+  );
 
   // The renderer has to be running on that same Electron; anything else would
   // mean the window we are driving did not come from this package.

--- a/test-e2e/packaged/persistence.spec.js
+++ b/test-e2e/packaged/persistence.spec.js
@@ -1,0 +1,62 @@
+// Packaged smoke — step 6 of the release-process.md §6 checklist:
+// "change one trivial setting (e.g. theme), close the app fully, reopen,
+// confirm the change stuck".
+//
+// Theme is the playbook's example and the setting `settings.spec.js` toggles
+// from source. What makes this a *packaging* test is the second launch: it
+// starts the same executable again against the same profile directory, so a
+// package that cannot persist its userData (a sandboxed path, a store that
+// only resolves in a source tree, a settings file written somewhere the next
+// launch does not read) fails here instead of in a user's hands.
+
+const fs = require('fs');
+const path = require('path');
+
+const { test, expect, browserWindow } = require('../fixtures');
+
+// Start from an explicit theme rather than the default "system": "system"
+// renders as light or dark depending on the host, whereas explicit "dark"
+// always leaves <html> without data-theme and explicit "light" always sets it.
+// The assertions below are then the same on every machine.
+test.use({ seedSettings: { theme: 'dark' } });
+
+test('a theme change survives a full quit and relaunch', async ({
+  window,
+  electronApp,
+  relaunchApp,
+  userDataDir,
+}) => {
+  const html = window.locator('html');
+  await expect(html).not.toHaveAttribute('data-theme', 'light');
+
+  await window.evaluate(() => window.electronAPI.saveSettings({ theme: 'light' }));
+  await expect(html).toHaveAttribute('data-theme', 'light');
+
+  // The change has to reach disk before the process goes away, otherwise the
+  // relaunch would only be re-reading a race. saveSettings writes
+  // <userData>/settings.json; poll for it so a future async write does not
+  // turn this into a flake.
+  const settingsFile = path.join(userDataDir, 'settings.json');
+  await expect
+    .poll(() => {
+      try {
+        return JSON.parse(fs.readFileSync(settingsFile, 'utf-8')).theme;
+      } catch {
+        return null;
+      }
+    })
+    .toBe('light');
+
+  // Full quit: every window closed and the main process gone, not a reload.
+  await electronApp.close();
+
+  const relaunched = await relaunchApp();
+  const relaunchedWindow = await browserWindow(relaunched);
+
+  // Had the setting not survived, the seeded "dark" would render here with no
+  // data-theme attribute at all.
+  await expect(relaunchedWindow.locator('html')).toHaveAttribute('data-theme', 'light');
+  expect(
+    await relaunchedWindow.evaluate(async () => (await window.electronAPI.getSettings()).theme)
+  ).toBe('light');
+});

--- a/test-e2e/packaged/preflight.setup.js
+++ b/test-e2e/packaged/preflight.setup.js
@@ -1,0 +1,58 @@
+// Setup project for `packaged` (playwright.config.js `dependencies`).
+//
+// The packaged specs drive a built Freedom binary named by
+// FREEDOM_E2E_EXECUTABLE. Without it the fixtures would fall back to a source
+// launch and the suite would "pass" while testing nothing about the artifact,
+// so check the variable once, up front — a failure here skips every packaged
+// spec instead of running them against the wrong thing.
+//
+// Named `.setup.js` rather than `.spec.js` so the `packaged` project itself
+// does not pick it up.
+
+const fs = require('fs');
+
+const { test } = require('@playwright/test');
+
+const EXECUTABLE_VAR = 'FREEDOM_E2E_EXECUTABLE';
+
+const USAGE = `Set ${EXECUTABLE_VAR} to a packaged Freedom binary, for example:
+
+  npm run build -- --linux --x64
+  ${EXECUTABLE_VAR}="$PWD/dist/linux-unpacked/freedom" \\
+    FREEDOM_E2E_NO_SANDBOX=1 xvfb-run -a npm run test:e2e:packaged
+
+Installed packages work too: /opt/Freedom/freedom from the .deb, or the
+freedom binary inside an AppImage extracted with --appimage-extract.`;
+
+test('FREEDOM_E2E_EXECUTABLE points at an executable packaged build', () => {
+  // Trimmed for the same reason the fixture trims it: a trailing space from a
+  // shell or a YAML `env:` value must not read as a valid path.
+  const executable = (process.env[EXECUTABLE_VAR] || '').trim();
+
+  if (!executable) {
+    throw new Error(
+      `The "packaged" project needs ${EXECUTABLE_VAR} and it is not set.\n\n${USAGE}`
+    );
+  }
+
+  let stats;
+  try {
+    stats = fs.statSync(executable);
+  } catch (error) {
+    throw new Error(`${EXECUTABLE_VAR}="${executable}" cannot be read.\n\n${USAGE}`, {
+      cause: error,
+    });
+  }
+
+  if (!stats.isFile()) {
+    throw new Error(`${EXECUTABLE_VAR}="${executable}" is not a file.\n\n${USAGE}`);
+  }
+
+  try {
+    fs.accessSync(executable, fs.constants.X_OK);
+  } catch {
+    throw new Error(`${EXECUTABLE_VAR}="${executable}" is not executable.\n\n${USAGE}`);
+  }
+
+  console.log(`[packaged] driving ${executable}`);
+});

--- a/test-e2e/packaged/preflight.setup.js
+++ b/test-e2e/packaged/preflight.setup.js
@@ -48,6 +48,8 @@ test('FREEDOM_E2E_EXECUTABLE points at an executable packaged build', () => {
     throw new Error(`${EXECUTABLE_VAR}="${executable}" is not a file.\n\n${USAGE}`);
   }
 
+  // On Windows fs.accessSync(X_OK) degrades to an existence check (no execute
+  // bit), so this guard only means something on Linux/macOS.
   try {
     fs.accessSync(executable, fs.constants.X_OK);
   } catch {

--- a/test-e2e/packaged/version.spec.js
+++ b/test-e2e/packaged/version.spec.js
@@ -1,0 +1,33 @@
+// Packaged smoke — step 2 of the release-process.md §6 checklist:
+// "About / freedom://settings shows <version> from package.json".
+//
+// `app.getVersion()` is that number: Electron reads it from the package.json
+// inside the artifact's asar, and `src/main/index.js` passes the same value to
+// `app.setAboutPanelOptions({ applicationVersion })`, which is what the About
+// panel renders (a native panel Playwright cannot open or read). The release
+// workflow passes the tag version in FREEDOM_E2E_EXPECTED_VERSION, so a `v0.8.5`
+// tag that somehow packaged 0.8.4 fails this leg instead of shipping.
+
+const { test, expect } = require('../fixtures');
+
+// Trimmed: `FREEDOM_E2E_EXPECTED_VERSION=0.8.5 ` (a trailing space picked up
+// from a shell or a YAML env block) must not fail a correct build.
+const expectedVersion =
+  (process.env.FREEDOM_E2E_EXPECTED_VERSION || '').trim() || require('../../package.json').version;
+
+test('the packaged app reports the expected version', async ({ electronApp }) => {
+  const app = await electronApp.evaluate(({ app: electron }) => ({
+    version: electron.getVersion(),
+    // Where that version was read from: a packaged build serves its app out of
+    // the artifact's own resources directory, so this shows the number came
+    // from the package under test rather than from a source tree.
+    appPath: electron.getAppPath(),
+    // `src/main/index.js` renames the app for packaged Linux builds; the same
+    // branch decides the log and userData directories.
+    name: electron.getName(),
+  }));
+
+  expect(app.version).toBe(expectedVersion);
+  expect(app.appPath).toContain('resources');
+  expect(app.name).toBe(process.platform === 'linux' ? 'freedom' : 'Freedom');
+});


### PR DESCRIPTION
## Summary

Phase 1 of automating the release smoke test (`docs/agent-playbooks/release-process.md` §6): **launch, version and persistence**, run against the artifact a release actually ships instead of against the source tree. Nodes, navigation, the headline feature and upgrade-from-previous-version stay manual (later phases / other platforms).

- **`test-e2e/fixtures.js`** — the harness fixture launches through `FREEDOM_E2E_EXECUTABLE` when that variable is set (`executablePath`, no `'.'` argument, plus `--no-sandbox` when `FREEDOM_E2E_NO_SANDBOX=1`), and behaves exactly as before when it is not. The scratch profile moved out of `electronApp` into its own `userDataDir` fixture so a spec can quit the app and start a second instance on the same on-disk state; that is the new `relaunchApp` fixture. `browserWindow(app)` is exported so a relaunched app can be waited on the same way. `live-fixtures.js` / `onboarding-fixtures.js` are untouched.
- **`playwright.config.js`** — new `packaged` project over `test-e2e/packaged/`, with `harness` narrowed to exclude that directory. A `packaged-preflight` setup project (`dependencies: ['packaged-preflight']`) validates `FREEDOM_E2E_EXECUTABLE` before any Electron process starts: unset, unreadable, not a file, or not executable each fail with the fix in the message and every packaged spec is skipped. (A top-level `globalSetup` was the first attempt and is wrong here — `config.projects` in `globalSetup` is *not* filtered by `--project`, so the guard fired on plain `npm run test:e2e` runs too.)
- **`test-e2e/packaged/`** — `launch.spec.js` (chrome mounts, exactly one live `BrowserWindow`, `process.versions.electron`/`chrome` non-empty and matching the renderer's UA, `app.isPackaged`), `version.spec.js` (`app.getVersion()` — the value `index.js` feeds to `setAboutPanelOptions`, i.e. what About shows — equals `FREEDOM_E2E_EXPECTED_VERSION` or `package.json`), `persistence.spec.js` (theme change survives a full quit and relaunch of the same executable against the same profile).
- **`npm run test:e2e:packaged`**.
- **`.github/workflows/release.yml`** — new `smoke-linux-x64` job: `needs: [linux]`, `npm ci --ignore-scripts` (nothing is rebuilt here), Playwright system deps via the existing composite action, downloads the `freedom-linux-x64` artifact, installs the `.deb` through `scripts/ci/apt-hardening.sh` (bounded/retried, like every other apt call on a Linux runner), runs the suite against `/opt/Freedom/freedom`, then extracts the AppImage and runs it again against `squashfs-root/freedom`. Reports/traces upload as `smoke-linux-x64-report` with `if: always()`. `release` now `needs` this job as well, so a Linux x64 artifact that cannot launch, misreports its version, or loses a setting across a restart never reaches a release page. The mac/windows/linux-arm64 jobs and the attach script are unchanged.
- **Docs** — §6 of the release playbook (what is automated, what still is not, how to run it locally), a bullet in its Appendix B, and the testing section + script table of `docs/development.md`.

## Related issue

<!-- none -->

## Verification

Everything below was run on this branch (`b361ab9c`), Linux x64, Node 24.19.0.

- [x] `npm run lint` — clean.
- [x] Relevant unit tests — `npm test` (see comment below for the summary line; no `src/` file changed, so this is a no-regression check).
- [x] Relevant Playwright or live smoke tests:
  - **Fixture switch is a no-op when the env var is unset**: `xvfb-run -a npm run test:e2e -- test-e2e/settings.spec.js` → **6 passed (34.0s)**.
  - **Packaged suite against a local build**: `npm run build -- --linux --x64` (after `adblock/ant/ipfs/radicle --linux --x64/myotis` downloads; Tor skipped), then `FREEDOM_E2E_EXECUTABLE="$PWD/dist/linux-unpacked/freedom" FREEDOM_E2E_NO_SANDBOX=1 xvfb-run -a npm run test:e2e:packaged` → **5 passed (27.6s)** (4 specs + the preflight setup test).
  - **Mutation tests**, so the new assertions are known to carry weight:
    - `FREEDOM_E2E_EXPECTED_VERSION=0.0.1-bogus` → version spec fails (`Expected "0.0.1-bogus", Received "0.8.5-dev"`).
    - `relaunchApp` temporarily pointed at a *fresh* profile dir → persistence spec fails (`Expected "light", Received "system"`); reverted.
    - `FREEDOM_E2E_EXECUTABLE` pointed at the unpackaged `node_modules/electron/dist/electron` → both launch specs fail.
    - Preflight: unset → `The "packaged" project needs FREEDOM_E2E_EXECUTABLE and it is not set` + `4 did not run`; `/no/such/freedom` → "cannot be read"; a non-executable file (`package.json`) → "is not executable".
- [x] `npx prettier --check` on every changed file — clean (`.github/workflows/release.yml`, both docs, `package.json`, `playwright.config.js`, `test-e2e/fixtures.js`, `test-e2e/packaged/*.js`).
- [x] `git diff --check` — clean. `shellcheck` on the new job's `run:` blocks (extracted from the YAML) — clean. `actionlint` is not installed on this machine; the workflow parses as YAML and the job graph was asserted programmatically (`smoke-linux-x64 needs [linux]`, `release needs [mac-arm64, linux, windows-x64, smoke-linux-x64]`).

**Runner verification** of the workflow change is in a follow-up comment — a `workflow_dispatch` run on this branch (`signed=false`, `bundle_tor=false`) is the only way to exercise it, since the job cannot run on a PR trigger. The `release` job is push-only and shows as skipped on a dispatch run, which is expected.

## Visual changes

No UI change. Screenshots below are acceptance evidence from the packaged binary the new suite drives (see follow-up comment): the app after launch, and after the quit/relaunch with the persisted `theme: light`.

## Security and privacy

No change. No new dependency, no new IPC channel, no runtime code touched — the app-side change is zero; everything new is test/CI/doc. The new job runs on a public repo's `ubuntu-latest` runner with the default read-only token, reads no secrets, and only installs the run's own artifact.

## AI assistance

Written by an automated agent (Claude, via the alan PR loop). Every command quoted above was actually run in this working tree and its output read; the mutation tests exist precisely so the new assertions are not taken on trust. A human should still review the workflow job before merging.
