### PR TITLE
docs(changelog): lead 0.8.5 with the daily-driver story and add UI hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,31 +6,12 @@ All notable changes to Freedom will be documented in this file.
 
 ### Added
 
-- Contract-hosted onchain apps on `web3://<address>[:<chainId>]/` — the app itself lives in the contract, not on a web server:
-  - Address-bar shield popover reporting the chain, block, contract and content hash behind the page
-  - The wallet provider is pinned to the app's chain; a page cannot switch it
-  - Reasoning: the page is a contract read, not a hosted file; the shield reports whether that read was verified
-- Three new wallet account types, usable with the vault locked and across dApp signing and sends:
-  - Ledger hardware accounts, confirmed on the device, including x402 payments
-  - Phone accounts over Open Lavatory: QR pairing, signing on the phone, including x402 payments
-  - Safe multi-owner accounts on Gnosis, with a signing board owners sign in any order
-- Radicle repositories are browsable and writable from the browser — open a `rad:` URL the way you would a web page:
-  - `rad:` as a fetchable scheme, plus a consented `window.radicle` provider for issues, comments and patches
-  - Seed-to-browse reports per-peer clone phases, with retry and cancellation
-  - Repository view pinned to any commit id, with commit, branch and contributor counts
-  - Nodes menu shows the Radicle node's connected peers, seeded repositories and addon version
-- Tor for `.onion` addresses through a bundled [Arti](https://gitlab.torproject.org/tpo/core/arti) 1.4.4 client, off by default under Settings > Experimental (clearnet traffic keeps connecting directly)
-  - Prompt to use a system Tor client, such as Tor Browser, instead of Arti
-- [Myotis](https://github.com/biafra23/myotis) 0.1.7, a peer-to-peer Ethereum and Gnosis light client, as an experimental verified source, off by default:
-  - Draggable read and verification order per chain under Settings > Chains, alongside Colibri and RPC
-  - Reasoning: reads are proven against a chain head Myotis syncs from peers itself, rather than trusted from an endpoint
-- `.tez` name resolution from the Tezos Domains contracts, for bare names and `ipfs://` / `ipns://` targets
-- Encrypted point-to-point messaging and topic broadcast for Swarm apps through `window.swarm`, behind its own consent tier
-- Swarm apps can ship a `freedom-manifest.json` so their permissions are one decision instead of a stream of prompts
-- Ad and tracker blocking, on by default, which also hides the empty spaces blocked ads leave:
+- Ad and tracker blocking, on by default — the first of the everyday-browsing basics this release is built around:
   - Settings > Ad Blocking with a per-site allowlist and live rule counts
+  - Blocked ads leave no empty gaps in the page
   - Cookie-banner and annoyance filtering, off by default
   - Filter lists refresh over Swarm without an app update
+- Find in page (`Cmd/Ctrl+F`, or Edit > Find in Page): overlay bar with a live match counter, `Enter` / `Shift+Enter` to cycle matches, `Esc` to close
 - Download manager covering every download source, including `bzz://` and `ipfs://` content:
   - Shelf card with live progress and cancel; Open / Show in Folder on completion
   - `freedom://downloads` page (`Cmd/Ctrl+Shift+J`) with search, pause/resume, and Clear All
@@ -44,14 +25,34 @@ All notable changes to Freedom will be documented in this file.
   - Downloads leave the list on close and permission decisions are session-only; files stay on disk
   - Wallet and `window.ethereum` / `window.swarm` / `window.radicle` providers are unavailable; x402 payment interception is off
   - Start page listing what private windows do and do not protect
-- Find in page (`Cmd/Ctrl+F`, also under Edit in the menu): overlay bar with a live match counter, `Enter` / `Shift+Enter` to cycle matches, `Esc` to close
-- Audio indicator on tabs playing sound; click it or use "Mute Tab" in the tab context menu to mute/unmute (mute survives navigation)
 - Remappable keyboard shortcuts under Settings > Shortcuts:
   - Searchable list grouped by category; click a binding and press the new combination
   - Conflict warning with a one-click swap when a combination is already taken
   - Per-shortcut reset and a Restore defaults button; changes apply without a restart
 - Page zoom on `Cmd/Ctrl` with `=`, `-` and `0`, remappable like every other binding (thanks @alexwbend!)
 - Address-bar search for typed input that isn't a URL, with DuckDuckGo, Google, Bing, Brave Search, Ecosia, Startpage or a custom engine under Settings > Search
+- Audio indicator on tabs playing sound; click it or use "Mute Tab" in the tab context menu to mute/unmute (mute survives navigation)
+- Contract-hosted onchain apps on `web3://<address>[:<chainId>]/` — the app itself lives in the contract, not on a web server:
+  - Address-bar shield popover reporting the chain, block, contract and content hash behind the page
+  - The wallet provider is pinned to the app's chain; a page cannot switch it
+  - Reasoning: the page is a contract read, not a hosted file; the shield reports whether that read was verified
+- Radicle repositories are browsable and writable from the browser — open a `rad:` URL the way you would a web page:
+  - `rad:` as a fetchable scheme, plus a consented `window.radicle` provider for issues, comments and patches
+  - Seed-to-browse reports per-peer clone phases, with retry and cancellation
+  - Repository view pinned to any commit id, with commit, branch and contributor counts
+  - Nodes menu in the toolbar shows Radicle's connected peers, seeded repositories and addon version
+- [Myotis](https://github.com/biafra23/myotis) 0.1.7, a peer-to-peer Ethereum and Gnosis light client, as an experimental verified source, off by default:
+  - Draggable read and verification order per chain under Settings > Chains, alongside Colibri and RPC
+  - Reasoning: reads are proven against a chain head Myotis syncs from peers itself, rather than trusted from an endpoint
+- `.tez` name resolution from the Tezos Domains contracts, for bare names and `ipfs://` / `ipns://` targets
+- Encrypted point-to-point messaging and topic broadcast for Swarm apps through `window.swarm`, behind its own consent tier
+- Swarm apps can ship a `freedom-manifest.json` so their permissions are one decision instead of a stream of prompts
+- Three new wallet account types, usable with the vault locked and across dApp signing and sends:
+  - Ledger hardware accounts, confirmed on the device, including x402 payments
+  - Phone accounts over Open Lavatory: QR pairing, signing on the phone, including x402 payments
+  - Safe multi-owner accounts on Gnosis, with a signing board owners sign in any order
+- Tor for `.onion` addresses through a bundled [Arti](https://gitlab.torproject.org/tpo/core/arti) 1.4.4 client, off by default under Settings > Experimental (clearnet traffic keeps connecting directly)
+  - Prompt to use a system Tor client, such as Tor Browser, instead of Arti
 
 ### Changed
 


### PR DESCRIPTION
Re-sorts the `[Unreleased]` (0.8.5) `Added` section so the daily-driver capabilities lead as one story, then the decentralized-web and wallet work, and adds a few UI hints. Touches `CHANGELOG.md` only, on top of `release/0.8.5` (base is the release branch, not `main`, per `release-process.md` §3 — the merge is the approval).

## What changed

**Order (`Added`), matching the maintainer's daily-driver run:**

1. Ad and tracker blocking (now the headline)
2. Find in page
3. Download manager
4. Per-site permission prompts
5. Private windows
6. Remappable keyboard shortcuts
7. Page zoom (kept adjacent to shortcuts — its own text says "remappable like every other binding", so splitting it from the shortcuts entry read worse than the strict list order)
8. Address-bar search
9. Tab audio indicator and mute
10. Onchain apps → 11. Radicle → 12. Myotis → 13. `.tez` → 14. Swarm messaging → 15. Swarm manifests → 16. Wallet account types (Ledger / phone / Safe) → 17. Tor

`Changed`, `Removed`, `Fixed` and `Security` are untouched and stay in Keep a Changelog order (the playbook forbids reordering sections).

**Text edits — four lines, no entry or sub-bullet dropped:**

| Line | Before → after | Why |
| --- | --- | --- |
| Ad blocking parent | `…on by default, which also hides the empty spaces blocked ads leave:` → `…on by default — the first of the everyday-browsing basics this release is built around:` | carries the daily-driver theme on the headline entry |
| Ad blocking sub-bullet (new) | — → `Blocked ads leave no empty gaps in the page` | the clause displaced from the parent, kept verbatim in meaning |
| Find in page | `also under Edit in the menu` → `or Edit > Find in Page` | concrete click path in the playbook's `X > Y` form |
| Radicle sub-bullet | `Nodes menu shows the Radicle node's connected peers…` → `Nodes menu in the toolbar shows Radicle's connected peers…` | tells the reader where the Nodes menu is |

A sorted line-by-line diff of the old and new `Added` sections shows exactly these four differences — nothing else moved except position.

### Headline vs. intro line

The playbook has no precedent for a prose intro above `### Added` — every shipped section (`0.6.0`–`0.8.0`) starts straight on a bullet — but it does allow "a short dash-tagline on the headline entry that says what the thing is _for_" (`Native x402 payment support — pay as you browse…`, `0.7.4`). So the theme rides on the first entry rather than a new intro line, as the task's fallback specifies.

## Per-hint verification

Verified against the tree at `release/0.8.5` head (0c0db666) and, for all but one, in the running app (`FREEDOM_TEST_MODE=1` under xvfb via the `run-freedom` driver — screenshots below).

| Hint (as it appears in the changelog) | Verified against | Result |
| --- | --- | --- |
| `Settings > Ad Blocking` | `settings.html` nav (`data-target="adblock"`, label "Ad Blocking") + screenshot | exact |
| `Settings > Site Permissions` | nav `data-target="permissions"`, label "Site Permissions" + screenshot | exact |
| `Settings > Search` | nav `data-target="search"`, label "Search" + screenshot (engine dropdown, custom engines) | exact |
| `Settings > Shortcuts` | nav `data-target="shortcuts"`, label "Shortcuts" + screenshot | exact |
| `Settings > Downloads` | nav `data-target="downloads"`, label "Downloads" + screenshot | exact |
| `Settings > Chains` (Myotis) | nav `data-target="chains"`, label "Chains" | exact |
| `Settings > Experimental` (Tor) | nav `data-target="experimental"` + the "Enable Tor (.onion access)" row in that panel (screenshot) | exact |
| `Cmd/Ctrl+F`, `Edit > Find in Page` | `shortcuts.js` `page.findInPage` default `CmdOrCtrl+F`; live application-menu dump: `Edit → Find in Page...  [CmdOrCtrl+F]`; find bar screenshot shows the `1/3` counter | exact |
| `Cmd/Ctrl+Shift+N`, `File > New Private Window` | `shortcuts.js` `window.newPrivate` = `CmdOrCtrl+Shift+N`; menu dump: `File → New Private Window  [CmdOrCtrl+Shift+N]`; opened a private window in the app | exact |
| `freedom://downloads` (`Cmd/Ctrl+Shift+J`) | `shortcuts.js` `downloads.show` = `CmdOrCtrl+Shift+J`; `menu.js` sends `tab:new-with-url` `freedom://downloads`; menu dump: `File → Downloads  [CmdOrCtrl+Shift+J]`; page loaded and screenshotted | exact |
| `Nodes menu in the toolbar` | `index.html` toolbar button `aria-label="Nodes Menu"`; opened it — Radicle card shows Connected Peers / Seeded Repositories / `libradicle v0.7.1` | exact |
| `Address-bar shield popover` (onchain apps) | `index.html` `#trust-shield` in the address bar; opened the popover on a `web3://` fixture — chain, block, contract, HTML hash | exact |

Hint wording deliberately **not** used:

- **`Settings > Experimental > Tor`** — there is no item labelled "Tor" under Experimental; the control is a row labelled "Enable Tor (.onion access)". (A card literally labelled "Tor" exists, but under Settings > Nodes.) Kept the already-correct `Settings > Experimental`.
- **`Edit > Find`** — the menu item is `Find in Page...`; used `Edit > Find in Page`.
- No hints added to the wallet account types, Swarm messaging/manifests, `.tez` or the tab audio indicator: the first three have no single click path (accounts are added from the wallet sidebar's account switcher; the Swarm entries are page APIs), and the audio indicator entry already names the tab context menu. Per the task, hints go only where they help.

## Judgement call for the releaser: "internal pages following the theme"

The requested order includes internal pages following the theme, **but there is no such entry in this section and the capability is not on this branch**. `fix(ui): make internal pages follow the Appearance theme, not the OS colour scheme` is PR #245, merged to `main` on 2026-09-07; `git merge-base --is-ancestor 2e56f483 origin/release/0.8.5` → not an ancestor. Running this branch's build with `theme: dark` shows `freedom://downloads` still rendering light chrome (screenshot below), so announcing it in 0.8.5 would promise something an rc tester cannot see. I did not invent the entry.

If #245 (and the sibling light-theme fixes #262/#264) are merged into `release/0.8.5` before the final tag, the entry belongs between "Address-bar search" and "Audio indicator on tabs", and this text fits the surrounding density:

```
- Internal pages — home, history, downloads, payments, settings — follow the Appearance theme instead of the OS colour scheme
```

## Side-by-side against 0.8.0 (playbook § Review gate)

Measured on the file at this commit:

| | `[Unreleased]` (0.8.5) | `[0.8.0]` shipped |
| --- | --- | --- |
| Added: top-level / sub | 17 / 30 | 7 / 9 |
| Changed | 4 / 0 | 2 / 0 |
| Removed | 1 / 0 | 1 / 0 |
| Fixed | 7 / 0 | 5 / 0 |
| Security | 4 / 4 | 3 / 16 |
| Sub-bullets, whole release | 34 | 25 |
| Top-bullet words: median / max / over 25 | 17 / 29 / 3 | 17 / 23 / 0 |
| Sub-bullet words: median / max / over 15 | 13 / 19 / 2 | 4 / 18 / 1 |

Reading:

- **Register and per-entry length match.** Median top-level bullet is 17 words in both. Lead patterns hold per section: `Added` noun-phrase ("Ad and tracker blocking…"), `Changed` noun-phrase, `Removed` with a dash clause saying why, `Fixed` subject-led, `Security` imperative ("Escape repository-supplied names…").
- **Volume is larger, as expected.** The playbook itself budgets "`0.8.5` about 30" sub-bullets for a two-month, 50-PR cycle; Added carries 30 of the 34, and no parent has more than 4. This PR adds exactly one sub-bullet (the ad-blocking gap line displaced from its parent) and removes none.
- **Over-budget lines are all pre-existing**, unchanged by this PR: two `Reasoning:` sub-bullets at 19 words (the form the playbook explicitly sanctions), the 26-word Find in page entry (26 before and after — the hint swap is length-neutral), and the `Installers are about 15 MB smaller` / `Adopting a system Radicle node` entries in `Changed`/`Removed`. My new sub-bullet is 8 words; the new headline tagline is 18.
- Sub-bullet density is the one visible difference from 0.8.0 (median 13 vs 4), inherited from the approved #217 text; reordering does not change it, and cutting it would be the content-dropping this task forbids. Flagging rather than acting on it.

## Verification

- `npx prettier --check CHANGELOG.md` — clean.
- Sorted-set diff of the `Added` section before/after: 4 changed lines, 1 added line, 0 removed. Every original entry and sub-bullet is present.
- App run for the hints: `FB_ROOT=$PWD NODE_PATH=$PWD/node_modules xvfb-run -a -s "-screen 0 1440x900x24" node <run-freedom driver>` — dumped the real `Menu.getApplicationMenu()` tree and screenshotted Settings (adblock, permissions, search, shortcuts, downloads, experimental), `freedom://downloads`, the toolbar Nodes menu, the find bar, the onchain trust popover and a private window. All steps passed. (The driver comes from the `run-freedom` skill, which lives on `main`, not on this branch; it was run from `/tmp` against this branch's source and nothing from it is committed.)
- `## [Unreleased]` stays the heading — 0.8.5 is still in candidates.
