### PR TITLE
docs(release): sync the changelog steps with the 0.8.5 flow and retro lessons

### DIFF
--- a/docs/agent-playbooks/changelog-process.md
+++ b/docs/agent-playbooks/changelog-process.md
@@ -33,7 +33,7 @@ Use this playbook when asked to update `CHANGELOG.md` for a new version.
 6. Merge related commits into a single user-facing entry.
 7. Inspect PR merge commits by reviewing underlying commits.
 8. Re-run the git log before editing to catch late commits.
-9. Prepend the new version section above the previous one. If a `## [Unreleased]` heading is present, replace it with `## [<version>] - <YYYY-MM-DD>`. If it is absent (rare, since the dev cycle on `main` accumulates entries under `[Unreleased]`), add the new version heading directly. When writing the first user-facing change in the next dev cycle, re-introduce a `## [Unreleased]` heading above the latest released version.
+9. Prepend the new version section above the previous one. While the release is still in candidates (`rc.N` tags), keep the heading as `## [Unreleased]` and only replace it with `## [<version>] - <YYYY-MM-DD>` when the bare version is cut (see `release-process.md` §1/§3). If the heading is absent (rare, since the dev cycle on `main` accumulates entries under `[Unreleased]`), add the version heading directly. When writing the first user-facing change in the next dev cycle, re-introduce a `## [Unreleased]` heading above the latest released version.
 
 ## Output Style
 
@@ -47,13 +47,13 @@ Mechanical sanity checks:
 
 - Top-level bullets: aim ≤ 25 words.
 - Sub-bullets: aim ≤ 15 words.
-- Sub-bullets across the whole release: aim ≤ 10 total, excluding the per-package dependency sub-bullets (see Structure rules). If you're over, fold related surfaces into the parent or drop them.
+- Sub-bullets across the whole release: aim ≤ 10 total for a two-to-three-week release, excluding the per-package dependency sub-bullets (see Structure rules). A longer cycle scales roughly with its length (`0.8.0`, two months, shipped 25; `0.8.5` about 30), but no single parent should carry more than 4 and no sub-bullet should restate its parent. If you're over, fold related surfaces into the parent or drop them.
 
 Drift patterns to cut on sight (every one of these has shipped into a draft and had to be trimmed later):
 
 - **Mechanism in user-facing copy.** RPC method names (`eth_call`), protocol terms ("Universal Resolver", "sync committee"), helper-function names — the reader doesn't need the protocol step. Leave it in the commit message and PR description.
 - **"so X" tails justifying the change.** `Forward and reverse lookups are both verified, so the wallet's recipient-name display carries the same guarantee` — the parent bullet already conveys it; drop the tail.
-- **Em-dash explanations expanding into mechanism.** `X keeps working — the prover does Y, ethers does Z, the final callback is independently proven`. The `X keeps working` half is the entry; drop the expansion.
+- **Em-dash explanations expanding into mechanism.** `X keeps working — the prover does Y, ethers does Z, the final callback is independently proven`. The `X keeps working` half is the entry; drop the expansion. This is different from the short dash-tagline on a headline entry that says what the thing is _for_ (`— pay as you browse, straight from the built-in wallet`), which the voice rules allow.
 - **Consecutive sub-bullets repeating their subject.** Two bullets both opening with `Wallet send review screen shows…` — open each with the distinct surface (`Green ✓ next to a verified name`, `Amber ⚠ next to a spoofed name`) and let the parent carry the shared context.
 - **Defensive parentheticals.** `(zk-proven sync bootstrap by default)`, `(stale record or spoofing attempt)` — drop unless the reader genuinely can't infer the case.
 - **Thin sub-bullet groups.** If a parent has only 1–2 sub-bullets and they add no surface variety, fold them into the parent.
@@ -136,6 +136,13 @@ The vague historical phrasing (`Chromium and Node patches`, used in `0.7.1`'s `E
 ### Review gate
 
 An agent draft is a starting point, not a final. After drafting, diff the new section against the previous shipped release and trim/restructure until per-entry density matches. Compare more than word counts: lead patterns per section, whether first-shipped components carry version and link, whether update lines stay bare, and register (a `0.8.5` draft matched `0.8.0`'s headings and bullet counts while drifting on all four).
+
+**Verify claims, not prose.** Before presenting, check every factual claim against the tree at the release head, and say in the review note what each entry was verified against:
+
+- Version pairs from both ends of the range (`git show v<prev>:scripts/fetch-*.js`, lockfile at both refs), never from a PR description.
+- A trailing clause shared by several sibling items (`…, usable across dApp signing, sends and x402 payments` over Ledger / phone / Safe) must hold for **every** sibling; check each in code. The 0.8.5 draft claimed x402 for Safe accounts, which cannot sign x402 authorizations.
+- An entry about a shared list or config (external-node candidates, chain catalogue, shortcut map, search providers) is checked against the **whole list at head**, not just the PR that motivated the entry: in 0.8.5 one PR removed the Radicle candidate (documented) while another PR in the same window had added a Tor candidate to the same array (missed).
+- Credits via `gh pr view <n> --json author`; links with a real request returning 200; feature reachability in `src/` (a route or IPC channel that nothing in the renderer calls is not a feature).
 
 **Nothing disappears silently.** When a draft trims or replaces entries that were already in `[Unreleased]` (or in an earlier agent draft), the PR or review note lists what was dropped and why — "Ant internals with no Freedom UI surface", "duplicate of the Added parent" — so the releaser decides, not the compressor. Restoring a dropped capability requires checking in `src/` that a user can actually reach it in this build; the old text is not evidence.
 

--- a/docs/agent-playbooks/release-process.md
+++ b/docs/agent-playbooks/release-process.md
@@ -134,9 +134,10 @@ Per `changelog-process.md` § Categorising dependency updates, dependency update
 
 Follow `changelog-process.md` in full. Key points for release branches:
 
-- The baseline for `git log` is the last `package.json` version bump commit.
-- Replace the `## [Unreleased]` heading with `## [<version>] - <YYYY-MM-DD>` using the date from `git show -s --format="%ad" --date=short HEAD`.
+- **Baseline is the previous release's tag** (`git rev-list -n 1 v<prev>`), not "the last version bump commit" — on a release branch the last bump is the `cut <version>-rc.N` commit and would yield an empty range. Sweep merged PRs in that window as well as commits; read PR descriptions, not titles.
+- **Two phases.** During the candidate loop the section stays under `## [Unreleased]`: write and review it early (ideally before `rc.1`, at the latest while `rc.1` is being tested) so testers read the same notes the release will ship. When the bare version is cut, replace the heading with `## [<version>] - <YYYY-MM-DD>` (date from `git show -s --format="%ad" --date=short HEAD`) in the same commit as the version bump or right after it.
 - Do **not** leave an empty `## [Unreleased]` section behind. The first user-facing change after the release re-introduces the heading above the latest version.
+- `CHANGELOG.md` is not read by §4 (verify) or by candidate builds (§5, `rc.N` tags), so those run in parallel with the review. The **final** tag (§5) and the website update (§7) freeze the changelog state visible to end users and must wait until the reviewed text is on the release branch.
 
 Commit style:
 
@@ -144,9 +145,12 @@ Commit style:
 docs(changelog): add user-facing <version> release notes
 ```
 
-**Review gate (when drafted by an agent).** If the changelog entries were drafted by an agent — or by anyone other than the releaser — **do not create the `docs(changelog): …` commit yet**. Leave the `CHANGELOG.md` edits unstaged (or staged, but uncommitted) on the release branch, present the diff to the releaser, and wait for explicit approval before committing. Iterating in the working tree is cheaper than amending a commit, and avoids the `git commit --amend` ambiguity for agents whose tooling discourages amending without an explicit user request. `CHANGELOG.md` is not read by §4 (verify) or by candidate builds (§5, `rc.N` tags), so those can run in parallel with the review. The **final** tag (§5) and the website update (§7) freeze the changelog state visible to end users and must wait until the commit lands.
+**Review gate (when drafted by an agent).** Agent-drafted changelog text is not committed to the release branch until the releaser has approved it. Two ways to hold that, pick by who is drafting:
 
-If the changelog is already committed when a correction is requested (e.g. the releaser drafted it themselves, or this gate was missed), amend the existing `docs(changelog): …` commit rather than stacking a second changelog commit.
+- _Releaser working in their own checkout with an agent:_ leave the `CHANGELOG.md` edits unstaged, present the diff, create the `docs(changelog): …` commit only after explicit approval. Corrections before approval are edits in the working tree, not amends.
+- _Agent working on its own branch (the alan flow used for 0.8.5):_ the agent opens a PR **against `release/<version>`** (explicit `--base`; the default is `main`) touching only `CHANGELOG.md`, with a per-entry "verified against" list in the description. The PR is the presentation; the releaser's merge is the approval. Corrections land as further commits on the PR branch — do not amend — and the PR description must state which entries changed and any judgement calls left for the releaser (category placement, whether to announce a feature whose PR is still open, link targets). Expect more than one round: the 0.8.5 changelog took an alan review plus two maintainer-directed fix rounds before merge. `alan fix <repo> <pr> "<numbered instructions>"` is the tool for those rounds.
+
+Either way, run the side-by-side comparison in `changelog-process.md` § Review gate against the previous shipped section before presenting, and again after each fix round; the rules there were written from what the 0.8.5 draft got wrong.
 
 ## 4. Verify before tagging
 


### PR DESCRIPTION
## Summary

Audit of the changelog guidance after the 0.8.5 changelog (#217) landed. `changelog-process.md` had already received the precedent rules (#219, #220), but two things were still out of date and the #217 retro lessons were not encoded:

**`release-process.md` §3** still described the pre-CI, single-phase flow:
- baseline "the last `package.json` version bump commit" → on a release branch that is the `cut <version>-rc.N` commit and yields an empty range; now: the previous release's tag, plus a sweep of merged PRs in the window;
- the `[Unreleased]` → `[<version>]` rename as the first step → now two phases: stay under `[Unreleased]` during candidates (write it early so testers read the shipping notes), rename when the bare version is cut;
- review gate only knew the unstaged-diff variant → now both variants, including the agent-on-own-branch PR against `release/<version>` (explicit `--base`), corrections as further commits not amends, judgement calls stated in the PR, and `alan fix` for the rounds.

**`changelog-process.md`**:
- step 9 keeps the heading during candidates;
- sub-bullet budget scales with cycle length (0.8.0 shipped 25, 0.8.5 ~30) with a per-parent cap of 4;
- the em-dash drift pattern is distinguished from the allowed headline tagline (#220);
- new **Verify claims, not prose** list from the #217 retro: version pairs from both ends; a shared trailing clause must hold for every sibling (the Safe/x402 miss); entries about a shared list are checked against the whole list at head (the Tor candidate miss); credits, links and reachability checked in tree.

Docs only.

## Related issue

Follows #217, #219, #220.

## Verification

- [x] `npx prettier --check`, `git diff --check`
- [ ] Tests – not applicable

## Visual changes

Not applicable.

## Security and privacy

No change.

## AI assistance

Drafted by Claude Code; the maintainer reviews and merges.