### PR TITLE
fix(main): prepare the clipboard IPC and node-abi for Electron 44

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11840,9 +11840,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.32.0.tgz",
-      "integrity": "sha512-2cvOMwK7aQ8eQhHTG9DBK/akKfNaJDwtbxgUaA1u3BHGpd6cbUvWCbA0u3aKan+s7Nl60tMGx4tn11+VS1fiUA==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.35.0.tgz",
+      "integrity": "sha512-ymk4aIzxdPopw2giv8Fs1Ec6vybGkjmyxUwVqhkI4MCy2tVfXdkOGGWieWVjL0THgH+7a8lRdevyupoYj3Js/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12595,9 +12595,9 @@
       }
     },
     "node_modules/prebuild-install/node_modules/node-abi": {
-      "version": "3.93.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.93.0.tgz",
-      "integrity": "sha512-Cu6yUpX5Iavugm8BeX7c0wgU9CvOqfd1yM6A1d2q2ZMjym7GjpASv2GdRcTq3Fx+Sb5OgBkEEpw4VnAbY6Y5RA==",
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -5,7 +5,15 @@ const { promisify } = require('util');
 const log = require('./logger');
 
 const execFileAsync = promisify(execFile);
-const { ipcMain, app, dialog, clipboard, nativeImage, webContents } = require('electron');
+const {
+  ipcMain,
+  app,
+  dialog,
+  clipboard,
+  nativeImage,
+  webContents,
+  ClipboardItem,
+} = require('electron');
 const { URL } = require('url');
 const path = require('path');
 const { activeBzzBases } = require('./state');
@@ -623,6 +631,40 @@ async function deleteProfileFromIpc(payload = {}, options = {}) {
   }
 }
 
+// Electron 44.0 rearchitected the main-process `clipboard` module around the
+// W3C Clipboard API: `writeText`/`readText` return promises, and
+// `writeImage`/`readImage` were removed in favour of
+// `clipboard.write([new ClipboardItem({ '<mime>': <Blob> })])`.
+//
+// Awaiting the text calls is correct on both majors - on Electron 43 they
+// return plain values and `await` passes them straight through - so those
+// call sites need no branching. The image write does: Electron 43's
+// `clipboard.write(data)` takes a `{ text, html, image, ... }` object and
+// silently ignores an array (verified on 43.6.0: `write([{ 'image/png': img }])`
+// resolves, then `readImage()` comes back empty), while 44 rejects anything
+// that is not an array of `ClipboardItem` instances. So pick the shape by
+// what the running Electron actually exposes rather than writing one form and
+// hoping - a wrong guess here fails silently on 43 and loudly on 44.
+async function writeImageToClipboard(image) {
+  if (typeof clipboard.writeImage === 'function') {
+    // Electron <= 43.
+    await clipboard.writeImage(image);
+    return;
+  }
+
+  if (typeof ClipboardItem !== 'function') {
+    throw new Error('clipboard exposes neither writeImage nor ClipboardItem');
+  }
+
+  // Electron >= 44. `ClipboardItem` payloads must be a string or a Blob -
+  // a `nativeImage` is rejected - so hand it the PNG encoding of the image
+  // we already validated with `isEmpty()`.
+  const png = image.toPNG();
+  await clipboard.write([
+    new ClipboardItem({ 'image/png': new Blob([png], { type: 'image/png' }) }),
+  ]);
+}
+
 function registerBaseIpcHandlers(callbacks = {}) {
   ipcMain.handle(IPC.BZZ_SET_BASE, (_event, payload = {}) => {
     const { webContentsId, baseUrl } = payload;
@@ -947,10 +989,11 @@ function registerBaseIpcHandlers(callbacks = {}) {
     }
   });
 
-  // Copy text to clipboard
-  ipcMain.handle('clipboard:copy-text', (_event, text) => {
+  // Copy text to clipboard. `writeText` returns a promise on Electron >= 44,
+  // so it has to be awaited before we can claim the write landed.
+  ipcMain.handle('clipboard:copy-text', async (_event, text) => {
     if (text) {
-      clipboard.writeText(text);
+      await clipboard.writeText(text);
       return { success: true };
     }
     return { success: false, error: 'No text provided' };
@@ -961,11 +1004,15 @@ function registerBaseIpcHandlers(callbacks = {}) {
   // could otherwise exfiltrate the user's clipboard without a paste
   // gesture by invoking this IPC directly through the exposed
   // electronAPI on a hostile page.
-  ipcMain.handle('clipboard:read-text', (event) => {
+  //
+  // `readText` returns a promise on Electron >= 44; returning it unawaited
+  // puts a Promise in the reply payload, which the IPC serializer cannot
+  // structured-clone, so `ipcRenderer.invoke` never settles at all.
+  ipcMain.handle('clipboard:read-text', async (event) => {
     if (event?.sender?.hostWebContents) {
       return { success: false, error: 'Untrusted sender' };
     }
-    return { success: true, text: clipboard.readText() };
+    return { success: true, text: await clipboard.readText() };
   });
 
   // Copy image to clipboard
@@ -982,7 +1029,7 @@ function registerBaseIpcHandlers(callbacks = {}) {
         return { success: false, error: 'Failed to create image from data' };
       }
 
-      clipboard.writeImage(image);
+      await writeImageToClipboard(image);
       return { success: true };
     } catch (error) {
       log.error('[clipboard] Failed to copy image:', error);

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -990,13 +990,23 @@ function registerBaseIpcHandlers(callbacks = {}) {
   });
 
   // Copy text to clipboard. `writeText` returns a promise on Electron >= 44,
-  // so it has to be awaited before we can claim the write landed.
+  // so it has to be awaited before we can claim the write landed - and an
+  // awaited promise can reject, so it needs the same catch `clipboard:copy-image`
+  // already has. Without it a rejection escapes the `{ success, error }` reply
+  // contract as an `ipcRenderer.invoke` rejection and the renderer's
+  // navigator.clipboard fallback never runs.
   ipcMain.handle('clipboard:copy-text', async (_event, text) => {
-    if (text) {
+    if (!text) {
+      return { success: false, error: 'No text provided' };
+    }
+
+    try {
       await clipboard.writeText(text);
       return { success: true };
+    } catch (error) {
+      log.error('[clipboard] Failed to copy text:', error);
+      return { success: false, error: error.message };
     }
-    return { success: false, error: 'No text provided' };
   });
 
   // Address-bar chrome context menu Paste fallback. Restricted to the
@@ -1007,12 +1017,21 @@ function registerBaseIpcHandlers(callbacks = {}) {
   //
   // `readText` returns a promise on Electron >= 44; returning it unawaited
   // puts a Promise in the reply payload, which the IPC serializer cannot
-  // structured-clone, so `ipcRenderer.invoke` never settles at all.
+  // structured-clone, so `ipcRenderer.invoke` never settles at all. That
+  // promise can also reject, so the read is wrapped the same way the write is
+  // - the sender check stays outside the try, it is a trust gate and not
+  // something a clipboard failure may be allowed to reword.
   ipcMain.handle('clipboard:read-text', async (event) => {
     if (event?.sender?.hostWebContents) {
       return { success: false, error: 'Untrusted sender' };
     }
-    return { success: true, text: await clipboard.readText() };
+
+    try {
+      return { success: true, text: await clipboard.readText() };
+    } catch (error) {
+      log.error('[clipboard] Failed to read text:', error);
+      return { success: false, error: error.message };
+    }
   });
 
   // Copy image to clipboard

--- a/src/main/ipc-handlers.test.js
+++ b/src/main/ipc-handlers.test.js
@@ -31,6 +31,72 @@ function createIpcEvent(url = SETTINGS_PAGE_URL) {
   };
 }
 
+const PNG_BYTES = Buffer.from('png-bytes');
+
+function createNativeImageMock(overrides = {}) {
+  return {
+    isEmpty: () => false,
+    toPNG: jest.fn(() => PNG_BYTES),
+    ...overrides,
+  };
+}
+
+// The main-process `clipboard` module has two incompatible shapes across the
+// Electron majors this code has to run on, and the difference is invisible to
+// a mock that only models one of them. Electron <= 43 is synchronous, with
+// `writeImage`/`readImage`; Electron >= 44 rearchitected the module around the
+// W3C Clipboard API — `writeText`/`readText` return promises,
+// `writeImage`/`readImage` are gone, and images go through
+// `clipboard.write([new ClipboardItem({ '<mime>': <Blob> })])`.
+//
+// Both factories are used deliberately: the 43 shape guards back-compat on the
+// Electron we ship today, the 44 shape guards the three regressions
+// docs/audits/electron-44-compatibility-2026-09.md found (B2) — which the old
+// synchronous-only mock passed straight through while the real app was broken.
+function createElectron43ClipboardMock(overrides = {}) {
+  return {
+    writeText: jest.fn(),
+    readText: jest.fn(() => ''),
+    writeImage: jest.fn(),
+    readImage: jest.fn(),
+    write: jest.fn(),
+    clear: jest.fn(),
+    ...overrides,
+  };
+}
+
+class ClipboardItemMock {
+  constructor(payload) {
+    this.payload = payload;
+    this.types = Object.keys(payload);
+  }
+}
+
+function createElectron44ClipboardMock(overrides = {}) {
+  const mock = {
+    writeText: jest.fn(async () => undefined),
+    readText: jest.fn(async () => ''),
+    write: jest.fn(async () => undefined),
+    read: jest.fn(async () => []),
+    clear: jest.fn(async () => undefined),
+    has: jest.fn(() => false),
+    ...overrides,
+  };
+  // Electron 44 removed these outright — a mock that still carries them would
+  // let the legacy branch keep winning and the regression tests pass vacuously.
+  delete mock.writeImage;
+  delete mock.readImage;
+  return mock;
+}
+
+function loadElectron44ClipboardModule(options = {}) {
+  return loadIpcHandlersModule({
+    ...options,
+    clipboard: options.clipboard || createElectron44ClipboardMock(),
+    electronOverrides: { ClipboardItem: ClipboardItemMock },
+  });
+}
+
 function loadIpcHandlersModule(options = {}) {
   const ipcMain = options.ipcMain || createIpcMainMock();
   const log = {
@@ -45,14 +111,9 @@ function loadIpcHandlersModule(options = {}) {
   const dialog = options.dialog || {
     showSaveDialog: jest.fn(),
   };
-  const clipboard = options.clipboard || {
-    writeText: jest.fn(),
-    writeImage: jest.fn(),
-  };
+  const clipboard = options.clipboard || createElectron43ClipboardMock();
   const nativeImage = options.nativeImage || {
-    createFromBuffer: jest.fn(() => ({
-      isEmpty: () => false,
-    })),
+    createFromBuffer: jest.fn(() => createNativeImageMock()),
   };
   const activeProfile = Object.prototype.hasOwnProperty.call(options, 'activeProfile')
     ? options.activeProfile
@@ -171,6 +232,7 @@ function loadIpcHandlersModule(options = {}) {
     nativeImage,
     webContents: options.webContents,
     webContentsList: options.webContentsList,
+    electronOverrides: options.electronOverrides,
     extraMocks: {
       [require.resolve('./logger')]: () => log,
       [require.resolve('./settings-store')]: () => ({ loadSettings }),
@@ -296,7 +358,6 @@ describe('ipc-handlers', () => {
       })
     ).resolves.toEqual(success());
     expect(ctx.state.activeBzzBases.has(5)).toBe(false);
-
   });
 
   test('registers window, app, and internal routing handlers', async () => {
@@ -717,9 +778,7 @@ describe('ipc-handlers', () => {
       HOST_RENDERER_URL
     );
 
-    expect(result).toEqual(
-      failure('PROFILE_FOCUS_FAILED', 'The running profile did not respond')
-    );
+    expect(result).toEqual(failure('PROFILE_FOCUS_FAILED', 'The running profile did not respond'));
   });
 
   test('forwards openSettings (edit button) to openOrFocusProfile', async () => {
@@ -964,10 +1023,9 @@ describe('ipc-handlers', () => {
     // The no-ack fallback must probe the lock with an effectively-infinite
     // stale window, so a still-held lock can't read as released merely because
     // its heartbeat lapsed (dev profiles have a 5s stale < the delete wait).
-    expect(ctx.isProfileLocked).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'work' }),
-      { staleMs: Number.MAX_SAFE_INTEGER }
-    );
+    expect(ctx.isProfileLocked).toHaveBeenCalledWith(expect.objectContaining({ id: 'work' }), {
+      staleMs: Number.MAX_SAFE_INTEGER,
+    });
   });
 
   test('updates active profile node config through validated IPC', async () => {
@@ -1267,16 +1325,12 @@ describe('ipc-handlers', () => {
   });
 
   test('copies text and images to the clipboard with error handling', async () => {
-    const emptyImage = {
-      isEmpty: () => true,
-    };
+    const emptyImage = createNativeImageMock({ isEmpty: () => true });
     const ctx = loadIpcHandlersModule({
       nativeImage: {
         createFromBuffer: jest
           .fn()
-          .mockReturnValueOnce({
-            isEmpty: () => false,
-          })
+          .mockReturnValueOnce(createNativeImageMock())
           .mockReturnValueOnce(emptyImage),
       },
     });
@@ -1303,7 +1357,7 @@ describe('ipc-handlers', () => {
     // Webview senders (hostWebContents !== null) must not be able to
     // siphon the user's clipboard without a paste gesture.
     const webviewEvent = { sender: { hostWebContents: { id: 99 } } };
-    expect(ctx.ipcMain.handlers.get('clipboard:read-text')(webviewEvent)).toEqual({
+    await expect(ctx.ipcMain.handlers.get('clipboard:read-text')(webviewEvent)).resolves.toEqual({
       success: false,
       error: 'Untrusted sender',
     });
@@ -1319,7 +1373,11 @@ describe('ipc-handlers', () => {
       success: true,
     });
     expect(ctx.fetchBuffer).toHaveBeenCalledWith('https://example.com/image.png');
+    // Electron 43 still gets `writeImage`, on purpose: its `clipboard.write`
+    // takes a `{ image }` object and silently ignores an array, so routing the
+    // array form here would drop the image with no error at all.
     expect(ctx.clipboard.writeImage).toHaveBeenCalled();
+    expect(ctx.clipboard.write).not.toHaveBeenCalled();
 
     await expect(
       ctx.ipcMain.handlers.get('clipboard:copy-image')({}, 'https://example.com/empty.png')
@@ -1343,6 +1401,114 @@ describe('ipc-handlers', () => {
       '[clipboard] Failed to copy image:',
       expect.any(Error)
     );
+  });
+
+  // Regression coverage for the three clipboard breakages that
+  // docs/audits/electron-44-compatibility-2026-09.md (B2) found on Electron
+  // 44.2.0. They are exercised against a mock of 44's clipboard surface so
+  // they fail here, on the Electron 43 we ship today, rather than only in the
+  // one e2e job that a `npm ci` failure was hiding.
+  describe('clipboard handlers on the Electron 44 clipboard surface', () => {
+    test('clipboard:read-text resolves a structured-cloneable string, never a promise', async () => {
+      const ctx = loadElectron44ClipboardModule({
+        clipboard: createElectron44ClipboardMock({
+          readText: jest.fn(async () => 'from-main-async'),
+        }),
+      });
+      ctx.mod.registerBaseIpcHandlers();
+
+      const result = await ctx.ipcMain.invoke('clipboard:read-text');
+      expect(result).toEqual({ success: true, text: 'from-main-async' });
+      expect(typeof result.text).toBe('string');
+
+      // The real failure mode: an unawaited `readText()` puts a Promise in the
+      // reply, Electron's IPC serializer cannot structured-clone it, and
+      // `ipcRenderer.invoke` never settles — it does not even reject.
+      expect(() => structuredClone(result)).not.toThrow();
+      expect(ctx.clipboard.readText).toHaveBeenCalled();
+    });
+
+    test('clipboard:copy-image writes an image/png ClipboardItem through clipboard.write', async () => {
+      const image = createNativeImageMock();
+      const ctx = loadElectron44ClipboardModule({
+        nativeImage: { createFromBuffer: jest.fn(() => image) },
+      });
+      ctx.mod.registerBaseIpcHandlers();
+
+      // `writeImage` is gone on 44, so calling it throws a TypeError that the
+      // handler's own catch turns into a silent "Copy image" failure.
+      expect(ctx.clipboard.writeImage).toBeUndefined();
+
+      await expect(
+        ctx.ipcMain.invoke('clipboard:copy-image', 'https://example.com/image.png')
+      ).resolves.toEqual({ success: true });
+      expect(ctx.log.error).not.toHaveBeenCalled();
+
+      expect(ctx.clipboard.write).toHaveBeenCalledTimes(1);
+      const [items] = ctx.clipboard.write.mock.calls[0];
+      expect(Array.isArray(items)).toBe(true);
+      expect(items).toHaveLength(1);
+      expect(items[0]).toBeInstanceOf(ClipboardItemMock);
+      expect(items[0].types).toEqual(['image/png']);
+      // `ClipboardItem` payloads must be a string or a Blob — a nativeImage is
+      // rejected outright — so the handler has to encode the image first.
+      expect(image.toPNG).toHaveBeenCalled();
+      const blob = items[0].payload['image/png'];
+      expect(blob).toBeInstanceOf(Blob);
+      expect(blob.type).toBe('image/png');
+      await expect(blob.arrayBuffer().then((b) => Buffer.from(b))).resolves.toEqual(PNG_BYTES);
+    });
+
+    test('clipboard:copy-text only reports success once the write has landed', async () => {
+      let settleWrite;
+      const writeText = jest.fn(
+        () =>
+          new Promise((resolve) => {
+            settleWrite = resolve;
+          })
+      );
+      const ctx = loadElectron44ClipboardModule({
+        clipboard: createElectron44ClipboardMock({ writeText }),
+      });
+      ctx.mod.registerBaseIpcHandlers();
+
+      const pending = ctx.ipcMain.invoke('clipboard:copy-text', 'hello');
+      let settled = false;
+      pending.then(() => {
+        settled = true;
+      });
+
+      // Drain the microtask queue: an unawaited `writeText` would have let the
+      // handler return `{ success: true }` by now, before the write landed.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(writeText).toHaveBeenCalledWith('hello');
+      expect(settled).toBe(false);
+
+      settleWrite();
+      await expect(pending).resolves.toEqual({ success: true });
+    });
+
+    test('clipboard:copy-image surfaces a clipboard.write rejection as a failed result', async () => {
+      const ctx = loadElectron44ClipboardModule({
+        clipboard: createElectron44ClipboardMock({
+          write: jest.fn(async () => {
+            throw new Error('clipboard.write expects an array of ClipboardItem');
+          }),
+        }),
+      });
+      ctx.mod.registerBaseIpcHandlers();
+
+      await expect(
+        ctx.ipcMain.invoke('clipboard:copy-image', 'https://example.com/image.png')
+      ).resolves.toEqual({
+        success: false,
+        error: 'clipboard.write expects an array of ClipboardItem',
+      });
+      expect(ctx.log.error).toHaveBeenCalledWith(
+        '[clipboard] Failed to copy image:',
+        expect.any(Error)
+      );
+    });
   });
 
   test('wires bzz content probe handlers through start/await/cancel', async () => {

--- a/src/main/ipc-handlers.test.js
+++ b/src/main/ipc-handlers.test.js
@@ -1509,6 +1509,68 @@ describe('ipc-handlers', () => {
         expect.any(Error)
       );
     });
+
+    // The text handlers await promises on 44, so they can reject where the
+    // synchronous 43 calls could not. A rejection that escapes the handler
+    // leaves `ipcRenderer.invoke` rejecting instead of replying
+    // `{ success: false, error }`, and the renderer's `navigator.clipboard`
+    // fallback only runs on a falsy `success` — an invoke rejection skips it.
+    test('clipboard:copy-text surfaces a writeText rejection as a failed result', async () => {
+      const ctx = loadElectron44ClipboardModule({
+        clipboard: createElectron44ClipboardMock({
+          writeText: jest.fn(async () => {
+            throw new Error('clipboard unavailable');
+          }),
+        }),
+      });
+      ctx.mod.registerBaseIpcHandlers();
+
+      await expect(ctx.ipcMain.invoke('clipboard:copy-text', 'hello')).resolves.toEqual({
+        success: false,
+        error: 'clipboard unavailable',
+      });
+      expect(ctx.log.error).toHaveBeenCalledWith(
+        '[clipboard] Failed to copy text:',
+        expect.any(Error)
+      );
+    });
+
+    test('clipboard:read-text surfaces a readText rejection as a failed result', async () => {
+      const ctx = loadElectron44ClipboardModule({
+        clipboard: createElectron44ClipboardMock({
+          readText: jest.fn(async () => {
+            throw new Error('clipboard unavailable');
+          }),
+        }),
+      });
+      ctx.mod.registerBaseIpcHandlers();
+
+      await expect(ctx.ipcMain.invoke('clipboard:read-text')).resolves.toEqual({
+        success: false,
+        error: 'clipboard unavailable',
+      });
+      expect(ctx.log.error).toHaveBeenCalledWith(
+        '[clipboard] Failed to read text:',
+        expect.any(Error)
+      );
+    });
+
+    test('clipboard:read-text still rejects a webview sender before touching the clipboard', async () => {
+      const clipboard = createElectron44ClipboardMock({
+        readText: jest.fn(async () => 'secret'),
+      });
+      const ctx = loadElectron44ClipboardModule({ clipboard });
+      ctx.mod.registerBaseIpcHandlers();
+
+      // The trust gate lives outside the new try/catch: a webview sender must
+      // still get the `Untrusted sender` error, not a clipboard read.
+      const webviewEvent = { sender: { hostWebContents: {} } };
+      await expect(ctx.ipcMain.handlers.get('clipboard:read-text')(webviewEvent)).resolves.toEqual({
+        success: false,
+        error: 'Untrusted sender',
+      });
+      expect(clipboard.readText).not.toHaveBeenCalled();
+    });
   });
 
   test('wires bzz content probe handlers through start/await/cancel', async () => {

--- a/src/renderer/lib/chrome-input-context-menu.test.js
+++ b/src/renderer/lib/chrome-input-context-menu.test.js
@@ -247,6 +247,32 @@ describe('chrome-input-context-menu', () => {
     expect(input.value).toBe('hello pastedworld');
   });
 
+  // The other half of the main-process handlers' `{ success, error }` contract:
+  // a clipboard failure has to come back as a resolved falsy `success` so this
+  // fallback runs. If the handler let the rejection escape as an
+  // `ipcRenderer.invoke` rejection instead, `readClipboard` would throw out of
+  // the `void runEditAction(...)` call and Paste would silently do nothing.
+  test('falls back to navigator clipboard read when the electron read reports failure', async () => {
+    const input = createInput('hello world');
+    input.setSelectionRange(6, 6);
+    const { menu } = await loadModule({
+      input,
+      electronAPI: {
+        copyText: jest.fn().mockResolvedValue({ success: true }),
+        readClipboardText: jest
+          .fn()
+          .mockResolvedValue({ success: false, error: 'clipboard unavailable' }),
+      },
+    });
+
+    openContextMenu(input);
+    await clickMenu(menu, 'paste');
+
+    expect(window.electronAPI.readClipboardText).toHaveBeenCalled();
+    expect(navigator.clipboard.readText).toHaveBeenCalled();
+    expect(input.value).toBe('hello pastedworld');
+  });
+
   test('paste uses live caret when right-click did not capture a range', async () => {
     const input = createInput('abcdef');
     // User clicks at caret position 3 with no selection; the right-click


### PR DESCRIPTION
Step 1 of 2 of the Electron 44 upgrade. This clears the **two in-repo blockers**
that [#289](https://github.com/solardev-xyz/freedom-browser/pull/289)'s audit
found (`docs/audits/electron-44-compatibility-2026-09.md`, B1 and B2), on the
**current Electron 43**, so the bump PR that follows can actually run CI end to
end. **Electron itself is deliberately not bumped here**, and no other
dependency is touched.

Two commits, in the order the audit's "proposed sequence" recommends.

## B1 — `chore(deps): refresh node-abi so the registry knows Electron 44` (`9fa85465`)

`node-abi` is transitive (`electron-builder` → `app-builder-lib` →
`@electron/rebuild`, which declares `node-abi: ^4.2.0`). The lockfile pinned
`4.32.0`, whose ABI registry stops at Electron 43 / ABI 148, so on an Electron
44 branch `getAbi()` throws before a single native module is examined:

```
Could not detect abi for version 44.2.0 and runtime electron.
Updating "node-abi" might help solve this issue if it is a new release of electron
```

That is what killed all 16 `npm ci` CI jobs on #289 at the *install* step, on
ubuntu, macOS and Windows alike — which is why CI could not observe B2 at all.

`npm update node-abi`, lockfile only. `package.json` is untouched.

| | before | after |
| --- | --- | --- |
| `node-abi` | 4.32.0 | 4.35.0 (4.33.0 added Electron 44; inside the existing `^4.2.0`) |
| `node-abi` (nested under `prebuild-install`, `^3.3.0`) | 3.93.0 | 3.96.0 |

## B2 — `fix(main): port the clipboard IPC to the Electron 44 clipboard contract` (`e8ee81f1`)

Electron 44.0 rearchitected the main-process `clipboard` module around the W3C
Clipboard API. Our three call sites in `src/main/ipc-handlers.js` each break
differently:

| channel | what 44 does | user-visible effect | fix |
| --- | --- | --- | --- |
| `clipboard:read-text` | `readText()` returns a Promise; the reply carried `{ success: true, text: <Promise> }`, which the IPC serializer cannot structured-clone | `ipcRenderer.invoke` **never settles** — neither resolves nor rejects. Address-bar context-menu **Paste** silently does nothing | `await` it |
| `clipboard:copy-image` | `writeImage`/`readImage` removed outright | `TypeError` swallowed by the handler's own `catch` → **"Copy image" always fails** | `clipboard.write([new ClipboardItem({ 'image/png': <Blob> })])` |
| `clipboard:copy-text` | `writeText()` returns an unawaited Promise | reports `{ success: true }` **before the write lands** | `await` it |

**Correct on both 43 and 44.** Awaiting the two text calls needs no branching —
on 43 they return plain values and `await` passes those straight through.

The image write does need a branch, and it is **not cosmetic**: the naive "just
use the array form everywhere" port fails *silently* on 43, because 43's
`clipboard.write(data)` takes a `{ text, html, image, … }` object and quietly
ignores an array. Probed on a real 43.6.0 main process:

```
electron 43.6.0   write({ image })              -> ok, readImage() = HAS-IMAGE {"width":1,"height":1}
electron 43.6.0   write([{ 'image/png': img }]) -> ok, readImage() = EMPTY          <-- silent data loss
electron 44.2.0   write({ image })              -> THREW: clipboard.write expects an array of ClipboardItem
electron 44.2.0   write([{ 'image/png': img }]) -> THREW: clipboard.write expects an array of ClipboardItem
electron 44.2.0   write([new ClipboardItem({ 'image/png': <Blob> })]) -> ok, read() types ["image/png"]
```

So `writeImageToClipboard()` picks the shape from what the running Electron
actually exposes, preferring the 44 form and falling back to `writeImage` while
it is still there. `ClipboardItem` payloads must be a string or a Blob (a
`nativeImage` is rejected: *"ClipboardItem payload values must be a string or a
Blob"*), hence the `image.toPNG()` encode after the existing `isEmpty()`
validation. `ClipboardItem` is exported from the `electron` module on 44 — it is
**not** a global in the main process.

**Renderer contract unchanged.** Same IPC channel names, same arguments, same
`{ success, text?, error? }` replies. `preload.js`, `chrome-input-context-menu.js`
and `page-context-menu.js` already `await` these calls, so none of them needed a
change and their tests pass unmodified. Sibling sweep: grepped every remaining
main-process `clipboard.*` call site — `ipc-handlers.js` is the only one; the
`webview-preload.js` and `github-bridge-ui.js` hits are `navigator.clipboard`
(the web API), which 44 does not touch.

### Tests

The old mock was the reason the unit suite stayed green while the real app was
broken — it modelled only the synchronous 43 surface, so all three regressions
passed straight through it. There are now two mock shapes:
`createElectron43ClipboardMock` (synchronous, has `writeImage`) guards
back-compat on the Electron we ship, and `createElectron44ClipboardMock`
(promise-returning `writeText`/`readText`, **no** `writeImage`/`readImage`, with
a `ClipboardItem` injected through the electron mock) carries one new regression
test per audit finding, plus a `clipboard.write`-rejection path. The pre-existing
test also now asserts 43 does **not** get the array form.

## Verification

| step | result |
| --- | --- |
| `npm ci` (Electron 43, refreshed lockfile) | **PASS** — exit 0, `electron-builder install-app-deps` completes |
| `git diff --stat package-lock.json` | 1 file, 6+/6- — **both hunks are `node-abi`**, nothing else moved |
| `npm run lint` | **PASS** — exit 0 |
| `npm test` | **PASS** — 3784 passed / 197 suites, **0 failed** |
| `npx playwright test --project=harness` (full, xvfb) | 98 passed, 4 skipped, 2 failed — **both pre-existing/flake, neither clipboard** (see below) |
| `address-bar-clipboard.spec.js` on Electron **43.0.0** | **4 passed** |
| `address-bar-clipboard.spec.js` on Electron **44.2.0**, pre-fix | **1 failed, 3 passed** — reproduces the audit's failure exactly |
| `address-bar-clipboard.spec.js` on Electron **44.2.0**, post-fix | **4 passed** |

**node-abi, before/after** (`getAbi(v, 'electron')`):

```
4.32.0:  43.0.0 -> 148    44.2.0 -> THREW "Could not detect abi for version 44.2.0"
4.35.0:  43.0.0 -> 148    44.2.0 -> 149    (43.6.0 -> 148 unchanged)
```

**Mutation-tested every new assertion** against a real revert — each mutation
fails **only** its own test, and the pre-existing test passes under the first
three, which is precisely why it never caught them:

| mutation | fails |
| --- | --- |
| un-`await` `readText` | only *"resolves a structured-cloneable string, never a promise"* |
| restore `clipboard.writeImage(image)` | only *"writes an image/png ClipboardItem through clipboard.write"* |
| un-`await` `writeText` | only *"only reports success once the write has landed"* |
| force the array form on the 43 mock | only the pre-existing back-compat test |

**Real Electron 44.2.0 run.** `node_modules/electron` was swapped for 44.2.0
locally (nothing committed, restored afterwards) and the clipboard spec run
before and after the fix:

```
PRE-FIX  ✘ 3 chrome context menu cut, copy, paste, and select all
           Timeout 7500ms exceeded while waiting on the predicate
             at expectRendererClipboard (address-bar-clipboard.spec.js:30:6)
         1 failed, 3 passed          <-- same line, same shape as the audit
POST-FIX ✓ 1 ✓ 2 ✓ 3 ✓ 4            4 passed
```

**Acceptance evidence, both majors.** A scratch probe (deleted before commit)
drove the *real* IPC path from the renderer against a local PNG server —
`copy-image` is not covered by the e2e suite, so this is the only thing that
exercises it end to end:

```
electron 44.2.0   copyImageFromUrl -> {"success":true}
                  clipboard read back -> {"via":"read","types":["image/png"],"bytes":153}
                  copyText -> {"success":true}; readText immediately = "e44-acceptance" (no polling)
                  readClipboardText -> {"success":true,"text":"e44-acceptance"}
electron 43.0.0   copyImageFromUrl -> {"success":true}
                  clipboard read back -> {"via":"readImage","empty":false,"size":{"width":16,"height":16}}
electron 44.2.0, PRE-FIX
                  copyImageFromUrl -> {"success":false,"error":"clipboard.writeImage is not a function"}
```

### The two full-suite e2e failures

Neither is this PR.

- `chrome-input-focus.spec.js:146` — **flake under full-suite load**; passes on
  re-run in isolation.
- `settings-adblock.spec.js:30` (`#adblock-status` never reaches "Filter lists")
  — **pre-existing on `main`**: reproduced at base commit `2d7ea9a9` with this
  branch's changes reverted, same failure, same line.

## Not in this PR

Per the audit's sequence: no Electron bump, no `keccak` `binding.gyp` pruning
(#204), no `freedom-ipfs` asset rename. The follow-up bump PR still owes the
cross-platform / cross-arch packaging pass (a real mac(arm64)→win(x64) run, not
a same-arch build — PR #197) and the Chromium 152 manual smoke list.
