### PR TITLE
docs(changelog): drop the editorial framing from the ad-blocking entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Freedom will be documented in this file.
 
 ### Added
 
-- Ad and tracker blocking, on by default — the first of the everyday-browsing basics this release is built around:
+- Ad and tracker blocking, on by default, which also hides the empty spaces blocked ads leave:
   - Settings > Ad Blocking with a per-site allowlist and live rule counts
   - Blocked ads leave no empty gaps in the page
   - Cookie-banner and annoyance filtering, off by default


### PR DESCRIPTION
Removes the theme sentence added in #265 ("the first of the everyday-browsing basics this release is built around") and restores the plain wording, including the note that blocked ads leave no gaps. The daily-driver ordering from #265 stays. The matching playbook rule is #285.