### PR TITLE
docs(changelog): add user-facing 0.8.5 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to Freedom will be documented in this file.
 - Address-bar search for typed input that isn't a URL, with DuckDuckGo, Google, Bing, Brave Search, Ecosia, Startpage or a custom engine under Settings > Search
 - Three new wallet account types, usable with the vault locked and across dApp signing and sends:
   - Ledger hardware accounts, confirmed on the device, including x402 payments
-  - Phone accounts over Open Lavatory: scan a QR code, signing happens on the phone, including x402 payments
+  - Phone accounts over Open Lavatory: QR pairing, signing on the phone, including x402 payments
   - Safe multi-owner accounts on Gnosis, with a signing board owners sign in any order
 - Contract-hosted onchain apps on `web3://<address>[:<chainId>]/`, read straight from the chain with no gateway:
   - Address-bar shield popover reporting the chain, block, contract and content hash behind the page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Freedom will be documented in this file.
 
 ### Added
 
-- Ad and tracker blocking, on by default, with cosmetic hiding of the empty gaps blocking leaves behind:
+- Ad and tracker blocking, on by default, which also hides the empty spaces blocked ads leave:
   - Settings > Ad Blocking with a per-site allowlist and live rule counts
   - Cookie-banner and annoyance filtering, off by default
   - Filter lists refresh over Swarm without an app update
@@ -19,10 +19,10 @@ All notable changes to Freedom will be documented in this file.
   - Remembered decisions per profile under Settings > Site Permissions, with per-site and remove-all revocation
   - Indicator icon in the address bar with quick revoke on sites holding granted permissions
 - Private windows (`Cmd/Ctrl+Shift+N`, File > New Private Window): ephemeral browsing on a per-window in-memory session with dark, badged chrome
-  - No history, favicon-cache, or autocomplete writes; cookies and site data evaporate on close
-  - Downloads are flagged and drop out of the list when the window closes (files stay on disk); permission decisions are session-only
+  - No history, favicon-cache or autocomplete writes; cookies and site data end on close
+  - Downloads leave the list on close and permission decisions are session-only; files stay on disk
   - Wallet and `window.ethereum` / `window.swarm` / `window.radicle` providers are unavailable; x402 payment interception is off
-  - Honest start page: what's protected (local traces) and what isn't (network observers, sites you log into, your IP)
+  - Start page listing what private windows do and do not protect
 - Find in page (`Cmd/Ctrl+F`, also under Edit in the menu): overlay bar with a live match counter, `Enter` / `Shift+Enter` to cycle matches, `Esc` to close
 - Audio indicator on tabs playing sound; click it or use "Mute Tab" in the tab context menu to mute/unmute (mute survives navigation)
 - Remappable keyboard shortcuts under Settings > Shortcuts:
@@ -33,31 +33,34 @@ All notable changes to Freedom will be documented in this file.
 - Address-bar search for typed input that isn't a URL, with DuckDuckGo, Google, Bing, Brave Search, Ecosia, Startpage or a custom engine under Settings > Search
 - Three new wallet account types, usable with the vault locked and across dApp signing, sends and x402 payments:
   - Ledger hardware accounts, confirmed on the device
-  - Phone accounts over Open Lavatory: scan a QR code, confirm on the phone, the key never leaves it
-  - Safe multi-owner accounts on Gnosis, with a signing board each owner works through at their own pace
+  - Phone accounts over Open Lavatory: scan a QR code, signing happens on the phone
+  - Safe multi-owner accounts on Gnosis, with a signing board owners sign in any order
 - Contract-hosted onchain apps on `web3://<address>[:<chainId>]/`, read straight from the chain with no gateway:
   - Address-bar shield popover reporting the chain, block, contract and content hash behind the page
-  - The wallet provider is pinned to the app's chain and a page cannot switch it away
+  - The wallet provider is pinned to the app's chain; a page cannot switch it
 - Radicle repositories are browsable and writable from the browser:
   - `rad:` as a fetchable scheme, plus a consented `window.radicle` provider for issues, comments and patches
-  - Seed-to-browse reports real per-peer clone phases with retry and cancellation instead of assuming success
-- Encrypted point-to-point and broadcast messaging for Swarm apps through `window.swarm`, behind its own consent tier
+  - Seed-to-browse reports per-peer clone phases, with retry and cancellation
+  - Repository view pinned to any commit id, with commit, branch and contributor counts
+  - Nodes menu shows the Radicle node's connected peers, seeded repositories and addon version
+- Encrypted point-to-point messaging and topic broadcast for Swarm apps through `window.swarm`, behind its own consent tier
 - Swarm apps can ship a `freedom-manifest.json` so their permissions are one decision instead of a stream of prompts
-- Tor for `.onion` addresses through a bundled Arti client, off by default under Settings > Experimental (clearnet traffic keeps connecting directly)
-  - A system Tor client found on its default port, such as Tor Browser, can be adopted instead of the bundled Arti
-- Myotis, a fully peer-to-peer Ethereum and Gnosis light client, as an experimental verified source, off by default:
-  - Draggable read and verification order per chain under Settings > Chains, alongside Colibri, RPC quorum and direct RPC
+- Tor for `.onion` addresses through a bundled [Arti](https://gitlab.torproject.org/tpo/core/arti) 1.4.4 client, off by default under Settings > Experimental (clearnet traffic keeps connecting directly)
+  - Prompt to use a system Tor client, such as Tor Browser, instead of Arti
+- [Myotis](https://github.com/biafra23/myotis) 0.1.7, a peer-to-peer Ethereum and Gnosis light client, as an experimental verified source, off by default:
+  - Draggable read and verification order per chain under Settings > Chains, alongside Colibri and RPC
 - `.tez` name resolution from the Tezos Domains contracts, for bare names and `ipfs://` / `ipns://` targets
 
 ### Changed
 
-- Radicle runs as an embedded libradicle 0.7.1 addon instead of separate daemon, HTTP and CLI processes, and takes no local port
+- Radicle runs as an embedded [libradicle](https://github.com/solardev-xyz/libradicle) 0.7.1 addon instead of separate daemon, HTTP and CLI processes, and takes no local port
+- Swarm peers count up from launch instead of sitting at 0 during startup
 - Installers are about 15 MB smaller: each build now ships only the `better-sqlite3` native addon for its own platform and architecture instead of all eight upstream prebuilds
 - The Windows installer is named `Freedom-Setup-<version>.exe`, previously `Freedom Setup <version>.exe`
 
 ### Removed
 
-- Adopting a system Radicle node found on its default port as an external node
+- Adopting a system Radicle node found on its default port as an external node — the embedded Radicle node takes no local port, so there is nothing to adopt
 
 ### Fixed
 
@@ -65,12 +68,14 @@ All notable changes to Freedom will be documented in this file.
 - A `bzz://` deep link resolves when the manifest has no root index document instead of stranding on the not-found page
 - Pages that call `preventDefault()` on a context menu no longer also get Freedom's native menu
 - Custom RPC endpoints accept `http://` for loopback addresses such as `http://localhost:8545`, and save errors appear at the field (thanks @biafra23!)
+- Uploads around 250 MiB no longer stall
+- Expired or invalid postage batches fail fast with a clear error instead of stalling uploads
 - macOS disk images pass Gatekeeper without an online check
 
 ### Security
 
 - Updated bundled nodes:
-  - [Ant](https://github.com/freedom-hq/ant) 0.5.33 to 0.5.44 (Swarm peers count up from launch, no ~250 MiB upload stall, expired postage batches fail fast)
+  - [Ant](https://github.com/freedom-hq/ant) 0.5.33 to 0.5.44
 - Updated runtime dependencies:
   - `@corpus-core/colibri-stateless` 1.1.30 to 2.0.4 (thanks @simon-jentzsch!)
   - `better-sqlite3` 12.11.1 to 13.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to Freedom will be documented in this file.
 
 ### Added
 
+- Contract-hosted onchain apps on `web3://<address>[:<chainId>]/` — the app itself lives in the contract, not on a web server:
+  - Address-bar shield popover reporting the chain, block, contract and content hash behind the page
+  - The wallet provider is pinned to the app's chain; a page cannot switch it
+  - Reasoning: the page is a contract read, not a hosted file; the shield reports whether that read was verified
+- Three new wallet account types, usable with the vault locked and across dApp signing and sends:
+  - Ledger hardware accounts, confirmed on the device, including x402 payments
+  - Phone accounts over Open Lavatory: QR pairing, signing on the phone, including x402 payments
+  - Safe multi-owner accounts on Gnosis, with a signing board owners sign in any order
+- Radicle repositories are browsable and writable from the browser — open a `rad:` URL the way you would a web page:
+  - `rad:` as a fetchable scheme, plus a consented `window.radicle` provider for issues, comments and patches
+  - Seed-to-browse reports per-peer clone phases, with retry and cancellation
+  - Repository view pinned to any commit id, with commit, branch and contributor counts
+  - Nodes menu shows the Radicle node's connected peers, seeded repositories and addon version
+- Tor for `.onion` addresses through a bundled [Arti](https://gitlab.torproject.org/tpo/core/arti) 1.4.4 client, off by default under Settings > Experimental (clearnet traffic keeps connecting directly)
+  - Prompt to use a system Tor client, such as Tor Browser, instead of Arti
+- [Myotis](https://github.com/biafra23/myotis) 0.1.7, a peer-to-peer Ethereum and Gnosis light client, as an experimental verified source, off by default:
+  - Draggable read and verification order per chain under Settings > Chains, alongside Colibri and RPC
+  - Reasoning: reads are proven against a chain head Myotis syncs from peers itself, rather than trusted from an endpoint
+- `.tez` name resolution from the Tezos Domains contracts, for bare names and `ipfs://` / `ipns://` targets
+- Encrypted point-to-point messaging and topic broadcast for Swarm apps through `window.swarm`, behind its own consent tier
+- Swarm apps can ship a `freedom-manifest.json` so their permissions are one decision instead of a stream of prompts
 - Ad and tracker blocking, on by default, which also hides the empty spaces blocked ads leave:
   - Settings > Ad Blocking with a per-site allowlist and live rule counts
   - Cookie-banner and annoyance filtering, off by default
@@ -31,25 +52,6 @@ All notable changes to Freedom will be documented in this file.
   - Per-shortcut reset and a Restore defaults button; changes apply without a restart
 - Page zoom on `Cmd/Ctrl` with `=`, `-` and `0`, remappable like every other binding (thanks @alexwbend!)
 - Address-bar search for typed input that isn't a URL, with DuckDuckGo, Google, Bing, Brave Search, Ecosia, Startpage or a custom engine under Settings > Search
-- Three new wallet account types, usable with the vault locked and across dApp signing and sends:
-  - Ledger hardware accounts, confirmed on the device, including x402 payments
-  - Phone accounts over Open Lavatory: QR pairing, signing on the phone, including x402 payments
-  - Safe multi-owner accounts on Gnosis, with a signing board owners sign in any order
-- Contract-hosted onchain apps on `web3://<address>[:<chainId>]/`, read straight from the chain with no gateway:
-  - Address-bar shield popover reporting the chain, block, contract and content hash behind the page
-  - The wallet provider is pinned to the app's chain; a page cannot switch it
-- Radicle repositories are browsable and writable from the browser:
-  - `rad:` as a fetchable scheme, plus a consented `window.radicle` provider for issues, comments and patches
-  - Seed-to-browse reports per-peer clone phases, with retry and cancellation
-  - Repository view pinned to any commit id, with commit, branch and contributor counts
-  - Nodes menu shows the Radicle node's connected peers, seeded repositories and addon version
-- Encrypted point-to-point messaging and topic broadcast for Swarm apps through `window.swarm`, behind its own consent tier
-- Swarm apps can ship a `freedom-manifest.json` so their permissions are one decision instead of a stream of prompts
-- Tor for `.onion` addresses through a bundled [Arti](https://gitlab.torproject.org/tpo/core/arti) 1.4.4 client, off by default under Settings > Experimental (clearnet traffic keeps connecting directly)
-  - Prompt to use a system Tor client, such as Tor Browser, instead of Arti
-- [Myotis](https://github.com/biafra23/myotis) 0.1.7, a peer-to-peer Ethereum and Gnosis light client, as an experimental verified source, off by default:
-  - Draggable read and verification order per chain under Settings > Chains, alongside Colibri and RPC
-- `.tez` name resolution from the Tezos Domains contracts, for bare names and `ipfs://` / `ipns://` targets
 
 ### Changed
 
@@ -74,6 +76,8 @@ All notable changes to Freedom will be documented in this file.
 
 ### Security
 
+- Escape repository-supplied names and identifiers in the Radicle repository viewer's HTML attributes, blocking script execution from a crafted file name
+- `window.ethereum` responses reach only the document that made the request, so a reply arriving after a navigation cannot land in the next page
 - Updated bundled nodes:
   - [Ant](https://github.com/freedom-hq/ant) 0.5.33 to 0.5.44
 - Updated runtime dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,9 @@ All notable changes to Freedom will be documented in this file.
   - Per-shortcut reset and a Restore defaults button; changes apply without a restart
 - Page zoom on `Cmd/Ctrl` with `=`, `-` and `0`, remappable like every other binding (thanks @alexwbend!)
 - Address-bar search for typed input that isn't a URL, with DuckDuckGo, Google, Bing, Brave Search, Ecosia, Startpage or a custom engine under Settings > Search
-- Three new wallet account types, usable with the vault locked and across dApp signing, sends and x402 payments:
-  - Ledger hardware accounts, confirmed on the device
-  - Phone accounts over Open Lavatory: scan a QR code, signing happens on the phone
+- Three new wallet account types, usable with the vault locked and across dApp signing and sends:
+  - Ledger hardware accounts, confirmed on the device, including x402 payments
+  - Phone accounts over Open Lavatory: scan a QR code, signing happens on the phone, including x402 payments
   - Safe multi-owner accounts on Gnosis, with a signing board owners sign in any order
 - Contract-hosted onchain apps on `web3://<address>[:<chainId>]/`, read straight from the chain with no gateway:
   - Address-bar shield popover reporting the chain, block, contract and content hash behind the page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,53 +6,72 @@ All notable changes to Freedom will be documented in this file.
 
 ### Added
 
-- Remappable keyboard shortcuts under Settings > Shortcuts:
-  - Searchable list grouped by category; click a binding and press the new combination
-  - Conflict warning with a one-click swap when a combination is already taken
-  - Per-shortcut reset and a Restore defaults button; changes apply without a restart
-- Private windows (`Cmd+Shift+N` / `Ctrl+Shift+N`, File > New Private Window): ephemeral browsing on a per-window in-memory session with dark, badged chrome
-  - No history, favicon-cache, or autocomplete writes; cookies and site data evaporate on close
-  - Downloads are allowed but flagged and drop out of the downloads list when the window closes (files stay on disk); permission prompts work but decisions are session-only
-  - Wallet and `window.ethereum` / `window.swarm` / `window.radicle` providers are unavailable in private windows (EIP-6963 silent); x402 payment interception is off
-  - Honest private start page: what's protected (local traces) and what isn't (network observers, sites you log into, your IP)
-- Find in page (`Cmd+F` / `Ctrl+F`, also under Edit in the menu): overlay bar over the page with a live match counter, `Enter` / `Shift+Enter` to cycle matches, `Esc` to close
+- Ad and tracker blocking, on by default, with cosmetic hiding of the empty gaps blocking leaves behind:
+  - Settings > Ad Blocking with a per-site allowlist and live rule counts
+  - Cookie-banner and annoyance filtering, off by default
+  - Filter lists refresh over Swarm without an app update
 - Download manager covering every download source, including `bzz://` and `ipfs://` content:
   - Shelf card with live progress and cancel; Open / Show in Folder on completion
-  - `freedom://downloads` page (Cmd/Ctrl+Shift+J) with search, pause/resume, and Clear All
+  - `freedom://downloads` page (`Cmd/Ctrl+Shift+J`) with search, pause/resume, and Clear All
   - "Ask where to save each file" toggle under Settings > Downloads
 - Per-site permission prompts for camera, microphone, notifications, clipboard reading, location, and MIDI, replacing the previous silent denial:
   - Prompt under the address bar with Allow / Block and "Remember for this site"
   - Remembered decisions per profile under Settings > Site Permissions, with per-site and remove-all revocation
   - Indicator icon in the address bar with quick revoke on sites holding granted permissions
-  - Location prompts note that positioning may be unreliable
-- Download manager covering every download source, including `bzz://` and `ipfs://` content:
-  - Shelf card with live progress and cancel; Open / Show in Folder on completion
-  - `freedom://downloads` page (Cmd/Ctrl+Shift+J) with search, pause/resume, and Clear All
-  - "Ask where to save each file" toggle under Settings > Downloads
-- Find in page (`Cmd+F` / `Ctrl+F`, also under Edit in the menu): overlay bar over the page with a live match counter, `Enter` / `Shift+Enter` to cycle matches, `Esc` to close
+- Private windows (`Cmd/Ctrl+Shift+N`, File > New Private Window): ephemeral browsing on a per-window in-memory session with dark, badged chrome
+  - No history, favicon-cache, or autocomplete writes; cookies and site data evaporate on close
+  - Downloads are flagged and drop out of the list when the window closes (files stay on disk); permission decisions are session-only
+  - Wallet and `window.ethereum` / `window.swarm` / `window.radicle` providers are unavailable; x402 payment interception is off
+  - Honest start page: what's protected (local traces) and what isn't (network observers, sites you log into, your IP)
+- Find in page (`Cmd/Ctrl+F`, also under Edit in the menu): overlay bar with a live match counter, `Enter` / `Shift+Enter` to cycle matches, `Esc` to close
 - Audio indicator on tabs playing sound; click it or use "Mute Tab" in the tab context menu to mute/unmute (mute survives navigation)
+- Remappable keyboard shortcuts under Settings > Shortcuts:
+  - Searchable list grouped by category; click a binding and press the new combination
+  - Conflict warning with a one-click swap when a combination is already taken
+  - Per-shortcut reset and a Restore defaults button; changes apply without a restart
+- Page zoom on `Cmd/Ctrl` with `=`, `-` and `0`, remappable like every other binding (thanks @alexwbend!)
+- Address-bar search for typed input that isn't a URL, with DuckDuckGo, Google, Bing, Brave Search, Ecosia, Startpage or a custom engine under Settings > Search
+- Three new wallet account types, usable with the vault locked and across dApp signing, sends and x402 payments:
+  - Ledger hardware accounts, confirmed on the device
+  - Phone accounts over Open Lavatory: scan a QR code, confirm on the phone, the key never leaves it
+  - Safe multi-owner accounts on Gnosis, with a signing board each owner works through at their own pace
+- Contract-hosted onchain apps on `web3://<address>[:<chainId>]/`, read straight from the chain with no gateway:
+  - Address-bar shield popover reporting the chain, block, contract and content hash behind the page
+  - The wallet provider is pinned to the app's chain and a page cannot switch it away
+- Radicle repositories are browsable and writable from the browser:
+  - `rad:` as a fetchable scheme, plus a consented `window.radicle` provider for issues, comments and patches
+  - Seed-to-browse reports real per-peer clone phases with retry and cancellation instead of assuming success
+- Encrypted point-to-point and broadcast messaging for Swarm apps through `window.swarm`, behind its own consent tier
+- Swarm apps can ship a `freedom-manifest.json` so their permissions are one decision instead of a stream of prompts
+- Tor for `.onion` addresses through a bundled Arti client, off by default under Settings > Experimental (clearnet traffic keeps connecting directly)
+- Myotis, a fully peer-to-peer Ethereum and Gnosis light client, as an experimental verified source, off by default:
+  - Draggable read and verification order per chain under Settings > Chains, alongside Colibri, RPC quorum and direct RPC
+- `.tez` name resolution from the Tezos Domains contracts, for bare names and `ipfs://` / `ipns://` targets
 
 ### Changed
 
-- Updated bundled [Ant](https://github.com/freedom-hq/ant) 0.5.33 to 0.5.44:
-  - Fixes the ~250 MiB upload stall
-  - Upload-side Reed-Solomon encoding, end-to-end Swarm content encryption, local pinning, and ACT access control
-  - Fewer intermittent upload failures under feed workloads, faster feed resolution
-  - Expired or invalid postage batches fail fast with a clear error instead of stalling uploads
-  - Freshly bought batches rejected by peers during propagation now recover on their own
-  - Encrypted point-to-point and broadcast messaging on the light node
-- The Swarm node's API now comes up instantly on start, so the node menu shows peers counting up live instead of sitting at 0 during startup
-- Radicle now runs as an embedded libradicle 0.7.1 addon instead of separate daemon, HTTP, and CLI processes:
-  - Native browsing, seeding, synchronization, unseeding, GitHub imports, and provider writes
-  - Live peer-level clone phases with cancellation, retry, and timeout handling
-  - Concurrent cold-start discovery across a device-ranked 14-node seed book
-  - Historical commit browsing with repository remotes, branches, commits, and contributor stats
-  - Profile-scoped identity, peer and repository counts, and addon version in the Nodes menu
+- Radicle runs as an embedded libradicle 0.7.1 addon instead of separate daemon, HTTP and CLI processes, and takes no local port
 - Installers are about 15 MB smaller: each build now ships only the `better-sqlite3` native addon for its own platform and architecture instead of all eight upstream prebuilds
+- The Windows installer is named `Freedom-Setup-<version>.exe`, previously `Freedom Setup <version>.exe`
+
+### Removed
+
+- Adopting a system Radicle node found on its default port as an external node
+
+### Fixed
+
+- Save image as and Copy image work on images loaded from `bzz://`, `ipfs://` and `ipns://` pages
+- A `bzz://` deep link resolves when the manifest has no root index document instead of stranding on the not-found page
+- Pages that call `preventDefault()` on a context menu no longer also get Freedom's native menu
+- Custom RPC endpoints accept `http://` for loopback addresses such as `http://localhost:8545`, and save errors appear at the field (thanks @biafra23!)
+- macOS disk images pass Gatekeeper without an online check
 
 ### Security
 
+- Updated bundled nodes:
+  - [Ant](https://github.com/freedom-hq/ant) 0.5.33 to 0.5.44 (Swarm peers count up from launch, no ~250 MiB upload stall, expired postage batches fail fast)
 - Updated runtime dependencies:
+  - `@corpus-core/colibri-stateless` 1.1.30 to 2.0.4 (thanks @simon-jentzsch!)
   - `better-sqlite3` 12.11.1 to 13.0.3
   - `micro-key-producer` 0.9.0 to 0.10.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to Freedom will be documented in this file.
 - Encrypted point-to-point and broadcast messaging for Swarm apps through `window.swarm`, behind its own consent tier
 - Swarm apps can ship a `freedom-manifest.json` so their permissions are one decision instead of a stream of prompts
 - Tor for `.onion` addresses through a bundled Arti client, off by default under Settings > Experimental (clearnet traffic keeps connecting directly)
+  - A system Tor client found on its default port, such as Tor Browser, can be adopted instead of the bundled Arti
 - Myotis, a fully peer-to-peer Ethereum and Gnosis light client, as an experimental verified source, off by default:
   - Draggable read and verification order per chain under Settings > Chains, alongside Colibri, RPC quorum and direct RPC
 - `.tez` name resolution from the Tezos Domains contracts, for bare names and `ipfs://` / `ipns://` targets


### PR DESCRIPTION
## Summary

Brings `CHANGELOG.md`'s `## [Unreleased]` section up to date for the 0.8.5 cycle, against **`release/0.8.5`** (not `main`) per `release-process.md` §3. The heading stays `## [Unreleased]` — `v0.8.5-rc.3` is the current pre-release, so the `## [0.8.5] - <date>` rename belongs to the commit that cuts the bare version. `package.json` is untouched; `CHANGELOG.md` is the only file changed.

**This PR is the §3 review gate.** The playbook says agent-drafted changelog text must be approved by the releaser before it lands on the release branch — merging this PR *is* that approval. I will not merge it.

### Baseline and method

Baseline is the `v0.8.0` tag (`54a9b86f`), not the `cut 0.8.5-rc.N` commits. I walked `git log v0.8.0..origin/release/0.8.5` plus every PR merged in that window (`gh pr list --state merged --base main --search "merged:>=2026-07-02"`, 50 PRs) and read each PR body rather than inferring from titles.

### What I changed vs. the existing draft

- **Removed a duplicate block**: the download-manager and find-in-page entries were each present twice.
- **Added 14 shipped features the draft was missing**: ad blocking, per-site permissions, address-bar search, Ledger, phone signing, Safe accounts, onchain apps, Radicle browsing, Swarm messaging, Swarm permission manifests, Tor, Myotis, `.tez`, zoom shortcuts.
- **Added `Removed` and `Fixed` sections** (the draft had none).
- **Recategorised the Ant bump** from `Changed` to `Security` under an `Updated bundled nodes:` category lead, per § *Categorising dependency updates* ("default to **Security**"; matching `0.7.3`'s `Bee 2.7.1 to 2.8.0` placement) — the 0.5.34→0.5.44 range does carry integrity hardening (strict pushsync receipts, startup verification of persisted issuers, fail-closed stamp issuance). Its six sub-bullets collapse into one dependency line with a short impact parenthetical, and the separate "Swarm node's API comes up instantly" bullet folds in with it rather than double-listing one change across two sections.
- **Split the embedded-Radicle entry**: the new user-facing surfaces (`rad:`, `window.radicle`, seed-to-browse) are `Added` — they never shipped before; only the runtime swap (daemon/httpd/CLI → embedded addon, no local port) is `Changed`, since the managed Radicle node itself shipped in 0.8.0. Its five sub-bullets are trimmed to two.
- **Added the two release-plumbing items that are user-visible**: the Windows installer file name and the self-stapled macOS `.dmg`.

### Headings, in order

`Added`, `Changed`, `Removed`, `Fixed`, `Security` — Keep a Changelog order per § *Procedure* step 4, with `Deprecated` omitted (no entries).

### What I verified per entry

Every claim below was checked against the merged diff on `release/0.8.5`, not the PR title.

**Added**

| Entry | PRs | How verified |
| --- | --- | --- |
| Ad blocking | #144 | `settings-store.js` defaults: `adblockEnabled/Ads/Privacy: true`, `adblockCookies/Annoyances: false`, `adblockAutoUpdate: true`; asserted live in the running app (see below) |
| Download manager | #151 | `internal-pages.json` gained `downloads`; `downloads.show` = `CmdOrCtrl+Shift+J` in `shortcuts.js`; File > Downloads in `menu.js:257`; `askWhereToSave: false` default |
| Per-site permission prompts | #152 | Settings > Site Permissions section present; dropped the draft's 4th sub-bullet ("location may be unreliable") for density |
| Private windows | #186 | `window.newPrivate` = `CmdOrCtrl+Shift+N`, File > New Private Window at `menu.js:279`; start-page copy screenshotted below |
| Find in page | #150 | `page.findInPage` = `CmdOrCtrl+F`; Edit > Find in Page… at `menu.js:500` (note: the first landing at `73ee4a01` was reverted at `de47fdc4` and re-landed via #150 — it does ship) |
| Tab audio indicator / mute | #155 | — |
| Remappable shortcuts | #156 | Settings > Shortcuts section present in the running app |
| Page zoom shortcuts | #193 | `page.zoomIn/zoomOut/zoomReset` in `src/shared/shortcuts.js` |
| Address-bar search | #146 | `SEARCH_PROVIDERS` in `search-utils.js` lists exactly the six named; `searchProvider: 'duckduckgo'` default asserted live |
| Ledger / phone / Safe accounts | #149, #196 (feature originally #159), #160 | **#160 is still open** — its commits (`34cc89ea`, `50c76558`, `8aa98143`, `45f729d3`, …) reached `release/0.8.5` via #192's stacked base, and the Safe UI is live in `index.html`. Flagging explicitly so you can confirm you want it announced in 0.8.5 |
| Onchain apps `web3://` | #192 | — |
| Radicle browsing | #145, #194 | — |
| `window.swarm` messaging | #165 | Backed by Ant 0.5.42's PSS/GSOC support |
| Swarm permission manifests | #168 | — |
| Tor / `.onion` | #191 | `enableTorIntegration: false` default asserted live; Settings > Experimental row at `settings.html:1557`; Arti pinned to 1.4.4 in `scripts/fetch-arti.js` |
| Myotis | #181 | `startMyotisAtLaunch: false` default asserted live; `chains.json` gained `access.readOrder` / `verification.order` |
| `.tez` resolution | #164 | — |

**Changed**

| Entry | PRs | How verified |
| --- | --- | --- |
| Embedded libradicle 0.7.1, no local port | #194 | `RADICLE_ADDON_VERSION = '0.7.1'`; `scripts/fetch-radicle.js` and `init-radicle.js` deleted |
| Installers ~15 MB smaller | #197 | `75c8c15e` measured `prebuilds/` 8 files (17 MB) → 1 file (2.2 MB); per-platform `files` exclusions added to the mac/linux/win blocks in `package.json` |
| Windows installer name | #210 (fix in `b932474b`) | `build.nsis.artifactName` = `${productName}-Setup-${version}.${ext}`; the shipped `v0.8.5-rc.3` release asset is literally `Freedom-Setup-0.8.5-rc.3.exe` |

**Removed**

| Entry | PRs | How verified |
| --- | --- | --- |
| Adopting a system Radicle node | #194 | `profile-external-candidates.js` had `radicle:` at `v0.8.0`; at head it has `bee` and `tor` (the Tor candidate, #191, is noted as a sub-bullet of the Tor `Added` entry) — the 0.8.0 `Added` entry for that prompt no longer covers Radicle |

**Fixed**

| Entry | PRs | How verified |
| --- | --- | --- |
| Save/Copy image on dweb URLs | #158 (hygiene follow-up #182 folded in, not listed separately — in-release polish) | — |
| `bzz://` deep link with no root index | #173 | Fixes #172 |
| `preventDefault()` on context menu honored | #167 | — |
| Loopback `http://` RPC endpoints | #105 | Credited `(thanks @biafra23!)` |
| macOS `.dmg` passes Gatekeeper offline | #207 (`8b3da0fd`) | `build.mac.notarize: true` staples only `Freedom.app`; the `v0.8.5-rc.3` run (`33908546728`) shows the mac job's **"Notarize and staple the disk image"** step succeeded, so the shipped image now carries its own ticket. Prior state rests on `release-process.md` at `v0.8.0` naming the inline flow "the default mac release flow" |

**Security**

| Entry | Verified |
| --- | --- |
| Ant 0.5.33 → 0.5.44 | `PINNED_RELEASE_TAG = 'v0.5.44'` in `scripts/fetch-ant.js` (#147, #162, #171, #206). Each impact clause traced to an upstream release note: peers-from-launch = 0.5.36, ~250 MiB stall = 0.5.35, expired-batch fast-fail = 0.5.41 |
| `@corpus-core/colibri-stateless` 1.1.30 → 2.0.4 | Lockfile diff. Declared range moved 1.1.30 → ^2.0.0 by @simon-jentzsch (#161), then ^2.0.1 (#170), resolving to 2.0.4. Credited on this line as his most significant entry |
| `better-sqlite3` 12.11.1 → 13.0.3, `micro-key-producer` 0.9.0 → 0.10.2 | Lockfile diff (#197) |

### Deliberately excluded

- **Electron**: unchanged at 43.0.0 (lockfile-verified) — no entry, so no Chromium/Node line is owed this cycle.
- **freedom-ipfs**: unchanged at `v0.4.3` in `scripts/fetch-freedom-ipfs-native.js`, despite being listed as a "probably user-facing" candidate in the task. Verified, not bumped.
- **Arti 1.4.4 / Myotis 0.1.7 / libradicle 0.7.1**: first shipped this cycle, so they are named in their `Added`/`Changed` parents rather than listed as bundled-node *updates* (§ "Skip in-release version drift for dependencies first added in this release"). Same for the new npm deps (`@ghostery/adblocker`, `@ledgerhq/*`, `@openlv/*`, `@safe-global/protocol-kit`).
- **New dev dependencies** (`aedes`, `esbuild`) and the `engines` bump to Node 24: developer-only.
- **Internal CI/tooling/test work**: #148, #176, #182, #188, #189, #190, #199, #201, #202, #203, #209, #211, #212, #213, #214, #215 — all developer-only or test-only per § *Procedure* step 5. #188's README/docs rewrite is explicitly a "README/docs rewrite" skip.
- **#216** — merged to `main` after the rc.3 cut and is **not** on `release/0.8.5`; test-only either way.

### Density check

Per the § *Density budget*, I diffed side-by-side against `[0.8.0]`. Top-level bullets are all ≤ 25 words. Sub-bullets are ≤ 15 words apart from two ~18-word lines in the private-windows block. **I am over the ≤ 10 sub-bullet guideline: 21 across the release** (0.8.0 shipped with 9). 0.8.5 lands roughly three times 0.8.0's feature count, and I judged that folding e.g. the private-window protection scope or the three new wallet account types into their parents would cost real information. I trimmed where I could — Ant 6 → 1, embedded Radicle 5 → 2, permissions 4 → 3 — and merged Ledger/phone/Safe into one parent with three sub-bullets rather than three top-level entries. **Happy to cut further if you'd rather hold the budget.**

## Related issue

None.

## Verification

- [ ] `npm run lint` – not applicable (no JS changed)
- [ ] Relevant unit tests – not applicable
- [x] Relevant Playwright or live smoke tests – a throwaway harness spec (deleted before committing; the commit is `CHANGELOG.md` only) drove the real app to assert the claims below
- [x] `npx prettier --check CHANGELOG.md`
- [x] `git diff --check`
- [x] Every PR number cited above confirmed with `gh pr view <n> --json state,mergedAt` — all `MERGED` except **#160**, which is `OPEN` (its commits landed via #192, called out above)

Live assertions against the running app (`xvfb-run -a npx playwright test --project=harness`, 2 passed):

```
SECTION TITLES: ["Appearance","Search","Profile","Nodes","Automatic Startup","Downloads",
"Shortcuts","Chains","RPC Providers","Ethereum Name Resolution","Site Permissions",
"Ad Blocking","Experimental","Updates"]

DEFAULTS: {"searchProvider":"duckduckgo","askWhereToSave":false,"adblockEnabled":true,
"adblockAds":true,"adblockPrivacy":true,"adblockCookies":false,"adblockAnnoyances":false,
"enableTorIntegration":false,"startMyotisAtLaunch":false}
```

## Visual changes

No UI change — the screenshots below are acceptance evidence that the entries describe what a user actually sees. Posted as a follow-up comment.

## Security and privacy

No change. Documentation only; no code, permission, IPC, network, storage or wallet surface is touched. No tags pushed, no releases created, no file outside `CHANGELOG.md` modified.

## AI assistance

Drafted end to end by Claude Code (alan writer loop) at the maintainer's request: PR bodies and upstream Ant release notes read individually, every version claim re-derived from the lockfile / pin scripts / shipped release assets rather than from the previous draft, and the UI claims checked by running the app. Per §3's review gate, nothing here lands until @meinharrd reviews and merges — I do not merge.



---

## Dropped from the earlier draft, and why

*(Added by the alan fix round, per the maintainer's review item 4. Every item below was checked against `src/` at the PR head — not taken from the old draft's word. Nothing vanishes silently.)*

**Restored to the changelog** (a user can reach these):

| Item | Where a user reaches it |
| --- | --- |
| Historical browsing at a pinned commit + repo stats | `rad://<rid>/tree/<sha>` in the address bar; `renderStats` at `src/renderer/pages/scripts/rad-browser.js:460-499` renders the commits/branches/contributors bar. Screenshotted below |
| Nodes-menu peer / seeded-repo / addon-version counts | Nodes menu → Radicle rows (`#radicle-peers-count`, `#radicle-repos-count`, `#radicle-version-text`), `src/renderer/lib/radicle-ui.js:28-46`. Screenshotted below |

**Left out — no Freedom surface in this build.** These are capabilities of the bundled Ant node or of the libradicle addon that the browser never exposes. The releaser decides whether to announce a dependency's capability the product cannot reach; my recommendation is no.

| Item | Why |
| --- | --- |
| Upload-side Reed-Solomon encoding | No `Swarm-Redundancy-Level` header is ever set; all three upload paths (`src/main/swarm/publish-service.js:76-138`) pass only `pin`/`deferred`/`contentType`/`size`/`indexDocument`. The only redundancy in the repo is retrieval-side and hardcoded (`bzz-protocol.js:111-112`), and shipped before this release |
| End-to-end Swarm content encryption | No encrypt option in any publish flow; `handlePublishData` destructures exactly `{ data, contentType, name }` (`swarm-provider-ipc.js:465`). Freedom can *display* an encrypted reference (shipped in 0.7.x) but never creates one |
| Local pinning | `pin: true` is hardcoded on every upload with no toggle, no unpin, no pin-list UI, and no IPC channel (`ipc-channels.js:311-345`). An implementation detail, not an operable feature |
| ACT access control | Zero implementation — no `grantee`, `Swarm-Act`, or `historyAddress` anywhere in `src/` or `docs/` |
| Device-ranked seed-book cold-start discovery | Entirely inside the native addon. Its diagnostics go only to `main.log` (`radicle-manager.js:118-128`); no IPC, no renderer consumer, and no "14 nodes" claim is verifiable from this repo |
| Commit *list* / commit *diff* / remotes / branch switcher | The radapi routes exist (`radicle-api-protocol.js:214-251`) but no rad-browser caller does. `remotes` is fetched only as a head-SHA fallback and never rendered; there is no branch picker in `rad-browser.html`. Reachable only from a third-party app (canopy) that Freedom does not bundle |
| "Radicle identity" in the Nodes menu | The Nodes menu has no DID row — the DID and alias live in the sidebar Nodes tab (`wallet-ui.js:283-292`), a different surface. The restored entry says peers/repos/version only |

**Also corrected while sweeping:** `Encrypted point-to-point and broadcast messaging` → `Encrypted point-to-point messaging and topic broadcast`. GSOC broadcast is a *signed* single-owner chunk, not encrypted (`messaging-service.js:165-172`), and Freedom's own approval copy tells the user so (`swarm-connect.js:659`: "visible to the Swarm network"). The old wording implied both legs were encrypted.
