### PR TITLE
ui: Swarm approval screens use the shared blue primary and 'Reject' (#239)

### DIFF
--- a/docs/agent-playbooks/ui-consistency.md
+++ b/docs/agent-playbooks/ui-consistency.md
@@ -27,19 +27,35 @@ hashes and keys; search boxes and names use the sans font.
 
 **Buttons.** Primary action filled `--accent`, secondary outlined, destructive
 outlined `--danger` ("Clear All", "Remove all", "Restore defaults"). The same
-action uses the same verb everywhere (a remembered permission is _removed_
-in every surface; a request from a site is _rejected_). Every approval screen
-in the sidebar — wallet, dApp and Swarm — pairs one filled `--accent` primary
-with an outlined secondary; the Swarm screens' orange primary and "Cancel"
-secondary were the one exception until #239. "Cancel" stays where there is no
-request to reject: dismissing a form, an unlock prompt.
+action uses the same verb everywhere (a remembered permission is _removed_ in
+every surface). Every approval screen in the sidebar — wallet, dApp and Swarm —
+pairs one filled `--accent` primary with an outlined secondary; the Swarm
+screens' orange primary was the one exception until #239.
+
+The _reject_ verb has not converged. The four dApp approvals and the four Swarm
+approvals say "Reject", and `renderer-copy.test.js` pins that on those eight
+screens only. Elsewhere the same decision is still worded per screen: Radicle
+Access says "Cancel" (`#radicle-consent-reject`), App permissions says "Don't
+allow" (`#swarm-manifest-reject`), the toolbar permission prompt says "Block"
+(`#permission-prompt-block`). Treat those as unpinned drift, not as a rule
+being broken — check the verb against the screen you are touching, and settle a
+screen's wording on its issue before changing it. "Cancel" is correct where
+there is no request to reject: dismissing a form, an unlock prompt.
 
 **Approval callouts.** Two kinds, both in `styles/sidebar.css`: amber with the
 warning triangle (`.dapp-tx-warning`, `.swarm-connect-warning`) for the
 consequence of the action being confirmed, blue with the "i" glyph
 (`.dapp-sign-warning`, `.swarm-connect-note`) for what the access being
-granted means. The icon lives in the markup, so changing the kind means
-changing both the class and the glyph.
+granted means. The icon lives in the markup, not in the class, so changing the
+kind means changing both.
+
+`renderer-copy.test.js` pins that pairing on the four Swarm approvals only, and
+two amber callouts outside that sweep do not follow it: the Radicle Access
+callout uses `.swarm-connect-warning` with the "i" glyph, and App permissions'
+`#swarm-manifest-identity-note` is a `.swarm-connect-warning` with no glyph at
+all. Both are known drift waiting on a per-screen kind decision (#239); do not
+repaint them to the pairing without one, and do not read them as evidence the
+pairing above is wrong.
 
 **Sidebar sub-screens.** One header component: chevron, "Back", title, and
 the same close control on every screen (Send, Confirm Transaction, Sign

--- a/docs/agent-playbooks/ui-consistency.md
+++ b/docs/agent-playbooks/ui-consistency.md
@@ -28,8 +28,18 @@ hashes and keys; search boxes and names use the sans font.
 **Buttons.** Primary action filled `--accent`, secondary outlined, destructive
 outlined `--danger` ("Clear All", "Remove all", "Restore defaults"). The same
 action uses the same verb everywhere (a remembered permission is _removed_
-in every surface; a dApp request is _rejected_). Swarm approval screens use
-the orange primary deliberately; do not spread it to non-Swarm screens.
+in every surface; a request from a site is _rejected_). Every approval screen
+in the sidebar — wallet, dApp and Swarm — pairs one filled `--accent` primary
+with an outlined secondary; the Swarm screens' orange primary and "Cancel"
+secondary were the one exception until #239. "Cancel" stays where there is no
+request to reject: dismissing a form, an unlock prompt.
+
+**Approval callouts.** Two kinds, both in `styles/sidebar.css`: amber with the
+warning triangle (`.dapp-tx-warning`, `.swarm-connect-warning`) for the
+consequence of the action being confirmed, blue with the "i" glyph
+(`.dapp-sign-warning`, `.swarm-connect-note`) for what the access being
+granted means. The icon lives in the markup, so changing the kind means
+changing both the class and the glyph.
 
 **Sidebar sub-screens.** One header component: chevron, "Back", title, and
 the same close control on every screen (Send, Confirm Transaction, Sign

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3361,7 +3361,7 @@
                   </ul>
                 </div>
 
-                <div class="swarm-connect-warning">
+                <div class="swarm-connect-note">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <circle cx="12" cy="12" r="10" />
                     <line x1="12" y1="16" x2="12" y2="12" />
@@ -3384,7 +3384,7 @@
 
                 <div class="swarm-connect-actions">
                   <button type="button" class="swarm-connect-reject-btn" id="swarm-connect-reject">
-                    Cancel
+                    Reject
                   </button>
                   <button
                     type="button"
@@ -3432,9 +3432,11 @@
 
                 <div class="swarm-connect-warning">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <circle cx="12" cy="12" r="10" />
-                    <line x1="12" y1="16" x2="12" y2="12" />
-                    <line x1="12" y1="8" x2="12.01" y2="8" />
+                    <path
+                      d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+                    />
+                    <line x1="12" y1="9" x2="12" y2="13" />
+                    <line x1="12" y1="17" x2="12.01" y2="17" />
                   </svg>
                   <span
                     >This will use your stamps and bandwidth. Content will be publicly accessible on
@@ -3449,7 +3451,7 @@
 
                 <div class="swarm-connect-actions">
                   <button type="button" class="swarm-connect-reject-btn" id="swarm-publish-reject">
-                    Cancel
+                    Reject
                   </button>
                   <button
                     type="button"
@@ -3490,9 +3492,9 @@
 
                 <div class="swarm-connect-warning">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <circle cx="12" cy="12" r="10"/>
-                    <line x1="12" y1="16" x2="12" y2="12"/>
-                    <line x1="12" y1="8" x2="12.01" y2="8"/>
+                    <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+                    <line x1="12" y1="9" x2="12" y2="13"/>
+                    <line x1="12" y1="17" x2="12.01" y2="17"/>
                   </svg>
                   <span id="swarm-messaging-warning">Sending messages uses your stamps. Open subscriptions use bandwidth while the page is loaded.</span>
                 </div>
@@ -3503,7 +3505,7 @@
                 </label>
 
                 <div class="swarm-connect-actions">
-                  <button type="button" class="swarm-connect-reject-btn" id="swarm-messaging-reject">Cancel</button>
+                  <button type="button" class="swarm-connect-reject-btn" id="swarm-messaging-reject">Reject</button>
                   <button type="button" class="swarm-connect-approve-btn" id="swarm-messaging-confirm">Allow</button>
                 </div>
               </div>
@@ -3538,7 +3540,7 @@
                   <div id="swarm-feed-identity-selector"></div>
                 </div>
 
-                <div class="swarm-connect-warning">
+                <div class="swarm-connect-note">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <circle cx="12" cy="12" r="10" />
                     <line x1="12" y1="16" x2="12" y2="12" />
@@ -3605,7 +3607,7 @@
 
                 <div class="swarm-connect-actions">
                   <button type="button" class="swarm-connect-reject-btn" id="swarm-feed-reject">
-                    Cancel
+                    Reject
                   </button>
                   <button
                     type="button"

--- a/src/renderer/lib/wallet/swarm-connect.js
+++ b/src/renderer/lib/wallet/swarm-connect.js
@@ -460,7 +460,7 @@ function setupSwarmPublishScreen() {
 
 /**
  * Show the per-publish approval prompt (queued behind any prompt already on
- * screen). Resolves on "Publish", rejects (code 4001) on "Cancel".
+ * screen). Resolves on "Publish", rejects (code 4001) on "Reject".
  */
 export function showSwarmPublishApproval(permissionKey, params, resolve, reject, method) {
   // A live device confirmation owns the sidebar (see signature-flight.js).

--- a/src/renderer/renderer-copy.test.js
+++ b/src/renderer/renderer-copy.test.js
@@ -270,3 +270,88 @@ describe('error page heading case (#260)', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// #239 — approval screens: one secondary verb, one callout glyph per kind
+// ---------------------------------------------------------------------------
+
+// The four Swarm approvals and their dApp siblings answer the same question —
+// does this site get to do the thing it asked for? — so they answer it with
+// the same word. "Cancel" belongs to a form or an unlock prompt, where there
+// is no request to reject.
+describe('approval screens (#239)', () => {
+  const index = read(path.join(RENDERER, 'index.html'));
+
+  // Sidebar sub-screens are laid out one after another, so a screen runs from
+  // its own `id="sidebar-…"` to the next one.
+  const screen = (id) => {
+    const start = index.indexOf(`id="${id}"`);
+    if (start < 0) throw new Error(`no ${id} in index.html`);
+    const next = index.indexOf('id="sidebar-', start + 1);
+    return index.slice(start, next < 0 ? index.length : next);
+  };
+
+  const SWARM_SCREENS = [
+    ['sidebar-swarm-connect', 'swarm-connect-reject'],
+    ['sidebar-swarm-publish-approve', 'swarm-publish-reject'],
+    ['sidebar-swarm-messaging-approve', 'swarm-messaging-reject'],
+    ['sidebar-swarm-feed-approve', 'swarm-feed-reject'],
+  ];
+
+  const label = (html, id) => {
+    const match = html.match(new RegExp(`id="${id}"[^>]*>\\s*([^<]*?)\\s*<`));
+    if (!match) throw new Error(`no button #${id}`);
+    return match[1];
+  };
+
+  test.each(SWARM_SCREENS)('%s rejects, it does not cancel', (id, rejectId) => {
+    expect(label(screen(id), rejectId)).toBe('Reject');
+  });
+
+  test('the dApp siblings the verb comes from still say it', () => {
+    expect(label(screen('sidebar-dapp-tx'), 'dapp-tx-reject')).toBe('Reject');
+    expect(label(screen('sidebar-dapp-sign'), 'dapp-sign-reject')).toBe('Reject');
+    expect(label(screen('sidebar-dapp-connect'), 'dapp-connect-reject')).toBe('Reject');
+  });
+
+  // Callout kind and glyph are set in two places — the class in the markup,
+  // the `<path>`/`<circle>` inside it — so they drift as a pair. Amber
+  // (`.swarm-connect-warning`, `.dapp-tx-warning`) carries the warning
+  // triangle; blue (`.swarm-connect-note`, `.dapp-sign-warning`) carries "i".
+  const TRIANGLE = /M10\.29 3\.86L1\.82 18/;
+  const INFO_CIRCLE = /<circle cx="12" cy="12" r="10"/;
+
+  const callouts = (html) => [
+    ...html.matchAll(
+      /<div class="(swarm-connect-warning|swarm-connect-note)"[^>]*>([\s\S]*?)<\/svg>/g
+    ),
+  ];
+
+  test.each(SWARM_SCREENS)('%s pairs its callout class with the matching glyph', (id) => {
+    const found = callouts(screen(id));
+    expect(found).toHaveLength(1);
+    const [, kind, body] = found[0];
+    if (kind === 'swarm-connect-warning') {
+      expect(body).toMatch(TRIANGLE);
+      expect(body).not.toMatch(INFO_CIRCLE);
+    } else {
+      expect(body).toMatch(INFO_CIRCLE);
+      expect(body).not.toMatch(TRIANGLE);
+    }
+  });
+
+  test('the confirm-an-action screens warn and the grant-access screens inform', () => {
+    const kindOf = (id) => callouts(screen(id))[0][1];
+    expect(kindOf('sidebar-swarm-publish-approve')).toBe('swarm-connect-warning');
+    expect(kindOf('sidebar-swarm-messaging-approve')).toBe('swarm-connect-warning');
+    expect(kindOf('sidebar-swarm-connect')).toBe('swarm-connect-note');
+    expect(kindOf('sidebar-swarm-feed-approve')).toBe('swarm-connect-note');
+  });
+
+  test('the dApp screens the two kinds are copied from keep their glyphs', () => {
+    const tx = screen('sidebar-dapp-tx');
+    expect(tx.match(/class="dapp-tx-warning hidden"[\s\S]*?<\/svg>/)[0]).toMatch(TRIANGLE);
+    const sign = screen('sidebar-dapp-sign');
+    expect(sign.match(/class="dapp-sign-warning"[\s\S]*?<\/svg>/)[0]).toMatch(INFO_CIRCLE);
+  });
+});

--- a/src/renderer/renderer-copy.test.js
+++ b/src/renderer/renderer-copy.test.js
@@ -354,4 +354,60 @@ describe('approval screens (#239)', () => {
     const sign = screen('sidebar-dapp-sign');
     expect(sign.match(/class="dapp-sign-warning"[\s\S]*?<\/svg>/)[0]).toMatch(INFO_CIRCLE);
   });
+
+  // The playbook used to state the "Reject" verb as a settled rule with the
+  // Swarm screens as its one exception, which was never true: three approval
+  // surfaces word the same decision differently. Rather than restate a rule the
+  // markup does not follow, the playbook now names those three, and this pins
+  // the naming in both directions so neither side can drift alone.
+  describe('ui-consistency.md on the reject verb', () => {
+    const playbook = fs
+      .readFileSync(path.join(__dirname, '../../docs/agent-playbooks/ui-consistency.md'), 'utf8')
+      .replace(/\s+/g, ' ');
+
+    // Straight vs. typographic apostrophes differ between prose and markup.
+    const norm = (text) => text.replace(/[’‘]/g, "'").trim();
+
+    // Every `… says "Verb" (`#id`)` the playbook lists as unpinned drift.
+    const documented = [...playbook.matchAll(/"([^"]+)" \(`#([a-z0-9-]+)`\)/g)].map((match) => [
+      match[2],
+      norm(match[1]),
+    ]);
+
+    // A secondary that is legitimately "Cancel"/not a reject at all: a form, an
+    // unlock prompt, the middle "ask each time" choice.
+    const NOT_A_REJECT = new Set([
+      'vault-unlock-cancel',
+      'publisher-identity-create-cancel',
+      'swarm-manifest-individual',
+    ]);
+
+    test('the playbook names exactly the three it says it does', () => {
+      expect(documented.map(([id]) => id).sort()).toEqual([
+        'permission-prompt-block',
+        'radicle-consent-reject',
+        'swarm-manifest-reject',
+      ]);
+    });
+
+    // doc -> markup: each documented verb is the one actually rendered.
+    test.each(documented)('#%s still reads "%s"', (id, verb) => {
+      expect(norm(label(index, id))).toBe(verb);
+    });
+
+    // markup -> doc: any other approval secondary that stops saying "Reject" is
+    // new drift, and has to be documented (or fixed) rather than land silently.
+    test('no undocumented approval secondary has drifted off "Reject"', () => {
+      const drifted = [];
+      for (const match of index.matchAll(
+        /class="(?:swarm-connect|dapp-tx|dapp-sign|dapp-connect)-reject-btn"\s+id="([a-z0-9-]+)"[^>]*>\s*([^<]*?)\s*</g
+      )) {
+        const [, id, text] = match;
+        if (NOT_A_REJECT.has(id) || norm(text) === 'Reject') continue;
+        if (documented.some(([documentedId]) => documentedId === id)) continue;
+        drifted.push(`#${id} says "${norm(text)}"`);
+      }
+      expect(drifted).toEqual([]);
+    });
+  });
 });

--- a/src/renderer/styles/approval-primary.test.js
+++ b/src/renderer/styles/approval-primary.test.js
@@ -74,6 +74,61 @@ describe('approval primaries (#239)', () => {
     expect(AMBER.test(background(rule.body))).toBe(true);
   });
 
+  // A fill is not the only way back to orange. The dead Feed Access rules #239
+  // deleted tinted a radio (`accent-color`), a checked border and a link-style
+  // button's text — none of which the fill sweep above would have seen. These
+  // are the remaining amber-carrying properties on an interactive control.
+  const TINTS = ['accent-color', 'color', 'border-color', 'border', 'outline-color'];
+
+  test('no control tints itself amber at rest either', () => {
+    const offenders = [];
+    for (const sheet of sheets) {
+      for (const rule of rulesOf(read(sheet))) {
+        for (const property of TINTS) {
+          const value = declaration(rule.body, property);
+          if (!value || !AMBER.test(value)) continue;
+          for (const selector of rule.selector.split(',').map((part) => part.trim())) {
+            if (STATEFUL.test(selector)) continue;
+            // `accent-color` only ever paints a form control, so it needs no
+            // button check; the rest are amber on plain text or a callout glyph
+            // unless they land on a button.
+            if (property !== 'accent-color' && !isButton(selector)) continue;
+            offenders.push(`${sheet}: ${selector} { ${property}: ${value} }`);
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test('the tint detector fires on the Feed Access rules #239 deleted', () => {
+    // Mutation check: these two are verbatim the dead rules, and both trip.
+    const cases = [
+      [
+        '.swarm-feed-identity-option input[type="radio"] { accent-color: #f59e0b; }',
+        'accent-color',
+      ],
+      ['.swarm-feed-manage-btn { color: #f59e0b; }', 'color'],
+    ];
+    for (const [css, property] of cases) {
+      const rule = rulesOf(css)[0];
+      expect(AMBER.test(declaration(rule.body, property))).toBe(true);
+      expect(property === 'accent-color' || isButton(rule.selector)).toBe(true);
+      expect(STATEFUL.test(rule.selector)).toBe(false);
+    }
+
+    // The third deleted rule, `.swarm-feed-identity-option:has(input:checked) {
+    // border-color: #f59e0b }`, is deliberately *not* covered: it is a state
+    // selector on a non-button, and flagging every amber `border-color` in that
+    // shape would sweep up legitimate callout borders. It cannot arrive alone —
+    // it styles the same radio list as the `accent-color` rule above, which does
+    // trip — so the pair is caught through its sibling.
+    const checked = rulesOf(
+      '.swarm-feed-identity-option:has(input:checked) { border-color: #f59e0b; }'
+    )[0];
+    expect(STATEFUL.test(checked.selector)).toBe(true);
+  });
+
   test('the Swarm primary fills --accent, like the dApp primaries it sits next to', () => {
     const sidebar = rulesOf(read('sidebar.css'));
     const fillOf = (selector) => {

--- a/src/renderer/styles/approval-primary.test.js
+++ b/src/renderer/styles/approval-primary.test.js
@@ -1,0 +1,125 @@
+/**
+ * Every approval screen in the sidebar shares one primary button (#239).
+ *
+ * `docs/agent-playbooks/ui-consistency.md`: "Primary action filled `--accent`,
+ * secondary outlined". The wallet and dApp approvals followed that — Confirm,
+ * Sign, Connect — while the four Swarm approvals (Swarm Access, Confirm
+ * Publish, Confirm Message, Feed Access) filled their primary `#f59e0b`. Two
+ * prompts for the same class of decision, in the same sidebar, in two
+ * different colours, with the orange one reading as the more alarming.
+ *
+ * The regression this guards is a *new* approval screen arriving with its own
+ * fill, not just those four buttons: it sweeps every chrome stylesheet for an
+ * approve/confirm button that paints itself amber at rest, the same shape as
+ * `destructive-buttons.test.js`'s danger sweep.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const STYLES_DIR = __dirname;
+
+const sheets = fs
+  .readdirSync(STYLES_DIR)
+  .filter((name) => name.endsWith('.css'))
+  .sort();
+
+const read = (name) => fs.readFileSync(path.join(STYLES_DIR, name), 'utf8');
+
+/** Flat `selector { body }` pairs. The chrome sheets are not nested. */
+const rulesOf = (css) =>
+  [...css.replace(/\/\*[\s\S]*?\*\//g, '').matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((match) => ({
+    selector: match[1].trim().replace(/\s+/g, ' '),
+    body: match[2],
+  }));
+
+const declaration = (body, property) => {
+  const match = body.match(new RegExp(String.raw`(?:^|;)\s*${property}\s*:\s*([^;]+)`));
+  return match ? match[1].trim() : null;
+};
+
+const background = (body) =>
+  declaration(body, 'background') || declaration(body, 'background-color');
+
+// The amber the Swarm primaries used, plus its hover shade and the `--warning-fg`
+// token. A callout keeps painting itself amber; a button must not.
+const AMBER = /var\(--warning-fg\b|#f59e0b|#d97706|#d29922/i;
+
+// A resting state is anything that is not a user-driven state selector.
+const STATEFUL = /:(hover|active|focus|focus-visible|checked|target)\b/;
+
+const isButton = (selector) => /(^|[\s.#>+~])[^\s,]*(btn|button)/i.test(selector);
+
+describe('approval primaries (#239)', () => {
+  test('no button fills itself amber at rest', () => {
+    const offenders = [];
+    for (const sheet of sheets) {
+      for (const rule of rulesOf(read(sheet))) {
+        const fill = background(rule.body);
+        if (!fill || !AMBER.test(fill)) continue;
+        for (const selector of rule.selector.split(',').map((part) => part.trim())) {
+          if (!isButton(selector) || STATEFUL.test(selector)) continue;
+          offenders.push(`${sheet}: ${selector} { background: ${fill} }`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test('the detector still fires on the fill the Swarm screens shipped', () => {
+    // Mutation check: the sweep above passes today, so prove it would fail if
+    // the orange primary came back.
+    const rule = rulesOf('.swarm-connect-approve-btn { background: #f59e0b; color: #fff; }')[0];
+    expect(isButton(rule.selector)).toBe(true);
+    expect(AMBER.test(background(rule.body))).toBe(true);
+  });
+
+  test('the Swarm primary fills --accent, like the dApp primaries it sits next to', () => {
+    const sidebar = rulesOf(read('sidebar.css'));
+    const fillOf = (selector) => {
+      const rule = sidebar.find((entry) => entry.selector === selector);
+      expect(rule).toBeDefined();
+      return background(rule.body);
+    };
+
+    const swarm = fillOf('.swarm-connect-approve-btn');
+    expect(swarm).toMatch(/var\(--accent\b/);
+    expect(fillOf('.dapp-tx-approve-btn')).toBe(swarm);
+    expect(fillOf('.dapp-sign-approve-btn')).toBe(swarm);
+    expect(fillOf('.dapp-connect-approve-btn')).toBe(swarm);
+  });
+
+  test('the Swarm secondary stays outlined, like the dApp secondaries', () => {
+    const sidebar = rulesOf(read('sidebar.css'));
+    const ruleFor = (selector) => sidebar.find((entry) => entry.selector === selector);
+
+    const reject = ruleFor('.swarm-connect-reject-btn');
+    expect(reject).toBeDefined();
+    expect(background(reject.body)).toBe('var(--toolbar)');
+    expect(declaration(reject.body, 'border-color')).toBe('var(--border)');
+
+    const dappReject = ruleFor('.dapp-tx-reject-btn');
+    expect(background(dappReject.body)).toBe('var(--toolbar)');
+  });
+
+  test('the two callout kinds match their dApp originals', () => {
+    const sidebar = rulesOf(read('sidebar.css'));
+    const ruleFor = (selector) => sidebar.find((entry) => entry.selector === selector);
+
+    // Warning: amber, like the dApp transaction screen.
+    expect(background(ruleFor('.swarm-connect-warning, .swarm-connect-note').body)).toBe(
+      background(ruleFor('.dapp-tx-warning').body)
+    );
+    expect(
+      declaration(ruleFor('.swarm-connect-warning svg, .swarm-connect-note svg').body, 'color')
+    ).toBe('#f59e0b');
+
+    // Informational: blue, like the dApp sign screen.
+    expect(background(ruleFor('.swarm-connect-note').body)).toBe(
+      background(ruleFor('.dapp-sign-warning').body)
+    );
+    expect(declaration(ruleFor('.swarm-connect-note svg').body, 'color')).toBe(
+      declaration(ruleFor('.dapp-sign-warning svg').body, 'stroke')
+    );
+  });
+});

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -2990,7 +2990,13 @@
   font-weight: 700;
 }
 
-.swarm-connect-warning {
+/* Callouts on the Swarm/Radicle approval screens. Two kinds, the same pair the
+   dApp screens already use (#239): amber + triangle glyph warns about the
+   consequence of the action being confirmed (`.dapp-tx-warning`), blue + "i"
+   glyph explains what the access being granted means (`.dapp-sign-warning`).
+   The icon lives in the markup, so a callout that changes kind changes both. */
+.swarm-connect-warning,
+.swarm-connect-note {
   display: flex;
   align-items: flex-start;
   gap: 10px;
@@ -3004,12 +3010,22 @@
   line-height: 1.4;
 }
 
-.swarm-connect-warning svg {
+.swarm-connect-warning svg,
+.swarm-connect-note svg {
   width: 18px;
   height: 18px;
   flex-shrink: 0;
   color: #f59e0b;
   margin-top: 1px;
+}
+
+.swarm-connect-note {
+  background: rgba(59, 130, 246, 0.1);
+  border-color: rgba(59, 130, 246, 0.3);
+}
+
+.swarm-connect-note svg {
+  color: rgb(59, 130, 246);
 }
 
 .auto-approve-badge {
@@ -3213,7 +3229,7 @@
   font-weight: 600;
   cursor: pointer;
   border: 1px solid transparent;
-  transition: background 0.15s, border-color 0.15s;
+  transition: background 0.15s, border-color 0.15s, opacity 0.15s;
 }
 
 .swarm-connect-reject-btn {
@@ -3226,13 +3242,18 @@
   background: var(--hover);
 }
 
+/* The one approval primary: filled `--accent`, like `.dapp-tx-approve-btn`,
+   `.dapp-connect-approve-btn` and the wallet's own Confirm. These screens used
+   to fill themselves `#f59e0b` (orange), which read as a different, more
+   alarming class of action than the blue Confirm/Sign/Connect sitting next to
+   them in the same sidebar (#239). */
 .swarm-connect-approve-btn {
-  background: #f59e0b;
+  background: var(--accent);
   color: #fff;
 }
 
 .swarm-connect-approve-btn:hover:not(:disabled) {
-  background: #d97706;
+  opacity: 0.9;
 }
 
 .swarm-connect-approve-btn:disabled {

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -3311,97 +3311,14 @@
   margin-bottom: 10px;
 }
 
-.swarm-feed-identity-help {
-  margin: 8px 0 0;
-  font-size: 12px;
-  color: var(--muted);
-  line-height: 1.4;
-}
-
-.swarm-feed-identity-option {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  padding: 10px 12px;
-  margin-bottom: 6px;
-  background: var(--toolbar);
-  border-radius: 8px;
-  cursor: pointer;
-  border: 1px solid var(--border);
-  transition: border-color 0.15s;
-}
-
-.swarm-feed-identity-option:has(input:checked) {
-  border-color: #f59e0b;
-}
-
-.swarm-feed-identity-option input[type="radio"] {
-  margin-top: 2px;
-  accent-color: #f59e0b;
-}
-
-.swarm-feed-identity-label {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.swarm-feed-identity-name {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--foreground);
-}
-
-.swarm-feed-identity-desc {
-  font-size: 12px;
-  color: var(--muted);
-  line-height: 1.3;
-}
-
-.swarm-feed-current-identity {
-  margin-bottom: 16px;
-  padding: 12px;
-  background: var(--toolbar);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-}
-
-.swarm-feed-current-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 8px;
-}
-
-.swarm-feed-current-label {
-  font-size: 12px;
-  color: var(--muted);
-}
-
-.swarm-feed-current-name {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--foreground);
-  text-align: right;
-}
-
-.swarm-feed-current-desc {
-  margin: 0 0 10px;
-  font-size: 12px;
-  color: var(--muted);
-  line-height: 1.4;
-}
-
-.swarm-feed-manage-btn {
-  padding: 0;
-  background: transparent;
-  border: 0;
-  color: #f59e0b;
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-}
+/* Feed Access renders its picker into `#swarm-feed-identity-selector` through
+   `publisher-identity-selector.js`, which brings its own `.wallet-selector-*`
+   classes. The hand-rolled radio list and "current identity" card this section
+   used to style are gone from the markup; their rules were removed with #239's
+   amber sweep, since two of them (the radio `accent-color` / checked border and
+   the manage button's text colour) were the last `#f59e0b` left on this screen
+   and would have put orange back next to the blue primary if the markup ever
+   came back. The two rules above are the section's only live ones. */
 
 /* ============================================
    Publisher Identities List


### PR DESCRIPTION
Closes #239

## What changed

Maintainer decision on #239: the orange primary on the Swarm approval
screens is not deliberate Swarm branding — use blue. So the orange rules
are removed, not overridden.

The four Swarm approvals in the wallet sidebar (**Swarm Access** /
`showSwarmConnect`, **Confirm Publish**, **Confirm Message**, **Feed
Access**) now match the wallet and dApp approvals they sit next to:

- **Primary** — `.swarm-connect-approve-btn` fills `var(--accent)` and
  dims on hover, exactly like `.dapp-tx-approve-btn`,
  `.dapp-sign-approve-btn` and `.dapp-connect-approve-btn`. The
  `#f59e0b` / `#d97706` declarations are deleted.
- **Secondary** — outlined as before, relabelled `Cancel` → **Reject**,
  the verb the dApp screens use for the same decision.
- **Callouts** — the glyph now follows the kind, as on the dApp screens:
  the two confirm-an-action screens (Confirm Publish, Confirm Message)
  keep the amber `.swarm-connect-warning` and get the **warning
  triangle** (`.dapp-tx-warning`'s glyph); the two grant-access screens
  (Swarm Access, Feed Access) move to a new blue `.swarm-connect-note`
  with the **info** glyph (`.dapp-sign-warning`'s pair). No copy
  changed in either.

No behaviour changes and no copy changes beyond the verb.
`docs/agent-playbooks/ui-consistency.md` said the opposite ("Swarm
approval screens use the orange primary deliberately"), so its Buttons
paragraph is rewritten and a short **Approval callouts** paragraph
documents the two kinds.

### Also affected, deliberately

`.swarm-connect-approve-btn` is shared with the **Radicle Access** and
**App permissions** sub-screens, so their primaries turn blue too. That
is the same consistency fix on screens #239 did not name; the
alternative would have been an orange override, which the issue rules
out. Their secondary verbs and callout glyphs are untouched — the
Radicle prompt's callout text varies per action (connect / seed /
unseed / signing), so which kind each one is is a separate call.

## Guards (both mutation-tested)

- `src/renderer/styles/approval-primary.test.js` (new) — sweeps every
  chrome stylesheet for a button that fills itself amber at rest (the
  shape of `destructive-buttons.test.js`'s danger sweep, so a *new*
  approval screen arriving with its own fill is caught), and pins the
  Swarm primary's fill to the three dApp primaries' and the secondary
  to the outlined dApp shape. Reverting the fill to `#f59e0b` fails
  2/5 tests.
- `src/renderer/renderer-copy.test.js` (extended) — pins the secondary
  verb on all four Swarm screens (and the three dApp screens it comes
  from) and the class↔glyph pairing of each callout. Putting `Cancel`
  back fails 1 test; putting the info circle back on Confirm Publish
  fails 1; flipping Feed Access's callout class without its glyph fails 2.

## Verification

- `npm run lint` — clean.
- `npm test` — 3773 passed, 18 skipped, 0 failed.
- `xvfb-run npx playwright test --project=harness
  test-e2e/sidebar-subscreen-headers.spec.js` — 3 passed.
- Visual: `.claude/skills/run-freedom`, recipe `swarmApproval` for all
  four kinds, in **dark and light**, before and after. Screenshots in
  the comment below.