### PR TITLE
fix(chrome): keep the typed name on ENS/Tezos interstitials, give the error page its own title

### DIFF
--- a/src/renderer/lib/navigation-utils-helpers.test.js
+++ b/src/renderer/lib/navigation-utils-helpers.test.js
@@ -221,6 +221,39 @@ describe('navigation-utils extracted helpers', () => {
       })
     ).toBe('lagged.tez');
 
+    // Fail-safe: an interstitial with no `name` param clears the address bar
+    // rather than falling through to its on-disk path — the same fallback the
+    // active-tab did-navigate handler applies.
+    expect(
+      mod.deriveSwitchedTabDisplay({
+        url: 'file:///app/pages/ens-conflict.html',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+      })
+    ).toBe('');
+
+    expect(
+      mod.deriveSwitchedTabDisplay({
+        url: 'file:///app/pages/ens-unverified.html?uri=ipfs%3A%2F%2FQmRetryTez',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+      })
+    ).toBe('');
+
+    // The interstitial test runs on the committed URL as-is, never on the
+    // `view-source:` inner URL: viewing an interstitial's source is source
+    // text, not the block itself, and the active-tab handler's view-source
+    // branch (which runs ahead of its interstitial branch) shows
+    // `view-source:<inner display>`. Both surfaces have to agree.
+    expect(
+      mod.deriveSwitchedTabDisplay({
+        url: 'view-source:file:///app/pages/ens-conflict.html?name=lagged.tez&block=%7B%7D',
+        isViewingSource: true,
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+      })
+    ).toBe('view-source:file:///app/pages/ens-conflict.html?name=lagged.tez&block=%7B%7D');
+
     // #235 regression: a remote page served at a chrome-look-alike path must
     // never dictate the switched-tab address bar. `deriveSwitchedTabDisplay`
     // used to run both the interstitial and the error-page recovery on a bare

--- a/src/renderer/lib/navigation-utils-helpers.test.js
+++ b/src/renderer/lib/navigation-utils-helpers.test.js
@@ -202,6 +202,24 @@ describe('navigation-utils extracted helpers', () => {
         ipnsRoutePrefix: 'http://127.0.0.1:8080/ipns/',
       })
     ).toBe('ipfs://vitalik.eth');
+
+    // Same rule for the name-resolution interstitials (#235): a tab parked
+    // on one restores the blocked name, never the interstitial's file:// path.
+    expect(
+      mod.deriveSwitchedTabDisplay({
+        url: 'file:///app/pages/ens-unverified.html?name=retry.tez&uri=ipfs%3A%2F%2FQmRetryTez',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+      })
+    ).toBe('retry.tez');
+
+    expect(
+      mod.deriveSwitchedTabDisplay({
+        url: 'file:///app/pages/ens-conflict.html?name=lagged.tez&block=%7B%7D&groups=%5B%5D',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+      })
+    ).toBe('lagged.tez');
   });
 
   test('computes bookmark bar state and extracts original urls from error pages', async () => {

--- a/src/renderer/lib/navigation-utils-helpers.test.js
+++ b/src/renderer/lib/navigation-utils-helpers.test.js
@@ -220,6 +220,28 @@ describe('navigation-utils extracted helpers', () => {
         homeUrlNormalized: 'file:///app/pages/home.html',
       })
     ).toBe('lagged.tez');
+
+    // #235 regression: a remote page served at a chrome-look-alike path must
+    // never dictate the switched-tab address bar. `deriveSwitchedTabDisplay`
+    // used to run both the interstitial and the error-page recovery on a bare
+    // `/<file>.html` substring test, so `https://evil.test/error.html?url=…`
+    // repainted the address bar (protocol icon included) with the attacker's
+    // chosen value while the webview rendered the attacker's page.
+    expect(
+      mod.deriveSwitchedTabDisplay({
+        url: 'https://evil.test/error.html?error=offline&url=bzz%3A%2F%2Fvitalik.eth&protocol=swarm',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+      })
+    ).toBe('https://evil.test/error.html?error=offline&url=bzz%3A%2F%2Fvitalik.eth&protocol=swarm');
+
+    expect(
+      mod.deriveSwitchedTabDisplay({
+        url: 'https://evil.test/ens-conflict.html?name=bank.eth',
+        bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+        homeUrlNormalized: 'file:///app/pages/home.html',
+      })
+    ).toBe('https://evil.test/ens-conflict.html?name=bank.eth');
   });
 
   test('computes bookmark bar state and extracts original urls from error pages', async () => {
@@ -255,7 +277,14 @@ describe('navigation-utils extracted helpers', () => {
         'file:///app/pages/error.html'
       )
     ).toBe('https://example.com');
-    expect(mod.getOriginalUrlFromErrorPage('https://example.com', 'file:///app/pages/error.html')).toBeNull();
-    expect(mod.getOriginalUrlFromErrorPage('not-a-url/error.html?', 'file:///app/pages/error.html')).toBeNull();
+    expect(mod.getOriginalUrlFromErrorPage('https://example.com')).toBeNull();
+    expect(mod.getOriginalUrlFromErrorPage('not-a-url/error.html?')).toBeNull();
+    // Only the shell's own error page counts (#235).
+    expect(
+      mod.getOriginalUrlFromErrorPage('https://evil.test/error.html?url=bzz%3A%2F%2Fvitalik.eth')
+    ).toBeNull();
+    expect(
+      mod.getOriginalUrlFromErrorPage('file:///app/pages/error.html.evil?url=https%3A%2F%2Fa.test')
+    ).toBeNull();
   });
 });

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -3,7 +3,7 @@ import {
   deriveDisplayValue,
   parseOnchainAppUrl,
 } from './url-utils.js';
-import { getInternalPageName, parseEnsInput } from './page-urls.js';
+import { getInternalPageName, getInterstitialDisplayName, parseEnsInput } from './page-urls.js';
 import { isDwebNameHost } from './origin-utils.js';
 
 // Extract the Ethereum name from an address bar value, or null if the value isn't
@@ -542,6 +542,14 @@ export const deriveSwitchedTabDisplay = ({
   }
 
   const strippedUrl = url.startsWith('view-source:') ? url.slice(12) : url;
+  // A tab parked on a name-resolution interstitial restores the blocked name
+  // (`lagged.tez`), never the interstitial's `file://` path — same rule the
+  // active-tab did-navigate handler applies. See #235.
+  const blockedName = getInterstitialDisplayName(strippedUrl);
+  if (blockedName) {
+    return blockedName;
+  }
+
   // A tab parked on `pages/error.html?...&url=<original>` should restore the
   // friendly original target (e.g. `ipfs://vitalik.eth`), not the raw
   // `file://.../error.html?...` URL Chromium actually committed. Mirrors the

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -3,7 +3,12 @@ import {
   deriveDisplayValue,
   parseOnchainAppUrl,
 } from './url-utils.js';
-import { getInternalPageName, getInterstitialDisplayName, parseEnsInput } from './page-urls.js';
+import {
+  getInternalPageName,
+  getInterstitialDisplayName,
+  isErrorPageUrl,
+  parseEnsInput,
+} from './page-urls.js';
 import { isDwebNameHost } from './origin-utils.js';
 
 // Extract the Ethereum name from an address bar value, or null if the value isn't
@@ -596,14 +601,14 @@ export const getBookmarkBarState = ({
   };
 };
 
-export const getOriginalUrlFromErrorPage = (url, errorUrlBase = '') => {
-  if (!url) {
-    return null;
-  }
-
-  const isErrorPage =
-    (errorUrlBase && url.startsWith(errorUrlBase)) || url.includes('/error.html?');
-  if (!isErrorPage) {
+// The friendly target an error page is standing in for, or null when `url`
+// isn't *our* error page. The chrome test is `isErrorPageUrl` (exact match on
+// the shell's own `pages/error.html`) rather than a `/error.html?` substring:
+// the `url` param is echoed straight into the address bar and the protocol
+// icon, so a remote `https://evil.test/error.html?url=bzz://vitalik.eth` would
+// otherwise get to pick both while rendering attacker HTML. See #235.
+export const getOriginalUrlFromErrorPage = (url) => {
+  if (!isErrorPageUrl(url)) {
     return null;
   }
 

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -7,6 +7,7 @@ import {
   getInternalPageName,
   getInterstitialDisplayName,
   isErrorPageUrl,
+  isInterstitialPageUrl,
   parseEnsInput,
 } from './page-urls.js';
 import { isDwebNameHost } from './origin-utils.js';
@@ -549,10 +550,14 @@ export const deriveSwitchedTabDisplay = ({
   const strippedUrl = url.startsWith('view-source:') ? url.slice(12) : url;
   // A tab parked on a name-resolution interstitial restores the blocked name
   // (`lagged.tez`), never the interstitial's `file://` path — same rule the
-  // active-tab did-navigate handler applies. See #235.
-  const blockedName = getInterstitialDisplayName(strippedUrl);
-  if (blockedName) {
-    return blockedName;
+  // active-tab did-navigate handler applies, and on the same input: the test
+  // is against the committed URL itself, not the `view-source:` inner URL, so
+  // both surfaces agree on what counts as an interstitial. The name is empty
+  // only when the page was opened without its `name` param; an empty address
+  // bar is the fail-safe there, since the on-disk path must not be shown
+  // either. See #235.
+  if (isInterstitialPageUrl(url)) {
+    return getInterstitialDisplayName(url) || '';
   }
 
   // A tab parked on `pages/error.html?...&url=<original>` should restore the

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -50,12 +50,12 @@ import {
 import {
   homeUrl,
   homeUrlNormalized,
-  errorUrlBase,
   internalPages,
   detectProtocol,
   isHistoryRecordable,
   getInternalPageName,
   getInterstitialDisplayName,
+  isErrorPageUrl,
   isInterstitialPageUrl,
   parseEnsInput,
   buildInternalPageUrl,
@@ -1699,7 +1699,7 @@ export const loadHomePage = () => {
 // Shared error-page retry logic used by both reload variants and the reload button
 const retryErrorPageOrReload = (webview, hard) => {
   const current = webview.getURL();
-  const originalUrl = getOriginalUrlFromErrorPage(current, errorUrlBase);
+  const originalUrl = getOriginalUrlFromErrorPage(current);
   if (originalUrl) {
     // Hard reload of an ENS error page also bypasses `ensResultCache` so the
     // recovery resolution actually re-runs under today's verification method
@@ -1712,7 +1712,7 @@ const retryErrorPageOrReload = (webview, hard) => {
     loadTarget(originalUrl);
     return;
   }
-  if (current.startsWith(errorUrlBase) || current.includes('/error.html?')) {
+  if (isErrorPageUrl(current)) {
     try {
       new URL(current);
     } catch (err) {
@@ -1888,7 +1888,7 @@ const handleNavigationEvent = (event) => {
       const blockedName = getInterstitialDisplayName(event.url) || '';
       addressInput.value = blockedName;
       pushDebug(`[AddressBar] Interstitial -> Blocked name: ${blockedName || '(none)'}`);
-    } else if (event.url.startsWith(errorUrlBase)) {
+    } else if (isErrorPageUrl(event.url)) {
       try {
         const parsed = new URL(event.url);
         const originalUrl = parsed.searchParams.get('url');

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -55,6 +55,8 @@ import {
   detectProtocol,
   isHistoryRecordable,
   getInternalPageName,
+  getInterstitialDisplayName,
+  isInterstitialPageUrl,
   parseEnsInput,
   buildInternalPageUrl,
 } from './page-urls.js';
@@ -1876,7 +1878,17 @@ const handleNavigationEvent = (event) => {
       return;
     }
 
-    if (event.url.startsWith(errorUrlBase)) {
+    // Name-resolution interstitials (unverified soft block, head/contenthash
+    // conflict hard block) get the same treatment as the error page: the
+    // address bar keeps the name the user asked for, never the interstitial's
+    // own `file:///…/pages/ens-*.html` path (#235). The name is empty only if
+    // the page was opened without its `name` param — an empty address bar is
+    // the fail-safe there, since the on-disk path must not be shown either.
+    if (isInterstitialPageUrl(event.url)) {
+      const blockedName = getInterstitialDisplayName(event.url) || '';
+      addressInput.value = blockedName;
+      pushDebug(`[AddressBar] Interstitial -> Blocked name: ${blockedName || '(none)'}`);
+    } else if (event.url.startsWith(errorUrlBase)) {
       try {
         const parsed = new URL(event.url);
         const originalUrl = parsed.searchParams.get('url');

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -67,6 +67,16 @@ const loadNavigationModule = async (options = {}) => {
   const homeUrl = 'file:///app/pages/home.html';
   const historyUrl = 'file:///app/pages/history.html';
   const errorUrlBase = 'file:///app/pages/error.html';
+  // Mirrors `page-urls.js`: chrome pages are matched on the shell's own
+  // resolved `pages/<file>` base, never a `/<file>.html` substring, so a
+  // remote look-alike path can't impersonate an internal page (#235).
+  const matchesInternalPage = (url, base) =>
+    typeof url === 'string' &&
+    (url === base || url.startsWith(`${base}?`) || url.startsWith(`${base}#`));
+  const isInterstitialPageUrlMock = (url) =>
+    ['file:///app/pages/ens-unverified.html', 'file:///app/pages/ens-conflict.html'].some((base) =>
+      matchesInternalPage(url, base)
+    );
   const state = {
     bzzRoutePrefix: 'https://gateway.example/bzz/',
     ipfsRoutePrefix: 'https://gateway.example/ipfs/',
@@ -161,7 +171,7 @@ const loadNavigationModule = async (options = {}) => {
       };
     }),
     getOriginalUrlFromErrorPage: jest.fn((url) => {
-      if (!url.includes('error.html')) return null;
+      if (!matchesInternalPage(url, errorUrlBase)) return null;
       try {
         return new URL(url).searchParams.get('url');
       } catch {
@@ -301,20 +311,14 @@ const loadNavigationModule = async (options = {}) => {
         Boolean(displayUrl) &&
         !displayUrl.startsWith('freedom://') &&
         !displayUrl.startsWith('view-source:') &&
-        !internalUrl.includes('/error.html')
+        !matchesInternalPage(internalUrl, errorUrlBase)
       );
     }),
     getInternalPageName: jest.fn((url) => (url === historyUrl ? 'history' : null)),
-    isInterstitialPageUrl: jest.fn(
-      (url) =>
-        typeof url === 'string' &&
-        (url.includes('/ens-unverified.html') || url.includes('/ens-conflict.html'))
-    ),
+    isErrorPageUrl: jest.fn((url) => matchesInternalPage(url, errorUrlBase)),
+    isInterstitialPageUrl: jest.fn((url) => isInterstitialPageUrlMock(url)),
     getInterstitialDisplayName: jest.fn((url) => {
-      if (
-        typeof url !== 'string' ||
-        !(url.includes('/ens-unverified.html') || url.includes('/ens-conflict.html'))
-      ) {
+      if (!isInterstitialPageUrlMock(url)) {
         return null;
       }
       try {
@@ -1513,6 +1517,28 @@ describe('navigation', () => {
         event: { url: 'file:///app/pages/ens-conflict.html' },
       });
       expect(ctx.elements.addressInput.value).toBe('');
+    });
+
+    test('a remote page at an interstitial-look-alike path cannot spoof the address bar', async () => {
+      // #235 regression: `isInterstitialPageUrl` matched a `/ens-*.html`
+      // substring, so any remote page served at that path was treated as
+      // chrome — the address bar showed the attacker's `?name=` value (and
+      // the trust shield could badge it) while the webview rendered the
+      // attacker's HTML. Only the shell's own `pages/ens-*.html` is chrome.
+      const ctx = await setupEnsDispatch({ blockUnverifiedEns: true });
+
+      for (const hostile of [
+        'https://evil.test/ens-conflict.html?name=bank.eth',
+        'https://evil.test/pages/ens-unverified.html?name=bank.eth',
+        'https://evil.test/error.html?url=bzz%3A%2F%2Fvitalik.eth',
+      ]) {
+        ctx.tabsMocks.webviewEventHandler('did-navigate', { event: { url: hostile } });
+        expect(ctx.elements.addressInput.value).not.toBe('bank.eth');
+        expect(ctx.elements.addressInput.value).not.toBe('bzz://vitalik.eth');
+        // Falls through to the ordinary content path — `deriveDisplayValue`
+        // (mocked here as a `display:` prefix) renders the real URL.
+        expect(ctx.elements.addressInput.value).toBe(`display:${hostile}`);
+      }
     });
 
     test('unverified proceeds normally when blockUnverifiedEns is off', async () => {

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -305,6 +305,24 @@ const loadNavigationModule = async (options = {}) => {
       );
     }),
     getInternalPageName: jest.fn((url) => (url === historyUrl ? 'history' : null)),
+    isInterstitialPageUrl: jest.fn(
+      (url) =>
+        typeof url === 'string' &&
+        (url.includes('/ens-unverified.html') || url.includes('/ens-conflict.html'))
+    ),
+    getInterstitialDisplayName: jest.fn((url) => {
+      if (
+        typeof url !== 'string' ||
+        !(url.includes('/ens-unverified.html') || url.includes('/ens-conflict.html'))
+      ) {
+        return null;
+      }
+      try {
+        return new URL(url).searchParams.get('name') || null;
+      } catch {
+        return null;
+      }
+    }),
     parseEnsInput: jest.fn(() => null),
     buildInternalPageUrl: jest.fn((file, params = null) => {
       const base = `file:///app/pages/${file}`;
@@ -1466,6 +1484,35 @@ describe('navigation', () => {
       const url = new URL(interstitialCall[0]);
       expect(url.searchParams.get('name')).toBe('lonely.eth');
       expect(url.searchParams.get('uri')).toContain('ipfs://QmFake');
+    });
+
+    test('committing an interstitial keeps the blocked name in the address bar', async () => {
+      // #235: the interstitials are chrome, not content. Their own
+      // `file:///…/pages/ens-*.html` URL must never reach the address bar —
+      // the user keeps seeing the name they asked for, exactly like the
+      // Swarm error page keeps `bzz://<hash>/`.
+      const ctx = await setupEnsDispatch({ blockUnverifiedEns: true });
+
+      ctx.tabsMocks.webviewEventHandler('did-navigate', {
+        event: {
+          url: 'file:///app/pages/ens-unverified.html?name=retry.tez&uri=ipfs%3A%2F%2FQmRetryTez',
+        },
+      });
+      expect(ctx.elements.addressInput.value).toBe('retry.tez');
+
+      ctx.tabsMocks.webviewEventHandler('did-navigate', {
+        event: {
+          url: 'file:///app/pages/ens-conflict.html?name=lagged.tez&block=%7B%7D&groups=%5B%5D',
+        },
+      });
+      expect(ctx.elements.addressInput.value).toBe('lagged.tez');
+
+      // Fail-safe: an interstitial without its `name` param still must not
+      // fall through to the raw file:// path.
+      ctx.tabsMocks.webviewEventHandler('did-navigate', {
+        event: { url: 'file:///app/pages/ens-conflict.html' },
+      });
+      expect(ctx.elements.addressInput.value).toBe('');
     });
 
     test('unverified proceeds normally when blockUnverifiedEns is off', async () => {

--- a/src/renderer/lib/page-urls.js
+++ b/src/renderer/lib/page-urls.js
@@ -7,10 +7,26 @@ import { isEnsHost, isTezosDomainHost } from './origin-utils.js';
 
 const ROUTABLE_PAGES = window.internalPages?.routable || {};
 
+// Resolve an internal page file to the shell's own `pages/<file>` URL.
+const internalPageUrl = (pageFile) => new URL(`pages/${pageFile}`, window.location.href).toString();
+
+// "Is this committed URL one of our own chrome pages?" Every such test must
+// compare against the *resolved* base URL above, never a `/<file>.html`
+// substring: a remote page is free to serve `https://evil.test/error.html` or
+// `https://evil.test/ens-conflict.html`, and a substring test would let it
+// impersonate chrome — taking over the address bar with its own `?url=` /
+// `?name=` value while the webview renders attacker HTML. Only the exact base
+// (optionally with a query string or fragment) counts. See issue #235.
+const matchesInternalPage = (url, base) =>
+  typeof url === 'string' &&
+  (url === base || url.startsWith(`${base}?`) || url.startsWith(`${base}#`));
+
 // URLs for pages
-export const homeUrl = new URL('pages/home.html', window.location.href).toString();
+export const homeUrl = internalPageUrl('home.html');
 export const homeUrlNormalized = homeUrl;
-export const errorUrlBase = new URL('pages/error.html', window.location.href).toString();
+export const errorUrlBase = internalPageUrl('error.html');
+
+export const isErrorPageUrl = (url) => matchesInternalPage(url, errorUrlBase);
 
 // Internal pages map for freedom:// protocol
 export const internalPages = Object.fromEntries(
@@ -41,10 +57,10 @@ export const buildInternalPageUrl = (pageFile, params = null) => {
 // carry the user-facing target in a query param, and — also like the error
 // page — their own `file:///…/pages/*.html` URL must never reach the address
 // bar, history, or any other chrome surface. See issue #235.
-const INTERSTITIAL_PAGE_FILES = ['ens-unverified.html', 'ens-conflict.html'];
+const INTERSTITIAL_PAGE_URLS = ['ens-unverified.html', 'ens-conflict.html'].map(internalPageUrl);
 
 export const isInterstitialPageUrl = (url) =>
-  typeof url === 'string' && INTERSTITIAL_PAGE_FILES.some((file) => url.includes(`/${file}`));
+  INTERSTITIAL_PAGE_URLS.some((base) => matchesInternalPage(url, base));
 
 // The user-facing name an interstitial is blocking (`lagged.tez`), or null
 // when `url` isn't an interstitial / carries no name. Mirrors
@@ -77,7 +93,7 @@ export const isHistoryRecordable = (displayUrl, internalUrl) => {
   if (!displayUrl || displayUrl === '') return false;
   if (displayUrl.startsWith('freedom://')) return false;
   if (displayUrl.startsWith('view-source:')) return false;
-  if (internalUrl?.includes('/error.html')) return false;
+  if (isErrorPageUrl(internalUrl)) return false;
   // A blocked name never lands on real content, so the interstitial is no
   // more history-worthy than the error page — and recording it would put the
   // interstitial's `file://` path (and its "RPC servers disagreed" title)

--- a/src/renderer/lib/page-urls.js
+++ b/src/renderer/lib/page-urls.js
@@ -35,6 +35,29 @@ export const buildInternalPageUrl = (pageFile, params = null) => {
   return url.toString();
 };
 
+// Name-resolution interstitials. These are chrome, not content: the shell
+// loads them into the webview when an ENS/Tezos name is blocked (unverified
+// soft block, head/contenthash conflict hard block). Like `error.html` they
+// carry the user-facing target in a query param, and — also like the error
+// page — their own `file:///…/pages/*.html` URL must never reach the address
+// bar, history, or any other chrome surface. See issue #235.
+const INTERSTITIAL_PAGE_FILES = ['ens-unverified.html', 'ens-conflict.html'];
+
+export const isInterstitialPageUrl = (url) =>
+  typeof url === 'string' && INTERSTITIAL_PAGE_FILES.some((file) => url.includes(`/${file}`));
+
+// The user-facing name an interstitial is blocking (`lagged.tez`), or null
+// when `url` isn't an interstitial / carries no name. Mirrors
+// `getOriginalUrlFromErrorPage` for the error page.
+export const getInterstitialDisplayName = (url) => {
+  if (!isInterstitialPageUrl(url)) return null;
+  try {
+    return new URL(url).searchParams.get('name') || null;
+  } catch {
+    return null;
+  }
+};
+
 // Detect protocol from display URL for history recording
 export const detectProtocol = (url) => {
   if (!url) return 'unknown';
@@ -55,6 +78,11 @@ export const isHistoryRecordable = (displayUrl, internalUrl) => {
   if (displayUrl.startsWith('freedom://')) return false;
   if (displayUrl.startsWith('view-source:')) return false;
   if (internalUrl?.includes('/error.html')) return false;
+  // A blocked name never lands on real content, so the interstitial is no
+  // more history-worthy than the error page — and recording it would put the
+  // interstitial's `file://` path (and its "RPC servers disagreed" title)
+  // into the history list and the autocomplete dropdown.
+  if (isInterstitialPageUrl(internalUrl)) return false;
   if (internalUrl === homeUrl || internalUrl === homeUrlNormalized) return false;
   return true;
 };

--- a/src/renderer/lib/page-urls.test.js
+++ b/src/renderer/lib/page-urls.test.js
@@ -55,6 +55,37 @@ describe('page-urls', () => {
     expect(mod.isHistoryRecordable('https://example.com', 'file:///app/pages/error.html')).toBe(false);
     expect(mod.isHistoryRecordable('https://example.com', mod.homeUrl)).toBe(false);
     expect(mod.isHistoryRecordable('https://example.com', 'https://example.com')).toBe(true);
+    // Interstitials (#235): recording them would put the interstitial's own
+    // file:// path and title into history and the autocomplete dropdown.
+    expect(
+      mod.isHistoryRecordable('lagged.tez', 'file:///app/pages/ens-conflict.html?name=lagged.tez')
+    ).toBe(false);
+    expect(
+      mod.isHistoryRecordable('retry.tez', 'file:///app/pages/ens-unverified.html?name=retry.tez')
+    ).toBe(false);
+  });
+
+  test('reads the blocked name from interstitial page urls', async () => {
+    const mod = await loadModule();
+
+    expect(
+      mod.getInterstitialDisplayName(
+        'file:///app/pages/ens-unverified.html?name=retry.tez&uri=ipfs%3A%2F%2FQmRetryTez'
+      )
+    ).toBe('retry.tez');
+    expect(
+      mod.getInterstitialDisplayName('file:///app/pages/ens-conflict.html?name=lagged.tez&block=%7B%7D')
+    ).toBe('lagged.tez');
+    // No name param, not an interstitial, or unparseable — never a file:// path.
+    expect(mod.getInterstitialDisplayName('file:///app/pages/ens-conflict.html')).toBeNull();
+    expect(mod.getInterstitialDisplayName('file:///app/pages/error.html?url=bzz%3A%2F%2Fabc')).toBeNull();
+    expect(mod.getInterstitialDisplayName('https://example.com')).toBeNull();
+    expect(mod.getInterstitialDisplayName(null)).toBeNull();
+
+    expect(mod.isInterstitialPageUrl('file:///app/pages/ens-unverified.html?name=a.eth')).toBe(true);
+    expect(mod.isInterstitialPageUrl('file:///app/pages/ens-conflict.html?name=a.eth')).toBe(true);
+    expect(mod.isInterstitialPageUrl('file:///app/pages/error.html')).toBe(false);
+    expect(mod.isInterstitialPageUrl(undefined)).toBe(false);
   });
 
   test('maps internal page urls back to freedom:// names', async () => {

--- a/src/renderer/lib/page-urls.test.js
+++ b/src/renderer/lib/page-urls.test.js
@@ -88,6 +88,42 @@ describe('page-urls', () => {
     expect(mod.isInterstitialPageUrl(undefined)).toBe(false);
   });
 
+  test('remote look-alike paths are never mistaken for chrome pages', async () => {
+    const mod = await loadModule();
+
+    // #235 regression: the interstitial/error-page tests used to match on a
+    // `/<file>.html` substring, so any remote page could serve that path and
+    // take over the address bar with its own `?name=` / `?url=` value while
+    // rendering attacker HTML.
+    for (const hostile of [
+      'https://evil.test/ens-conflict.html?name=bank.eth',
+      'https://evil.test/ens-unverified.html?name=bank.eth',
+      'https://evil.test/pages/ens-conflict.html?name=bank.eth',
+      'http://127.0.0.1:8080/ipfs/Qm123/ens-conflict.html?name=bank.eth',
+      // Same base with extra path/host characters glued on is not our page.
+      'file:///app/pages/ens-conflict.html.evil?name=bank.eth',
+      'file:///app/pages/ens-conflict.htmlx?name=bank.eth',
+    ]) {
+      expect(mod.isInterstitialPageUrl(hostile)).toBe(false);
+      expect(mod.getInterstitialDisplayName(hostile)).toBeNull();
+    }
+
+    for (const hostile of [
+      'https://evil.test/error.html?url=bzz%3A%2F%2Fvitalik.eth',
+      'https://evil.test/pages/error.html?url=bzz%3A%2F%2Fvitalik.eth',
+      'file:///app/pages/error.html.evil?url=bzz%3A%2F%2Fvitalik.eth',
+    ]) {
+      expect(mod.isErrorPageUrl(hostile)).toBe(false);
+      // A remote look-alike is real content, so it stays history-recordable.
+      expect(mod.isHistoryRecordable(hostile, hostile)).toBe(true);
+    }
+
+    expect(mod.isErrorPageUrl('file:///app/pages/error.html')).toBe(true);
+    expect(mod.isErrorPageUrl('file:///app/pages/error.html?url=https%3A%2F%2Fa.test')).toBe(true);
+    expect(mod.isErrorPageUrl('file:///app/pages/error.html#frag')).toBe(true);
+    expect(mod.isErrorPageUrl(undefined)).toBe(false);
+  });
+
   test('maps internal page urls back to freedom:// names', async () => {
     const mod = await loadModule({
       history: 'history.html',

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -566,6 +566,7 @@ const createWebview = (tabId, initialUrl) => {
         // Use webview.getURL() for full URL (includes view-source: prefix)
         // event.url doesn't include the view-source: prefix
         const webviewUrl = webview.getURL();
+        const previousUrl = tab.url;
         tab.url = webviewUrl;
         tab.hasCertError = false; // Reset cert error on new navigation
         // Track view-source state directly on tab for reliable detection in page-title-updated
@@ -583,6 +584,31 @@ const createWebview = (tabId, initialUrl) => {
           tab.navigationState.committedDisplayUrl =
             formatOnchainAppDisplayUrl(webviewUrl) || webviewUrl;
           tab.navigationState.committedNavigationSequence += 1;
+        }
+        // A committed main-frame navigation replaces the document, so the
+        // previous page's title must not survive it. Chromium fires
+        // `page-title-updated` only when the new document actually declares a
+        // title, so without this reset a titleless page — or one whose
+        // <title> arrives late — keeps showing the previous page's title, and
+        // the history entry written at did-stop-loading records it too. That
+        // is issue #236: the Swarm error page inherited "RPC servers
+        // disagreed" from the page visited before it. Clearing to the empty
+        // title renders as "New Tab", which is already what a titleless page
+        // loaded into a fresh tab shows. Same-URL commits (reload) keep their
+        // title so a reload doesn't flicker; view-source titles are owned by
+        // navigation.js and set right after this handler forwards the event.
+        if (
+          event.url &&
+          event.url !== 'about:blank' &&
+          webviewUrl !== previousUrl &&
+          !tab.isViewingSource &&
+          tab.title
+        ) {
+          tab.title = '';
+          renderTabs();
+          if (tabId === tabState.activeTabId) {
+            electronAPI?.setWindowTitle?.('');
+          }
         }
         void refreshOnchainProvenance(tab, webviewUrl);
         // Clear any stale favicon from the previous page when navigating to

--- a/src/renderer/lib/tabs.test.js
+++ b/src/renderer/lib/tabs.test.js
@@ -272,6 +272,66 @@ describe('Tab Navigation State Isolation', () => {
     });
   });
 
+  describe('did-navigate clears the previous document title (#236)', () => {
+    // Chromium fires `page-title-updated` only when the new document
+    // actually declares a title, so a page without a <title> — the Swarm
+    // error page being the reported case — otherwise keeps showing, and
+    // recording in history, the title of the page visited before it.
+    test('clears the carried-over title when a different URL commits', async () => {
+      const { createTab, switchTab } = await import('./tabs.js');
+
+      const tab = createTab('https://example.com/');
+      switchTab(tab.id);
+      tab.title = 'RPC servers disagreed';
+      mockElectronAPI.setWindowTitle.mockClear();
+
+      tab.webview.getURL.mockReturnValue('file:///app/pages/error.html?error=x');
+      tab.webview._eventHandlers['did-navigate']({
+        url: 'file:///app/pages/error.html?error=x',
+      });
+
+      expect(tab.title).toBe('');
+      expect(mockElectronAPI.setWindowTitle).toHaveBeenCalledWith('');
+    });
+
+    test('keeps the title when the same URL re-commits (reload)', async () => {
+      const { createTab } = await import('./tabs.js');
+
+      const tab = createTab('https://example.com/');
+      tab.webview.getURL.mockReturnValue('https://example.com/page');
+      tab.webview._eventHandlers['did-navigate']({ url: 'https://example.com/page' });
+      tab.title = 'Example Page';
+
+      tab.webview._eventHandlers['did-navigate']({ url: 'https://example.com/page' });
+
+      expect(tab.title).toBe('Example Page');
+    });
+
+    test('keeps the title through an about:blank commit', async () => {
+      // Same reasoning as committedDisplayUrl: "open in new window" passes
+      // through about:blank before the real navigation commits.
+      const { createTab } = await import('./tabs.js');
+
+      const tab = createTab('https://example.com/');
+      tab.title = 'Example Page';
+      tab.webview.getURL.mockReturnValue('about:blank');
+      tab.webview._eventHandlers['did-navigate']({ url: 'about:blank' });
+
+      expect(tab.title).toBe('Example Page');
+    });
+
+    test('leaves a view-source title alone (navigation.js owns it)', async () => {
+      const { createTab } = await import('./tabs.js');
+
+      const tab = createTab('https://example.com/');
+      tab.title = 'view-source:https://example.com/';
+      tab.webview.getURL.mockReturnValue('view-source:https://example.com/other');
+      tab.webview._eventHandlers['did-navigate']({ url: 'https://example.com/other' });
+
+      expect(tab.title).toBe('view-source:https://example.com/');
+    });
+  });
+
   describe('getActiveTabState helper', () => {
     test('should return navigation state of active tab', async () => {
       const { createTab, switchTab, getActiveTabState } = await import('./tabs.js');

--- a/src/renderer/pages/error.html
+++ b/src/renderer/pages/error.html
@@ -6,6 +6,12 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src http://127.0.0.1:*;"
     />
+    <!-- The error page must own its title. Without one, Chromium never fires
+         `page-title-updated`, so the tab (and the window title) keep showing
+         the title of whatever page the user was on before the failed
+         navigation. See issue #236. `displayError()` keeps this in sync with
+         the headline it picks for the specific failure. -->
+    <title>Content Unavailable</title>
     <style>
       html,
       body {
@@ -186,6 +192,15 @@
       const descriptionEl = document.getElementById('description');
       const titleEl = document.getElementById('title');
 
+      // Headline and document title move together: the tab, the window title
+      // and the history entry all read `document.title`, and a stale one is
+      // exactly the bug in #236. The static <title> above covers the case
+      // where this script never runs (CSP failure, parse error).
+      function setErrorTitle(text) {
+        titleEl.textContent = text;
+        document.title = text;
+      }
+
       async function getRegistry() {
         try {
           return await window.serviceRegistry?.getRegistry?.();
@@ -234,7 +249,7 @@
         // peer-to-peer page when they aren't.
         if (!protocol) {
           const host = hostFor(url);
-          titleEl.textContent = "Couldn't load this page";
+          setErrorTitle("Couldn't load this page");
           descriptionEl.textContent = host
             ? `${host} didn't respond, or the response was blocked. Check the URL and try again.`
             : "The server didn't respond, or the response was blocked. Check the URL and try again.";
@@ -244,7 +259,7 @@
           // The Bee HTTP API is reachable, but the requested content didn't
           // resolve within the probe timeout. Typically means the node is
           // still connecting to enough peers to locate the manifest.
-          titleEl.textContent = "Content not ready yet";
+          setErrorTitle('Content not ready yet');
           descriptionEl.innerHTML =
             "Couldn't find this content on the Swarm network yet. The node is " +
             "still connecting to peers &mdash; try again in a moment.";

--- a/test-e2e/chrome-page-spoof.spec.js
+++ b/test-e2e/chrome-page-spoof.spec.js
@@ -1,0 +1,64 @@
+// Chrome pages (the error page, the ENS/Tezos name-resolution interstitials)
+// deliberately keep their own `file:///…/pages/*.html` URL out of the address
+// bar and show the friendly target carried in a query param instead. That
+// makes "is this URL one of our chrome pages?" a security decision: matched on
+// a `/error.html` / `/ens-conflict.html` *substring*, any remote page could
+// serve that path and pick what the address bar (and the protocol icon) says
+// while rendering its own HTML. #235 — the checks are anchored to the shell's
+// own resolved `pages/<file>` base instead.
+//
+// Both cases below are driven through the real chrome: the harness owns the
+// https: scheme in test mode, so `evil.test` never reaches the network.
+
+const { test, expect } = require('./fixtures');
+
+const activeWebviewUrl = (window) =>
+  window.evaluate(() => {
+    const wv = document.querySelector('webview.active, webview:not(.hidden)');
+    return wv?.getURL?.() || '';
+  });
+
+const navigateTo = async (window, url) => {
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(url);
+  await input.press('Enter');
+  await expect
+    .poll(() => activeWebviewUrl(window), { timeout: 10_000, intervals: [200, 500] })
+    .toContain('evil.test');
+  return input;
+};
+
+test('a remote interstitial look-alike cannot pick the address bar value', async ({ window }) => {
+  const input = await navigateTo(window, 'https://evil.test/ens-conflict.html?name=bank.eth');
+
+  // The attacker's `?name=` must never be shown as the location. The real URL
+  // is; matching the interstitial branch would have replaced it with
+  // `bank.eth`, with the trust shield free to badge that name.
+  await expect(input).toHaveValue('https://evil.test/ens-conflict.html?name=bank.eth');
+});
+
+test('a remote error-page look-alike cannot pick the address bar value or protocol icon', async ({
+  window,
+}) => {
+  const hostile = 'https://evil.test/error.html?url=bzz%3A%2F%2Fvitalik.eth&protocol=swarm';
+  const input = await navigateTo(window, hostile);
+  await expect(input).toHaveValue(hostile);
+
+  // The switched-tab path derives its own display value, so it needs the same
+  // check as the active-tab did-navigate handler: open a second tab, come
+  // back, and confirm the repaint didn't hand the attacker the address bar.
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).toHaveClass(/active/);
+  await window.locator('[data-test="tab"][data-tab-id="1"]').click();
+  await expect(window.locator('[data-test="tab"][data-tab-id="1"]')).toHaveClass(/active/);
+
+  await expect(input).toHaveValue(hostile);
+  // The protocol icon follows the same derived value — it showed the orange
+  // Swarm mark for the spoofed `bzz://` target before the fix.
+  await expect
+    .poll(() =>
+      window.evaluate(() => document.getElementById('protocol-icon')?.getAttribute('data-protocol'))
+    )
+    .toBe('https');
+});

--- a/test-e2e/error-page.spec.js
+++ b/test-e2e/error-page.spec.js
@@ -6,6 +6,13 @@
 
 const { test, expect, SAMPLE_BZZ_HASH, SAMPLE_IPFS_CID } = require('./fixtures');
 
+// A second opaque CIDv1 for the titleless fixture. All-lowercase on purpose:
+// Chromium lowercases the host of a committed `ipfs://` URL, so a fixture key
+// carrying uppercase never matches the request the harness sees and the test
+// would silently assert against the harness's 404 fallback instead of its own
+// document.
+const NO_TITLE_IPFS_CID = 'bafybeic' + 'b'.repeat(51);
+
 test('a probe-not-found bzz:// navigation lands on the error page', async ({
   window,
   harness,
@@ -91,8 +98,8 @@ test('a page without a title does not record the previous page title in history'
   await harness.setContentFixture(`ipfs://${SAMPLE_IPFS_CID}`, {
     body: '<html><head><title>Alpha fixture page</title></head><body>alpha</body></html>',
   });
-  await harness.setContentFixture('ipfs://QmNoTitleFixture', {
-    body: '<html><body>no title of its own</body></html>',
+  await harness.setContentFixture(`ipfs://${NO_TITLE_IPFS_CID}`, {
+    body: '<html><body data-test="no-title-fixture">no title of its own</body></html>',
   });
 
   const input = window.locator('[data-test="address-input"]');
@@ -104,8 +111,30 @@ test('a page without a title does not record the previous page title in history'
   await expect(tabTitle).toHaveText('Alpha fixture page', { timeout: 10_000 });
 
   await input.click();
-  await input.fill('ipfs://QmNoTitleFixture');
+  await input.fill(`ipfs://${NO_TITLE_IPFS_CID}`);
   await input.press('Enter');
+
+  // The titleless document under test has to be *ours*, not the harness's
+  // 404 body: that fallback is only coincidentally titleless, so asserting
+  // against it would stop covering this scenario the moment it grows a
+  // <title>, without failing.
+  await expect
+    .poll(
+      () =>
+        window.evaluate(async () => {
+          const wv = document.querySelector('webview.active, webview:not(.hidden)');
+          if (!wv || typeof wv.executeJavaScript !== 'function') return null;
+          try {
+            return await wv.executeJavaScript(
+              'document.querySelector("[data-test=\\"no-title-fixture\\"]")?.textContent || ""'
+            );
+          } catch {
+            return null;
+          }
+        }),
+      { timeout: 10_000, intervals: [200, 500, 1000] }
+    )
+    .toBe('no title of its own');
 
   const historyFor = async (urlPart) =>
     window.evaluate(async (part) => {
@@ -113,7 +142,7 @@ test('a page without a title does not record the previous page title in history'
       return entries.find((entry) => entry.url.toLowerCase().includes(part)) || null;
     }, urlPart);
 
-  await expect.poll(() => historyFor('qmnotitlefixture'), { timeout: 10_000 }).not.toBeNull();
-  const entry = await historyFor('qmnotitlefixture');
+  await expect.poll(() => historyFor(NO_TITLE_IPFS_CID), { timeout: 10_000 }).not.toBeNull();
+  const entry = await historyFor(NO_TITLE_IPFS_CID);
   expect(entry.title).not.toBe('Alpha fixture page');
 });

--- a/test-e2e/error-page.spec.js
+++ b/test-e2e/error-page.spec.js
@@ -4,7 +4,7 @@
 // the webview's URL (the error page itself is loaded from the host
 // pages/ directory so it's accessible to Playwright as a frame).
 
-const { test, expect, SAMPLE_BZZ_HASH } = require('./fixtures');
+const { test, expect, SAMPLE_BZZ_HASH, SAMPLE_IPFS_CID } = require('./fixtures');
 
 test('a probe-not-found bzz:// navigation lands on the error page', async ({
   window,
@@ -37,4 +37,83 @@ test('a probe-not-found bzz:// navigation lands on the error page', async ({
       { timeout: 10_000, intervals: [200, 500, 1000] }
     )
     .toMatch(/pages\/error\.html\?error=swarm_content_not_found/);
+});
+
+// #236: the error page used to declare no <title>, so Chromium never fired
+// `page-title-updated` for it and the tab kept the previous page's title
+// ("RPC servers disagreed" in the reported screenshot). Reproduced exactly as
+// the issue describes: visit a titled fixture page, then a not-found hash.
+test('the swarm error page does not inherit the previous page title', async ({
+  window,
+  harness,
+}) => {
+  await harness.setContentFixture(`ipfs://${SAMPLE_IPFS_CID}`, {
+    body: '<html><head><title>Alpha fixture page</title></head><body>alpha</body></html>',
+  });
+  await harness.setProbeFixture(SAMPLE_BZZ_HASH, { ok: false, reason: 'not_found' });
+
+  const input = window.locator('[data-test="address-input"]');
+  const tabTitle = window.locator('[data-test="tab"] .tab-title').first();
+
+  await input.click();
+  await input.fill(`ipfs://${SAMPLE_IPFS_CID}`);
+  await input.press('Enter');
+  await expect(tabTitle).toHaveText('Alpha fixture page', { timeout: 10_000 });
+
+  await input.click();
+  await input.fill(`bzz://${SAMPLE_BZZ_HASH}`);
+  await input.press('Enter');
+
+  await expect
+    .poll(
+      async () =>
+        window.evaluate(() => {
+          const wv = document.querySelector('webview.active, webview:not(.hidden)');
+          return wv?.getURL?.() || '';
+        }),
+      { timeout: 10_000, intervals: [200, 500, 1000] }
+    )
+    .toMatch(/pages\/error\.html\?error=swarm_content_not_found/);
+
+  // The error page names itself. `swarm_content_not_found` renders the
+  // "Content not ready yet" headline and sets the document title to match.
+  await expect(tabTitle).toHaveText('Content not ready yet', { timeout: 10_000 });
+});
+
+// The other half of #236: the tab title is what the history entry records at
+// did-stop-loading. A page that declares no <title> of its own must not have
+// the previous page's title written against its URL — that is what put the
+// wrong title next to the URL in the autocomplete dropdown.
+test('a page without a title does not record the previous page title in history', async ({
+  window,
+  harness,
+}) => {
+  await harness.setContentFixture(`ipfs://${SAMPLE_IPFS_CID}`, {
+    body: '<html><head><title>Alpha fixture page</title></head><body>alpha</body></html>',
+  });
+  await harness.setContentFixture('ipfs://QmNoTitleFixture', {
+    body: '<html><body>no title of its own</body></html>',
+  });
+
+  const input = window.locator('[data-test="address-input"]');
+  const tabTitle = window.locator('[data-test="tab"] .tab-title').first();
+
+  await input.click();
+  await input.fill(`ipfs://${SAMPLE_IPFS_CID}`);
+  await input.press('Enter');
+  await expect(tabTitle).toHaveText('Alpha fixture page', { timeout: 10_000 });
+
+  await input.click();
+  await input.fill('ipfs://QmNoTitleFixture');
+  await input.press('Enter');
+
+  const historyFor = async (urlPart) =>
+    window.evaluate(async (part) => {
+      const entries = await window.electronAPI.getHistory({ limit: 50 });
+      return entries.find((entry) => entry.url.toLowerCase().includes(part)) || null;
+    }, urlPart);
+
+  await expect.poll(() => historyFor('qmnotitlefixture'), { timeout: 10_000 }).not.toBeNull();
+  const entry = await historyFor('qmnotitlefixture');
+  expect(entry.title).not.toBe('Alpha fixture page');
 });

--- a/test-e2e/tez-head-conflict.spec.js
+++ b/test-e2e/tez-head-conflict.spec.js
@@ -58,6 +58,12 @@ test('a Tezos chain-head disagreement renders the conflict interstitial', async 
     .toContain('chain head #400');
 
   expect(rendered.text).toContain('lagged.tez');
+  // The interstitial is chrome, not content (#235): the address bar keeps the
+  // name the user typed, never the interstitial's own
+  // `file:///…/pages/ens-conflict.html` path. Read once (not through a
+  // retrying matcher) now that the interstitial has rendered — the address bar
+  // is repainted by the same did-navigate that committed this page.
+  expect(await input.inputValue()).toBe('lagged.tez');
   expect(rendered.text).toContain('rpc-one.test');
   expect(rendered.text).toContain('chain head #1000');
   expect(rendered.text).toContain('rpc-two.test');

--- a/test-e2e/tez-unverified.spec.js
+++ b/test-e2e/tez-unverified.spec.js
@@ -37,6 +37,25 @@ test('the unverified interstitial "Continue once" loads the .tez content', async
   // Single-provider agreement → soft block on the interstitial.
   await expect.poll(webviewUrl, { timeout: 10_000 }).toMatch(/pages\/ens-unverified\.html/);
 
+  // The interstitial is chrome, not content (#235): the address bar keeps the
+  // name the user typed and must never expose the interstitial's own
+  // `file:///…/pages/ens-unverified.html` path. Polled on the interstitial's
+  // rendered name so the assertion runs after the navigation has committed
+  // (dom-ready follows did-navigate, which is what repaints the address bar),
+  // then read once — a retrying matcher could otherwise go green on the
+  // pre-navigation value before the file:// path replaced it.
+  await expect
+    .poll(
+      () =>
+        window.evaluate(() => {
+          const wv = document.querySelector('webview.active, webview:not(.hidden)');
+          return wv?.executeJavaScript?.('document.getElementById("name-el")?.textContent || ""');
+        }),
+      { timeout: 10_000 }
+    )
+    .toBe('retry.tez');
+  expect(await input.inputValue()).toBe('retry.tez');
+
   // Click the interstitial's own button inside the webview so the real
   // sendToHost → `ens:continue-unverified` ipc-message path runs.
   await window.evaluate(() => {


### PR DESCRIPTION
Fixes two pre-existing chrome bugs found in the 0.8.5 visual audit.

Closes #235
Closes #236

## #235 — `file://` path in the address bar on the interstitials

`ens-unverified.html` / `ens-conflict.html` are loaded into the webview by the shell when a name is blocked, but nothing in `handleNavigationEvent` recognised them, so they fell through to the generic display derivation and the address bar showed
`file:///…/src/renderer/pages/ens-conflict.html?name=lagged.tez&block=…&groups=…`.
The Swarm error page already avoids this via its `?url=` param; the interstitials now get the same treatment and keep the name the user typed.

Fixed at every site that turns a committed URL into chrome, not just the one the report named:

- `page-urls.js` — new `isInterstitialPageUrl` / `getInterstitialDisplayName` (mirrors `getOriginalUrlFromErrorPage`), keyed off the two interstitials already listed in `src/shared/internal-pages.json`.
- `navigation.js` `handleNavigationEvent` — the active-tab did-navigate branch, ahead of the error-page branch. An interstitial with no `name` param falls back to an empty address bar, never the on-disk path.
- `navigation-utils.js` `deriveSwitchedTabDisplay` — switching back to a tab parked on an interstitial restores the name too.
- `page-urls.js` `isHistoryRecordable` — **also a real leak**: the interstitial was history-recordable, so its `file://` path and its "RPC servers disagreed" title were being written into history and the autocomplete dropdown. Verified in the harness before the fix; now excluded exactly like `error.html`.

The trust shield keeps working off the bare name (conflict/unverified badge visible in the screenshots below), and the bookmark star stays hidden either way (a bare name isn't a bookmarkable URL, and neither was the `file://` path).

## #236 — stale tab/history title on the Swarm error page

Two causes, both fixed:

1. `error.html` had an `<h1 id="title">` but no `<title>`. Chromium only fires `page-title-updated` when the new document declares a title, so the tab kept the previous page's title. The page now declares `<title>Content Unavailable</title>`, and a small `setErrorTitle()` helper keeps `document.title` in sync with the headline `displayError()` picks for the specific failure (`Content not ready yet`, `Couldn't load this page`).
2. The carry-over itself: `tabs.js`' `did-navigate` handler now clears `tab.title` when a *different* URL commits in the main frame. Without this, any page that declares no `<title>` of its own keeps showing the previous page's title **and records it in history** at `did-stop-loading` (`title: activeTab?.title`), which is what put the wrong title next to the URL in the autocomplete dropdown. Guards: same-URL commits (reload) keep their title so a reload doesn't flicker, `about:blank` commits are skipped (same reason `committedDisplayUrl` skips them — "open in new window" passes through it), and view-source titles are left to `navigation.js`, which sets them right after this handler forwards the event. An empty title renders as "New Tab", which is already what a titleless page loaded into a fresh tab shows.

## Reproduction

Reproduced first in the harness, exactly as #236 describes — visit a titled fixture page, then a not-found `bzz://` hash — and by driving both `.tez` interstitials:

```
UNVERIFIED ADDRESS BAR: "file:///…/src/renderer/pages/ens-unverified.html?name=retry.tez&uri=ipfs%3A%2F%2FQmRetryTez"
CONFLICT ADDRESS BAR:   "file:///…/src/renderer/pages/ens-conflict.html?name=lagged.tez&block=%7B%7D&groups=…"
HISTORY:                [{"url":"file:///…/ens-conflict.html?name=lagged.tez&…","title":"RPC servers disagreed",…}]
TAB TITLE AFTER ERROR:  "Alpha fixture page"
```

After the fix: `"retry.tez"`, `"lagged.tez"`, `[]`, `"Content not ready yet"`.

## Tests

New/extended assertions (all four fail at this branch's parent — mutation-checked by stashing only the source changes and re-running, see the Verification section):

- `test-e2e/tez-unverified.spec.js` / `test-e2e/tez-head-conflict.spec.js` — address-bar assertion on each interstitial. Read once after the interstitial's own DOM has rendered (dom-ready follows did-navigate, which is what repaints the address bar) rather than through a retrying matcher, which could otherwise go green on the pre-navigation value before the `file://` path replaced it.
- `test-e2e/error-page.spec.js` — the #236 repro as an e2e test (titled fixture → not-found hash → tab title must become the error page's own), plus the history half: a page with no `<title>` must not have the previous page's title recorded against its URL.
- `src/renderer/lib/page-urls.test.js` — the new helpers and the `isHistoryRecordable` exclusion.
- `src/renderer/lib/navigation.test.js` — committing either interstitial (and the no-`name` fail-safe) keeps the name in the address bar.
- `src/renderer/lib/navigation-utils-helpers.test.js` — `deriveSwitchedTabDisplay` on both interstitials.
- `src/renderer/lib/tabs.test.js` — title reset on a different-URL commit, and the three cases that must *not* reset (same-URL reload, `about:blank`, view-source).

## Verification

- `npm run lint` — clean.
- `npm test` — 3570 passed / 18 skipped. One flake on the first run (`src/main/private/private-log-context.test.js`, an ordering assertion over concurrent async log contexts); passes in isolation twice and on a full-suite re-run, and is in main-process code this PR doesn't touch.
- `xvfb-run -a npx playwright test --project=harness` (full suite) — 79 passed, 1 failed: `settings-adblock.spec.js` expects bundled filter lists, and `assets/adblock/` doesn't exist in a fresh clone (it's produced by `npm run adblock:download`). Environmental, unrelated.
- Affected specs re-run in isolation after the final cleanup commit: `error-page`, `tez-unverified`, `tez-head-conflict`, `tabs`, `address-bar` — 12/12 passed.
- Mutation check: with only the five source files stashed (tests kept), `error-page` ×2, `tez-unverified` and `tez-head-conflict` all fail; restoring makes them pass.

Screenshots below.