### PR TITLE
fix(tabs): Chrome parity for link dispositions, tab-switch focus, strip overflow, private new tab and menu dismissal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,6 +503,50 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  # Tab activation, link dispositions and menu dismissal are all about *focus*
+  # — which of the shell and the guest `<webview>` owns the keyboard — and no
+  # unit test can see that: it is decided by the real Chromium focus tree.
+  # These two specs are the only place it is asserted, and they ran locally
+  # only until a focus regression in one shipped green through the curated
+  # list above (the `<webview>` holding focus after a tab switch swallowed the
+  # Escape that dismisses the page context menu; caught by hand, not by CI).
+  e2e-tabs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install Linux native USB build dependency
+        uses: ./.github/actions/install-linux-native-deps
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright system dependencies
+        uses: ./.github/actions/install-playwright-deps
+
+      - name: Run tabs + onchain-apps E2E
+        run: xvfb-run -a npm run test:e2e -- test-e2e/tabs.spec.js test-e2e/onchain-apps.spec.js
+
+      - name: Upload Playwright traces and screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-tabs-traces
+          path: |
+            test-results/
+            playwright-report/
+          if-no-files-found: ignore
+          retention-days: 14
+
   # Onboarding wizard must create node identities while a real Swarm node (now
   # antd) is running. Drives the full password wizard end-to-end against a real
   # antd spawn across all three desktop platforms — the cross-platform proof

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -183,7 +183,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('tab:close', handler);
   },
   onNewTabWithUrl: (callback) => {
-    const handler = (_event, url, targetName) => callback(url, targetName);
+    // `options` carries the link disposition Chromium reported
+    // (`{ background, newWindow }`); senders that don't set one send nothing
+    // and get the default foreground tab. See #303.
+    const handler = (_event, url, targetName, options) => callback(url, targetName, options || {});
     ipcRenderer.on('tab:new-with-url', handler);
     return () => ipcRenderer.removeListener('tab:new-with-url', handler);
   },

--- a/src/main/preload.test.js
+++ b/src/main/preload.test.js
@@ -236,7 +236,22 @@ describe('preload', () => {
     const listenerCases = [
       [exposures.electronAPI, 'onNewTab', 'tab:new', [], []],
       [exposures.electronAPI, 'onCloseTab', 'tab:close', [], []],
-      [exposures.electronAPI, 'onNewTabWithUrl', 'tab:new-with-url', ['https://example.com', 'named-target'], ['https://example.com', 'named-target']],
+      // The 4th IPC arg is the link disposition (#303); a sender that omits it
+      // reaches the callback as an empty object, i.e. a foreground tab.
+      [
+        exposures.electronAPI,
+        'onNewTabWithUrl',
+        'tab:new-with-url',
+        ['https://example.com', 'named-target'],
+        ['https://example.com', 'named-target', {}],
+      ],
+      [
+        exposures.electronAPI,
+        'onNewTabWithUrl',
+        'tab:new-with-url',
+        ['https://example.com', null, { background: true, newWindow: false }],
+        ['https://example.com', null, { background: true, newWindow: false }],
+      ],
       [exposures.electronAPI, 'onProfileUpdated', IPC.PROFILE_UPDATED, [{ id: 'work', displayName: 'Work' }], [{ id: 'work', displayName: 'Work' }]],
       [exposures.electronAPI, 'onExternalNodeCandidates', IPC.PROFILE_EXTERNAL_CANDIDATES, [{ requestId: 'req-1' }], [{ requestId: 'req-1' }]],
       [exposures.electronAPI, 'onNavigateToUrl', 'navigate-to-url', ['bzz://hash'], ['bzz://hash']],

--- a/src/main/webcontents-setup.js
+++ b/src/main/webcontents-setup.js
@@ -141,9 +141,10 @@ function registerWebContentsHandlers() {
         }
       });
 
-      contents.setWindowOpenHandler(({ url, frameName }) => {
+      contents.setWindowOpenHandler(({ url, frameName, disposition }) => {
         log.info(
-          `${tag} intercepted new window request: ${navUrlForLog(contents, url)} (target: ${frameName || 'none'})`
+          `${tag} intercepted new window request: ${navUrlForLog(contents, url)} ` +
+            `(target: ${frameName || 'none'}, disposition: ${disposition || 'default'})`
         );
         // Contract-hosted pages are not allowed to create windows themselves.
         // Trusted anchor activations are intercepted in webview-preload and
@@ -158,7 +159,19 @@ function registerWebContentsHandlers() {
           // Pass targetName for named link targets (e.g. target="mywindow")
           // Skip special targets (_blank, _self, _parent, _top) - they should use default behavior
           const isNamedTarget = frameName && !frameName.startsWith('_');
-          parentWindow.webContents.send('tab:new-with-url', url, isNamedTarget ? frameName : null);
+          // Chromium already resolved the activation's modifiers into a
+          // disposition: Ctrl/Cmd+click (and middle-click) give
+          // `background-tab`, Shift+click and sized `window.open` popups give
+          // `new-window`, a plain `target="_blank"` gives `foreground-tab`.
+          // Forward it instead of collapsing everything into a foreground tab
+          // the way this handler used to — that switched the user off the page
+          // they were reading on every Ctrl+click. See #303. The renderer turns
+          // `newWindow` back into the existing `window:new-with-url` request,
+          // which is where the private-window guard lives.
+          parentWindow.webContents.send('tab:new-with-url', url, isNamedTarget ? frameName : null, {
+            background: disposition === 'background-tab',
+            newWindow: disposition === 'new-window',
+          });
         }
         return { action: 'deny' };
       });

--- a/src/main/webcontents-setup.test.js
+++ b/src/main/webcontents-setup.test.js
@@ -137,7 +137,8 @@ describe('webcontents-setup', () => {
     expect(parentWindow.webContents.send).toHaveBeenCalledWith(
       'tab:new-with-url',
       'https://github.com/openai/project',
-      'named-tab'
+      'named-tab',
+      { background: false, newWindow: false }
     );
 
     const blankResult = contents.windowOpenHandler({
@@ -148,10 +149,62 @@ describe('webcontents-setup', () => {
     expect(parentWindow.webContents.send).toHaveBeenLastCalledWith(
       'tab:new-with-url',
       'https://example.com',
-      null
+      null,
+      { background: false, newWindow: false }
     );
     expect(ctx.log.info).toHaveBeenCalledWith(
       expect.stringContaining('intercepted new window request')
+    );
+  });
+
+  // #303: Chromium resolves the activation's modifiers into a disposition
+  // before it reaches this handler. Ctrl/Cmd+click and middle-click give
+  // `background-tab`, Shift+click (and sized `window.open` popups) give
+  // `new-window`. Both used to be collapsed into a foreground tab.
+  test('forwards the link disposition so modified clicks open in the background or a window', () => {
+    const parentWindow = { webContents: { id: 1, send: jest.fn() } };
+    const ctx = loadWebContentsSetupModule({ windows: [parentWindow] });
+    const contents = createContentsMock({ id: 23, type: 'webview', url: 'https://example.com/' });
+
+    ctx.mod.registerWebContentsHandlers();
+    ctx.app.emit('web-contents-created', {}, contents);
+
+    expect(
+      contents.windowOpenHandler({
+        url: 'https://example.com/bg',
+        frameName: '',
+        disposition: 'background-tab',
+      })
+    ).toEqual({ action: 'deny' });
+    expect(parentWindow.webContents.send).toHaveBeenLastCalledWith(
+      'tab:new-with-url',
+      'https://example.com/bg',
+      null,
+      { background: true, newWindow: false }
+    );
+
+    contents.windowOpenHandler({
+      url: 'https://example.com/win',
+      frameName: '',
+      disposition: 'new-window',
+    });
+    expect(parentWindow.webContents.send).toHaveBeenLastCalledWith(
+      'tab:new-with-url',
+      'https://example.com/win',
+      null,
+      { background: false, newWindow: true }
+    );
+
+    contents.windowOpenHandler({
+      url: 'https://example.com/fg',
+      frameName: '',
+      disposition: 'foreground-tab',
+    });
+    expect(parentWindow.webContents.send).toHaveBeenLastCalledWith(
+      'tab:new-with-url',
+      'https://example.com/fg',
+      null,
+      { background: false, newWindow: false }
     );
   });
 
@@ -349,7 +402,8 @@ describe('webcontents-setup', () => {
       expect(live.webContents.send).toHaveBeenCalledWith(
         'tab:new-with-url',
         'https://example.com/popup',
-        null
+        null,
+        { background: false, newWindow: false }
       );
       expect(dying.webContents.send).not.toHaveBeenCalled();
     });

--- a/src/main/webview-preload.js
+++ b/src/main/webview-preload.js
@@ -280,13 +280,18 @@ const handleDwebLinkActivation = (event) => {
   // dispatching a synthetic click is equivalent to a scripted redirect.
   if (globalThis.location?.protocol === 'web3:' && event.isTrusted !== true) return;
 
-  // Mirror Chromium's link disposition heuristic: middle-click,
-  // ctrl/cmd-click, shift-click, or `target="_blank"` open in a new tab;
-  // a named `target` (anything not starting with `_`) reuses an existing
-  // tab with that name (or opens a new one if none exists); everything
-  // else navigates the current tab. (We don't distinguish foreground vs
-  // background tab here — same as freedom's existing `tab:new-with-url`
-  // flow which always opens foreground.)
+  // Mirror Chromium's link disposition heuristic (#303):
+  //
+  //   Ctrl/Cmd+click, middle-click        → background tab (stay on this page)
+  //   Ctrl/Cmd+Shift+click, Shift+middle  → foreground tab
+  //   Shift+click                         → new window
+  //   target="_blank" / named target      → foreground tab
+  //   anything else                       → this tab
+  //
+  // The modifiers win over the target attribute for foreground-vs-background,
+  // as in Chrome: Ctrl+clicking a `target="_blank"` link still leaves you on
+  // the current page. A named target is still forwarded in every case so the
+  // renderer can reuse that name's tab.
   //
   // The target attribute is forwarded so the host renderer can route
   // through the same named-tab reuse path that Chromium's
@@ -299,18 +304,24 @@ const handleDwebLinkActivation = (event) => {
   const target = anchor.getAttribute?.('target') || '';
   const isBlank = /^_blank$/i.test(target);
   const isNamedTarget = target && !target.startsWith('_');
-  const wantsNewTab =
-    event.button === 1 ||
-    event.metaKey ||
-    event.ctrlKey ||
-    event.shiftKey ||
-    isBlank ||
-    isNamedTarget;
+  const isMiddleClick = event.button === 1;
+  const wantsNewTab = isMiddleClick || event.metaKey || event.ctrlKey;
+
+  let disposition;
+  if (wantsNewTab) {
+    disposition = event.shiftKey ? 'newTab' : 'newBackgroundTab';
+  } else if (event.shiftKey) {
+    disposition = 'newWindow';
+  } else if (isBlank || isNamedTarget) {
+    disposition = 'newTab';
+  } else {
+    disposition = 'currentTab';
+  }
 
   event.preventDefault();
   ipcRenderer.sendToHost('link:navigate', {
     url: href,
-    disposition: wantsNewTab ? 'newTab' : 'currentTab',
+    disposition,
     target: target || null,
   });
 };

--- a/src/main/webview-preload.test.js
+++ b/src/main/webview-preload.test.js
@@ -600,7 +600,7 @@ describe('webview-preload', () => {
     });
   });
 
-  test('intercepts modified clicks and target=_blank with newTab disposition', () => {
+  test('resolves modifiers into Chrome dispositions (background tab, foreground tab, new window)', () => {
     const makeAnchor = (target = '') => ({
       tagName: 'A',
       getAttribute: jest.fn((name) => {
@@ -617,15 +617,81 @@ describe('webview-preload', () => {
     // (UI Events spec). A previous implementation listened only to
     // `click` and checked `event.button === 1` inside, which is dead
     // code for real middle-clicks; fixed by registering both listeners.
+    // Dispositions match Chrome (#303): Ctrl/Cmd+click and middle-click open a
+    // BACKGROUND tab (you stay on the page you are reading), adding Shift
+    // promotes it to the foreground, and a bare Shift+click opens a window.
+    // Every one of these used to collapse into a single foreground `newTab`.
     const cases = [
-      { label: 'cmd-click', dispatchEvent: 'click', overrides: { metaKey: true } },
-      { label: 'ctrl-click', dispatchEvent: 'click', overrides: { ctrlKey: true } },
-      { label: 'shift-click', dispatchEvent: 'click', overrides: { shiftKey: true } },
-      { label: 'middle-click', dispatchEvent: 'auxclick', overrides: { button: 1 } },
-      { label: 'target=_blank', dispatchEvent: 'click', overrides: {}, target: '_blank' },
+      {
+        label: 'cmd-click',
+        dispatchEvent: 'click',
+        overrides: { metaKey: true },
+        expected: 'newBackgroundTab',
+      },
+      {
+        label: 'ctrl-click',
+        dispatchEvent: 'click',
+        overrides: { ctrlKey: true },
+        expected: 'newBackgroundTab',
+      },
+      {
+        label: 'ctrl-shift-click',
+        dispatchEvent: 'click',
+        overrides: { ctrlKey: true, shiftKey: true },
+        expected: 'newTab',
+      },
+      {
+        label: 'cmd-shift-click',
+        dispatchEvent: 'click',
+        overrides: { metaKey: true, shiftKey: true },
+        expected: 'newTab',
+      },
+      {
+        label: 'shift-click',
+        dispatchEvent: 'click',
+        overrides: { shiftKey: true },
+        expected: 'newWindow',
+      },
+      {
+        label: 'middle-click',
+        dispatchEvent: 'auxclick',
+        overrides: { button: 1 },
+        expected: 'newBackgroundTab',
+      },
+      {
+        label: 'shift-middle-click',
+        dispatchEvent: 'auxclick',
+        overrides: { button: 1, shiftKey: true },
+        expected: 'newTab',
+      },
+      {
+        label: 'target=_blank',
+        dispatchEvent: 'click',
+        overrides: {},
+        target: '_blank',
+        expected: 'newTab',
+      },
+      {
+        // Modifiers beat the target attribute, as in Chrome: Ctrl+clicking a
+        // `target="_blank"` link still leaves you on the current page.
+        label: 'ctrl-click on target=_blank',
+        dispatchEvent: 'click',
+        overrides: { ctrlKey: true },
+        target: '_blank',
+        expected: 'newBackgroundTab',
+      },
+      {
+        // A named target keeps its name in every disposition so the renderer's
+        // tab-reuse path still fires.
+        label: 'ctrl-click on a named target',
+        dispatchEvent: 'click',
+        overrides: { ctrlKey: true },
+        target: 'docs',
+        expected: 'newBackgroundTab',
+      },
     ];
 
-    for (const { label, dispatchEvent, overrides, target = '' } of cases) {
+    for (const { label, dispatchEvent, overrides, target = '', expected } of cases) {
       const { documentCaptureHandlers, ipcRenderer } = loadWebviewPreloadModule();
       const event = {
         target: makeAnchor(target),
@@ -640,12 +706,14 @@ describe('webview-preload', () => {
       };
       documentCaptureHandlers[dispatchEvent](event);
       expect(event.preventDefault).toHaveBeenCalled();
-      expect(ipcRenderer.sendToHost).toHaveBeenCalledWith('link:navigate', {
+      // `label` names the failing case in the assertion message.
+      expect({ label, ...ipcRenderer.sendToHost.mock.calls[0][1] }).toEqual({
+        label,
         url: 'ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG',
-        disposition: 'newTab',
+        disposition: expected,
         target: target || null,
       });
-      void label;
+      expect(ipcRenderer.sendToHost.mock.calls[0][0]).toBe('link:navigate');
     }
   });
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -4081,7 +4081,10 @@
     </div>
 
     <!-- Page Context Menu -->
-    <div id="page-context-menu" class="context-menu hidden">
+    <!-- `tabindex="-1"` so the menu can take the keyboard away from the guest
+         page it was raised over: an Escape that lands in the `<webview>` never
+         reaches the shell's keydown handler. Not tab-reachable. -->
+    <div id="page-context-menu" class="context-menu hidden" tabindex="-1">
       <!-- Page actions (shown when clicking on page background) -->
       <div class="context-menu-group" data-group="page">
         <button class="context-menu-item" data-action="back">Back</button>

--- a/src/renderer/lib/navigation-utils-helpers.test.js
+++ b/src/renderer/lib/navigation-utils-helpers.test.js
@@ -148,6 +148,38 @@ describe('navigation-utils extracted helpers', () => {
     });
   });
 
+  // #312: a private window's start page is that window's new-tab page, so it
+  // derives to an EMPTY address bar — like the home page, and unlike every
+  // other internal page, which derives to its `freedom://<page>` name. Chrome
+  // shows an empty omnibox on the Incognito NTP too.
+  test('derives an empty address bar for the private start page, both forms', async () => {
+    const mod = await loadNavigationUtils({
+      home: 'home.html',
+      private: 'private.html',
+      settings: 'settings.html',
+    });
+    const common = {
+      bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+      homeUrlNormalized: 'file:///app/pages/home.html',
+    };
+
+    // Resolved form (committed by Chromium once the page loads).
+    expect(mod.deriveSwitchedTabDisplay({ url: 'file:///app/pages/private.html', ...common })).toBe(
+      ''
+    );
+    expect(mod.deriveDisplayAddress({ url: 'file:///app/pages/private.html', ...common })).toBe('');
+
+    // Friendly form (what `tab.url` carries while the tab is still resolving —
+    // this is the one that produced `freedom://private` in the address bar).
+    expect(mod.deriveSwitchedTabDisplay({ url: 'freedom://private', ...common })).toBe('');
+    expect(mod.deriveDisplayAddress({ url: 'freedom://private', ...common })).toBe('');
+
+    // Other internal pages are unaffected.
+    expect(
+      mod.deriveSwitchedTabDisplay({ url: 'file:///app/pages/settings.html', ...common })
+    ).toBe('freedom://settings');
+  });
+
   test('derives switched tab display values for loading, internal pages, and view-source', async () => {
     const mod = await loadNavigationUtils({
       history: 'history.html',

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -10,6 +10,7 @@ import {
   getOnchainInterstitialTarget,
   isErrorPageUrl,
   isInterstitialPageUrl,
+  isNewTabPageUrl,
   isOnchainInterstitialPageUrl,
   parseEnsInput,
 } from './page-urls.js';
@@ -457,6 +458,14 @@ export const deriveDisplayAddress = ({
   radicleApiPrefix = null,
   knownEnsNames = new Map(),
 } = {}) => {
+  // A new-tab page derives to an empty address bar. `deriveDisplayValue`
+  // already does that for the home page (it compares against
+  // `homeUrlNormalized`), but the private window's start page is an internal
+  // page like any other and would otherwise paint its own `file://…` path —
+  // or, via the internal-page branch above, `freedom://private`. Chrome's
+  // Incognito NTP shows an empty omnibox, same as the normal NTP. See #312.
+  if (isNewTabPageUrl(url)) return '';
+
   const display = deriveDisplayValue(
     url,
     bzzRoutePrefix,
@@ -588,8 +597,13 @@ export const deriveSwitchedTabDisplay = ({
   // active-tab did-navigate handler, which derives the address bar from the
   // error page's `url` param.
   const urlToDerive = getOriginalUrlFromErrorPage(strippedUrl) || strippedUrl;
+  // New-tab pages (home, and the private window's start page) show an empty
+  // address bar rather than their `freedom://<page>` name — see #312 and
+  // `isNewTabPageUrl`. `home` reached the same empty result by falling through
+  // to `deriveDisplayAddress`; `private` did not.
+  if (isNewTabPageUrl(urlToDerive)) return '';
   const internalPageName = getInternalPageName(urlToDerive);
-  if (internalPageName && internalPageName !== 'home') {
+  if (internalPageName) {
     return `freedom://${internalPageName}`;
   }
 

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -58,6 +58,7 @@ import {
   getInterstitialDisplayName,
   isErrorPageUrl,
   isInterstitialPageUrl,
+  isNewTabPageUrl,
   isOnchainInterstitialPageUrl,
   isTrustInterstitialPageUrl,
   parseEnsInput,
@@ -1888,9 +1889,12 @@ const handleNavigationEvent = (event) => {
       return;
     }
 
-    // Check for internal pages first
+    // Check for internal pages first. New-tab pages (`home`, and the private
+    // window's start page) are excluded: they fall through to the generic
+    // derivation below, which resolves them to an empty address bar — Chrome
+    // shows an empty omnibox on both its NTP and its Incognito NTP. See #312.
     const internalPageName = getInternalPageName(event.url);
-    if (internalPageName && internalPageName !== 'home') {
+    if (internalPageName && !isNewTabPageUrl(event.url)) {
       addressInput.value = `freedom://${internalPageName}`;
       pushDebug(`[AddressBar] Internal page: freedom://${internalPageName}`);
       electronAPI?.setWindowTitle?.(
@@ -2419,7 +2423,17 @@ export const initNavigation = () => {
           const payload = data.args?.[0] || {};
           const url = payload.url;
           if (url) {
-            const disposition = payload.disposition === 'newTab' ? 'newTab' : 'currentTab';
+            // Dispositions mirror Chrome's link heuristic, resolved in
+            // webview-preload from the activation's modifiers: `newTab`
+            // (foreground — plain `target="_blank"`, Ctrl+Shift+click,
+            // Shift+middle-click), `newBackgroundTab` (Ctrl/Cmd+click,
+            // middle-click), `newWindow` (Shift+click). Anything else is a
+            // same-tab navigation. See #303.
+            const disposition = ['newTab', 'newBackgroundTab', 'newWindow'].includes(
+              payload.disposition
+            )
+              ? payload.disposition
+              : 'currentTab';
             const rawTarget = typeof payload.target === 'string' ? payload.target : '';
             // Mirrors webcontents-setup.js: only names without a
             // leading underscore are tracked as named targets. `_blank`,
@@ -2431,7 +2445,12 @@ export const initNavigation = () => {
                 (namedTarget ? `, target=${namedTarget}` : '') +
                 ')'
             );
-            if (disposition === 'newTab') {
+            if (disposition === 'newWindow') {
+              // Shift+click. Same main-process route (and same private-window
+              // guard on the sender) the page context menu's "Open Link in
+              // New Window" already uses.
+              electronAPI?.openUrlInNewWindow?.(url);
+            } else if (disposition === 'newTab' || disposition === 'newBackgroundTab') {
               // Mirrors the Chromium → setWindowOpenHandler →
               // tab:new-with-url path, but with the raw mixed-case href
               // intact. openInNewTabWithTarget routes through createTab
@@ -2440,7 +2459,9 @@ export const initNavigation = () => {
               // same way as a same-tab navigation, AND named targets
               // reuse their existing tab instead of always opening a
               // new one.
-              openInNewTabWithTarget(url, namedTarget);
+              openInNewTabWithTarget(url, namedTarget, {
+                background: disposition === 'newBackgroundTab',
+              });
             } else {
               loadTarget(url, null, webview);
             }
@@ -2517,14 +2538,31 @@ export const initNavigation = () => {
           }
           tabNavState.isWebviewLoading = isLoading;
           reloadBtn.dataset.state = isLoading ? 'stop' : 'reload';
-          // Focus address bar only for new empty tabs (home page)
-          // Don't focus for: view-source, links opened in new tab/window, etc.
+          // Where focus lands on a NEW tab. tabs.js focuses the page itself for
+          // every other kind of activation (#304) but defers this case here,
+          // because only the address-bar derivation knows whether the tab
+          // landed on this window's new-tab page.
+          //
+          // - New-tab page (the home page in a normal window, the private start
+          //   page in a private window — `isNewTabPageUrl`; before #312 the
+          //   private form failed this test, so a private new tab left focus on
+          //   <body> with nowhere to type): focus the address bar, as Chrome
+          //   does on both its NTP and its Incognito NTP.
+          // - Anything else (a link opened in a new foreground tab,
+          //   view-source, …): focus the page, so focus is never stranded on
+          //   the outgoing tab's now-hidden webview.
           const isEmptyNewTab =
-            !isViewingSource &&
-            !addressInput.value &&
-            (url === homeUrl || url === homeUrlNormalized || !url);
-          if (data.isNewTab && isEmptyNewTab) {
-            addressInput.focus();
+            !isViewingSource && !addressInput.value && (isNewTabPageUrl(url) || !url);
+          if (data.isNewTab) {
+            if (isEmptyNewTab) {
+              addressInput.focus();
+              // Match the explicit focus-address-bar shortcut (tabs.js), which
+              // focuses *and* selects; a no-op while the value is empty, but
+              // the two paths should not differ.
+              addressInput.select();
+            } else {
+              data.tab.webview?.focus?.();
+            }
           }
           // Update favicon for the switched-to tab (in case it wasn't set)
           if (!data.tab.favicon && display && !display.startsWith('freedom://')) {

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -2720,8 +2720,9 @@ export const initNavigation = () => {
           }
           tabNavState.isWebviewLoading = isLoading;
           reloadBtn.dataset.state = isLoading ? 'stop' : 'reload';
-          // Where focus lands on a NEW tab. tabs.js focuses the page itself for
-          // every other kind of activation (#304) but defers this case here,
+          // Where focus lands on a NEW tab, and on a switch back to a tab that
+          // is sitting on the new-tab page. tabs.js focuses the page itself for
+          // every other kind of activation (#304) but defers these two here,
           // because only the address-bar derivation knows whether the tab
           // landed on this window's new-tab page.
           //
@@ -2733,9 +2734,20 @@ export const initNavigation = () => {
           // - Anything else (a link opened in a new foreground tab,
           //   view-source, …): focus the page, so focus is never stranded on
           //   the outgoing tab's now-hidden webview.
+          //
+          // Switching *back* to a tab already on the new-tab page takes the
+          // same rule: `home.html`/`private.html` have no focus target, so
+          // handing that guest the keyboard drops whatever the user types
+          // next. A tab carrying an uncommitted draft is excluded — the #314
+          // branch above already focused the bar *and* restored its selection,
+          // and re-focusing would only drop the selection. The condition is
+          // the exact complement of tabs.js' `switchTab` guard; keep the two
+          // in step or a switch ends up with the keyboard nowhere.
           const isEmptyNewTab =
             !isViewingSource && !addressInput.value && (isNewTabPageUrl(url) || !url);
-          if (data.isNewTab) {
+          const ownsFocusForThisSwitch =
+            data.isNewTab || (!isAddressBarEditInProgress(tabNavState) && isNewTabPageUrl(url));
+          if (ownsFocusForThisSwitch) {
             if (isEmptyNewTab) {
               addressInput.focus();
               // Match the explicit focus-address-bar shortcut (tabs.js), which

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -66,6 +66,7 @@ const loadNavigationModule = async (options = {}) => {
 
   const homeUrl = 'file:///app/pages/home.html';
   const historyUrl = 'file:///app/pages/history.html';
+  const privateUrl = 'file:///app/pages/private.html';
   const errorUrlBase = 'file:///app/pages/error.html';
   // Mirrors `page-urls.js`: chrome pages are matched on the shell's own
   // resolved `pages/<file>` base, never a `/<file>.html` substring, so a
@@ -169,7 +170,11 @@ const loadNavigationModule = async (options = {}) => {
     deriveDisplayAddress: jest.fn(({ url }) => `display:${url}`),
     deriveSwitchedTabDisplay: jest.fn(
       ({ url, isLoading, addressBarSnapshot }) =>
-        (isLoading && addressBarSnapshot) || (url ? `switched:${url}` : '')
+        (isLoading && addressBarSnapshot) ||
+        // Mirrors the real helper on the one branch the focus rule depends on:
+        // a new-tab page (home, or a private window's start page) derives to an
+        // EMPTY address bar, not to its `freedom://<page>` name (#312).
+        (url && !pageUrlsMocks.isNewTabPageUrl(url) ? `switched:${url}` : '')
     ),
     extractEnsResolutionMetadata: jest.fn(() => ({
       knownEnsPairs: [],
@@ -314,6 +319,7 @@ const loadNavigationModule = async (options = {}) => {
     internalPages: {
       history: historyUrl,
       settings: 'file:///app/pages/settings.html',
+      private: privateUrl,
     },
     detectProtocol: jest.fn(() => 'https'),
     isHistoryRecordable: jest.fn((displayUrl, internalUrl) => {
@@ -324,7 +330,22 @@ const loadNavigationModule = async (options = {}) => {
         !matchesInternalPage(internalUrl, errorUrlBase)
       );
     }),
-    getInternalPageName: jest.fn((url) => (url === historyUrl ? 'history' : null)),
+    getInternalPageName: jest.fn((url) => {
+      if (url === historyUrl) return 'history';
+      if (url === privateUrl) return 'private';
+      if (url === homeUrl) return 'home';
+      return null;
+    }),
+    // Mirrors `page-urls.js#isNewTabPageUrl`: the home page and the private
+    // window's start page, in both the friendly `freedom://` form and the
+    // resolved `file://` one (#312).
+    isNewTabPageUrl: jest.fn(
+      (url) =>
+        url === homeUrl ||
+        url === privateUrl ||
+        url === 'freedom://home' ||
+        url === 'freedom://private'
+    ),
     getOnchainInterstitialTarget: jest.fn(() => null),
     isErrorPageUrl: jest.fn((url) => matchesInternalPage(url, errorUrlBase)),
     isInterstitialPageUrl: jest.fn((url) => isInterstitialPageUrlMock(url)),
@@ -365,6 +386,9 @@ const loadNavigationModule = async (options = {}) => {
     setBookmarkBarChecked: jest.fn(),
     setBookmarkBarToggleEnabled: jest.fn(),
     setWindowTitle: jest.fn(),
+    // Shift+click on a link routes here (#303) — same request the page context
+    // menu's "Open Link in New Window" uses.
+    openUrlInNewWindow: jest.fn(),
     fetchFaviconWithKey: jest.fn().mockResolvedValue('data:image/png;base64,favicon'),
     addHistory: jest.fn().mockResolvedValue(undefined),
     setBzzBase: jest.fn(),
@@ -2282,7 +2306,9 @@ describe('navigation', () => {
       });
       await flushMicrotasks();
 
-      expect(ctx.tabsMocks.openInNewTabWithTarget).toHaveBeenCalledWith(rawHref, null);
+      expect(ctx.tabsMocks.openInNewTabWithTarget).toHaveBeenCalledWith(rawHref, null, {
+        background: false,
+      });
       expect(ctx.tabsMocks.createTab).not.toHaveBeenCalled();
       expect(ctx.urlUtilsMocks.formatIpfsUrl).not.toHaveBeenCalled();
     });
@@ -2304,7 +2330,9 @@ describe('navigation', () => {
       });
       await flushMicrotasks();
 
-      expect(ctx.tabsMocks.openInNewTabWithTarget).toHaveBeenCalledWith(rawHref, 'docs');
+      expect(ctx.tabsMocks.openInNewTabWithTarget).toHaveBeenCalledWith(rawHref, 'docs', {
+        background: false,
+      });
     });
 
     test('ipc-message link:navigate with target=_blank does not register as a named tab', async () => {
@@ -2322,7 +2350,123 @@ describe('navigation', () => {
       });
       await flushMicrotasks();
 
-      expect(ctx.tabsMocks.openInNewTabWithTarget).toHaveBeenCalledWith(rawHref, null);
+      expect(ctx.tabsMocks.openInNewTabWithTarget).toHaveBeenCalledWith(rawHref, null, {
+        background: false,
+      });
+    });
+
+    // #303: Ctrl/Cmd+click and middle-click open a BACKGROUND tab in Chrome —
+    // the current page stays active and keeps keyboard focus. The preload
+    // resolves the modifiers into the disposition; this is the renderer half.
+    test('ipc-message link:navigate with disposition newBackgroundTab opens without switching', async () => {
+      const ctx = await setupEnsDispatch();
+      const rawHref = 'ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+
+      ctx.tabsMocks.webviewEventHandler('ipc-message', {
+        tabId: ctx.activeRef.tab.id,
+        channel: 'link:navigate',
+        args: [{ url: rawHref, disposition: 'newBackgroundTab', target: null }],
+      });
+      await flushMicrotasks();
+
+      expect(ctx.tabsMocks.openInNewTabWithTarget).toHaveBeenCalledWith(rawHref, null, {
+        background: true,
+      });
+      expect(ctx.electronAPI.openUrlInNewWindow).not.toHaveBeenCalled();
+    });
+
+    // #303: Shift+click opens a new window, through the same
+    // `window:new-with-url` request (and private-window guard) the page
+    // context menu's "Open Link in New Window" already uses.
+    test('ipc-message link:navigate with disposition newWindow opens a window, not a tab', async () => {
+      const ctx = await setupEnsDispatch();
+      const rawHref = 'ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+
+      ctx.tabsMocks.webviewEventHandler('ipc-message', {
+        tabId: ctx.activeRef.tab.id,
+        channel: 'link:navigate',
+        args: [{ url: rawHref, disposition: 'newWindow', target: null }],
+      });
+      await flushMicrotasks();
+
+      expect(ctx.electronAPI.openUrlInNewWindow).toHaveBeenCalledWith(rawHref);
+      expect(ctx.tabsMocks.openInNewTabWithTarget).not.toHaveBeenCalled();
+      expect(ctx.tabsMocks.createTab).not.toHaveBeenCalled();
+    });
+
+    // An unknown/absent disposition still means "this tab" — the fallback has
+    // to stay closed rather than defaulting into any of the new branches.
+    test('ipc-message link:navigate with an unknown disposition navigates the current tab', async () => {
+      const ctx = await setupEnsDispatch();
+      const rawHref = 'ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+
+      ctx.tabsMocks.webviewEventHandler('ipc-message', {
+        tabId: ctx.activeRef.tab.id,
+        channel: 'link:navigate',
+        args: [{ url: rawHref, disposition: 'newSomething', target: null }],
+      });
+      await flushMicrotasks();
+
+      expect(ctx.tabsMocks.openInNewTabWithTarget).not.toHaveBeenCalled();
+      expect(ctx.electronAPI.openUrlInNewWindow).not.toHaveBeenCalled();
+      expect(ctx.urlUtilsMocks.formatIpfsUrl).toHaveBeenCalledWith(
+        rawHref,
+        ctx.state.ipfsRoutePrefix
+      );
+    });
+  });
+
+  // #312: a private window's new tab has to focus an EMPTY address bar, the
+  // same as a normal window's. Before the fix the private start page derived
+  // to `freedom://private`, so the "empty new tab" test never fired and focus
+  // was left on <body>.
+  describe('new tab focus', () => {
+    const switchToNewTab = (ctx, url) => {
+      const tab = createTab(42, url);
+      ctx.tabsRef.list = [tab];
+      ctx.activeRef.tab = tab;
+      ctx.tabsMocks.webviewEventHandler('tab-switched', { tabId: tab.id, tab, isNewTab: true });
+    };
+
+    test('a new tab on the private start page focuses and selects an empty address bar', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+      ctx.elements.addressInput.focus.mockClear();
+
+      switchToNewTab(ctx, 'freedom://private');
+
+      expect(ctx.elements.addressInput.value).toBe('');
+      expect(ctx.elements.addressInput.focus).toHaveBeenCalled();
+      expect(ctx.elements.addressInput.select).toHaveBeenCalled();
+    });
+
+    test('a new tab on the home page still focuses the address bar', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+      ctx.elements.addressInput.focus.mockClear();
+
+      switchToNewTab(ctx, 'file:///app/pages/home.html');
+
+      expect(ctx.elements.addressInput.value).toBe('');
+      expect(ctx.elements.addressInput.focus).toHaveBeenCalled();
+    });
+
+    test('a tab opened on a real page focuses the page, not the address bar', async () => {
+      // A link opened in a new foreground tab: the address bar must not steal
+      // focus, and focus must not stay stranded on the outgoing tab's
+      // now-hidden webview either (#303/#304).
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+      ctx.elements.addressInput.focus.mockClear();
+
+      const tab = createTab(43, 'https://example.com/');
+      const webviewFocus = jest.spyOn(tab.webview, 'focus');
+      ctx.tabsRef.list = [tab];
+      ctx.activeRef.tab = tab;
+      ctx.tabsMocks.webviewEventHandler('tab-switched', { tabId: tab.id, tab, isNewTab: true });
+
+      expect(ctx.elements.addressInput.focus).not.toHaveBeenCalled();
+      expect(webviewFocus).toHaveBeenCalled();
     });
   });
 

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -2472,6 +2472,49 @@ describe('navigation', () => {
       expect(ctx.elements.addressInput.focus).not.toHaveBeenCalled();
       expect(webviewFocus).toHaveBeenCalled();
     });
+
+    // The switch-back case of the same rule: `home.html`/`private.html` have
+    // no focus target, so tabs.js hands an *existing* new-tab-page tab here
+    // too rather than focusing an inert guest that swallows the next keystroke.
+    test('switching back to a tab on the new-tab page focuses the address bar', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+      ctx.elements.addressInput.focus.mockClear();
+
+      const tab = createTab(44, 'freedom://home');
+      const webviewFocus = jest.spyOn(tab.webview, 'focus');
+      ctx.tabsRef.list = [tab];
+      ctx.activeRef.tab = tab;
+      ctx.tabsMocks.webviewEventHandler('tab-switched', { tabId: tab.id, tab, isNewTab: false });
+
+      expect(ctx.elements.addressInput.value).toBe('');
+      expect(ctx.elements.addressInput.focus).toHaveBeenCalled();
+      expect(ctx.elements.addressInput.select).toHaveBeenCalled();
+      expect(webviewFocus).not.toHaveBeenCalled();
+    });
+
+    // …but not when that tab carries an uncommitted draft: the #314 branch has
+    // already focused the bar *and* restored its selection, and re-running the
+    // focus/select pair here would drop the selection the user left behind.
+    test('a draft on a new-tab-page tab keeps its restored selection', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+      ctx.elements.addressInput.select.mockClear();
+
+      const tab = createTab(45, 'freedom://home');
+      tab.navigationState.addressBarPendingInput = 'half-typed';
+      tab.navigationState.addressBarPendingSelection = { start: 2, end: 6, direction: 'forward' };
+      const webviewFocus = jest.spyOn(tab.webview, 'focus');
+      ctx.tabsRef.list = [tab];
+      ctx.activeRef.tab = tab;
+      ctx.tabsMocks.webviewEventHandler('tab-switched', { tabId: tab.id, tab, isNewTab: false });
+
+      expect(ctx.elements.addressInput.value).toBe('half-typed');
+      expect(ctx.elements.addressInput.focus).toHaveBeenCalled();
+      // `select()` would replace the restored range with "select all".
+      expect(ctx.elements.addressInput.select).not.toHaveBeenCalled();
+      expect(webviewFocus).not.toHaveBeenCalled();
+    });
   });
 
   describe('trust shield', () => {

--- a/src/renderer/lib/page-context-menu.js
+++ b/src/renderer/lib/page-context-menu.js
@@ -13,6 +13,15 @@ let pageContextMenu = null;
 // Current context from webview
 let currentContext = null;
 
+// The webview the menu was opened over, captured when it is shown so the
+// keyboard can be handed back to exactly that page on dismissal — and never
+// to a different tab an action opened in the meantime.
+let menuWebview = null;
+
+// The active (foreground) guest, or null.
+const getActiveWebview = () =>
+  document.getElementById('webview-container')?.querySelector('webview:not(.hidden)') || null;
+
 // Convert internal gateway URL to dweb URL for display/copying
 const toDwebUrl = (url) => {
   if (!url) return url;
@@ -80,8 +89,8 @@ export const showPageContextMenu = (x, y, context) => {
   const forwardBtn = pageContextMenu.querySelector('[data-action="forward"]');
 
   // Get the webview from the active tab
-  const webviewContainer = document.getElementById('webview-container');
-  const activeWebview = webviewContainer?.querySelector('webview:not(.hidden)');
+  const activeWebview = getActiveWebview();
+  menuWebview = activeWebview;
 
   if (backBtn && activeWebview) {
     try {
@@ -106,6 +115,15 @@ export const showPageContextMenu = (x, y, context) => {
   pageContextMenu.style.top = `${y}px`;
   pageContextMenu.classList.remove('hidden');
 
+  // An open menu owns the keyboard. This is the one chrome surface raised from
+  // *inside* the guest page, so it is the only one that can be up while the
+  // `<webview>` still holds focus — and a keypress that lands in the guest
+  // never reaches the shell's own `keydown` handler, so Escape would not
+  // dismiss it. (Focusing the guest on every tab activation, #304, turned that
+  // from a rare state into the normal one.) Take focus here and hand it back
+  // to the page in `hidePageContextMenu`, the way a native menu does.
+  pageContextMenu.focus?.();
+
   // Adjust position if menu goes off screen
   requestAnimationFrame(() => {
     const rect = pageContextMenu.getBoundingClientRect();
@@ -126,24 +144,45 @@ export const showPageContextMenu = (x, y, context) => {
   });
 };
 
-// Hide the context menu
-export const hidePageContextMenu = () => {
+// Hide the context menu.
+//
+// `restoreFocus` hands the keyboard back to the page the menu was opened over
+// (see `showPageContextMenu`); pass `false` from paths that fire while the
+// window is already losing focus, so dismissal never pulls focus back in.
+export const hidePageContextMenu = ({ restoreFocus = true } = {}) => {
   if (pageContextMenu) {
     const wasVisible = !pageContextMenu.classList.contains('hidden');
+    // Only give the keyboard back when the menu still holds it: a click that
+    // moved focus elsewhere in chrome (the address bar, say) dismisses the
+    // menu too, and grabbing focus back for the page would undo that click.
+    const heldFocus = wasVisible && pageContextMenu.contains(document.activeElement);
     pageContextMenu.classList.add('hidden');
     if (wasVisible) {
       hideMenuBackdrop();
     }
+    // Never focus a *different* page: an action that opened a new tab has
+    // already moved the foreground on, and that tab owns its own focus
+    // (address bar on this window's new-tab page, #312).
+    if (restoreFocus && heldFocus && menuWebview && menuWebview === getActiveWebview()) {
+      menuWebview.focus?.();
+    }
   }
   currentContext = null;
+  menuWebview = null;
 };
 
 // Handle context menu action
 const handleAction = async (action) => {
-  if (!currentContext) return;
+  // A context that went missing (a window blur nulls it while the menu can
+  // still be on screen) means the action is a no-op — but the menu must come
+  // down all the same. Returning early used to leave it up with every item
+  // still live.
+  if (!currentContext) {
+    hidePageContextMenu();
+    return;
+  }
 
-  const webviewContainer = document.getElementById('webview-container');
-  const activeWebview = webviewContainer?.querySelector('webview:not(.hidden)');
+  const activeWebview = getActiveWebview();
 
   switch (action) {
     case 'back':
@@ -307,8 +346,9 @@ export const initPageContextMenu = async () => {
     }
   });
 
-  // Hide when window loses focus
-  window.addEventListener('blur', hidePageContextMenu);
+  // Hide when window loses focus — without the focus hand-back, which would
+  // pull the keyboard back into a window that is on its way out.
+  window.addEventListener('blur', () => hidePageContextMenu({ restoreFocus: false }));
 
   pushDebug('[PageContextMenu] Initialized');
 };

--- a/src/renderer/lib/page-context-menu.test.js
+++ b/src/renderer/lib/page-context-menu.test.js
@@ -45,6 +45,7 @@ const createElement = (initialClasses = []) => {
     style: {},
     dataset: {},
     disabled: false,
+    focus: jest.fn(),
     addEventListener: jest.fn((event, handler) => {
       handlers[event] = handler;
     }),
@@ -74,6 +75,7 @@ const loadPageContextMenuModule = async (options = {}) => {
       reloadIgnoringCache: jest.fn(),
       openDevTools: jest.fn(),
       send: jest.fn(),
+      focus: jest.fn(),
     },
     menuRect = {
       left: 0,
@@ -158,6 +160,8 @@ const loadPageContextMenuModule = async (options = {}) => {
       documentHandlers[event] = handler;
     }),
     dispatchEvent: jest.fn(),
+    // Nothing in the chrome document holds focus until a test says so.
+    activeElement: null,
   };
 
   global.navigator = {
@@ -531,6 +535,74 @@ describe('page-context-menu', () => {
     mod.showPageContextMenu(20, 30, { imageSrc: 'https://example.com/image.png' });
     await triggerMenuAction(pageContextMenu, 'copy-image-address');
     expect(electronAPI.copyText).toHaveBeenCalledWith('https://example.com/image.png');
+  });
+
+  test('takes the keyboard from the guest and hands it back to the same page', async () => {
+    const {
+      mod,
+      pageContextMenu,
+      activeWebview,
+      webviewContainer,
+      documentHandlers,
+      windowHandlers,
+    } = await loadPageContextMenuModule();
+
+    await mod.initPageContextMenu();
+
+    // Opening the menu pulls focus out of the guest. Without this, an Escape
+    // pressed over a focused `<webview>` never reaches the handler below —
+    // which is the normal state since tab activation focuses the page (#304).
+    mod.showPageContextMenu(20, 30, { pageUrl: 'https://example.com/page' });
+    expect(pageContextMenu.focus).toHaveBeenCalled();
+
+    // Escape dismisses and returns the keyboard to the page it was opened over.
+    global.document.activeElement = pageContextMenu;
+    pageContextMenu.contains.mockImplementation((el) => el === pageContextMenu);
+    documentHandlers.keydown({ key: 'Escape' });
+    expect(pageContextMenu.classList.add).toHaveBeenCalledWith('hidden');
+    expect(activeWebview.focus).toHaveBeenCalledTimes(1);
+
+    // A click that moved focus elsewhere in chrome (the address bar) dismisses
+    // the menu too — and must not yank focus back to the page.
+    mod.showPageContextMenu(20, 30, { pageUrl: 'https://example.com/page' });
+    global.document.activeElement = { id: 'address-input' };
+    documentHandlers.click({ target: {} });
+    expect(activeWebview.focus).toHaveBeenCalledTimes(1);
+
+    // A window blur hides the menu without pulling focus back into a window
+    // that is on its way out.
+    mod.showPageContextMenu(20, 30, { pageUrl: 'https://example.com/page' });
+    global.document.activeElement = pageContextMenu;
+    windowHandlers.blur();
+    expect(activeWebview.focus).toHaveBeenCalledTimes(1);
+
+    // An action that moved the foreground on (open-link-new-tab, view-source)
+    // leaves a different guest active: the new tab owns its own focus (#312),
+    // so the menu never focuses the page it was opened over after the fact.
+    mod.showPageContextMenu(20, 30, { pageUrl: 'https://example.com/page' });
+    global.document.activeElement = pageContextMenu;
+    webviewContainer.querySelector.mockReturnValue({ focus: jest.fn() });
+    documentHandlers.keydown({ key: 'Escape' });
+    expect(activeWebview.focus).toHaveBeenCalledTimes(1);
+  });
+
+  test('still dismisses when the context went away before the action ran', async () => {
+    const { mod, pageContextMenu, windowHandlers, backdrop } = await loadPageContextMenuModule();
+
+    await mod.initPageContextMenu();
+
+    mod.showPageContextMenu(20, 30, { pageUrl: 'https://example.com/page' });
+    // A window blur nulls the context; the menu can still be on screen when a
+    // click lands on it. The action is a no-op, but the menu must come down.
+    windowHandlers.blur();
+    pageContextMenu.classList.remove('hidden');
+    pageContextMenu.classList.add.mockClear();
+    backdrop.hideMenuBackdrop.mockClear();
+
+    await triggerMenuAction(pageContextMenu, 'reload');
+
+    expect(pageContextMenu.classList.add).toHaveBeenCalledWith('hidden');
+    expect(backdrop.hideMenuBackdrop).toHaveBeenCalled();
   });
 
   test('closes on outside interactions and wires webview ipc context-menu events', async () => {

--- a/src/renderer/lib/page-urls.js
+++ b/src/renderer/lib/page-urls.js
@@ -127,6 +127,25 @@ export const getInternalPageName = (url) => {
   return null;
 };
 
+// The internal pages that act as a window's *new-tab page*: `home` in a normal
+// window, `private` in a private window (`tabs.js#defaultNewTabUrl`). Chrome
+// treats its NTP and its Incognito NTP identically in the omnibox — both show
+// an EMPTY address bar and both take focus when the tab is opened — so both
+// names have to derive to an empty display value and both have to satisfy the
+// "this is a fresh empty tab" focus test. See issue #312.
+const NEW_TAB_PAGE_NAMES = new Set(['home', 'private']);
+
+// True for a new-tab-page URL in either form it appears in: the friendly
+// `freedom://home` / `freedom://private` one `tab.url` carries while the page
+// is still resolving, and the resolved `file://…/pages/<page>.html` one
+// Chromium commits.
+export const isNewTabPageUrl = (url) => {
+  if (!url || typeof url !== 'string') return false;
+  const friendly = /^freedom:\/\/([a-z0-9-]+)\/?$/i.exec(url);
+  const name = friendly ? friendly[1].toLowerCase() : getInternalPageName(url);
+  return !!name && NEW_TAB_PAGE_NAMES.has(name.split('/')[0]);
+};
+
 // Trust interstitials are deliberately not routable freedom:// pages, but the
 // browser chrome must keep showing the app the user asked for while one is
 // visible. Like the ENS interstitials above, the onchain gate's own

--- a/src/renderer/lib/page-urls.test.js
+++ b/src/renderer/lib/page-urls.test.js
@@ -169,6 +169,31 @@ describe('page-urls', () => {
     expect(mod.getInternalPageName('')).toBeNull();
   });
 
+  // #312: the private window's start page is a new-tab page like the home
+  // page, in both the friendly and the resolved form. Everything else — other
+  // internal pages, ordinary web pages — is not.
+  test('recognises the home and private start pages as new-tab pages', async () => {
+    const mod = await loadModule({
+      home: 'home.html',
+      private: 'private.html',
+      settings: 'settings.html',
+    });
+
+    expect(mod.isNewTabPageUrl('file:///app/pages/home.html')).toBe(true);
+    expect(mod.isNewTabPageUrl('freedom://home')).toBe(true);
+    expect(mod.isNewTabPageUrl('file:///app/pages/private.html')).toBe(true);
+    expect(mod.isNewTabPageUrl('freedom://private')).toBe(true);
+    expect(mod.isNewTabPageUrl('freedom://private/')).toBe(true);
+
+    expect(mod.isNewTabPageUrl('file:///app/pages/settings.html')).toBe(false);
+    expect(mod.isNewTabPageUrl('freedom://settings')).toBe(false);
+    expect(mod.isNewTabPageUrl('about:blank')).toBe(false);
+    expect(mod.isNewTabPageUrl('')).toBe(false);
+    expect(mod.isNewTabPageUrl(null)).toBe(false);
+    // A remote look-alike path must not pass as chrome's own page (#235).
+    expect(mod.isNewTabPageUrl('https://evil.test/pages/private.html')).toBe(false);
+  });
+
   test('extracts the web3 target only from the bundled onchain interstitial', async () => {
     const mod = await loadModule();
     const target = 'web3://0x00000095643cffa7d9fae407a84dfcb6406456c6.eip155-1/swap';

--- a/src/renderer/lib/tabs-audio-mute.test.js
+++ b/src/renderer/lib/tabs-audio-mute.test.js
@@ -160,6 +160,10 @@ const loadTabsModule = async (options = {}) => {
       typeof url === 'string' && url.includes('/pages/history.html') ? 'history' : null,
     getOnchainInterstitialTarget: () => null,
     internalPages: {},
+    // Mirrors `page-urls.js#isNewTabPageUrl` for this window's new-tab page,
+    // which `switchTab` consults to decide whether the page or the address bar
+    // gets the keyboard (#304).
+    isNewTabPageUrl: (url) => url === (options.homeUrl || HOME_URL) || url === 'freedom://private',
   }));
 
   const mod = await import('./tabs.js');

--- a/src/renderer/lib/tabs-find-nav.test.js
+++ b/src/renderer/lib/tabs-find-nav.test.js
@@ -102,6 +102,10 @@ const loadModules = async () => {
   jest.doMock('./page-urls.js', () => ({
     homeUrl: HOME_URL,
     getOnchainInterstitialTarget: () => null,
+    // Mirrors `page-urls.js#isNewTabPageUrl` for this window's new-tab page,
+    // which `switchTab` consults to decide whether the page or the address bar
+    // gets the keyboard (#304).
+    isNewTabPageUrl: (url) => url === HOME_URL || url === 'freedom://private',
   }));
 
   const tabs = await import('./tabs.js');

--- a/src/renderer/lib/tabs-ui.test.js
+++ b/src/renderer/lib/tabs-ui.test.js
@@ -172,9 +172,16 @@ const loadTabsModule = async (options = {}) => {
   jest.doMock('./menu-backdrop.js', () => backdropMocks);
   jest.doMock('./page-context-menu.js', () => pageContextMenuMocks);
   jest.doMock('./link-status.js', () => linkStatusMocks);
+  // `internalPages` is opt-in per test: with the default empty map no
+  // `freedom://<page>` URL is a recognised internal page, which is the shape
+  // every pre-existing test in this file assumes.
+  const internalPages = options.internalPages || {};
   jest.doMock('./page-urls.js', () => ({
     homeUrl: options.homeUrl || HOME_URL,
     getOnchainInterstitialTarget: () => null,
+    internalPages,
+    getInternalPageName: (url) =>
+      Object.entries(internalPages).find(([, pageUrl]) => pageUrl === url)?.[0] || null,
   }));
 
   const mod = await import('./tabs.js');
@@ -1285,6 +1292,80 @@ describe('tabs ui behavior', () => {
     expect(mod.getActiveTab().id).toBe(foregroundTab.id);
   });
 
+  // #303: a `freedom://` internal page is a singleton tab, but that must not
+  // outrank the disposition — Ctrl/Cmd+click on a `freedom://settings` link
+  // inside a page (e.g. a web3:// onchain app, whose preload forwards
+  // freedom: hrefs) has to leave the user on the page they are reading.
+  test('a background open of a freedom:// page does not switch away from the current tab', async () => {
+    jest.useFakeTimers();
+    const { mod } = await loadTabsModule({
+      internalPages: { settings: 'file:///app/pages/settings.html' },
+    });
+    const onLoadTarget = jest.fn();
+    mod.setLoadTargetHandler(onLoadTarget);
+    await mod.initTabs();
+
+    const activeTab = mod.getActiveTab();
+    const activeFocus = jest.spyOn(activeTab.webview, 'focus');
+
+    // No settings tab yet: created hidden, in the background.
+    const opened = mod.openInNewTabWithTarget('freedom://settings', null, { background: true });
+    expect(mod.getTabs()).toHaveLength(2);
+    expect(mod.getActiveTab().id).toBe(activeTab.id);
+    expect(opened.webview.classList.contains('hidden')).toBe(true);
+    expect(activeFocus).not.toHaveBeenCalled();
+
+    // A second background open reuses the singleton tab and routes it to the
+    // requested section — into that tab's own webview, still without switching.
+    const reused = mod.openInNewTabWithTarget('freedom://settings/profile', null, {
+      background: true,
+    });
+    expect(reused.id).toBe(opened.id);
+    expect(mod.getTabs()).toHaveLength(2);
+    expect(mod.getActiveTab().id).toBe(activeTab.id);
+    jest.runOnlyPendingTimers();
+    expect(onLoadTarget).toHaveBeenCalledWith('freedom://settings/profile', null, opened.webview);
+
+    // Without the flag the singleton is focused, exactly as before.
+    const focused = mod.openInNewTabWithTarget('freedom://settings', null);
+    expect(focused.id).toBe(opened.id);
+    expect(mod.getActiveTab().id).toBe(opened.id);
+  });
+
+  // #303: Chrome resolves the modifier before the `target` attribute — a
+  // Ctrl/Cmd+click never re-navigates the window a name already points at,
+  // which when that window is the current tab would navigate the page out from
+  // under the user.
+  test('a background open of a named target opens a new tab instead of reusing it', async () => {
+    jest.useFakeTimers();
+    const { mod } = await loadTabsModule();
+    const onLoadTarget = jest.fn();
+    mod.setLoadTargetHandler(onLoadTarget);
+    await mod.initTabs();
+
+    // A plain click on <a target="foo"> opens the tab and registers the name.
+    const named = mod.openInNewTabWithTarget('ipfs://one', 'foo');
+    expect(mod.getActiveTab().id).toBe(named.id);
+    jest.runOnlyPendingTimers();
+    onLoadTarget.mockClear();
+
+    // Ctrl+click on a second target="foo" link, from inside that very tab.
+    const opened = mod.openInNewTabWithTarget('ipfs://two', 'foo', { background: true });
+    expect(opened.id).not.toBe(named.id);
+    expect(mod.getTabs()).toHaveLength(3);
+    expect(mod.getActiveTab().id).toBe(named.id);
+    expect(opened.webview.classList.contains('hidden')).toBe(true);
+    jest.runOnlyPendingTimers();
+    // The tab the user is reading was never re-navigated; the new one was.
+    expect(onLoadTarget).not.toHaveBeenCalledWith('ipfs://two', null, named.webview);
+    expect(onLoadTarget).toHaveBeenCalledWith('ipfs://two', null, opened.webview);
+
+    // The fresh tab took the name over, so an unmodified click reuses it.
+    const reused = mod.openInNewTabWithTarget('ipfs://three', 'foo');
+    expect(reused.id).toBe(opened.id);
+    expect(mod.getTabs()).toHaveLength(3);
+  });
+
   // #303: the main process forwards the disposition Chromium derived from the
   // click's modifiers over `tab:new-with-url`.
   test('tab:new-with-url honours the background and new-window dispositions', async () => {
@@ -1340,6 +1421,68 @@ describe('tabs ui behavior', () => {
     expect(elements.tabContextMenu.classList.contains('hidden')).toBe(false);
     mod.closeTab(secondTab.id);
     expect(elements.tabContextMenu.classList.contains('hidden')).toBe(true);
+  });
+
+  // #315: re-activating the tab that is already foreground (Ctrl+1 on tab 1
+  // while tab 1 is active) is still an activation — it has to dismiss the
+  // menu, which is anchored to some other tab with every destructive item
+  // live. The dismissal therefore runs before switchTab's already-foreground
+  // early return, without taking any of the swap's other side effects with it.
+  test('a tab context menu is dismissed by re-activating the already-active tab', async () => {
+    const { mod, elements, linkStatusMocks } = await loadTabsModule();
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+    mod.switchTab(firstTab.id);
+
+    // Menu open over tab 2 while tab 1 is the active one.
+    findTabElement(elements.tabBar, secondTab.id).dispatch('contextmenu', {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      clientX: 20,
+      clientY: 30,
+    });
+    expect(elements.tabContextMenu.classList.contains('hidden')).toBe(false);
+
+    linkStatusMocks.clearLinkStatus.mockClear();
+    mod.switchTab(firstTab.id);
+
+    expect(elements.tabContextMenu.classList.contains('hidden')).toBe(true);
+    // Still an early return otherwise: no find-bar close, no webview re-hide.
+    expect(mod.getActiveTab().id).toBe(firstTab.id);
+    expect(linkStatusMocks.clearLinkStatus).not.toHaveBeenCalled();
+  });
+
+  // #311: the strip only scrolls the active tab back into view on activation,
+  // so the two other things that reflow it — a window resize, and closing a
+  // tab that sits left of the viewport — could leave the active tab past an
+  // edge, unreachable, until the next tab switch.
+  test('the active tab is scrolled back into view on a resize and on a close', async () => {
+    const { mod, elements, windowHandlers } = await loadTabsModule();
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    mod.createTab('https://second.example');
+    const thirdTab = mod.createTab('https://third.example');
+    const thirdTabEl = findTabElement(elements.tabBar, thirdTab.id);
+    thirdTabEl.scrollIntoView = jest.fn();
+
+    windowHandlers.resize();
+    expect(thirdTabEl.scrollIntoView).toHaveBeenCalledWith({
+      block: 'nearest',
+      inline: 'nearest',
+    });
+
+    // Closing a tab to the left of the active one takes its width out of the
+    // strip and slides everything after it.
+    thirdTabEl.scrollIntoView.mockClear();
+    mod.closeTab(firstTab.id);
+    expect(mod.getActiveTab().id).toBe(thirdTab.id);
+    expect(thirdTabEl.scrollIntoView).toHaveBeenCalledWith({
+      block: 'nearest',
+      inline: 'nearest',
+    });
   });
 
   // #315: belt and braces — if some future path leaves a menu up over a tab

--- a/src/renderer/lib/tabs-ui.test.js
+++ b/src/renderer/lib/tabs-ui.test.js
@@ -24,6 +24,9 @@ const createElectronApi = () => {
       updateTabMenuState: jest.fn(),
       closeWindow: jest.fn(),
       getWebviewPreloadPath: jest.fn().mockResolvedValue('/tmp/webview-preload.js'),
+      // Shift+click / `new-window` disposition routes back out through the
+      // existing "Open Link in New Window" request (#303).
+      openUrlInNewWindow: jest.fn(),
       getCachedFavicon: jest.fn().mockResolvedValue('data:image/png;base64,favicon'),
       onNewTab: register('newTab'),
       onCloseTab: register('closeTab'),
@@ -937,8 +940,12 @@ describe('tabs ui behavior', () => {
       clientY: 30,
     });
     windowHandlers.blur();
-    elements.bzzWebview.dispatch('focus');
-    elements.bzzWebview.dispatch('mousedown');
+    // The `#bzz-webview` focus/mousedown dismissal that used to live in
+    // initTabs was dead code — webviews are created id-less, so the lookup was
+    // always null (#315, #306). The fake DOM *does* resolve that id, so this
+    // asserts the listeners are really gone rather than merely never firing.
+    expect(elements.bzzWebview.handlers.focus).toBeUndefined();
+    expect(elements.bzzWebview.handlers.mousedown).toBeUndefined();
 
     elements.newTabBtn.dispatch('click');
     expect(mod.getTabs()).toHaveLength(3);
@@ -958,12 +965,22 @@ describe('tabs ui behavior', () => {
     jest.runOnlyPendingTimers();
     await flushMicrotasks();
     expect(mod.getTabs()).toHaveLength(beforeReuseCount);
-    expect(onLoadTarget).toHaveBeenCalledWith('https://reuse-target.example');
+    // The reused tab's own webview is named explicitly so a background
+    // re-navigation can't land in whatever tab happens to be active (#303).
+    expect(onLoadTarget).toHaveBeenCalledWith(
+      'https://reuse-target.example',
+      null,
+      expect.objectContaining({ tagName: 'WEBVIEW' })
+    );
 
     electronHandlers.newTabWithUrl('ipfs://cid', 'ipfs-target');
     jest.runOnlyPendingTimers();
     await flushMicrotasks();
-    expect(onLoadTarget).toHaveBeenCalledWith('ipfs://cid');
+    expect(onLoadTarget).toHaveBeenCalledWith(
+      'ipfs://cid',
+      null,
+      expect.objectContaining({ tagName: 'WEBVIEW' })
+    );
 
     electronHandlers.navigateToUrl('https://navigate.example');
     electronHandlers.loadUrl('https://load.example');
@@ -1142,5 +1159,212 @@ describe('tabs ui behavior', () => {
     mod.switchTab(firstTab.id);
     expect(linkStatusMocks.clearLinkStatus).toHaveBeenCalledWith({ immediate: true });
     expect(linkStatusMocks.setLinkStatusSide).toHaveBeenLastCalledWith('right');
+  });
+  // #304: activating a tab hands keyboard focus to that tab's page, the way
+  // Chrome does — otherwise focus is left on the tab button (mouse switch) or
+  // stranded on the now-hidden outgoing webview (keyboard switch), and
+  // scrolling/typing does nothing until the user clicks into the page.
+  test('switchTab focuses the incoming page and never the hidden outgoing one', async () => {
+    const { mod } = await loadTabsModule();
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+    const firstFocus = jest.spyOn(firstTab.webview, 'focus');
+    const secondFocus = jest.spyOn(secondTab.webview, 'focus');
+
+    mod.switchTab(firstTab.id);
+    expect(firstFocus).toHaveBeenCalledTimes(1);
+    expect(secondFocus).not.toHaveBeenCalled();
+
+    // Keyboard switch (Ctrl+Tab) goes through the same path.
+    mod.switchToNextTab();
+    expect(mod.getActiveTab().id).toBe(secondTab.id);
+    expect(secondFocus).toHaveBeenCalledTimes(1);
+    expect(firstFocus).toHaveBeenCalledTimes(1);
+  });
+
+  // #304: the tab promoted when the active tab closes is focused too.
+  test('closing the active tab focuses the tab promoted in its place', async () => {
+    const { mod } = await loadTabsModule();
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+    const firstFocus = jest.spyOn(firstTab.webview, 'focus');
+
+    expect(mod.getActiveTab().id).toBe(secondTab.id);
+    mod.closeTab(secondTab.id);
+
+    expect(mod.getActiveTab().id).toBe(firstTab.id);
+    expect(firstFocus).toHaveBeenCalled();
+  });
+
+  // #311: below the tabs' minimum width the strip scrolls instead of clipping,
+  // so the newly activated tab has to be scrolled back into view — a tab you
+  // cannot see or click is the bug this fixes.
+  test('switchTab scrolls the activated tab into view', async () => {
+    const { mod, elements } = await loadTabsModule();
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+    const firstTabEl = findTabElement(elements.tabBar, firstTab.id);
+    firstTabEl.scrollIntoView = jest.fn();
+
+    mod.switchTab(firstTab.id);
+
+    expect(firstTabEl.scrollIntoView).toHaveBeenCalledWith({
+      block: 'nearest',
+      inline: 'nearest',
+    });
+    void secondTab;
+  });
+
+  // #311: the edge fades are the only cue that more tabs exist in a direction,
+  // since the strip's scrollbar is hidden.
+  test('the tab strip marks which edge has more tabs behind it', async () => {
+    const { mod, elements } = await loadTabsModule();
+    await mod.initTabs();
+
+    // Not overflowing: neither fade.
+    elements.tabBar.scrollWidth = 400;
+    elements.tabBar.clientWidth = 400;
+    elements.tabBar.scrollLeft = 0;
+    mod.createTab('https://second.example');
+    expect(elements.tabBar.classList.contains('overflow-start')).toBe(false);
+    expect(elements.tabBar.classList.contains('overflow-end')).toBe(false);
+
+    // Overflowing, scrolled to the left end: more tabs to the right only.
+    elements.tabBar.scrollWidth = 1200;
+    elements.tabBar.clientWidth = 400;
+    elements.tabBar.scrollLeft = 0;
+    elements.tabBar.dispatch('scroll');
+    expect(elements.tabBar.classList.contains('overflow-start')).toBe(false);
+    expect(elements.tabBar.classList.contains('overflow-end')).toBe(true);
+
+    // Scrolled into the middle: tabs hidden on both sides.
+    elements.tabBar.scrollLeft = 300;
+    elements.tabBar.dispatch('scroll');
+    expect(elements.tabBar.classList.contains('overflow-start')).toBe(true);
+    expect(elements.tabBar.classList.contains('overflow-end')).toBe(true);
+
+    // Scrolled to the right end: more tabs to the left only.
+    elements.tabBar.scrollLeft = 800;
+    elements.tabBar.dispatch('scroll');
+    expect(elements.tabBar.classList.contains('overflow-start')).toBe(true);
+    expect(elements.tabBar.classList.contains('overflow-end')).toBe(false);
+  });
+
+  // #303: Ctrl/Cmd+click and middle-click open a background tab — the tab is
+  // created and navigated, but the user stays on the page they were reading
+  // and it keeps keyboard focus.
+  test('a background tab is created without switching away from the current one', async () => {
+    jest.useFakeTimers();
+    const { mod } = await loadTabsModule();
+    const onLoadTarget = jest.fn();
+    mod.setLoadTargetHandler(onLoadTarget);
+    await mod.initTabs();
+
+    const activeTab = mod.getActiveTab();
+    const activeFocus = jest.spyOn(activeTab.webview, 'focus');
+
+    const backgroundTab = mod.openInNewTabWithTarget('ipfs://cid', null, { background: true });
+    jest.runOnlyPendingTimers();
+
+    expect(mod.getTabs()).toHaveLength(2);
+    expect(mod.getActiveTab().id).toBe(activeTab.id);
+    expect(activeFocus).not.toHaveBeenCalled();
+    expect(backgroundTab.webview.classList.contains('hidden')).toBe(true);
+    // The dweb URL still resolves — into the BACKGROUND tab's webview, not
+    // into whatever tab is active.
+    expect(onLoadTarget).toHaveBeenCalledWith('ipfs://cid', null, backgroundTab.webview);
+
+    // Without the flag the same call still opens in the foreground.
+    const foregroundTab = mod.openInNewTabWithTarget('https://fg.example', null);
+    expect(mod.getActiveTab().id).toBe(foregroundTab.id);
+  });
+
+  // #303: the main process forwards the disposition Chromium derived from the
+  // click's modifiers over `tab:new-with-url`.
+  test('tab:new-with-url honours the background and new-window dispositions', async () => {
+    const { mod, electronAPI, electronHandlers } = await loadTabsModule();
+    await mod.initTabs();
+
+    const activeTab = mod.getActiveTab();
+    electronHandlers.newTabWithUrl('https://bg.example', null, { background: true });
+    expect(mod.getTabs()).toHaveLength(2);
+    expect(mod.getActiveTab().id).toBe(activeTab.id);
+
+    electronHandlers.newTabWithUrl('https://win.example', null, { newWindow: true });
+    expect(electronAPI.openUrlInNewWindow).toHaveBeenCalledWith('https://win.example');
+    expect(mod.getTabs()).toHaveLength(2);
+
+    // No options → the previous foreground-tab behaviour.
+    electronHandlers.newTabWithUrl('https://fg.example', null);
+    expect(mod.getTabs()).toHaveLength(3);
+    expect(mod.getActiveTab().url).toBe('https://fg.example');
+  });
+
+  // #315: the menu was dismissed by a mouse tab switch (the strip click
+  // reaches the document listener) but not by a keyboard one, leaving every
+  // destructive item bound to the tab the user had just left.
+  test('a tab context menu is dismissed by any tab activation and by a close', async () => {
+    const { mod, elements } = await loadTabsModule();
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+    mod.switchTab(firstTab.id);
+    const firstTabEl = findTabElement(elements.tabBar, firstTab.id);
+
+    const openMenu = () =>
+      firstTabEl.dispatch('contextmenu', {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        clientX: 20,
+        clientY: 30,
+      });
+
+    openMenu();
+    expect(elements.tabContextMenu.classList.contains('hidden')).toBe(false);
+
+    // Keyboard switch (Ctrl+Tab / Ctrl+PageDown / Ctrl+1..8).
+    mod.switchToNextTab();
+    expect(mod.getActiveTab().id).toBe(secondTab.id);
+    expect(elements.tabContextMenu.classList.contains('hidden')).toBe(true);
+
+    // A tab closing invalidates the menu's anchor and its target too.
+    mod.switchTab(firstTab.id);
+    openMenu();
+    expect(elements.tabContextMenu.classList.contains('hidden')).toBe(false);
+    mod.closeTab(secondTab.id);
+    expect(elements.tabContextMenu.classList.contains('hidden')).toBe(true);
+  });
+
+  // #315: belt and braces — if some future path leaves a menu up over a tab
+  // that no longer exists, its destructive items refuse rather than resolving
+  // to whichever tab took that id's place.
+  test('a tab context menu item refuses to act on a tab that is gone', async () => {
+    const { mod, elements } = await loadTabsModule();
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+    const secondTabEl = findTabElement(elements.tabBar, secondTab.id);
+
+    secondTabEl.dispatch('contextmenu', {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      clientX: 20,
+      clientY: 30,
+    });
+    // Drop the tab out from under the menu without going through closeTab's
+    // dismissal, then click "Close Tab".
+    mod.getTabs().splice(1, 1);
+    elements.tabContextMenu.dispatch('click', { target: elements.closeBtn });
+
+    expect(mod.getTabs().map((tab) => tab.id)).toEqual([firstTab.id]);
+    expect(elements.tabContextMenu.classList.contains('hidden')).toBe(true);
   });
 });

--- a/src/renderer/lib/tabs-ui.test.js
+++ b/src/renderer/lib/tabs-ui.test.js
@@ -182,6 +182,15 @@ const loadTabsModule = async (options = {}) => {
     internalPages,
     getInternalPageName: (url) =>
       Object.entries(internalPages).find(([, pageUrl]) => pageUrl === url)?.[0] || null,
+    // Mirrors `page-urls.js#isNewTabPageUrl`: this window's new-tab page in
+    // both the friendly `freedom://` form and the resolved internal-page one
+    // (#312), for a normal window (`home`) and a private one (`private`).
+    isNewTabPageUrl: (url) =>
+      url === (options.homeUrl || HOME_URL) ||
+      url === 'freedom://home' ||
+      url === 'freedom://private' ||
+      url === internalPages.home ||
+      url === internalPages.private,
   }));
 
   const mod = await import('./tabs.js');
@@ -1186,6 +1195,10 @@ describe('tabs ui behavior', () => {
     await mod.initTabs();
 
     const firstTab = mod.getActiveTab();
+    // The window's first tab starts on the new-tab page, which defers focus to
+    // the address bar (see the next test) — navigate it to a real page so this
+    // one is about the ordinary page-focus rule.
+    firstTab.url = 'https://first.example';
     const secondTab = mod.createTab('https://second.example');
     const firstFocus = jest.spyOn(firstTab.webview, 'focus');
     const secondFocus = jest.spyOn(secondTab.webview, 'focus');
@@ -1198,6 +1211,44 @@ describe('tabs ui behavior', () => {
     mod.switchToNextTab();
     expect(mod.getActiveTab().id).toBe(secondTab.id);
     expect(secondFocus).toHaveBeenCalledTimes(1);
+    expect(firstFocus).toHaveBeenCalledTimes(1);
+  });
+
+  // #304, the switch-back case: a tab sitting on this window's new-tab page
+  // has no focus target in its guest (`home.html`/`private.html` are inert),
+  // so focusing the page there drops the keystroke the user is about to type.
+  // Chrome focuses the omnibox instead — which is navigation.js' `tab-switched`
+  // job, the same deferral a brand-new tab uses.
+  test('switchTab leaves the page unfocused for a tab on the new-tab page', async () => {
+    const { mod } = await loadTabsModule();
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+    const firstFocus = jest.spyOn(firstTab.webview, 'focus');
+    const secondFocus = jest.spyOn(secondTab.webview, 'focus');
+
+    // The first tab is still on the new-tab page it was opened with.
+    expect(firstTab.url).toBe(HOME_URL);
+    mod.switchTab(firstTab.id);
+    expect(mod.getActiveTab().id).toBe(firstTab.id);
+    expect(firstFocus).not.toHaveBeenCalled();
+    // The deferral is one-sided: the tab on a real page still gets the
+    // keyboard on the way back.
+    mod.switchTab(secondTab.id);
+    expect(secondFocus).toHaveBeenCalledTimes(1);
+
+    // …and once that tab has navigated somewhere real it is an ordinary tab
+    // again. `tab.url` is the friendly form; the resolved `file://…/home.html`
+    // one Chromium commits lands in `currentPageUrl`, and both have to count.
+    firstTab.url = 'https://first.example';
+    mod.switchTab(firstTab.id);
+    expect(firstFocus).toHaveBeenCalledTimes(1);
+
+    mod.switchTab(secondTab.id);
+    firstTab.url = null;
+    firstTab.navigationState.currentPageUrl = HOME_URL;
+    mod.switchTab(firstTab.id);
     expect(firstFocus).toHaveBeenCalledTimes(1);
   });
 
@@ -1214,6 +1265,9 @@ describe('tabs ui behavior', () => {
     await mod.initTabs();
 
     const firstTab = mod.getActiveTab();
+    // On a real page, so the new-tab-page deferral above isn't what's being
+    // measured — the draft has to carry this on its own.
+    firstTab.url = 'https://first.example';
     const secondTab = mod.createTab('https://second.example');
     const firstFocus = jest.spyOn(firstTab.webview, 'focus');
 
@@ -1244,6 +1298,9 @@ describe('tabs ui behavior', () => {
     await mod.initTabs();
 
     const firstTab = mod.getActiveTab();
+    // On a real page: the promoted tab gets the keyboard, unless it is sitting
+    // on the new-tab page, where the address bar takes it instead.
+    firstTab.url = 'https://first.example';
     const secondTab = mod.createTab('https://second.example');
     const firstFocus = jest.spyOn(firstTab.webview, 'focus');
 

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -9,6 +9,7 @@ import {
   getInternalPageName,
   getOnchainInterstitialTarget,
   internalPages,
+  isNewTabPageUrl,
 } from './page-urls.js';
 import { getPrivatePartition, isPrivateWindow } from './private-mode.js';
 import { setupWebviewProvider, setActiveWebview } from './dapp-provider.js';
@@ -1636,26 +1637,40 @@ export const switchTab = (tabId, options = {}) => {
   // the tab button, and it is never stranded on the now-hidden outgoing
   // webview (#304).
   //
-  // Two cases are deliberately excluded and handed to the navigation module's
-  // `tab-switched` case instead, because both of them focus the *address bar*
-  // and only that module knows it:
+  // Three cases are deliberately excluded and handed to the navigation
+  // module's `tab-switched` case instead, because all of them focus the
+  // *address bar* and only that module knows it:
   //
   // - A brand-new tab: only the address-bar derivation knows whether the tab
   //   landed on this window's new-tab page (focus the address bar — #312) or
   //   on a real page opened from a link (focus the page).
+  // - An existing tab sitting on this window's new-tab page: the guest there
+  //   (`home.html` / `private.html`) has no focus target, so focusing it drops
+  //   the keystroke the user is about to type. Chrome focuses the omnibox when
+  //   you switch back to a tab on the NTP; the same `isNewTabPageUrl` test the
+  //   brand-new case uses recognises both forms of that URL.
   // - A tab left with an uncommitted address-bar edit: it comes back mid-edit
   //   with the bar focused and its selection restored (#314), so the page must
   //   not take the keyboard from under the draft. `addressBarPendingInput` is
   //   a string only while such an edit is in flight — see `address-bar-edit.js`,
   //   which owns the field this module declares in `createNavigationState`.
   //   (Read directly rather than through that module's helper: it imports
-  //   `tabs.js`, so importing it back would close an import cycle.)
+  //   `tabs.js`, so importing it back would close an import cycle.) A draft
+  //   outranks the new-tab-page rule: the bar is focused either way, but only
+  //   this branch restores the selection, so the URL test must not claim it.
   //
-  // Focusing here as well is not harmless in either case: `<webview>.focus()`
+  // Focusing here as well is not harmless in any of them: `<webview>.focus()`
   // hands focus to the guest asynchronously, so it lands *after* a synchronous
   // `addressInput.focus()` and takes the address bar's focus away again.
+  //
+  // The URL read mirrors navigation.js' `tab-switched` case exactly
+  // (`tab.url` first, then the navigation state's committed URL): the two
+  // conditions are complements, so any drift would leave a switch with the
+  // keyboard nowhere at all.
   const tabHasAddressBarEdit = typeof tab.navigationState?.addressBarPendingInput === 'string';
-  if (!options.isNewTab && !tabHasAddressBarEdit) {
+  const tabIsOnNewTabPage =
+    !tabHasAddressBarEdit && isNewTabPageUrl(tab.url || tab.navigationState?.currentPageUrl || '');
+  if (!options.isNewTab && !tabHasAddressBarEdit && !tabIsOnNewTabPage) {
     tab.webview?.focus?.();
   }
 

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -1379,6 +1379,12 @@ export const closeTab = (tabId) => {
   }
 
   renderTabs();
+  // Closing a tab reflows the strip: one that sat left of the viewport takes
+  // its width with it and slides the active tab towards (or past) an edge.
+  // `renderTabs` only repaints the fades, so scroll the active tab back too —
+  // the close that promoted a new active tab already went through `switchTab`,
+  // this covers the closes that did not (#311).
+  scrollActiveTabIntoView();
   pushTabMenuState();
   pushDebug(`Closed tab ${tabId}`);
 };
@@ -1545,16 +1551,25 @@ export const hideTabContextMenu = () => {
 export const switchTab = (tabId, options = {}) => {
   const tab = tabState.tabs.find((t) => t.id === tabId);
   if (!tab) return;
-  // Already foreground — nothing to swap, and running the swap anyway has
-  // real side effects (closing an open find bar, re-hiding webviews).
-  if (tabState.activeTabId === tabId) return;
 
   // Any tab activation dismisses the tab context menu, whatever caused it.
   // A strip *click* already reached the document-click listener; a keyboard
-  // switch (Ctrl+Tab, Ctrl+PageDown, Ctrl+1..8) did not, leaving the menu open
-  // over the tab you just left with Close Tab / Close Others / Close to the
-  // Right / Pin / Mute all still bound to it. See #315.
+  // switch (Ctrl+Tab, Ctrl+PageDown) did not, leaving the menu open over the
+  // tab you just left with Close Tab / Close Others / Close to the Right /
+  // Pin / Mute all still bound to it. See #315.
+  //
+  // Dismissal happens *before* the already-foreground early return below:
+  // activating the tab that is already foreground (the address bar's
+  // "switch to open tab" suggestion for the current tab, or any future
+  // select-tab-by-index binding) is still an activation, and the menu it
+  // leaves up is anchored to another tab with every destructive item live.
+  // Hiding an already-hidden menu is a no-op, so this costs nothing on the
+  // ordinary path.
   hideTabContextMenu();
+
+  // Already foreground — nothing to swap, and running the swap anyway has
+  // real side effects (closing an open find bar, re-hiding webviews).
+  if (tabState.activeTabId === tabId) return;
 
   // Reset the link-hover preview before swapping active tabs:
   // - immediate clear so the previous tab's URL never trails into the new tab
@@ -1644,9 +1659,11 @@ export const switchTab = (tabId, options = {}) => {
  * be intercepted before Chromium lowercases the host).
  *
  * `options.background` opens the tab without leaving the current one — the
- * Ctrl/Cmd+click and middle-click disposition (#303). A *reused* named target
- * is still navigated in place but likewise not switched to, so the modifier
- * means the same thing whether or not the name already had a tab.
+ * Ctrl/Cmd+click and middle-click disposition (#303). It also suppresses named
+ * -target *reuse*: as in Chrome, the modifier wins over the `target` attribute
+ * and always yields a fresh background tab (which then takes the name), rather
+ * than navigating the named — possibly current — tab in place. It carries into
+ * the `freedom://` internal-page singleton branch below for the same reason.
  *
  * @param {string} url - target URL
  * @param {string|null} targetName - HTML `target` attribute, if any
@@ -1679,19 +1696,32 @@ export const openInNewTabWithTarget = (url, targetName, options = {}) => {
   // (settings/profile) reuses the base page's tab and routes it to that section.
   if (!targetName) {
     const internal = freedomInternalPageTarget(url);
-    if (internal) return openOrFocusInternalPage(internal.pageName, internal.subPath);
+    // `background` carries through: a Ctrl/Cmd+click or middle-click on a
+    // `freedom://` link must leave the user where they are, exactly like every
+    // other background open (#303). Without it the singleton branch below
+    // switched to (or foreground-created) the internal page's tab regardless
+    // of the disposition Chromium had already derived.
+    if (internal)
+      return openOrFocusInternalPage(internal.pageName, internal.subPath, { background });
   }
 
-  if (targetName && namedTargets.has(targetName)) {
+  // A named target is only *reused* for an unmodified activation. Chrome
+  // resolves the modifier first: Ctrl/Cmd+click and middle-click always open a
+  // new background tab, they never re-navigate the window the `target` names —
+  // which, when the named tab is the one the user is reading, would navigate
+  // the page out from under them, the opposite of what the modifier asks for
+  // (#303). The fresh tab takes over the name, as Chromium's own
+  // `CreateNewWindow` does with the activation's frame name.
+  if (targetName && !background && namedTargets.has(targetName)) {
     const existingTabId = namedTargets.get(targetName);
     const existingTab = tabState.tabs.find((t) => t.id === existingTabId);
     if (existingTab) {
       pushDebug(`Reusing tab ${existingTabId} for target "${targetName}": ${url}`);
-      if (!background) switchTab(existingTabId);
+      switchTab(existingTabId);
       setTimeout(() => {
         if (onLoadTarget) {
-          // Same reason as `createTab`: name the webview so a background
-          // re-navigation cannot land in whatever tab happens to be active.
+          // Same reason as `createTab`: name the webview so a re-navigation
+          // cannot land in whatever tab happens to be active.
           onLoadTarget(url, null, existingTab.webview);
         }
       }, 50);
@@ -1731,12 +1761,19 @@ export const openInNewTabWithTarget = (url, targetName, options = {}) => {
  * opened tab is created on the deep link. Tab matching is always by base page,
  * so the edit pencil's `settings/profile` reuses a plain `settings` tab.
  *
+ * `options.background` (a Ctrl/Cmd+click or middle-click on a `freedom://`
+ * link, #303) keeps the user on the page they are reading: an existing tab is
+ * still routed to the requested section, and a new one is created hidden — in
+ * neither case is it switched to.
+ *
  * @param {string} pageName - internal page name, e.g. 'profiles'
  * @param {string|null} [subPath] - optional section within the page
+ * @param {{ background?: boolean }} [options] - opening disposition
  * @returns {object|null} the focused or newly created tab, or null on noop
  */
-export const openOrFocusInternalPage = (pageName, subPath = null) => {
+export const openOrFocusInternalPage = (pageName, subPath = null, options = {}) => {
   if (!pageName) return null;
+  const background = !!options.background;
 
   const fullUrl = subPath ? `freedom://${pageName}/${subPath}` : `freedom://${pageName}`;
 
@@ -1753,19 +1790,20 @@ export const openOrFocusInternalPage = (pageName, subPath = null) => {
   });
 
   if (existingTab) {
-    pushDebug(`Focusing existing ${pageName} tab ${existingTab.id}`);
-    switchTab(existingTab.id);
-    // Route the reused tab to the requested section. switchTab makes it active,
-    // so onLoadTarget lands in its webview. (Same switch-then-load handoff the
-    // named-target reuse path above uses.) Bare pages need no re-navigation.
+    pushDebug(`${background ? 'Routing' : 'Focusing'} existing ${pageName} tab ${existingTab.id}`);
+    if (!background) switchTab(existingTab.id);
+    // Route the reused tab to the requested section. The webview is named
+    // explicitly — as the named-target reuse path above does — so a background
+    // re-navigation lands in that tab rather than in whichever one the user is
+    // still looking at. Bare pages need no re-navigation.
     if (subPath && onLoadTarget) {
-      setTimeout(() => onLoadTarget(fullUrl), 50);
+      setTimeout(() => onLoadTarget(fullUrl, null, existingTab.webview), 50);
     }
     return existingTab;
   }
 
-  pushDebug(`Opening ${pageName} in a new tab`);
-  return createTab(fullUrl);
+  pushDebug(`Opening ${pageName} in a new${background ? ' background' : ''} tab`);
+  return createTab(fullUrl, { background });
 };
 
 // Initialize tabs module
@@ -1838,7 +1876,10 @@ export const initTabs = async () => {
   // themselves (trackpad/shift-wheel), not just with the programmatic
   // `scrollActiveTabIntoView` ones (#311).
   tabBar?.addEventListener('scroll', updateTabStripOverflow, { passive: true });
-  window.addEventListener('resize', updateTabStripOverflow);
+  // A resize changes how much of the strip is visible, so the active tab can
+  // end up past the new edge — the same "a tab you cannot see or click" bug
+  // #311 is about. Scroll it back rather than only repainting the fades.
+  window.addEventListener('resize', scrollActiveTabIntoView);
 
   // Fetch webview preload path for internal pages
   try {

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -1082,6 +1082,45 @@ const updateTabElement = (tabEl, tab, isActive, isBeforeActive) => {
   separator.style.display = !isActive && !isBeforeActive ? '' : 'none';
 };
 
+// Tab-strip overflow (#311).
+//
+// Tabs shrink to the `min-width` floor in tabs.css first; past that the strip
+// scrolls horizontally instead of clipping, which is what Chrome does. Two
+// things have to follow from that: the edges need a fade so it is visible that
+// more tabs exist in that direction, and the *active* tab must always be
+// scrolled into view — a tab you cannot see or click is the actual bug.
+
+// Toggle the edge-fade classes from the current scroll offsets. Cheap enough
+// to run on every scroll event; reads only layout properties the browser has
+// already computed for the scroll.
+const updateTabStripOverflow = () => {
+  if (!tabBar?.classList) return;
+  const scrollLeft = tabBar.scrollLeft || 0;
+  const scrollWidth = tabBar.scrollWidth || 0;
+  const clientWidth = tabBar.clientWidth || 0;
+  // 1px slack absorbs sub-pixel layout rounding, which would otherwise leave
+  // a permanent fade on a strip that is not actually overflowing.
+  const overflowing = scrollWidth - clientWidth > 1;
+  tabBar.classList.toggle('overflow-start', overflowing && scrollLeft > 1);
+  tabBar.classList.toggle(
+    'overflow-end',
+    overflowing && scrollLeft + clientWidth < scrollWidth - 1
+  );
+};
+
+// Keep the active tab reachable. Called from `switchTab` (and after a close
+// promotes another tab) rather than from `renderTabs`, which also runs on
+// title/loading churn — scrolling the strip back on every spinner tick would
+// fight a user who scrolled it themselves.
+const scrollActiveTabIntoView = () => {
+  const tabEl = tabElements.get(tabState.activeTabId);
+  // `scrollIntoView` is a real-DOM API; the unit tests' fake DOM omits it.
+  if (typeof tabEl?.scrollIntoView === 'function') {
+    tabEl.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+  updateTabStripOverflow();
+};
+
 // Render the tab bar incrementally
 const renderTabs = () => {
   if (!tabBar) return;
@@ -1126,6 +1165,9 @@ const renderTabs = () => {
 
     previousSibling = tabEl;
   });
+
+  // Adding or removing a tab changes whether the strip overflows.
+  updateTabStripOverflow();
 };
 
 // URLs `createTab` is allowed to load directly as the initial webview
@@ -1160,8 +1202,13 @@ const resolveInternalPageUrl = (url) => {
   return target.subPath ? `${pageUrl}#${target.subPath}` : pageUrl;
 };
 
-// Create a new tab
-export const createTab = (url = null) => {
+// Create a new tab.
+//
+// `options.background` leaves the current tab active and keeps its keyboard
+// focus — Chrome's disposition for Ctrl/Cmd+click and middle-click on a link
+// (#303). The tab is still created, appended and navigated; only the switch is
+// skipped. Everything else opens in the foreground, as before.
+export const createTab = (url = null, options = {}) => {
   const tabId = tabState.nextTabId++;
   // Direct loads: empty/null (use homeUrl), http(s), about:blank, and
   // the app's own `homeUrl` (production: file:///…/pages/home.html).
@@ -1182,6 +1229,12 @@ export const createTab = (url = null) => {
   const isDirect = resolvedInternalUrl != null || isDirectLoadUrl(url);
   const webviewUrl = resolvedInternalUrl || (isDirect ? url || fallbackUrl : 'about:blank');
   const webview = createWebview(tabId, webviewUrl);
+  // Webviews are created visible and `switchTab` hides every other one. A
+  // background tab never switches, so it has to start hidden or it would
+  // render on top of the page the user is still reading (#303).
+  if (options.background) {
+    webview.classList.add('hidden');
+  }
 
   const tab = {
     id: tabId,
@@ -1198,8 +1251,14 @@ export const createTab = (url = null) => {
   tabState.tabs.push(tab);
   webviewContainer?.appendChild(webview);
 
-  // Switch to the new tab
-  switchTab(tabId, { isNewTab: true });
+  // Switch to the new tab — unless it was asked for in the background, in
+  // which case the strip still has to pick up the new tab element.
+  if (options.background) {
+    renderTabs();
+    pushTabMenuState();
+  } else {
+    switchTab(tabId, { isNewTab: true });
+  }
 
   // Anything that isn't a direct-load URL flows through the resolution
   // pipeline. For routed schemes (bzz://, ipfs://, ens://, rad:,
@@ -1208,9 +1267,13 @@ export const createTab = (url = null) => {
   // navigation; for unrecognised inputs (file://, data:, javascript:,
   // etc.) it falls through to a debug-log no-op, leaving the tab on
   // about:blank. Recognised freedom:// pages took the direct path above.
+  //
+  // The new tab's own webview is passed explicitly: `loadTarget` otherwise
+  // falls back to the *active* webview, which for a background tab is the tab
+  // the user is still looking at (#303).
   if (!isDirect) {
     setTimeout(() => {
-      if (onLoadTarget) onLoadTarget(url);
+      if (onLoadTarget) onLoadTarget(url, null, webview);
     }, 50);
   }
 
@@ -1235,6 +1298,13 @@ const cleanupWebview = (webview) => {
 export const closeTab = (tabId) => {
   const tabIndex = tabState.tabs.findIndex((t) => t.id === tabId);
   if (tabIndex === -1) return;
+
+  // A tab context menu open over the strip is anchored to a layout — and to a
+  // `contextMenuTabId` — that closing a tab invalidates. Chrome dismisses it;
+  // leaving it up pointed every destructive item at whatever tab now sits
+  // under it. Harmless when the close *came from* the menu (the item handler
+  // hides it first). See #315.
+  hideTabContextMenu();
 
   const tab = tabState.tabs[tabIndex];
 
@@ -1479,6 +1549,13 @@ export const switchTab = (tabId, options = {}) => {
   // real side effects (closing an open find bar, re-hiding webviews).
   if (tabState.activeTabId === tabId) return;
 
+  // Any tab activation dismisses the tab context menu, whatever caused it.
+  // A strip *click* already reached the document-click listener; a keyboard
+  // switch (Ctrl+Tab, Ctrl+PageDown, Ctrl+1..8) did not, leaving the menu open
+  // over the tab you just left with Close Tab / Close Others / Close to the
+  // Right / Pin / Mute all still bound to it. See #315.
+  hideTabContextMenu();
+
   // Reset the link-hover preview before swapping active tabs:
   // - immediate clear so the previous tab's URL never trails into the new tab
   // - restore side from the incoming tab's last-known cursor-zone state
@@ -1511,6 +1588,23 @@ export const switchTab = (tabId, options = {}) => {
     setActiveWebview(tab.webview);
   }
 
+  // Give the page keyboard focus, the way Chrome does on every tab
+  // activation (click, Ctrl+Tab, Ctrl+1..8, the tab promoted when another
+  // closes): scrolling and typing work immediately, focus is never left on
+  // the tab button, and it is never stranded on the now-hidden outgoing
+  // webview (#304).
+  //
+  // A brand-new tab is deliberately excluded and handed to the navigation
+  // module's `tab-switched` case instead, which knows whether the tab landed
+  // on this window's new-tab page (focus the address bar — #312) or on a real
+  // page opened from a link (focus the page). Focusing here as well is not
+  // harmless: `<webview>.focus()` hands focus to the guest asynchronously, so
+  // it lands *after* a synchronous `addressInput.focus()` and takes the
+  // address bar's focus away again.
+  if (!options.isNewTab) {
+    tab.webview?.focus?.();
+  }
+
   // Update window title
   if (tab.title) {
     electronAPI?.setWindowTitle?.(tab.title);
@@ -1522,6 +1616,9 @@ export const switchTab = (tabId, options = {}) => {
   }
 
   renderTabs();
+  // The strip scrolls once tabs hit their minimum width, so the tab we just
+  // activated can be sitting past its edge (#311).
+  scrollActiveTabIntoView();
   pushTabMenuState();
 
   pushDebug(`Switched to tab ${tabId}`);
@@ -1546,8 +1643,14 @@ export const switchTab = (tabId, options = {}) => {
  * because dweb clicks bypass `setWindowOpenHandler` (so the click can
  * be intercepted before Chromium lowercases the host).
  *
+ * `options.background` opens the tab without leaving the current one — the
+ * Ctrl/Cmd+click and middle-click disposition (#303). A *reused* named target
+ * is still navigated in place but likewise not switched to, so the modifier
+ * means the same thing whether or not the name already had a tab.
+ *
  * @param {string} url - target URL
  * @param {string|null} targetName - HTML `target` attribute, if any
+ * @param {{ background?: boolean }} [options] - opening disposition
  * @returns {object|null} the (possibly new) tab, or null on noop
  */
 // Parse a `freedom://<page>[/<sub>]` URL into `{ pageName, subPath }` when
@@ -1563,8 +1666,9 @@ const freedomInternalPageTarget = (url) => {
   return { pageName, subPath: match[2] ? match[2].toLowerCase() : null };
 };
 
-export const openInNewTabWithTarget = (url, targetName) => {
+export const openInNewTabWithTarget = (url, targetName, options = {}) => {
   if (!url) return null;
+  const background = !!options.background;
 
   // EVERY freedom:// internal page (profiles, history, settings, …) is treated
   // as a singleton: an untargeted open focuses the existing tab instead of
@@ -1583,10 +1687,12 @@ export const openInNewTabWithTarget = (url, targetName) => {
     const existingTab = tabState.tabs.find((t) => t.id === existingTabId);
     if (existingTab) {
       pushDebug(`Reusing tab ${existingTabId} for target "${targetName}": ${url}`);
-      switchTab(existingTabId);
+      if (!background) switchTab(existingTabId);
       setTimeout(() => {
         if (onLoadTarget) {
-          onLoadTarget(url);
+          // Same reason as `createTab`: name the webview so a background
+          // re-navigation cannot land in whatever tab happens to be active.
+          onLoadTarget(url, null, existingTab.webview);
         }
       }, 50);
       return existingTab;
@@ -1604,7 +1710,7 @@ export const openInNewTabWithTarget = (url, targetName) => {
   // Critically, this also makes `tab.url` reflect the actual target,
   // so the `tab-switched` handler can derive a meaningful address bar
   // value immediately instead of leaving it empty until ENS resolves.
-  const newTab = createTab(url);
+  const newTab = createTab(url, { background });
 
   if (targetName && newTab) {
     namedTargets.set(targetName, newTab.id);
@@ -1674,23 +1780,33 @@ export const initTabs = async () => {
   if (tabContextMenu) {
     tabContextMenu.addEventListener('click', (e) => {
       const action = e.target.dataset?.action;
-      if (!action || !contextMenuTabId) return;
+      const targetTabId = contextMenuTabId;
+      if (!action || !targetTabId) return;
+      // Fail safe on a stale target. Every activation and every close now
+      // dismisses the menu (#315), so a menu that is still up always points at
+      // a live tab — but each item here is destructive, so a target that has
+      // gone away is refused rather than resolved to whatever tab took its
+      // place.
+      if (!tabState.tabs.some((t) => t.id === targetTabId)) {
+        hideTabContextMenu();
+        return;
+      }
 
       switch (action) {
         case 'close':
-          closeTab(contextMenuTabId);
+          closeTab(targetTabId);
           break;
         case 'close-others':
-          closeOtherTabs(contextMenuTabId);
+          closeOtherTabs(targetTabId);
           break;
         case 'close-right':
-          closeTabsToRight(contextMenuTabId);
+          closeTabsToRight(targetTabId);
           break;
         case 'pin':
-          togglePinTab(contextMenuTabId);
+          togglePinTab(targetTabId);
           break;
         case 'mute':
-          toggleMuteTab(contextMenuTabId);
+          toggleMuteTab(targetTabId);
           break;
       }
       hideTabContextMenu();
@@ -1711,11 +1827,18 @@ export const initTabs = async () => {
     }
   });
   window.addEventListener('blur', hideTabContextMenu);
+  // (The `focus`/`mousedown` dismissal that used to hang off
+  // `document.getElementById('bzz-webview')` is gone: webviews are created
+  // id-less, so that lookup was always null and the listeners never existed.
+  // `#menu-backdrop` covers the window while the menu is open, so a click into
+  // the page dismisses it through the document-click listener above. See #315,
+  // #306.)
 
-  // Hide context menu when webview gets focus
-  const webviewElement = document.getElementById('bzz-webview');
-  webviewElement?.addEventListener('focus', hideTabContextMenu);
-  webviewElement?.addEventListener('mousedown', hideTabContextMenu);
+  // Keep the tab strip's edge fades in sync with a scroll the user drove
+  // themselves (trackpad/shift-wheel), not just with the programmatic
+  // `scrollActiveTabIntoView` ones (#311).
+  tabBar?.addEventListener('scroll', updateTabStripOverflow, { passive: true });
+  window.addEventListener('resize', updateTabStripOverflow);
 
   // Fetch webview preload path for internal pages
   try {
@@ -1743,10 +1866,19 @@ export const initTabs = async () => {
     }
   });
 
-  electronAPI?.onNewTabWithUrl?.((url, targetName) => {
-    if (url) {
-      openInNewTabWithTarget(url, targetName || null);
+  electronAPI?.onNewTabWithUrl?.((url, targetName, options = {}) => {
+    if (!url) return;
+    // The main process forwards the disposition Chromium derived from the
+    // activation's modifiers (`setWindowOpenHandler`), so a Ctrl/Cmd+click or
+    // middle-click on an http(s) link opens in the background and a
+    // Shift+click opens a window — see #303. Callers that don't send options
+    // (the app menu's "Open Downloads/History/Profiles", the webview
+    // context menu) keep the plain foreground-tab behaviour.
+    if (options?.newWindow) {
+      electronAPI?.openUrlInNewWindow?.(url);
+      return;
     }
+    openInNewTabWithTarget(url, targetName || null, { background: !!options?.background });
   });
 
   electronAPI?.onNavigateToUrl?.((url) => {

--- a/src/renderer/lib/tabs.test.js
+++ b/src/renderer/lib/tabs.test.js
@@ -433,7 +433,14 @@ describe('openOrFocusInternalPage', () => {
       expect(getTabs().length).toBe(before); // no new tab opened
 
       jest.runOnlyPendingTimers();
-      expect(onLoadTarget).toHaveBeenCalledWith('freedom://settings/profile'); // routed to section
+      // Routed to the section, in the reused tab's own webview — named
+      // explicitly so a background open (#303) can't land the navigation in
+      // whatever tab the user is still looking at.
+      expect(onLoadTarget).toHaveBeenCalledWith(
+        'freedom://settings/profile',
+        null,
+        existing.webview
+      );
     } finally {
       jest.useRealTimers();
     }

--- a/src/renderer/styles/menus.css
+++ b/src/renderer/styles/menus.css
@@ -29,6 +29,12 @@
   display: none;
 }
 
+/* The page context menu takes focus so Escape works while the guest page had
+   the keyboard; that focus is plumbing, not a highlight the user should see. */
+.context-menu:focus {
+  outline: none;
+}
+
 .context-menu-item {
   display: block;
   width: 100%;

--- a/src/renderer/styles/tabs.css
+++ b/src/renderer/styles/tabs.css
@@ -41,17 +41,51 @@
   user-select: none;
 }
 
+/* Tabs shrink to `.tab { min-width }` first; past that the strip scrolls
+   horizontally instead of clipping the tabs it cannot fit — which used to hide
+   tabs (including the active one) past the right edge with no way to reach
+   them. The scrollbar itself is hidden: the strip is driven by
+   `scrollActiveTabIntoView()` in tabs.js plus the edge fades below, the same
+   way Chrome's strip has no visible scrollbar. See #311. */
 .tabs-container {
   display: flex;
   align-items: flex-end;
   gap: 0;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
   flex: 0 1 auto;
   min-width: 0;
   padding-left: 10px; /* Room for corner flare on left */
   padding-right: 10px; /* Room for corner flare on right */
   margin-left: -10px; /* Compensate for padding */
   margin-right: -10px;
+}
+
+.tabs-container::-webkit-scrollbar {
+  display: none;
+}
+
+/* Edge fades: the only cue that there are more tabs in that direction, since
+   the scrollbar is hidden. Classes are toggled from the live scroll offsets by
+   `updateTabStripOverflow()` in tabs.js, so a strip that fits carries neither
+   and renders exactly as before. */
+.tabs-container.overflow-start {
+  mask-image: linear-gradient(to right, transparent 0, #000 24px);
+}
+
+.tabs-container.overflow-end {
+  mask-image: linear-gradient(to left, transparent 0, #000 24px);
+}
+
+.tabs-container.overflow-start.overflow-end {
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 24px,
+    #000 calc(100% - 24px),
+    transparent 100%
+  );
 }
 
 /* Base tab styles */
@@ -71,6 +105,12 @@
   height: 30px;
   margin-bottom: 4px;
   container-type: inline-size;
+  /* Slack for `scrollActiveTabIntoView()` (#311): the strip's 10px side
+     padding is room for the active tab's corner flare and is part of the
+     scrollable area, so aligning a tab flush with the content edge would
+     scroll its own flare out of view (and, at the left end, light up the
+     edge fade with nothing actually hidden behind it). */
+  scroll-margin-inline: 16px;
 }
 
 /* Inactive tab - pill/button shape */

--- a/test-e2e/private-windows.spec.js
+++ b/test-e2e/private-windows.spec.js
@@ -713,3 +713,63 @@ test('a private dweb request writes no URL to the persistent log', async ({
   expect(logText).toContain('bzz://<private>');
   expect(logText).not.toContain(SECRET_HASH);
 });
+
+// #312: a new tab in a private window focuses an EMPTY address bar, exactly
+// like a normal window's. Before the fix the private start page derived to
+// `freedom://private` in the bar, which meant the renderer's "this is a fresh
+// empty tab" test never fired: focus was left on <body> and typing went
+// nowhere until the user clicked the address bar.
+test('private window: New Tab focuses an empty address bar', async ({ window, electronApp }) => {
+  const addressState = (page) =>
+    page.evaluate(() => {
+      const input = document.getElementById('address-input');
+      return {
+        value: input?.value ?? null,
+        focused: document.activeElement === input,
+        activeElement: `${document.activeElement?.tagName}#${document.activeElement?.id || ''}`,
+        tabs: document.querySelectorAll('[data-test="tab"]').length,
+      };
+    });
+
+  // Control: a normal window's new tab already does this.
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect
+    .poll(() => addressState(window), { message: 'normal window new tab' })
+    .toMatchObject({
+      value: '',
+      focused: true,
+      tabs: 2,
+    });
+
+  const priv = await openPrivateWindow(electronApp);
+
+  // The private window's *first* tab is on the private start page too, and
+  // shows an empty address bar rather than `freedom://private`.
+  await expect
+    .poll(() => priv.locator('[data-test="address-input"]').inputValue(), {
+      message: 'private window initial address bar',
+    })
+    .toBe('');
+
+  await priv.locator('[data-test="new-tab-btn"]').click();
+  await expect
+    .poll(() => addressState(priv), { message: 'private window new tab' })
+    .toMatchObject({
+      value: '',
+      focused: true,
+      activeElement: 'INPUT#address-input',
+      tabs: 2,
+    });
+
+  // The private start page is still what actually loaded — the empty address
+  // bar is a display rule, not a blank tab.
+  await expect
+    .poll(
+      () =>
+        priv.evaluate(
+          () => document.querySelector('webview:not(.hidden)')?.getAttribute('src') || ''
+        ),
+      { message: 'Waiting for the private start page to be the visible tab' }
+    )
+    .toContain('private.html');
+});

--- a/test-e2e/tabs.spec.js
+++ b/test-e2e/tabs.spec.js
@@ -1,7 +1,92 @@
 // Tab strip — open via the new-tab button, close via the per-tab close
 // affordance, count tabs from the renderer DOM directly.
+//
+// The Chrome-parity behaviours (#303 link dispositions, #304 tab-switch
+// focus, #311 strip overflow, #315 context-menu dismissal) are driven with
+// real pointer/keyboard input at window coordinates rather than DOM
+// `element.click()`, because they are about focus, modifiers and dismissal —
+// the exact things a synthetic dispatch cannot exercise.
 
-const { test, expect } = require('./fixtures');
+const { test, expect, SAMPLE_BZZ_HASH } = require('./fixtures');
+
+const PAGE_A = `bzz://${SAMPLE_BZZ_HASH}/`;
+const PAGE_B = `bzz://${'b'.repeat(64)}/`;
+
+// Serve a page whose only content is a link to `PAGE_B`, and open it in the
+// active tab. Returns the link's coordinates in *window* space, so
+// `page.mouse` clicks go through the real hit-test path into the guest.
+async function openLinkPage(window, harness) {
+  await harness.setContentFixture(PAGE_A, {
+    body:
+      '<!doctype html><title>Page A</title><style>body{margin:0;padding:40px}' +
+      'a{display:inline-block;padding:20px;font-size:24px}</style>' +
+      `<a id="lnk" href="${PAGE_B}">link</a>`,
+  });
+  await harness.setContentFixture(PAGE_B, {
+    body: '<!doctype html><title>Page B</title><h1>B</h1>',
+  });
+
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(PAGE_A);
+  await input.press('Enter');
+
+  let point;
+  await expect
+    .poll(
+      async () => {
+        point = await window.evaluate(async () => {
+          const wv = document.querySelector('webview:not(.hidden)');
+          if (!wv || typeof wv.executeJavaScript !== 'function') return null;
+          try {
+            const box = await wv.executeJavaScript(
+              "(() => { const a = document.getElementById('lnk'); if (!a) return null;" +
+                'const r = a.getBoundingClientRect();' +
+                'return { x: r.x + r.width / 2, y: r.y + r.height / 2 }; })()'
+            );
+            if (!box) return null;
+            const rect = wv.getBoundingClientRect();
+            return { x: rect.x + box.x, y: rect.y + box.y };
+          } catch {
+            return null;
+          }
+        });
+        return !!point;
+      },
+      { message: 'Waiting for the link fixture to render', timeout: 15_000 }
+    )
+    .toBe(true);
+  return point;
+}
+
+const tabTitles = (window) =>
+  window.evaluate(() =>
+    [...document.querySelectorAll('[data-test="tab"]')].map((tab) => ({
+      title: tab.querySelector('.tab-title')?.textContent,
+      active: tab.classList.contains('active'),
+    }))
+  );
+
+// Click an application-menu item by id. Keyboard shortcuts cannot be driven
+// with `page.keyboard` once the page has focus (which, after #304, is where
+// focus lives right after a tab switch): input dispatched to the chrome window
+// is routed to the focused guest frame, exactly as in a real browser. The
+// accelerators are application-menu items in the main process, so clicking the
+// item is the same path a real Ctrl+Tab / Ctrl+W takes.
+const clickMenuItem = (electronApp, id) =>
+  electronApp.evaluate(({ Menu }, itemId) => {
+    const item = Menu.getApplicationMenu()?.getMenuItemById(itemId);
+    if (!item) throw new Error(`Menu item not found: ${itemId}`);
+    item.click();
+  }, id);
+
+// Count real browser windows from the main process rather than Playwright's
+// page list: a webview guest surfaces as a page too, and a freshly created
+// window's page URL is still `about:blank` for a while on a loaded machine.
+const chromeWindowCount = (electronApp) =>
+  electronApp.evaluate(
+    ({ BrowserWindow }) => BrowserWindow.getAllWindows().filter((win) => !win.isDestroyed()).length
+  );
 
 test('starts with one tab, can open more, can close them', async ({ window }) => {
   const tabs = window.locator('[data-test="tab"]');
@@ -32,4 +117,215 @@ test('clicking a tab activates it', async ({ window }) => {
   await window.locator('[data-test="tab"][data-tab-id="1"]').click();
   await expect(window.locator('[data-test="tab"][data-tab-id="1"]')).toHaveClass(/active/);
   await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).not.toHaveClass(/active/);
+});
+
+// #304: activating a tab focuses that tab's page, so scrolling and typing
+// work immediately. Before the fix, DOM focus in the chrome document stayed
+// on the `<button class="tab">` that was clicked (mouse switch) or on the
+// outgoing tab's button (Ctrl+Tab), and the guest reported
+// `document.hasFocus() === false`.
+test('switching tabs focuses the page, not the tab button', async ({
+  window,
+  electronApp,
+  harness,
+}) => {
+  await harness.setContentFixture(PAGE_A, {
+    body: '<!doctype html><title>Page A</title><p>a</p>',
+  });
+
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(PAGE_A);
+  await input.press('Enter');
+
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(2);
+
+  // Mouse switch back to the first tab.
+  await window.locator('[data-test="tab"][data-tab-id="1"]').click();
+  await expect
+    .poll(
+      () =>
+        window.evaluate(() => {
+          const el = document.activeElement;
+          return `${el?.tagName}.${el?.className || ''}`;
+        }),
+      { message: 'Waiting for the page to take focus after a mouse tab switch' }
+    )
+    .toMatch(/^WEBVIEW/);
+
+  // The focused webview is the visible one, never a hidden background tab.
+  expect(await window.evaluate(() => document.activeElement?.classList.contains('hidden'))).toBe(
+    false
+  );
+
+  // Keyboard switch (Ctrl+Tab) has to do the same — that was the mirror-image
+  // half of the bug, which left focus on the *outgoing* tab's button.
+  await clickMenuItem(electronApp, 'next-tab');
+  await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).toHaveClass(/active/);
+  await expect
+    .poll(
+      () =>
+        window.evaluate(() => {
+          const el = document.activeElement;
+          return `${el?.tagName}.${el?.className || ''}`;
+        }),
+      { message: 'Waiting for the page to take focus after Ctrl+Tab' }
+    )
+    .toMatch(/^WEBVIEW/);
+});
+
+// #303: Ctrl/Cmd+click and middle-click open a BACKGROUND tab — the tab is
+// created and loads, but the current page stays active and keeps focus.
+test('ctrl+click and middle-click open a background tab', async ({ window, harness }) => {
+  const point = await openLinkPage(window, harness);
+  const tabs = window.locator('[data-test="tab"]');
+  await expect(tabs).toHaveCount(1);
+
+  await window.keyboard.down('Control');
+  await window.mouse.click(point.x, point.y);
+  await window.keyboard.up('Control');
+
+  await expect(tabs).toHaveCount(2);
+  // Still on Page A, and its tab is still the active one.
+  await expect(window.locator('[data-test="tab"][data-tab-id="1"]')).toHaveClass(/active/);
+  await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).not.toHaveClass(/active/);
+  // The background tab's webview must be hidden — it is created after the
+  // switch that would otherwise have hidden it.
+  expect(
+    await window.evaluate(() => document.querySelectorAll('webview:not(.hidden)').length)
+  ).toBe(1);
+
+  // Middle-click behaves the same way.
+  await window.mouse.click(point.x, point.y, { button: 'middle' });
+  await expect(tabs).toHaveCount(3);
+  await expect(window.locator('[data-test="tab"][data-tab-id="1"]')).toHaveClass(/active/);
+
+  // The background tabs really did load Page B (a background tab that never
+  // navigates would pass every assertion above).
+  await expect
+    .poll(async () => (await tabTitles(window)).map((tab) => tab.title), {
+      message: 'Waiting for the background tabs to load Page B',
+      timeout: 15_000,
+    })
+    .toEqual(['Page A', 'Page B', 'Page B']);
+});
+
+// #303: Ctrl+Shift+click promotes the same link to a FOREGROUND tab.
+test('ctrl+shift+click opens a foreground tab', async ({ window, harness }) => {
+  const point = await openLinkPage(window, harness);
+
+  await window.keyboard.down('Control');
+  await window.keyboard.down('Shift');
+  await window.mouse.click(point.x, point.y);
+  await window.keyboard.up('Shift');
+  await window.keyboard.up('Control');
+
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(2);
+  await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).toHaveClass(/active/);
+});
+
+// #303: Shift+click opens a new *window*, not a tab in this one.
+test('shift+click opens a new window', async ({ window, electronApp, harness }) => {
+  const point = await openLinkPage(window, harness);
+  const before = await chromeWindowCount(electronApp);
+
+  await window.keyboard.down('Shift');
+  await window.mouse.click(point.x, point.y);
+  await window.keyboard.up('Shift');
+
+  await expect
+    .poll(() => chromeWindowCount(electronApp), {
+      message: 'Waiting for the shift+click window',
+      timeout: 15_000,
+    })
+    .toBe(before + 1);
+  // …and no extra tab in the window the link was clicked in.
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(1);
+});
+
+// #311: past the tabs' minimum width the strip scrolls instead of clipping,
+// and the active tab is always scrolled into view. Before the fix a 20th tab
+// in a 1200px window sat past the container's right edge, invisible and
+// unclickable, with no scroll or overflow affordance at all.
+test('the tab strip scrolls instead of clipping, keeping the active tab visible', async ({
+  window,
+  electronApp,
+}) => {
+  const newTabBtn = window.locator('[data-test="new-tab-btn"]');
+  for (let i = 0; i < 19; i += 1) {
+    await newTabBtn.click();
+  }
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(20);
+
+  const measure = () =>
+    window.evaluate(() => {
+      const container = document.querySelector('.tabs-container');
+      const rect = container.getBoundingClientRect();
+      const active = document.querySelector('[data-test="tab"].active');
+      const activeRect = active.getBoundingClientRect();
+      return {
+        scrollable: container.scrollWidth - container.clientWidth > 1,
+        overflowX: getComputedStyle(container).overflowX,
+        activeVisible: activeRect.left >= rect.left - 1 && activeRect.right <= rect.right + 1,
+        activeTabId: active.dataset.tabId,
+        hasEdgeFade:
+          container.classList.contains('overflow-start') ||
+          container.classList.contains('overflow-end'),
+      };
+    });
+
+  const overflowing = await measure();
+  expect(overflowing.overflowX).toBe('auto');
+  expect(overflowing.scrollable).toBe(true);
+  // The most recently opened tab is the active one and it is on screen.
+  expect(overflowing.activeTabId).toBe('20');
+  expect(overflowing.activeVisible).toBe(true);
+  // An edge fade marks the direction the hidden tabs are in.
+  expect(overflowing.hasEdgeFade).toBe(true);
+
+  // Switching to a tab scrolled off the other end brings it into view too —
+  // this is the case that used to leave you on a tab you could not see.
+  await window.evaluate(() => {
+    document.querySelector('.tabs-container').scrollLeft = 0;
+  });
+  await clickMenuItem(electronApp, 'next-tab');
+  await expect(window.locator('[data-test="tab"][data-tab-id="1"]')).toHaveClass(/active/);
+  const wrapped = await measure();
+  expect(wrapped.activeTabId).toBe('1');
+  expect(wrapped.activeVisible).toBe(true);
+});
+
+// #315: the tab context menu was dismissed by a mouse tab switch (the strip
+// click reaches the document listener) but not by a keyboard one, leaving
+// Close Tab / Close Others / Close to the Right / Pin / Mute live against a
+// tab the user was no longer on.
+test('the tab context menu closes on a keyboard tab switch and on a tab close', async ({
+  window,
+  electronApp,
+}) => {
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(2);
+  await window.locator('[data-test="tab"][data-tab-id="1"]').click();
+
+  const menu = window.locator('#tab-context-menu');
+  const openMenuOnFirstTab = async () => {
+    await window.locator('[data-test="tab"][data-tab-id="1"]').click({ button: 'right' });
+    await expect(menu).toBeVisible();
+  };
+
+  await openMenuOnFirstTab();
+  await clickMenuItem(electronApp, 'next-tab');
+  await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).toHaveClass(/active/);
+  await expect(menu).toBeHidden();
+  // Both tabs are still there: the switch dismissed the menu rather than
+  // leaving Close Tab / Close Others live against the tab just left.
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(2);
+
+  // A tab closing invalidates the menu's anchor and its target as well —
+  // here the menu is raised on tab 1 while tab 2 is the one being closed.
+  await openMenuOnFirstTab();
+  await clickMenuItem(electronApp, 'close-tab');
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(1);
+  await expect(menu).toBeHidden();
 });

--- a/test-e2e/tabs.spec.js
+++ b/test-e2e/tabs.spec.js
@@ -12,6 +12,23 @@ const { test, expect, SAMPLE_BZZ_HASH } = require('./fixtures');
 const PAGE_A = `bzz://${SAMPLE_BZZ_HASH}/`;
 const PAGE_B = `bzz://${'b'.repeat(64)}/`;
 
+// A guest swallows input for a moment after it attaches, so the first click on
+// a freshly rendered page can be lost — and a lost *link* click is a false
+// failure, not a regression. Spend that window on an empty part of the page
+// (bottom-right of the webview, clear of every fixture's links) so the click
+// under test is the second one. Deliberately not a retry loop: retrying the
+// activation itself could paper over the very dispositions being asserted.
+async function wakeGuest(window) {
+  const spot = await window.evaluate(() => {
+    const wv = document.querySelector('webview:not(.hidden)');
+    if (!wv) return null;
+    const rect = wv.getBoundingClientRect();
+    return { x: rect.right - 12, y: rect.bottom - 12 };
+  });
+  if (spot) await window.mouse.click(spot.x, spot.y);
+  await window.waitForTimeout(150);
+}
+
 // Serve a page whose only content is a link to `PAGE_B`, and open it in the
 // active tab. Returns the link's coordinates in *window* space, so
 // `page.mouse` clicks go through the real hit-test path into the guest.
@@ -56,8 +73,18 @@ async function openLinkPage(window, harness) {
       { message: 'Waiting for the link fixture to render', timeout: 15_000 }
     )
     .toBe(true);
+  // Spend the guest's post-attach input-swallow window before the caller's
+  // click on the link — see `wakeGuest`.
+  await wakeGuest(window);
   return point;
 }
+
+// The tab element of the tab *before* the active one carries `before-active`,
+// which `toHaveClass(/active/)` also matches — so "tab N is the active one" is
+// asserted against the single `.active` element by id rather than by a regex
+// over one tab's class string.
+const expectActiveTab = (window, tabId) =>
+  expect(window.locator('[data-test="tab"].active')).toHaveAttribute('data-tab-id', String(tabId));
 
 const tabTitles = (window) =>
   window.evaluate(() =>
@@ -111,11 +138,11 @@ test('clicking a tab activates it', async ({ window }) => {
   // Open a second tab; new tabs become active automatically.
   await window.locator('[data-test="new-tab-btn"]').click();
   await expect(tabs).toHaveCount(2);
-  await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).toHaveClass(/active/);
+  await expectActiveTab(window, 2);
 
   // Switch back to the first tab.
   await window.locator('[data-test="tab"][data-tab-id="1"]').click();
-  await expect(window.locator('[data-test="tab"][data-tab-id="1"]')).toHaveClass(/active/);
+  await expectActiveTab(window, 1);
   await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).not.toHaveClass(/active/);
 });
 
@@ -162,7 +189,7 @@ test('switching tabs focuses the page, not the tab button', async ({
   // Keyboard switch (Ctrl+Tab) has to do the same — that was the mirror-image
   // half of the bug, which left focus on the *outgoing* tab's button.
   await clickMenuItem(electronApp, 'next-tab');
-  await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).toHaveClass(/active/);
+  await expectActiveTab(window, 2);
   await expect
     .poll(
       () =>
@@ -188,7 +215,7 @@ test('ctrl+click and middle-click open a background tab', async ({ window, harne
 
   await expect(tabs).toHaveCount(2);
   // Still on Page A, and its tab is still the active one.
-  await expect(window.locator('[data-test="tab"][data-tab-id="1"]')).toHaveClass(/active/);
+  await expectActiveTab(window, 1);
   await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).not.toHaveClass(/active/);
   // The background tab's webview must be hidden — it is created after the
   // switch that would otherwise have hidden it.
@@ -199,7 +226,7 @@ test('ctrl+click and middle-click open a background tab', async ({ window, harne
   // Middle-click behaves the same way.
   await window.mouse.click(point.x, point.y, { button: 'middle' });
   await expect(tabs).toHaveCount(3);
-  await expect(window.locator('[data-test="tab"][data-tab-id="1"]')).toHaveClass(/active/);
+  await expectActiveTab(window, 1);
 
   // The background tabs really did load Page B (a background tab that never
   // navigates would pass every assertion above).
@@ -209,6 +236,157 @@ test('ctrl+click and middle-click open a background tab', async ({ window, harne
       timeout: 15_000,
     })
     .toEqual(['Page A', 'Page B', 'Page B']);
+});
+
+// Coordinates, in *window* space, of an element in the foreground guest.
+async function pointInGuest(window, selector) {
+  let point;
+  await expect
+    .poll(
+      async () => {
+        point = await window.evaluate(async (sel) => {
+          const wv = document.querySelector('webview:not(.hidden)');
+          if (!wv || typeof wv.executeJavaScript !== 'function') return null;
+          try {
+            const box = await wv.executeJavaScript(
+              `(() => { const a = document.querySelector(${JSON.stringify(sel)});` +
+                'if (!a) return null; const r = a.getBoundingClientRect();' +
+                'return { x: r.x + r.width / 2, y: r.y + r.height / 2 }; })()'
+            );
+            if (!box) return null;
+            const rect = wv.getBoundingClientRect();
+            return { x: rect.x + box.x, y: rect.y + box.y };
+          } catch {
+            return null;
+          }
+        }, selector);
+        return !!point;
+      },
+      { message: `Waiting for ${selector} to render in the guest`, timeout: 15_000 }
+    )
+    .toBe(true);
+  return point;
+}
+
+const ctrlClick = async (window, point) => {
+  await window.keyboard.down('Control');
+  await window.mouse.click(point.x, point.y);
+  await window.keyboard.up('Control');
+};
+
+// #303: a `freedom://` internal page is a singleton tab, but the singleton
+// rule must not outrank the disposition. Ctrl+click on a freedom:// link had
+// the tab-reuse branch run before `background` was consulted, so it switched
+// the user onto Settings — the exact "stay on this page" behaviour the
+// modifier asks for.
+test('ctrl+click on a freedom:// link opens the internal page in the background', async ({
+  window,
+  harness,
+}) => {
+  await harness.setContentFixture(PAGE_A, {
+    body:
+      '<!doctype html><title>Page A</title><style>body{margin:0;padding:40px}' +
+      'a{display:inline-block;padding:20px;font-size:24px}</style>' +
+      '<a id="settings" href="freedom://settings">settings</a>',
+  });
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(PAGE_A);
+  await input.press('Enter');
+
+  const point = await pointInGuest(window, '#settings');
+  await wakeGuest(window);
+  await ctrlClick(window, point);
+
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(2);
+  // Still on Page A: the Settings tab was opened behind it, hidden.
+  await expectActiveTab(window, 1);
+  expect(
+    await window.evaluate(() => document.querySelectorAll('webview:not(.hidden)').length)
+  ).toBe(1);
+  // The background tab really is Settings (a tab that never navigated would
+  // pass every assertion above).
+  await expect
+    .poll(async () => (await tabTitles(window)).map((tab) => tab.title), {
+      message: 'Waiting for the background Settings tab to load',
+      timeout: 15_000,
+    })
+    .toEqual(['Page A', 'Settings']);
+
+  // A second Ctrl+click reuses the singleton tab rather than opening a
+  // duplicate — and still leaves the user on Page A.
+  await ctrlClick(window, point);
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(2);
+  await expectActiveTab(window, 1);
+});
+
+// #303: Chrome resolves the modifier before the `target` attribute — a
+// Ctrl+click never re-navigates the window a name already points at. When that
+// window is the tab the user is reading, reuse navigated the page out from
+// under them, the opposite of what the modifier asks for.
+//
+// Driven over `ipfs://`, not `bzz://`, on purpose: only `ipfs:`/`ipns:`/`web3:`
+// hrefs (and everything on a `web3:` page) are intercepted by
+// webview-preload's own disposition heuristic, which forwards the `target`
+// attribute in every disposition. A `bzz://` link goes out through Chromium's
+// `setWindowOpenHandler` instead, and Chromium has already dropped the frame
+// name by then — so a bzz fixture would pass with or without this fix.
+test('ctrl+click on a named-target link opens a new tab instead of reusing the named one', async ({
+  window,
+  harness,
+}) => {
+  const IPFS_A = `ipfs://bafybeib${'a'.repeat(51)}/`;
+  const IPFS_B = `ipfs://bafybeib${'b'.repeat(51)}/`;
+  const IPFS_C = `ipfs://bafybeib${'c'.repeat(51)}/`;
+  // Page B lives in the tab named "foo" and links to Page C with the same
+  // target — the self-targeting case from the audit.
+  await harness.setContentFixture(IPFS_A, {
+    body:
+      '<!doctype html><title>Page A</title><style>body{margin:0;padding:40px}' +
+      'a{display:inline-block;padding:20px;font-size:24px}</style>' +
+      `<a id="lnk" target="foo" href="${IPFS_B}">b</a>`,
+  });
+  await harness.setContentFixture(IPFS_B, {
+    body:
+      '<!doctype html><title>Page B</title><style>body{margin:0;padding:40px}' +
+      'a{display:inline-block;padding:20px;font-size:24px}</style>' +
+      `<a id="lnk" target="foo" href="${IPFS_C}">c</a>`,
+  });
+  await harness.setContentFixture(IPFS_C, {
+    body: '<!doctype html><title>Page C</title><h1>C</h1>',
+  });
+
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(IPFS_A);
+  await input.press('Enter');
+
+  // Plain click: Page B opens in a new foreground tab, which takes the name.
+  const linkInA = await pointInGuest(window, '#lnk');
+  await wakeGuest(window);
+  await window.mouse.click(linkInA.x, linkInA.y);
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(2);
+  await expectActiveTab(window, 2);
+  await expect
+    .poll(async () => (await tabTitles(window)).map((tab) => tab.title), {
+      message: 'Waiting for the named tab to load Page B',
+      timeout: 15_000,
+    })
+    .toEqual(['Page A', 'Page B']);
+
+  // Ctrl+click the target="foo" link *inside* that tab: a third tab opens in
+  // the background and Page B stays where it is.
+  const linkInB = await pointInGuest(window, '#lnk');
+  await wakeGuest(window);
+  await ctrlClick(window, linkInB);
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(3);
+  await expectActiveTab(window, 2);
+  await expect
+    .poll(async () => (await tabTitles(window)).map((tab) => tab.title), {
+      message: 'Waiting for the background tab to load Page C',
+      timeout: 15_000,
+    })
+    .toEqual(['Page A', 'Page B', 'Page C']);
 });
 
 // #303: Ctrl+Shift+click promotes the same link to a FOREGROUND tab.
@@ -222,7 +400,7 @@ test('ctrl+shift+click opens a foreground tab', async ({ window, harness }) => {
   await window.keyboard.up('Control');
 
   await expect(window.locator('[data-test="tab"]')).toHaveCount(2);
-  await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).toHaveClass(/active/);
+  await expectActiveTab(window, 2);
 });
 
 // #303: Shift+click opens a new *window*, not a tab in this one.
@@ -290,7 +468,7 @@ test('the tab strip scrolls instead of clipping, keeping the active tab visible'
     document.querySelector('.tabs-container').scrollLeft = 0;
   });
   await clickMenuItem(electronApp, 'next-tab');
-  await expect(window.locator('[data-test="tab"][data-tab-id="1"]')).toHaveClass(/active/);
+  await expectActiveTab(window, 1);
   const wrapped = await measure();
   expect(wrapped.activeTabId).toBe('1');
   expect(wrapped.activeVisible).toBe(true);
@@ -316,7 +494,7 @@ test('the tab context menu closes on a keyboard tab switch and on a tab close', 
 
   await openMenuOnFirstTab();
   await clickMenuItem(electronApp, 'next-tab');
-  await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).toHaveClass(/active/);
+  await expectActiveTab(window, 2);
   await expect(menu).toBeHidden();
   // Both tabs are still there: the switch dismissed the menu rather than
   // leaving Close Tab / Close Others live against the tab just left.

--- a/test-e2e/tabs.spec.js
+++ b/test-e2e/tabs.spec.js
@@ -159,6 +159,9 @@ test('switching tabs focuses the page, not the tab button', async ({
   await harness.setContentFixture(PAGE_A, {
     body: '<!doctype html><title>Page A</title><p>a</p>',
   });
+  await harness.setContentFixture(PAGE_B, {
+    body: '<!doctype html><title>Page B</title><p>b</p>',
+  });
 
   const input = window.locator('[data-test="address-input"]');
   await input.click();
@@ -167,6 +170,12 @@ test('switching tabs focuses the page, not the tab button', async ({
 
   await window.locator('[data-test="new-tab-btn"]').click();
   await expect(window.locator('[data-test="tab"]')).toHaveCount(2);
+  // Put the second tab on a real page too: a tab still sitting on the new-tab
+  // page hands the keyboard to the address bar instead, which is the next
+  // test's subject.
+  await input.click();
+  await input.fill(PAGE_B);
+  await input.press('Enter');
 
   // Mouse switch back to the first tab.
   await window.locator('[data-test="tab"][data-tab-id="1"]').click();
@@ -200,6 +209,51 @@ test('switching tabs focuses the page, not the tab button', async ({
       { message: 'Waiting for the page to take focus after Ctrl+Tab' }
     )
     .toMatch(/^WEBVIEW/);
+});
+
+// #304, the other end of the same rule: a tab sitting on this window's new-tab
+// page has no focus target inside its guest (`home.html`/`private.html` are
+// inert documents), so handing it the keyboard means the next keystroke goes
+// nowhere. Chrome focuses the omnibox when you switch to a tab on the NTP.
+test('switching back to a tab on the new-tab page focuses the address bar', async ({
+  window,
+  electronApp,
+  harness,
+}) => {
+  await harness.setContentFixture(PAGE_A, {
+    body: '<!doctype html><title>Page A</title><p>a</p>',
+  });
+
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(PAGE_A);
+  await input.press('Enter');
+
+  // A second tab, left on the new-tab page.
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(2);
+
+  // Away to the page tab (whose guest takes the keyboard) …
+  await window.locator('[data-test="tab"][data-tab-id="1"]').click();
+  const focusedTag = () =>
+    window.evaluate(() => `${document.activeElement?.tagName}.${document.activeElement?.id || ''}`);
+  await expect
+    .poll(focusedTag, { message: 'Waiting for the page to take focus' })
+    .toMatch(/^WEBVIEW/);
+
+  // … and back to the new-tab-page tab by keyboard (Ctrl+Tab), the case the
+  // user hits after a switch, not on a fresh tab.
+  await clickMenuItem(electronApp, 'next-tab');
+  await expectActiveTab(window, 2);
+  await expect
+    .poll(focusedTag, { message: 'Waiting for the address bar to take focus' })
+    .toBe('INPUT.address-input');
+  await expect(input).toHaveValue('');
+
+  // The point of focusing it: typing immediately goes into the address bar
+  // rather than being swallowed by the inert guest.
+  await window.keyboard.type('example.com');
+  await expect(input).toHaveValue('example.com');
 });
 
 // The other side of #304: with focus living in the guest after every tab

--- a/test-e2e/tabs.spec.js
+++ b/test-e2e/tabs.spec.js
@@ -202,6 +202,73 @@ test('switching tabs focuses the page, not the tab button', async ({
     .toMatch(/^WEBVIEW/);
 });
 
+// The other side of #304: with focus living in the guest after every tab
+// switch, a keypress no longer reaches the shell's own `keydown` handlers — so
+// the page context menu (the one chrome surface raised from *inside* the
+// guest) has to take the keyboard while it is up, the way a native menu does,
+// or Escape never dismisses it and every item stays live.
+test('the page context menu takes the keyboard from the page and hands it back', async ({
+  window,
+  harness,
+}) => {
+  await harness.setContentFixture(PAGE_A, {
+    body: '<!doctype html><title>Page A</title><p>a</p>',
+  });
+
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(PAGE_A);
+  await input.press('Enter');
+
+  // Switch away and back, which is what leaves the guest holding focus.
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(2);
+  await window.locator('[data-test="tab"][data-tab-id="1"]').click();
+  await expectActiveTab(window, 1);
+  const focusedTag = () =>
+    window.evaluate(() => `${document.activeElement?.tagName}.${document.activeElement?.id || ''}`);
+  await expect
+    .poll(focusedTag, { message: 'Waiting for the page to take focus after the tab switch' })
+    .toMatch(/^WEBVIEW/);
+
+  // Right-click inside the guest, through the real hit-test path.
+  await wakeGuest(window);
+  const spot = await window.evaluate(() => {
+    const rect = document.querySelector('webview:not(.hidden)').getBoundingClientRect();
+    return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+  });
+  await window.mouse.click(spot.x, spot.y, { button: 'right' });
+
+  const menu = window.locator('#page-context-menu');
+  await expect(menu).toBeVisible();
+  // The shell, not the guest, owns the keyboard while the menu is up.
+  await expect
+    .poll(focusedTag, { message: 'Waiting for the menu to take focus' })
+    .toBe('DIV.page-context-menu');
+
+  await window.keyboard.press('Escape');
+  await expect(menu).toBeHidden();
+  // …and the page gets it back, so scrolling and typing keep working — read
+  // from the guest itself, not just from the chrome document's activeElement.
+  await expect
+    .poll(focusedTag, { message: 'Waiting for the page to get focus back' })
+    .toMatch(/^WEBVIEW/);
+  await expect
+    .poll(
+      () =>
+        window.evaluate(async () => {
+          const wv = document.querySelector('webview:not(.hidden)');
+          try {
+            return await wv.executeJavaScript('document.hasFocus()');
+          } catch {
+            return null;
+          }
+        }),
+      { message: 'Waiting for the guest to report the keyboard back' }
+    )
+    .toBe(true);
+});
+
 // #303: Ctrl/Cmd+click and middle-click open a BACKGROUND tab — the tab is
 // created and loads, but the current page stays active and keeps focus.
 test('ctrl+click and middle-click open a background tab', async ({ window, harness }) => {


### PR DESCRIPTION
## What

Fixes five Chrome-parity bugs from the 2026-09 UI interaction audit
(`docs/audits/ui-interaction-2026-09.md`, PR #317), all in the tab strip and
the link-activation path. All were pre-existing on `main`.

**#303 — link dispositions.** `webview-preload.js` collapsed every modifier
into one `wantsNewTab` boolean, and `setWindowOpenHandler` destructured only
`url`/`frameName`, dropping the `disposition` Chromium had already derived. So
Ctrl/Cmd+click, middle-click *and* Shift+click all opened a **foreground** tab.
Both paths now resolve Chrome's heuristic:

| activation | before | now |
| --- | --- | --- |
| Ctrl/Cmd+click, middle-click | foreground tab | **background tab** |
| Ctrl/Cmd+Shift+click, Shift+middle-click | foreground tab | foreground tab |
| Shift+click | tab in this window | **new window** |
| `target="_blank"` / named target | foreground tab | foreground tab (unchanged) |

Modifiers win over the `target` attribute for foreground-vs-background, as in
Chrome; a named target is still forwarded in every disposition so tab reuse
keeps working. `createTab` / `openInNewTabWithTarget` gained a `background`
option: the tab is created, appended and navigated but not switched to, its
webview starts `hidden` (webviews are created visible and only `switchTab`
hides the others), and its own webview is passed to `loadTarget` so a
background navigation can't land in the tab the user is still looking at.
The `new-window` disposition is sent back out through the existing
`window:new-with-url` request, which is where the private-window guard lives —
a Shift+click in a private window still opens a private window.

**#304 — tab-switch focus.** `switchTab()` now focuses the activated tab's
webview, so scrolling and typing work immediately, focus is never left on the
`<button class="tab">`, and never stranded on the outgoing (now hidden)
webview. Three activations are deliberately excluded and handed to
navigation.js' `tab-switched` case, which is the only place that knows the
address bar is the target: a brand-new tab (new-tab page → focus the address
bar; a real page opened from a link → focus the page), an *existing* tab
sitting on the new-tab page (`home.html`/`private.html` have no focus target,
so the guest would swallow the next keystroke — Chrome focuses the omnibox
here too), and a tab left carrying an uncommitted address-bar edit, which
comes back mid-edit with the bar focused and its selection restored (#314).
Doing both in one switch is *not* harmless: `<webview>.focus()`
hands focus to the guest asynchronously, so it lands after a synchronous
`addressInput.focus()` and takes the address bar's focus away again — that is
exactly what the first draft did, and the private-window spec caught it.

**#311 — tab strip overflow.** `.tabs-container` was `overflow: hidden`, so
past the 50px tab-width floor the strip simply clipped — the active tab could
be off-screen and unclickable. It now scrolls horizontally (scrollbar hidden,
as in Chrome), `switchTab` scrolls the active tab into view, and edge fades
mark the direction the hidden tabs are in. `.tab { scroll-margin-inline }`
keeps the active tab's corner flare inside the strip's flare padding rather
than flush against the content edge.

**#312 — private new tab.** The private start page is now recognised as that
window's new-tab page (`isNewTabPageUrl`, covering both the friendly
`freedom://private` form `tab.url` carries while resolving and the resolved
`file://…/pages/private.html` form Chromium commits). It therefore derives to
an **empty** address bar — Chrome's Incognito NTP shows an empty omnibox, same
as its NTP — which in turn lets the existing "this is a fresh empty tab" rule
fire and focus the bar. The focus call now also `select()`s, matching the
explicit focus-address-bar shortcut in tabs.js, per the issue.

**#315 — tab context menu.** Any tab activation (click, Ctrl+Tab,
Ctrl+PageDown, Ctrl+1..8, the tab promoted when another closes) and any tab
close now dismisses the menu, not just the activations that happen to route
through a strip click. Its items additionally refuse a `contextMenuTabId` that
is no longer in the tab list, so a destructive item can never resolve to
whatever tab took that id's place. The dead `#bzz-webview` focus/mousedown
dismissal listeners in tabs.js are removed (webviews are created id-less, so
that lookup was always `null`) — the removal the issue asks for, tracked in
#306; the identical dead lookups in `menus.js`, `bookmarks-ui.js` and
`autocomplete.js` are left for #306's own PR.

## Why

These are five of the fourteen behaviour bugs filed from the interaction audit,
picked because they share two root causes the audit named: no focus policy for
tab activation (#303's stranded focus, #304, #312) and an inconsistent
dismissal set for the tab context menu (#315). Each one is a place where
Freedom's chrome does something a Chrome user would not expect — losing your
place on every Ctrl+click, a keystroke going to a page you can no longer see,
a tab you cannot click, an address bar you cannot type into.

## How it was verified

- `npm run lint` — clean. `npm test` — 3886 passed, 0 failed (head of branch;
  3835 when this PR was opened).
- `xvfb-run -a npx playwright test --project=harness test-e2e/tabs.spec.js test-e2e/private-windows.spec.js`
  — **21/21 passed**. New specs: background vs. foreground vs. new-window
  dispositions driven with real `mouse.click` / `down({button:'middle'})` at
  window coordinates with real modifier keys, tab-switch focus (mouse and
  keyboard, page tab and new-tab-page tab), strip overflow with 20 tabs,
  context-menu dismissal, private New Tab focus.
- `onchain-apps.spec.js` — **green**, and the record of it here has been
  corrected. The first version of this section listed its failure alongside
  `settings-adblock.spec.js` as reproducing on `origin/main` "as a load flake".
  It was not: review round R2 bisected it to this branch and showed it was
  deterministic — #304's guest focus meant Escape no longer reached the page
  context menu once the guest held the keyboard. It was a real regression from
  this PR and is fixed in `8dc0963c`, which also added an `e2e-tabs` CI job
  running `tabs.spec.js` + `onchain-apps.spec.js` (neither was in any CI job
  before, which is why the regression shipped green). **A red
  `onchain-apps.spec.js` is not a known environmental flake — treat it as a
  real failure.**
- `settings-adblock.spec.js` is the one full-suite failure that *does*
  reproduce on `origin/main` with this branch stashed, on the same machine:
  no filter lists are bundled in this clone.
- **Mutation-tested**: with the seven touched source files reverted to
  `origin/main` and the new tests kept, 22 tests fail — every new assertion
  fails against the unfixed source rather than passing vacuously.
- Ran the real app under `xvfb` via the `run-freedom` skill in **both themes**
  and read the screenshots; measured state is printed alongside each shot.

## Evidence

Twenty tabs in a 1200px window — the active (20th) tab is visible and
clickable, the strip is scrolled to it, and the left edge fades to show more
tabs are hidden that way. Compare with the wrong state in #311, where three
tabs including the active one were clipped past the edge with nothing to reach
them by. Measured:
`{"tabs":20,"scrollWidth":1140,"clientWidth":1010,"scrollLeft":130,"activeVisible":true,"classes":"tabs-container overflow-start"}`

![tab strip overflow, active tab visible (dark)](https://raw.githubusercontent.com/solardev-xyz/alan-artifacts/main/solardev-xyz/freedom-browser/pr319/20260908-233353-d-01-tab-strip-overflow-active-last.png)

Same state in light theme:

![tab strip overflow, active tab visible (light)](https://raw.githubusercontent.com/solardev-xyz/alan-artifacts/main/solardev-xyz/freedom-browser/pr319/20260908-233356-l-01-tab-strip-overflow-active-last.png)

After Ctrl+Tab from tab 20 wraps to tab 1, the strip scrolls back so tab 1 is
fully visible with its corner flare, and the fade flips to the right edge —
`{"activeTabId":"1","scrollLeft":0,"activeVisible":true,"classes":"tabs-container overflow-end"}`:

![strip scrolled back to the active tab](https://raw.githubusercontent.com/solardev-xyz/alan-artifacts/main/solardev-xyz/freedom-browser/pr319/20260908-233403-d-02-tab-strip-overflow-scrolled-to-active.png)

Ctrl+click on a link: Page B opens in a **background** tab, Page A stays
active, displayed and focused —
`{"tabs":[{"title":"Page A","active":true},{"title":"Page B","active":false}],"visibleWebviews":1,"focus":"WEBVIEW."}`:

![ctrl+click opens a background tab](https://raw.githubusercontent.com/solardev-xyz/alan-artifacts/main/solardev-xyz/freedom-browser/pr319/20260908-233407-d-03-ctrl-click-background-tab.png)

Tab context menu open over tab 1, then dismissed by a keyboard tab switch (the
app menu's Next Tab, i.e. Ctrl+Tab) — before, it stayed up over the old tab
with every destructive item live:

![tab context menu open](https://raw.githubusercontent.com/solardev-xyz/alan-artifacts/main/solardev-xyz/freedom-browser/pr319/20260908-233336-d-04-tab-context-menu-open.png)

![menu dismissed by the keyboard switch](https://raw.githubusercontent.com/solardev-xyz/alan-artifacts/main/solardev-xyz/freedom-browser/pr319/20260908-233341-d-05-tab-context-menu-dismissed-by-switch.png)

New Tab in a private window: empty address bar with the focus ring on it,
private start page loaded — `{"active":"INPUT#address-input","url":"","tabs":2}`
(was `{"active":"BODY#","url":"freedom://private"}`):

![private window new tab focuses an empty address bar](https://raw.githubusercontent.com/solardev-xyz/alan-artifacts/main/solardev-xyz/freedom-browser/pr319/20260908-233345-d-06-private-new-tab-focused-empty-address-bar.png)

## Review notes

- One deliberate scope call: `switchTab` dismisses the *tab* context menu
  only. The audit note in #315 also mentions the page context menu, but that is
  #308's own fix and lives in `page-context-menu.js`.
- Chromium reports `new-window` for a sized `window.open(url, '', 'width=…')`
  popup as well as for a Shift+click, so such popups now open a window instead
  of a tab. That is closer to Chrome than the previous "everything is a
  foreground tab", but it is a behaviour change beyond the literal issue text.
- Because the page now has focus right after a tab switch, keystrokes go to the
  guest — so the e2e specs drive Ctrl+Tab / Ctrl+W through the application menu
  items (`next-tab`, `close-tab`) rather than `page.keyboard`, which is the
  path a real accelerator takes. Renderer-only `window.keydown` handlers were
  already unreachable whenever the user had clicked into a page, so this
  changes no shortcut's reachability.

Closes #303
Closes #304
Closes #311
Closes #312
Closes #315

