### PR TITLE
fix(address bar): match Chrome's uncommitted-edit behaviour (#305, #310, #313, #314)

### DIFF
--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -44,11 +44,13 @@ import {
   hardReloadPage,
   onSettingsChanged,
   setOnHistoryRecorded,
+  setSuggestionPreviewProbe,
   closeTrustPopover,
 } from './lib/navigation.js';
 import {
   initAutocomplete,
   setOnNavigate,
+  isSuggestionPreviewActive,
   refreshCache as refreshAutocompleteCache,
   hide as hideAutocomplete,
 } from './lib/autocomplete.js';
@@ -128,6 +130,9 @@ setLoadTargetHandler(loadTarget);
 setReloadHandler(reloadPage);
 setHardReloadHandler(hardReloadPage);
 setOnNavigate(loadTarget);
+// Escape ownership between the two handlers bound to the address input:
+// while a suggestion is previewed, autocomplete.js takes the press. #310.
+setSuggestionPreviewProbe(isSuggestionPreviewActive);
 setOnHistoryRecorded(refreshAutocompleteCache);
 setOnOpenHistory(() => loadTarget('freedom://history'));
 setOnNewTab(() => createTab());

--- a/src/renderer/lib/address-bar-edit.js
+++ b/src/renderer/lib/address-bar-edit.js
@@ -1,0 +1,77 @@
+// Chrome's "user input in progress" state for the address bar, per tab.
+//
+// Chrome's omnibox tracks whether the user has an uncommitted edit. While
+// that flag is set:
+//   - a navigation committing in the tab updates the tab strip, the security
+//     chip and the page, but never rewrites the text the user is typing
+//     (issue #305), and
+//   - because the flag and the draft it carries live on the *tab*, switching
+//     away and back restores the edit and its selection (issue #314).
+// The edit ends when the user commits it (form submit / a picked suggestion,
+// both of which funnel through `loadTarget`) or reverts it (Escape).
+//
+// The draft is stored on the tab's `navigationState` (`addressBarPendingInput`
+// / `addressBarPendingSelection`) so it is per-tab by construction and dies
+// with the tab. It is deliberately *not* the same field as
+// `addressBarSnapshot`, which keeps holding the page's own display URL (the
+// omnibox "permanent text") so Escape and the trust/protocol surfaces still
+// have something truthful to fall back to while an edit is in flight.
+import { getActiveTabState } from './tabs.js';
+
+const activeNavState = () => {
+  try {
+    return typeof getActiveTabState === 'function' ? getActiveTabState() || null : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Record an uncommitted user edit of the address bar.
+ *
+ * @param {string} value - the text currently in the address input
+ * @param {{start: number, end: number, direction: string}|null} selection
+ * @param {object|null} navState - tab navigation state (defaults to active tab)
+ */
+export const setAddressBarEdit = (value, selection = null, navState = activeNavState()) => {
+  if (!navState) return;
+  navState.addressBarPendingInput = typeof value === 'string' ? value : '';
+  navState.addressBarPendingSelection = selection;
+};
+
+/** Forget any uncommitted edit (the user committed or reverted it). */
+export const clearAddressBarEdit = (navState = activeNavState()) => {
+  if (!navState) return;
+  navState.addressBarPendingInput = null;
+  navState.addressBarPendingSelection = null;
+};
+
+/** True while the user has an uncommitted edit in this tab's address bar. */
+export const isAddressBarEditInProgress = (navState = activeNavState()) =>
+  typeof navState?.addressBarPendingInput === 'string';
+
+/** The uncommitted draft for this tab, or null when there is none. */
+export const getAddressBarEdit = (navState = activeNavState()) =>
+  isAddressBarEditInProgress(navState) ? navState.addressBarPendingInput : null;
+
+/** Selection range of an input, or null when it can't be read. */
+export const captureInputSelection = (input) => {
+  if (!input) return null;
+  const { selectionStart, selectionEnd, selectionDirection } = input;
+  if (typeof selectionStart !== 'number' || typeof selectionEnd !== 'number') return null;
+  return {
+    start: selectionStart,
+    end: selectionEnd,
+    direction: selectionDirection || 'none',
+  };
+};
+
+/** Re-apply a selection captured by `captureInputSelection`. */
+export const applyInputSelection = (input, selection) => {
+  if (!input || !selection || typeof input.setSelectionRange !== 'function') return;
+  try {
+    input.setSelectionRange(selection.start, selection.end, selection.direction || 'none');
+  } catch {
+    // Inputs that don't support selection ranges (type=email/number) throw.
+  }
+};

--- a/src/renderer/lib/address-bar-edit.test.js
+++ b/src/renderer/lib/address-bar-edit.test.js
@@ -1,0 +1,81 @@
+const loadModule = async (navState) => {
+  jest.resetModules();
+  jest.doMock('./tabs.js', () => ({
+    getActiveTabState: jest.fn(() => navState),
+  }));
+  return import('./address-bar-edit.js');
+};
+
+describe('address-bar-edit (Chrome "user input in progress")', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('tracks and clears an uncommitted edit on the active tab', async () => {
+    const navState = { addressBarPendingInput: null, addressBarPendingSelection: null };
+    const mod = await loadModule(navState);
+
+    expect(mod.isAddressBarEditInProgress()).toBe(false);
+    expect(mod.getAddressBarEdit()).toBeNull();
+
+    mod.setAddressBarEdit('half-typed', { start: 3, end: 3, direction: 'none' });
+    expect(mod.isAddressBarEditInProgress()).toBe(true);
+    expect(mod.getAddressBarEdit()).toBe('half-typed');
+    expect(navState.addressBarPendingSelection).toEqual({ start: 3, end: 3, direction: 'none' });
+
+    // An emptied bar is still an edit in progress — Chrome doesn't repaint a
+    // bar the user deliberately cleared.
+    mod.setAddressBarEdit('');
+    expect(mod.isAddressBarEditInProgress()).toBe(true);
+    expect(mod.getAddressBarEdit()).toBe('');
+
+    mod.clearAddressBarEdit();
+    expect(mod.isAddressBarEditInProgress()).toBe(false);
+    expect(navState.addressBarPendingInput).toBeNull();
+    expect(navState.addressBarPendingSelection).toBeNull();
+  });
+
+  test('writes to an explicitly passed tab state, not just the active one', async () => {
+    const activeState = { addressBarPendingInput: null };
+    const otherState = { addressBarPendingInput: null };
+    const mod = await loadModule(activeState);
+
+    mod.setAddressBarEdit('draft for the other tab', null, otherState);
+
+    expect(otherState.addressBarPendingInput).toBe('draft for the other tab');
+    expect(activeState.addressBarPendingInput).toBeNull();
+    expect(mod.isAddressBarEditInProgress(otherState)).toBe(true);
+    expect(mod.isAddressBarEditInProgress()).toBe(false);
+  });
+
+  test('is a no-op when there is no active tab state', async () => {
+    const mod = await loadModule(null);
+
+    expect(() => mod.setAddressBarEdit('x')).not.toThrow();
+    expect(() => mod.clearAddressBarEdit()).not.toThrow();
+    expect(mod.isAddressBarEditInProgress()).toBe(false);
+  });
+
+  test('captures and re-applies an input selection', async () => {
+    const mod = await loadModule({});
+
+    expect(mod.captureInputSelection(null)).toBeNull();
+    expect(mod.captureInputSelection({})).toBeNull();
+    expect(
+      mod.captureInputSelection({ selectionStart: 2, selectionEnd: 5, selectionDirection: 'forward' })
+    ).toEqual({ start: 2, end: 5, direction: 'forward' });
+
+    const setSelectionRange = jest.fn();
+    mod.applyInputSelection({ setSelectionRange }, { start: 2, end: 5, direction: 'forward' });
+    expect(setSelectionRange).toHaveBeenCalledWith(2, 5, 'forward');
+
+    // Inputs that reject selection ranges must not break the restore path.
+    const throwing = {
+      setSelectionRange: jest.fn(() => {
+        throw new Error('not supported');
+      }),
+    };
+    expect(() => mod.applyInputSelection(throwing, { start: 0, end: 1 })).not.toThrow();
+    expect(() => mod.applyInputSelection({}, { start: 0, end: 1 })).not.toThrow();
+  });
+});

--- a/src/renderer/lib/autocomplete.js
+++ b/src/renderer/lib/autocomplete.js
@@ -35,6 +35,10 @@ let isOpen = false;
 // `originalSelection` keeps the caret/selection that went with it.
 let originalQuery = '';
 let originalSelection = null;
+// True once a keyboard preview has written a suggestion's URL over the typed
+// text (mouse hover only moves the highlight). It's what makes the first
+// Escape this module's to own — there is something to restore. See #310/#313.
+let previewWroteInput = false;
 
 // Callbacks
 let onNavigate = null;
@@ -201,6 +205,7 @@ export const hide = () => {
   dropdown.classList.add('hidden');
   isOpen = false;
   selectedIndex = -1;
+  previewWroteInput = false;
   currentSuggestions = [];
   originalQuery = '';
   originalSelection = null;
@@ -210,13 +215,17 @@ export const hide = () => {
 };
 
 /**
- * True while a suggestion is highlighted in an open dropdown — i.e. while the
- * address bar shows a previewed row rather than the user's own text. That is
- * exactly the state in which this module owns the Escape press (it returns to
- * the typed text); navigation.js reads it to stand down for that one press
- * and take over from the next. See #310.
+ * True while the address bar shows a *previewed* suggestion rather than the
+ * user's own text. That is exactly the state in which this module owns the
+ * Escape press (it returns to the typed text); navigation.js reads it to
+ * stand down for that one press and take over from the next. See #310.
+ *
+ * Keyed on whether a preview actually rewrote the input, not on the highlight:
+ * mouse hover moves the highlight without touching the bar's text, so an
+ * Escape after a mere hover has nothing to restore and must not cost the user
+ * an extra press — Chrome closes the list and reverts in one.
  */
-export const isSuggestionPreviewActive = () => isOpen && selectedIndex >= 0;
+export const isSuggestionPreviewActive = () => isOpen && previewWroteInput;
 
 /**
  * Update selection highlight
@@ -247,6 +256,7 @@ const captureTypedText = () => {
 /** Put the user's typed text (and caret) back, with nothing highlighted. */
 const restoreTypedText = () => {
   selectedIndex = -1;
+  previewWroteInput = false;
   updateSelection();
   addressInput.value = originalQuery;
   applyInputSelection(addressInput, originalSelection);
@@ -267,6 +277,7 @@ const previewRow = (index) => {
   selectedIndex = index;
   updateSelection();
   addressInput.value = currentSuggestions[selectedIndex]?.url || '';
+  previewWroteInput = true;
   // A previewed suggestion is still an uncommitted edit of this tab's address
   // bar: it survives page commits (#305) and tab switches (#314).
   setAddressBarEdit(addressInput.value, null);
@@ -358,8 +369,11 @@ const handleKeyDown = (e) => {
           // Picking a suggestion commits the omnibox: the tab we're leaving
           // no longer has an edit in progress. `loadTarget` does this for the
           // navigating branch below; the tab-switch branch has to do it here.
+          // `fromAddressBarCommit` tells the tab-switch handler not to adopt
+          // the bar's leftover text (the previewed target URL, or the query)
+          // as the leaving tab's page display.
           clearAddressBarEdit();
-          switchTab(suggestion.tabId);
+          switchTab(suggestion.tabId, { fromAddressBarCommit: true });
           addressInput.blur();
         } else if (onNavigate) {
           addressInput.value = suggestion.url;
@@ -379,7 +393,12 @@ const handleKeyDown = (e) => {
       // after that (focus the page). #310.
       e.preventDefault();
       e.stopPropagation();
-      if (selectedIndex >= 0) {
+      // Only a keyboard preview rewrote the bar; a hovered row left the typed
+      // text alone, so there is nothing to restore and navigation.js' handler
+      // (which ran first, having stood down only for a real preview) already
+      // reverted to the page URL. Writing `originalQuery` back here would undo
+      // that revert. #310.
+      if (previewWroteInput) {
         restoreTypedText();
       }
       hide();
@@ -412,9 +431,9 @@ const handleClick = (e) => {
   // If it's an open tab, switch to it
   if (tabId) {
     // Committing by mouse ends the edit for the tab we're leaving, same as
-    // the keyboard path.
+    // the keyboard path — including the "don't adopt the bar's text" flag.
     clearAddressBarEdit();
-    switchTab(parseInt(tabId, 10));
+    switchTab(parseInt(tabId, 10), { fromAddressBarCommit: true });
     addressInput.blur();
   } else if (url && onNavigate) {
     addressInput.value = url;

--- a/src/renderer/lib/autocomplete.js
+++ b/src/renderer/lib/autocomplete.js
@@ -8,6 +8,12 @@ import {
   generateSuggestions as generateAutocompleteSuggestions,
   getPlaceholderLetter,
 } from './autocomplete-utils.js';
+import {
+  applyInputSelection,
+  captureInputSelection,
+  clearAddressBarEdit,
+  setAddressBarEdit,
+} from './address-bar-edit.js';
 
 const electronAPI = window.electronAPI;
 
@@ -24,7 +30,11 @@ let selectedIndex = -1;
 let currentSuggestions = [];
 let debounceTimer = null;
 let isOpen = false;
-let originalQuery = ''; // Store original query for restoring on Escape
+// The text the user typed, restored whenever the highlight comes back to
+// "row 0" — arrowing off either end of the list, or the first Escape.
+// `originalSelection` keeps the caret/selection that went with it.
+let originalQuery = '';
+let originalSelection = null;
 
 // Callbacks
 let onNavigate = null;
@@ -193,10 +203,20 @@ export const hide = () => {
   selectedIndex = -1;
   currentSuggestions = [];
   originalQuery = '';
+  originalSelection = null;
   if (wasOpen) {
     hideMenuBackdrop();
   }
 };
+
+/**
+ * True while a suggestion is highlighted in an open dropdown — i.e. while the
+ * address bar shows a previewed row rather than the user's own text. That is
+ * exactly the state in which this module owns the Escape press (it returns to
+ * the typed text); navigation.js reads it to stand down for that one press
+ * and take over from the next. See #310.
+ */
+export const isSuggestionPreviewActive = () => isOpen && selectedIndex >= 0;
 
 /**
  * Update selection highlight
@@ -212,6 +232,56 @@ const updateSelection = () => {
   if (selectedIndex >= 0 && items[selectedIndex]) {
     items[selectedIndex].scrollIntoView({ block: 'nearest' });
   }
+};
+
+/**
+ * Remember the text the user typed before the highlight left "row 0", so any
+ * path back to it (ArrowUp off the first suggestion, Escape) can restore both
+ * the string and the caret.
+ */
+const captureTypedText = () => {
+  originalQuery = addressInput.value;
+  originalSelection = captureInputSelection(addressInput);
+};
+
+/** Put the user's typed text (and caret) back, with nothing highlighted. */
+const restoreTypedText = () => {
+  selectedIndex = -1;
+  updateSelection();
+  addressInput.value = originalQuery;
+  applyInputSelection(addressInput, originalSelection);
+  setAddressBarEdit(originalQuery, originalSelection);
+};
+
+/**
+ * Keyboard selection: highlight a row and preview its URL in the address bar.
+ * `index === -1` means the typed-text row, which is a real row here (Chrome's
+ * default match) rather than a wrap-around target. See #313.
+ */
+const previewRow = (index) => {
+  if (selectedIndex === -1) captureTypedText();
+  if (index < 0) {
+    restoreTypedText();
+    return;
+  }
+  selectedIndex = index;
+  updateSelection();
+  addressInput.value = currentSuggestions[selectedIndex]?.url || '';
+  // A previewed suggestion is still an uncommitted edit of this tab's address
+  // bar: it survives page commits (#305) and tab switches (#314).
+  setAddressBarEdit(addressInput.value, null);
+};
+
+/**
+ * Mouse hover: move the highlight without rewriting the address bar (Chrome
+ * previews on keyboard selection only), so Enter commits the row under the
+ * cursor instead of the typed text. See #313.
+ */
+const highlightRow = (index) => {
+  if (index === selectedIndex || !currentSuggestions[index]) return;
+  if (selectedIndex === -1) captureTypedText();
+  selectedIndex = index;
+  updateSelection();
 };
 
 /**
@@ -261,22 +331,20 @@ const handleKeyDown = (e) => {
   switch (e.key) {
     case 'ArrowDown':
       e.preventDefault();
-      if (selectedIndex === -1) {
-        originalQuery = addressInput.value; // Save original query on first navigation
+      // The list stops at its last row — no wrap back to the top. #313.
+      if (selectedIndex < currentSuggestions.length - 1) {
+        previewRow(selectedIndex + 1);
       }
-      selectedIndex = (selectedIndex + 1) % currentSuggestions.length;
-      updateSelection();
-      addressInput.value = currentSuggestions[selectedIndex].url;
       break;
 
     case 'ArrowUp':
       e.preventDefault();
-      if (selectedIndex === -1) {
-        originalQuery = addressInput.value; // Save original query on first navigation
+      // Row -1 *is* the user's typed text (Chrome's default match), so
+      // ArrowUp off the first suggestion returns to it — and stops there
+      // rather than wrapping to the bottom of the list. #313.
+      if (selectedIndex >= 0) {
+        previewRow(selectedIndex - 1);
       }
-      selectedIndex = selectedIndex <= 0 ? currentSuggestions.length - 1 : selectedIndex - 1;
-      updateSelection();
-      addressInput.value = currentSuggestions[selectedIndex].url;
       break;
 
     case 'Enter':
@@ -287,6 +355,10 @@ const handleKeyDown = (e) => {
 
         // If it's an open tab, switch to it
         if (suggestion.type === 'tab' && suggestion.tabId) {
+          // Picking a suggestion commits the omnibox: the tab we're leaving
+          // no longer has an edit in progress. `loadTarget` does this for the
+          // navigating branch below; the tab-switch branch has to do it here.
+          clearAddressBarEdit();
           switchTab(suggestion.tabId);
           addressInput.blur();
         } else if (onNavigate) {
@@ -301,10 +373,14 @@ const handleKeyDown = (e) => {
       break;
 
     case 'Escape':
+      // The dropdown owns the first Escape: come back to the text the user
+      // typed, keep focus in the bar, and close the list. navigation.js takes
+      // the next press (revert to the page URL, still focused) and the one
+      // after that (focus the page). #310.
       e.preventDefault();
-      if (originalQuery) {
-        addressInput.value = originalQuery;
-        originalQuery = '';
+      e.stopPropagation();
+      if (selectedIndex >= 0) {
+        restoreTypedText();
       }
       hide();
       break;
@@ -313,6 +389,8 @@ const handleKeyDown = (e) => {
       if (selectedIndex >= 0 && currentSuggestions[selectedIndex]) {
         e.preventDefault();
         addressInput.value = currentSuggestions[selectedIndex].url;
+        // Completed into the bar but not submitted: still an uncommitted edit.
+        setAddressBarEdit(addressInput.value, null);
         hide();
       }
       break;
@@ -333,6 +411,9 @@ const handleClick = (e) => {
 
   // If it's an open tab, switch to it
   if (tabId) {
+    // Committing by mouse ends the edit for the tab we're leaving, same as
+    // the keyboard path.
+    clearAddressBarEdit();
     switchTab(parseInt(tabId, 10));
     addressInput.blur();
   } else if (url && onNavigate) {
@@ -340,6 +421,17 @@ const handleClick = (e) => {
     onNavigate(url);
     addressInput.blur();
   }
+};
+
+/**
+ * Handle mouse hover over a suggestion
+ */
+const handleMouseMove = (e) => {
+  const item = e.target?.closest?.('.autocomplete-item');
+  if (!item) return;
+  const index = Number.parseInt(item.dataset.index, 10);
+  if (Number.isNaN(index)) return;
+  highlightRow(index);
 };
 
 /**
@@ -359,6 +451,9 @@ export const initAutocomplete = () => {
   addressInput.addEventListener('input', handleInput);
   addressInput.addEventListener('keydown', handleKeyDown);
   dropdown.addEventListener('click', handleClick);
+  // Mouse hover moves the highlight, so Enter commits the row under the
+  // cursor rather than the typed text. #313.
+  dropdown.addEventListener('mousemove', handleMouseMove);
 
   // Close on webview interaction or window blur
   webviewElement?.addEventListener('focus', hide);

--- a/src/renderer/lib/autocomplete.test.js
+++ b/src/renderer/lib/autocomplete.test.js
@@ -112,10 +112,14 @@ const loadAutocompleteModule = async (options = {}) => {
     getBookmarks: jest.fn().mockResolvedValue(bookmarks),
     getCachedFavicon: jest.fn((url) => faviconBehavior(url)),
   };
+  // Per-tab navigation state the address-bar edit tracker writes through
+  // (`address-bar-edit.js` reads it via `getActiveTabState`).
+  const navState = { addressBarPendingInput: null, addressBarPendingSelection: null };
   const tabsMocks = {
     getOpenTabs: jest.fn(() => openTabs),
     switchTab: jest.fn(),
     hideTabContextMenu: jest.fn(),
+    getActiveTabState: jest.fn(() => navState),
   };
   const menusMocks = {
     closeMenus: jest.fn(),
@@ -252,6 +256,7 @@ const loadAutocompleteModule = async (options = {}) => {
 
   return {
     mod,
+    navState,
     dropdown,
     addressInput,
     webviewElement,
@@ -364,7 +369,7 @@ describe('autocomplete', () => {
   test('supports keyboard navigation for switching tabs, navigating, tab completion, and escape', async () => {
     jest.useFakeTimers();
 
-    const { mod, dropdown, addressInput, tabsMocks, backdropMocks } =
+    const { mod, navState, dropdown, addressInput, tabsMocks, backdropMocks } =
       await loadAutocompleteModule({
         suggestionResolver: () => [
           {
@@ -409,6 +414,10 @@ describe('autocomplete', () => {
       block: 'nearest',
     });
 
+    // Previewing a row is an uncommitted edit of this tab's address bar, so
+    // it is tracked as one (page commits must not clobber it — #305).
+    expect(navState.addressBarPendingInput).toBe('https://tab.example');
+
     addressInput.handlers.keydown({
       key: 'Enter',
       preventDefault: jest.fn(),
@@ -417,16 +426,21 @@ describe('autocomplete', () => {
     expect(tabsMocks.switchTab).toHaveBeenCalledWith(11);
     expect(addressInput.blur).toHaveBeenCalled();
     expect(backdropMocks.hideMenuBackdrop).toHaveBeenCalled();
+    // Committing a suggestion ends the edit for the tab being left.
+    expect(navState.addressBarPendingInput).toBeNull();
 
     addressInput.value = 'nav';
     addressInput.handlers.input();
     jest.runAllTimers();
     await flushMicrotasks();
 
-    addressInput.handlers.keydown({
-      key: 'ArrowUp',
-      preventDefault: jest.fn(),
-    });
+    // ArrowDown stops on the last row instead of wrapping to the first (#313).
+    addressInput.handlers.keydown({ key: 'ArrowDown', preventDefault: jest.fn() });
+    addressInput.handlers.keydown({ key: 'ArrowDown', preventDefault: jest.fn() });
+    expect(addressInput.value).toBe('https://navigate.example');
+    addressInput.handlers.keydown({ key: 'ArrowDown', preventDefault: jest.fn() });
+    expect(addressInput.value).toBe('https://navigate.example');
+
     addressInput.handlers.keydown({
       key: 'Tab',
       preventDefault: jest.fn(),
@@ -439,10 +453,8 @@ describe('autocomplete', () => {
     jest.runAllTimers();
     await flushMicrotasks();
 
-    addressInput.handlers.keydown({
-      key: 'ArrowUp',
-      preventDefault: jest.fn(),
-    });
+    addressInput.handlers.keydown({ key: 'ArrowDown', preventDefault: jest.fn() });
+    addressInput.handlers.keydown({ key: 'ArrowDown', preventDefault: jest.fn() });
     addressInput.handlers.keydown({
       key: 'Enter',
       preventDefault: jest.fn(),
@@ -459,9 +471,99 @@ describe('autocomplete', () => {
     addressInput.handlers.keydown({
       key: 'Escape',
       preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
     });
 
     expect(dropdown.classList.add).toHaveBeenCalledWith('hidden');
+  });
+
+  test('arrow keys stop at both ends of the list and return to the typed text', async () => {
+    jest.useFakeTimers();
+
+    const { mod, navState, dropdown, addressInput } = await loadAutocompleteModule({
+      suggestionResolver: () => [
+        { title: 'First', url: 'https://first.example', protocol: 'https', type: 'history' },
+        { title: 'Second', url: 'https://second.example', protocol: 'https', type: 'history' },
+      ],
+    });
+
+    mod.initAutocomplete();
+    await flushMicrotasks();
+
+    addressInput.value = 'bzz';
+    addressInput.handlers.input();
+    jest.runAllTimers();
+    await flushMicrotasks();
+
+    // ArrowUp with nothing highlighted stays on the typed text — it must not
+    // teleport to the bottom of the list (#313).
+    addressInput.handlers.keydown({ key: 'ArrowUp', preventDefault: jest.fn() });
+    expect(addressInput.value).toBe('bzz');
+    expect(mod.isSuggestionPreviewActive()).toBe(false);
+
+    addressInput.handlers.keydown({ key: 'ArrowDown', preventDefault: jest.fn() });
+    expect(addressInput.value).toBe('https://first.example');
+    expect(mod.isSuggestionPreviewActive()).toBe(true);
+
+    // ArrowUp off the first suggestion goes back to what the user typed,
+    // with nothing highlighted, and stays there.
+    addressInput.handlers.keydown({ key: 'ArrowUp', preventDefault: jest.fn() });
+    expect(addressInput.value).toBe('bzz');
+    expect(navState.addressBarPendingInput).toBe('bzz');
+    expect(mod.isSuggestionPreviewActive()).toBe(false);
+    expect(dropdown.querySelectorAll('.autocomplete-item')[0].classList.toggle).toHaveBeenCalledWith(
+      'selected',
+      false
+    );
+
+    addressInput.handlers.keydown({ key: 'ArrowUp', preventDefault: jest.fn() });
+    expect(addressInput.value).toBe('bzz');
+
+    // Hovering a row moves the highlight, so Enter commits the row under the
+    // cursor rather than the typed text (#313).
+    dropdown.handlers.mousemove({
+      target: { closest: () => ({ dataset: { index: '1' } }) },
+    });
+    expect(mod.isSuggestionPreviewActive()).toBe(true);
+    const onNavigate = jest.fn();
+    mod.setOnNavigate(onNavigate);
+    addressInput.handlers.keydown({ key: 'Enter', preventDefault: jest.fn() });
+    expect(onNavigate).toHaveBeenCalledWith('https://second.example');
+  });
+
+  test('escape with a previewed suggestion restores the typed text and keeps focus', async () => {
+    jest.useFakeTimers();
+
+    const { mod, dropdown, addressInput } = await loadAutocompleteModule({
+      suggestionResolver: () => [
+        { title: 'First', url: 'https://first.example', protocol: 'https', type: 'history' },
+      ],
+    });
+
+    mod.initAutocomplete();
+    await flushMicrotasks();
+
+    addressInput.value = 'bzz';
+    addressInput.handlers.input();
+    jest.runAllTimers();
+    await flushMicrotasks();
+    addressInput.handlers.keydown({ key: 'ArrowDown', preventDefault: jest.fn() });
+    expect(addressInput.value).toBe('https://first.example');
+
+    const escape = {
+      key: 'Escape',
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    };
+    addressInput.handlers.keydown(escape);
+
+    // The typed text comes back, the list closes, focus stays in the bar and
+    // navigation.js' handler is left out of this press (#310).
+    expect(addressInput.value).toBe('bzz');
+    expect(dropdown.classList.add).toHaveBeenCalledWith('hidden');
+    expect(escape.stopPropagation).toHaveBeenCalled();
+    expect(addressInput.blur).not.toHaveBeenCalled();
+    expect(mod.isSuggestionPreviewActive()).toBe(false);
   });
 
   test('handles click selection, empty queries, blur interactions, and refresh errors', async () => {

--- a/src/renderer/lib/autocomplete.test.js
+++ b/src/renderer/lib/autocomplete.test.js
@@ -423,7 +423,9 @@ describe('autocomplete', () => {
       preventDefault: jest.fn(),
     });
 
-    expect(tabsMocks.switchTab).toHaveBeenCalledWith(11);
+    // The switch is flagged as address-bar-driven so the tab being left does
+    // not adopt the previewed target URL as its own page display (#310 M3).
+    expect(tabsMocks.switchTab).toHaveBeenCalledWith(11, { fromAddressBarCommit: true });
     expect(addressInput.blur).toHaveBeenCalled();
     expect(backdropMocks.hideMenuBackdrop).toHaveBeenCalled();
     // Committing a suggestion ends the edit for the tab being left.
@@ -520,11 +522,14 @@ describe('autocomplete', () => {
     expect(addressInput.value).toBe('bzz');
 
     // Hovering a row moves the highlight, so Enter commits the row under the
-    // cursor rather than the typed text (#313).
+    // cursor rather than the typed text (#313) — but it leaves the bar's text
+    // alone, so it does not count as a preview and does not cost the user an
+    // extra Escape press (#310).
     dropdown.handlers.mousemove({
       target: { closest: () => ({ dataset: { index: '1' } }) },
     });
-    expect(mod.isSuggestionPreviewActive()).toBe(true);
+    expect(mod.isSuggestionPreviewActive()).toBe(false);
+    expect(addressInput.value).toBe('bzz');
     const onNavigate = jest.fn();
     mod.setOnNavigate(onNavigate);
     addressInput.handlers.keydown({ key: 'Enter', preventDefault: jest.fn() });
@@ -564,6 +569,43 @@ describe('autocomplete', () => {
     expect(escape.stopPropagation).toHaveBeenCalled();
     expect(addressInput.blur).not.toHaveBeenCalled();
     expect(mod.isSuggestionPreviewActive()).toBe(false);
+  });
+
+  test('escape after a mere hover leaves the bar to navigation.js (#310)', async () => {
+    jest.useFakeTimers();
+
+    const { mod, dropdown, addressInput } = await loadAutocompleteModule({
+      suggestionResolver: () => [
+        { title: 'First', url: 'https://first.example', protocol: 'https', type: 'history' },
+      ],
+    });
+
+    mod.initAutocomplete();
+    await flushMicrotasks();
+
+    addressInput.value = 'bzz';
+    addressInput.handlers.input();
+    jest.runAllTimers();
+    await flushMicrotasks();
+
+    // Hover highlights the row but never rewrites the bar…
+    dropdown.handlers.mousemove({
+      target: { closest: () => ({ dataset: { index: '0' } }) },
+    });
+    expect(addressInput.value).toBe('bzz');
+    expect(mod.isSuggestionPreviewActive()).toBe(false);
+
+    // …so this module has nothing to restore: it only closes the list, and
+    // navigation.js (whose listener ran first, since it stood down only for a
+    // real preview) keeps its revert to the page URL. One press, like Chrome.
+    addressInput.value = 'display:https://page-a.example/';
+    addressInput.handlers.keydown({
+      key: 'Escape',
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    });
+    expect(addressInput.value).toBe('display:https://page-a.example/');
+    expect(dropdown.classList.add).toHaveBeenCalledWith('hidden');
   });
 
   test('handles click selection, empty queries, blur interactions, and refresh errors', async () => {
@@ -619,7 +661,7 @@ describe('autocomplete', () => {
         })),
       },
     });
-    expect(tabsMocks.switchTab).toHaveBeenCalledWith(11);
+    expect(tabsMocks.switchTab).toHaveBeenCalledWith(11, { fromAddressBarCommit: true });
 
     addressInput.value = 'navigate';
     addressInput.handlers.input();

--- a/src/renderer/lib/navigation-utils-helpers.test.js
+++ b/src/renderer/lib/navigation-utils-helpers.test.js
@@ -148,6 +148,38 @@ describe('navigation-utils extracted helpers', () => {
     });
   });
 
+  test('restores an uncommitted address-bar edit on tab switch (#314)', async () => {
+    const mod = await loadNavigationUtils({ history: 'history.html' });
+
+    const base = {
+      url: 'https://committed.example/page',
+      bzzRoutePrefix: 'http://127.0.0.1:1633/bzz/',
+      homeUrlNormalized: 'file:///app/pages/home.html',
+    };
+
+    // A draft wins over the committed URL whether or not the tab is loading —
+    // that gate is exactly what discarded the edit before.
+    expect(
+      mod.deriveSwitchedTabDisplay({ ...base, addressBarPendingInput: 'half-typed-url' })
+    ).toBe('half-typed-url');
+    expect(
+      mod.deriveSwitchedTabDisplay({
+        ...base,
+        isLoading: true,
+        addressBarSnapshot: 'snapshot value',
+        addressBarPendingInput: 'half-typed-url',
+      })
+    ).toBe('half-typed-url');
+
+    // A bar the user emptied restores as empty, not as the committed URL.
+    expect(mod.deriveSwitchedTabDisplay({ ...base, addressBarPendingInput: '' })).toBe('');
+
+    // No draft (the normal case): unchanged behaviour.
+    expect(mod.deriveSwitchedTabDisplay({ ...base, addressBarPendingInput: null })).toBe(
+      'https://committed.example/page'
+    );
+  });
+
   test('derives switched tab display values for loading, internal pages, and view-source', async () => {
     const mod = await loadNavigationUtils({
       history: 'history.html',

--- a/src/renderer/lib/navigation-utils.js
+++ b/src/renderer/lib/navigation-utils.js
@@ -538,6 +538,7 @@ export const deriveSwitchedTabDisplay = ({
   url = '',
   isLoading = false,
   addressBarSnapshot = '',
+  addressBarPendingInput = null,
   isViewingSource = false,
   bzzRoutePrefix,
   homeUrlNormalized,
@@ -546,6 +547,16 @@ export const deriveSwitchedTabDisplay = ({
   radicleApiPrefix = null,
   knownEnsNames = new Map(),
 } = {}) => {
+  // An uncommitted address-bar edit is per-tab state in Chrome: a tab you left
+  // mid-edit is still mid-edit when you come back, whether or not it happens
+  // to be loading. `addressBarPendingInput` is a string only while the user
+  // has such an edit in flight (`address-bar-edit.js`), so the empty draft of
+  // a bar the user cleared restores as empty rather than falling through to
+  // the committed URL. See #314.
+  if (typeof addressBarPendingInput === 'string') {
+    return addressBarPendingInput;
+  }
+
   if (isLoading && addressBarSnapshot) {
     return addressBarSnapshot;
   }

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -1089,6 +1089,13 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
   // the user drove the chrome once, at the *first* leg. See the
   // `clearAddressBarEdit` call below.
   //
+  // `options.keepsAddressBarEdit` — this call re-runs a navigation the tab is
+  // already on (reload / retry of an error page, a settings-driven refresh)
+  // rather than committing something the user typed. Chrome keeps user input
+  // in progress across a reload, and the plain `webview.reload()` sibling
+  // does too by construction, so these callers hold the draft as well.
+  // See the `clearAddressBarEdit` call below.
+  //
   // `options.bzzLoadUrl` / `options.swarmHash` — set by the ENS resolution
   // path when an ENS name resolves to Swarm content: the recursive call
   // into the bzz branch carries the ENS-named load URL plus the resolved
@@ -1136,7 +1143,12 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
   // possibly seconds ago, before a slow name lookup, so anything in the bar
   // now is a *new* draft the user started while the resolution was in flight.
   // Ending it here is the same clobber, one hop later (#305).
-  if (!options.pageInitiated && !options.continuesNavigation) {
+  //
+  // `options.keepsAddressBarEdit` marks the re-runs of the navigation the tab
+  // is already on (reload, error-page retry, a settings-driven refresh). They
+  // aren't a commit of the bar's contents, and the `webview.reload()` branch
+  // of the very same affordance holds the draft, so these must too.
+  if (!options.pageInitiated && !options.continuesNavigation && !options.keepsAddressBarEdit) {
     clearAddressBarEdit(navState);
   }
 
@@ -1825,7 +1837,9 @@ const retryErrorPageOrReload = (webview, hard) => {
       if (errorEns) invalidateContentName(errorEns);
     }
     pushDebug(`Retrying original URL from error page: ${originalUrl}`);
-    loadTarget(originalUrl);
+    // Reload is not a commit of the address bar: an uncommitted edit survives
+    // it, exactly as it does on the `webview.reload()` path at the tail.
+    loadTarget(originalUrl, null, null, { keepsAddressBarEdit: true });
     return;
   }
   if (isErrorPageUrl(current)) {
@@ -1860,7 +1874,7 @@ const retryErrorPageOrReload = (webview, hard) => {
     pushDebug(
       `${hard ? 'Hard reload' : 'Reload'} re-resolving ${nameSystemLabelForName(ensInput.name)}: ${committedDisplay}`
     );
-    loadTarget(committedDisplay);
+    loadTarget(committedDisplay, null, null, { keepsAddressBarEdit: true });
     return;
   }
 
@@ -1877,7 +1891,7 @@ const retryErrorPageOrReload = (webview, hard) => {
       pushDebug(
         `${hard ? 'Hard reload' : 'Reload'} dweb node unavailable — routing ${committedDisplay} to error page`
       );
-      loadTarget(committedDisplay);
+      loadTarget(committedDisplay, null, null, { keepsAddressBarEdit: true });
       return;
     }
   }
@@ -2146,17 +2160,26 @@ export const toggleBookmarkBar = async () => {
 // Called when settings change to refresh current page if needed
 export const onSettingsChanged = (settings = null) => {
   const navState = getNavState();
+  // Both refreshes below re-run the page the tab is *on*, so they key on
+  // `committedDisplayUrl` — written only by did-navigate — rather than the
+  // live input, which under the uncommitted-edit model can hold a half-typed
+  // draft the user never submitted (#305). Navigating to that draft (and
+  // ending the edit) because a settings broadcast happened to arrive is the
+  // clobber this PR exists to remove; they pass `keepsAddressBarEdit` for the
+  // same reason reload does.
+  const committedDisplay = (navState.committedDisplayUrl || '').trim();
   if (settings?.networkConfigUpdated === true) {
-    const currentAddress = (addressInput?.value || '').trim();
-    if (parseEnsInput(currentAddress)) {
-      loadTarget(currentAddress);
+    if (parseEnsInput(committedDisplay)) {
+      loadTarget(committedDisplay, null, null, { keepsAddressBarEdit: true });
       return;
     }
   }
 
   updateProtocolIcon();
   if (navState.currentPageUrl && navState.currentPageUrl.startsWith('bzz://')) {
-    loadTarget(addressInput.value);
+    loadTarget(committedDisplay || navState.currentPageUrl, null, null, {
+      keepsAddressBarEdit: true,
+    });
   }
 };
 
@@ -2265,7 +2288,8 @@ export const initNavigation = () => {
     const hadUserEdit = isAddressBarEditInProgress(navState);
     clearAddressBarEdit(navState);
     let pageDisplay = null;
-    if (!stopLoadingAndRestore() && navState.addressBarSnapshot) {
+    const stoppedLoad = stopLoadingAndRestore();
+    if (!stoppedLoad && navState.addressBarSnapshot) {
       pageDisplay = navState.addressBarSnapshot;
     } else if (navState.pendingTitleForUrl) {
       pageDisplay = deriveDisplayValue(
@@ -2276,6 +2300,13 @@ export const initNavigation = () => {
         state.ipnsRoutePrefix,
         state.radicleApiPrefix
       );
+    } else if (!stoppedLoad && typeof navState.addressBarSnapshot === 'string') {
+      // A page whose display *is* empty — the new-tab/home page — still has a
+      // permanent text to revert to: the empty string. Gating on truthiness
+      // instead left the typed fragment sitting in the bar with no edit
+      // tracking it any more, i.e. exactly the "neither the page URL nor a
+      // live edit" resting state #310 exists to remove.
+      pageDisplay = '';
     }
     const reverted = pageDisplay !== null && addressInput.value !== pageDisplay;
     if (pageDisplay !== null) {
@@ -2591,7 +2622,14 @@ export const initNavigation = () => {
                 captureInputSelection(addressInput),
                 prevTab.navigationState
               );
-            } else {
+            } else if (!data.fromAddressBarCommit) {
+              // A switch commanded by the address bar itself (a picked
+              // "switch to tab" suggestion) leaves the *target* tab's URL —
+              // or the leftover query — in the input, with the edit already
+              // cleared by the commit. Adopting that as the leaving tab's
+              // page display would make it the value Escape reverts to and
+              // the one `deriveSwitchedTabDisplay` paints while that tab
+              // loads, i.e. another tab's URL shown as this one's.
               prevTab.navigationState.addressBarSnapshot = addressInput.value;
             }
           }

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -33,6 +33,13 @@ import {
 } from './url-utils.js';
 import { buildSearchUrl } from './search-utils.js';
 import {
+  applyInputSelection,
+  captureInputSelection,
+  clearAddressBarEdit,
+  isAddressBarEditInProgress,
+  setAddressBarEdit,
+} from './address-bar-edit.js';
+import {
   getActiveWebview,
   getActiveTab,
   getActiveTabState,
@@ -85,6 +92,39 @@ import { matchesShortcut } from './shortcuts.js';
 
 // Helper to get active tab's navigation state (with fallback to empty object)
 const getNavState = () => getActiveTabState() || {};
+
+// True while the autocomplete dropdown is showing a previewed suggestion, in
+// which case that module owns the current Escape press (it returns to the
+// user's typed text) and this one stands down for it. index.js wires
+// autocomplete's `isSuggestionPreviewActive` in here at startup. The check
+// has to live on this side because `initNavigation()` registers its
+// address-input keydown listener *before* `initAutocomplete()` does, so a
+// `stopPropagation()` in the later listener cannot unwind one that has
+// already run. See #310.
+let isSuggestionPreviewActive = () => false;
+
+export const setSuggestionPreviewProbe = (probe) => {
+  isSuggestionPreviewActive = typeof probe === 'function' ? probe : () => false;
+};
+
+// Write a page-derived display value into the address bar, unless the user is
+// mid-edit. Chrome's omnibox keeps "user input in progress" text through any
+// navigation committing in the tab — a slow page finishing, a client-side
+// redirect, a meta refresh, a same-document navigation — and only replaces it
+// when the user commits, presses Escape, or the edit is otherwise ended.
+// `addressBarSnapshot` always gets the page's own display value so Escape and
+// tab switches still have the truthful page URL to fall back to. See #305.
+const commitAddressDisplay = (value, navState = getNavState()) => {
+  navState.addressBarSnapshot = value;
+  if (isAddressBarEditInProgress(navState)) {
+    pushDebug(`[AddressBar] Held (user edit in progress), page is: ${value}`);
+    return false;
+  }
+  if (addressInput.value !== value) {
+    addressInput.value = value;
+  }
+  return true;
+};
 
 // Maximum number of name-resolution hops a single navigation may take before
 // loadTarget gives up. One hop is the normal case (name → content URI); a
@@ -354,6 +394,15 @@ const setLoading = (isLoading, tabId = null) => {
 // invokes the trust-badge resolver on every call.
 const setAddressDisplayForTab = (displayValue, tabId, { isViewingSourceForTab = false } = {}) => {
   if (isActiveTab(tabId) || tabId === null) {
+    // Same rule as `commitAddressDisplay`: a resolution settling on the
+    // foreground tab (e.g. a slow ENS lookup) must not overwrite text the
+    // user is typing. See #305.
+    if (isAddressBarEditInProgress()) {
+      const navState = getNavState();
+      navState.addressBarSnapshot = displayValue;
+      pushDebug(`[AddressBar] Held (user edit in progress), page is: ${displayValue}`);
+      return;
+    }
     if (addressInput.value !== displayValue) {
       addressInput.value = displayValue;
       updateProtocolIcon();
@@ -1028,6 +1077,11 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
   // for this single call. Set by the ens-unverified page's "Continue once"
   // handler. Scope is this single loadTarget invocation.
   //
+  // `options.pageInitiated` — this navigation came from the page, not from
+  // the browser chrome (an intercepted in-page link or a scripted location
+  // change replayed through `navigate-to-url`). It leaves any uncommitted
+  // address-bar edit in place; see the `clearAddressBarEdit` call below.
+  //
   // `options.bzzLoadUrl` / `options.swarmHash` — set by the ENS resolution
   // path when an ENS name resolves to Swarm content: the recursive call
   // into the bzz branch carries the ENS-named load URL plus the resolved
@@ -1056,6 +1110,20 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
   // leaving Swarm entirely, in which case we don't want the old probe to
   // eventually navigate the webview to a now-stale bzz URL.
   cancelPendingSwarmProbe(navState);
+
+  // Every chrome-initiated navigation funnels through here (address-bar
+  // submit, a picked autocomplete suggestion, bookmarks, menu items), so this
+  // is the one place that reliably ends an uncommitted address-bar edit for
+  // the tab being navigated.
+  //
+  // `options.pageInitiated` marks the callers that are *not* the user driving
+  // the chrome: an in-page link click, and — the case #305 was reported
+  // against — a scripted `location.href` to a custom scheme, which the main
+  // process cancels and replays through here as `navigate-to-url`. Those must
+  // leave a half-typed address alone, exactly like the `did-navigate` path.
+  if (!options.pageInitiated) {
+    clearAddressBarEdit(navState);
+  }
 
   // Handle view-source: URLs - need to resolve dweb URLs before loading
   if (value.startsWith('view-source:')) {
@@ -1683,7 +1751,11 @@ const stopLoadingAndRestore = () => {
       state.ipnsRoutePrefix,
       state.radicleApiPrefix
     );
-    addressInput.value = display;
+    // Stopping a load repaints the address bar with the page it settled on —
+    // unless the user is mid-edit, in which case only the snapshot moves
+    // (#305). The Escape handler clears the edit before calling this, so the
+    // Escape path still repaints.
+    commitAddressDisplay(display, navState);
     pushDebug(`[AddressBar] Restored to: ${display} (raw: ${targetUrl})`);
   }
   reloadBtn.dataset.state = 'reload';
@@ -1698,6 +1770,8 @@ export const loadHomePage = () => {
     return;
   }
   syncBzzBase(null);
+  // Going home is a commit: any uncommitted edit is over.
+  clearAddressBarEdit(navState);
   addressInput.value = '';
   updateProtocolIcon();
   navState.pendingNavigationUrl = homeUrlNormalized;
@@ -1855,7 +1929,7 @@ const handleNavigationEvent = (event) => {
       const displayUrl = isOnchainInterstitialPageUrl(event.url)
         ? ''
         : `view-source:${displayInner || event.url}`;
-      addressInput.value = displayUrl;
+      commitAddressDisplay(displayUrl, navState);
       pushDebug(`[AddressBar] View source: ${displayUrl || '(withheld)'}`);
       navState.currentPageUrl = webviewUrl;
       // Update tab title to "view-source:<address>"
@@ -1865,7 +1939,6 @@ const handleNavigationEvent = (event) => {
       updateBookmarkButtonVisibility();
       updateGithubBridgeIcon();
       updateProtocolIcon();
-      navState.addressBarSnapshot = addressInput.value;
       return;
     }
 
@@ -1875,7 +1948,7 @@ const handleNavigationEvent = (event) => {
     const onchainInterstitialTarget = getOnchainInterstitialTarget(event.url);
     if (onchainInterstitialTarget) {
       const displayUrl = formatOnchainAppDisplayUrl(onchainInterstitialTarget);
-      if (displayUrl) addressInput.value = displayUrl;
+      if (displayUrl) commitAddressDisplay(displayUrl, navState);
       navState.pendingTitleForUrl = event.url;
       navState.pendingNavigationUrl = event.url;
       navState.currentPageUrl = event.url;
@@ -1884,14 +1957,13 @@ const handleNavigationEvent = (event) => {
       updateBookmarkButtonVisibility();
       updateGithubBridgeIcon();
       updateProtocolIcon();
-      navState.addressBarSnapshot = addressInput.value;
       return;
     }
 
     // Check for internal pages first
     const internalPageName = getInternalPageName(event.url);
     if (internalPageName && internalPageName !== 'home') {
-      addressInput.value = `freedom://${internalPageName}`;
+      commitAddressDisplay(`freedom://${internalPageName}`, navState);
       pushDebug(`[AddressBar] Internal page: freedom://${internalPageName}`);
       electronAPI?.setWindowTitle?.(
         `${internalPageName.charAt(0).toUpperCase() + internalPageName.slice(1)}`
@@ -1907,14 +1979,13 @@ const handleNavigationEvent = (event) => {
       // freedom:// URL — without this, navigating to Settings (etc.)
       // from an ENS page leaves the prior page's trust shield stuck on.
       updateProtocolIcon();
-      navState.addressBarSnapshot = addressInput.value;
       return;
     }
 
     // Check for rad-browser.html URLs (Radicle protocol)
     const radicleDisplayUrl = getRadicleDisplayUrl(event.url);
     if (radicleDisplayUrl) {
-      addressInput.value = radicleDisplayUrl;
+      commitAddressDisplay(radicleDisplayUrl, navState);
       pushDebug(`[AddressBar] Radicle page: ${radicleDisplayUrl}`);
       navState.pendingTitleForUrl = event.url;
       navState.pendingNavigationUrl = event.url;
@@ -1924,7 +1995,6 @@ const handleNavigationEvent = (event) => {
       updateBookmarkButtonVisibility();
       updateGithubBridgeIcon();
       updateProtocolIcon();
-      navState.addressBarSnapshot = addressInput.value;
       return;
     }
 
@@ -1936,7 +2006,7 @@ const handleNavigationEvent = (event) => {
     // the fail-safe there, since the on-disk path must not be shown either.
     if (isInterstitialPageUrl(event.url)) {
       const blockedName = getInterstitialDisplayName(event.url) || '';
-      addressInput.value = blockedName;
+      commitAddressDisplay(blockedName, navState);
       pushDebug(`[AddressBar] Interstitial -> Blocked name: ${blockedName || '(none)'}`);
     } else if (isErrorPageUrl(event.url)) {
       try {
@@ -1951,14 +2021,14 @@ const handleNavigationEvent = (event) => {
             state.ipnsRoutePrefix,
             state.radicleApiPrefix
           );
-          addressInput.value = display;
+          commitAddressDisplay(display, navState);
           pushDebug(`[AddressBar] Error Page -> Original: ${display}`);
         } else {
-          addressInput.value = 'Error';
+          commitAddressDisplay('Error', navState);
         }
       } catch (err) {
         pushDebug(`[Nav] Could not parse error page URL: ${err.message}`);
-        addressInput.value = 'Error';
+        commitAddressDisplay('Error', navState);
       }
       electronAPI?.setWindowTitle?.('Error');
     } else {
@@ -1976,11 +2046,8 @@ const handleNavigationEvent = (event) => {
       // (happens during "open in new window" before loadTarget runs)
       if (event.url === 'about:blank' && addressInput.value) {
         pushDebug(`[AddressBar] Preserved (about:blank navigation)`);
-      } else if (addressInput.value !== derived) {
-        addressInput.value = derived;
+      } else if (commitAddressDisplay(derived, navState)) {
         pushDebug(`[AddressBar] Updated to: ${derived} (derived from ${event.url})`);
-      } else {
-        pushDebug(`[AddressBar] Skipped update (already ${derived})`);
       }
 
       // Sync the only protocol still using the HTTP request rewriter (bzz).
@@ -2009,7 +2076,15 @@ const handleNavigationEvent = (event) => {
   // is written by tabs.js' per-webview did-navigate handler — that's the
   // single source of truth for "what page are we actually on", and it
   // covers background tabs too.
-  navState.addressBarSnapshot = addressInput.value;
+  //
+  // The branches above already snapshotted the page's own display value
+  // through `commitAddressDisplay`; this tail covers the events that carry
+  // no URL. While the user is mid-edit the live input holds their draft, so
+  // it must not be written over the page snapshot (#305) — the draft has its
+  // own per-tab home in `addressBarPendingInput`.
+  if (!isAddressBarEditInProgress(navState)) {
+    navState.addressBarSnapshot = addressInput.value;
+  }
 };
 
 // Update bookmark bar visibility for a URL change
@@ -2137,31 +2212,60 @@ export const initNavigation = () => {
 
   addressInput.addEventListener('focusin', () => {
     const navState = getNavState();
-    navState.addressBarSnapshot = addressInput.value;
+    // Focusing a bar that already carries an uncommitted draft (restored on
+    // tab switch) must not promote that draft to the page snapshot — the
+    // snapshot is what Escape reverts to. See #305/#314.
+    if (!isAddressBarEditInProgress(navState)) {
+      navState.addressBarSnapshot = addressInput.value;
+    }
   });
 
-  // Update protocol icon as user types
+  // Update protocol icon as user types, and record the edit as
+  // "user input in progress" for this tab (Chrome's omnibox model): page
+  // commits stop overwriting it (#305) and a tab switch carries it along
+  // (#314). Only real user input fires `input` — programmatic writes from
+  // the navigation layer don't, which is what keeps derived values out.
   addressInput.addEventListener('input', () => {
+    setAddressBarEdit(addressInput.value, captureInputSelection(addressInput));
     updateProtocolIcon();
   });
 
   addressInput.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      const navState = getNavState();
-      if (!stopLoadingAndRestore() && navState.addressBarSnapshot) {
-        addressInput.value = navState.addressBarSnapshot;
-      } else if (navState.pendingTitleForUrl) {
-        addressInput.value = deriveDisplayValue(
-          navState.pendingTitleForUrl,
-          state.bzzRoutePrefix,
-          homeUrlNormalized,
-          state.ipfsRoutePrefix,
-          state.ipnsRoutePrefix,
-          state.radicleApiPrefix
-        );
-      }
-      updateProtocolIcon();
+    if (event.key !== 'Escape') return;
+    // While a suggestion is previewed in the dropdown, autocomplete.js owns
+    // this press: it returns to the typed text and closes the list. This
+    // handler takes over from the next press. #310.
+    if (isSuggestionPreviewActive()) return;
+    event.preventDefault();
+    const navState = getNavState();
+    // Chrome's Escape sequence in the omnibox: revert an uncommitted edit to
+    // the page's URL while *keeping* focus (text selected), and only move
+    // focus to the page once there is nothing left to revert. The bar never
+    // comes to rest showing text that is neither the page URL nor a live
+    // edit. See #310.
+    const hadUserEdit = isAddressBarEditInProgress(navState);
+    clearAddressBarEdit(navState);
+    let pageDisplay = null;
+    if (!stopLoadingAndRestore() && navState.addressBarSnapshot) {
+      pageDisplay = navState.addressBarSnapshot;
+    } else if (navState.pendingTitleForUrl) {
+      pageDisplay = deriveDisplayValue(
+        navState.pendingTitleForUrl,
+        state.bzzRoutePrefix,
+        homeUrlNormalized,
+        state.ipfsRoutePrefix,
+        state.ipnsRoutePrefix,
+        state.radicleApiPrefix
+      );
+    }
+    const reverted = pageDisplay !== null && addressInput.value !== pageDisplay;
+    if (pageDisplay !== null) {
+      addressInput.value = pageDisplay;
+    }
+    updateProtocolIcon();
+    if (hadUserEdit || reverted) {
+      addressInput.select();
+    } else {
       addressInput.blur();
     }
   });
@@ -2442,7 +2546,9 @@ export const initNavigation = () => {
               // new one.
               openInNewTabWithTarget(url, namedTarget);
             } else {
-              loadTarget(url, null, webview);
+              // Same-tab link click: a page-driven commit, so it must not
+              // discard an address-bar edit the user has in flight (#305).
+              loadTarget(url, null, webview, { pageInitiated: true });
             }
           }
         }
@@ -2457,7 +2563,18 @@ export const initNavigation = () => {
         if (previousActiveTabId && previousActiveTabId !== data.tabId) {
           const prevTab = getTabs().find((t) => t.id === previousActiveTabId);
           if (prevTab && prevTab.navigationState) {
-            prevTab.navigationState.addressBarSnapshot = addressInput.value;
+            // An uncommitted edit belongs to the tab being left: refresh the
+            // draft (and its selection) rather than the page snapshot, so
+            // switching back restores what the user was typing. #314.
+            if (isAddressBarEditInProgress(prevTab.navigationState)) {
+              setAddressBarEdit(
+                addressInput.value,
+                captureInputSelection(addressInput),
+                prevTab.navigationState
+              );
+            } else {
+              prevTab.navigationState.addressBarSnapshot = addressInput.value;
+            }
           }
         }
         previousActiveTabId = data.tabId;
@@ -2481,6 +2598,7 @@ export const initNavigation = () => {
             url,
             isLoading,
             addressBarSnapshot: tabNavState.addressBarSnapshot,
+            addressBarPendingInput: tabNavState.addressBarPendingInput,
             isViewingSource,
             bzzRoutePrefix: state.bzzRoutePrefix,
             homeUrlNormalized,
@@ -2495,6 +2613,13 @@ export const initNavigation = () => {
             // Keep existing address bar value
           } else {
             addressInput.value = display;
+          }
+          // A tab left mid-edit comes back mid-edit: put the caret/selection
+          // back where it was and return focus to the bar, the way Chrome
+          // restores per-tab omnibox state. #314.
+          if (isAddressBarEditInProgress(tabNavState)) {
+            addressInput.focus();
+            applyInputSelection(addressInput, tabNavState.addressBarPendingSelection);
           }
           // Update bookmarks bar visibility based on current page
           updateBookmarkBarState(url);

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -1082,6 +1082,13 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
   // change replayed through `navigate-to-url`). It leaves any uncommitted
   // address-bar edit in place; see the `clearAddressBarEdit` call below.
   //
+  // `options.continuesNavigation` — this call is the second leg of a
+  // navigation that already ran the entry bookkeeping below (a name
+  // resolution settling, the search-provider fallback at the tail). Same
+  // effect as `pageInitiated` for the edit state, and for the same reason:
+  // the user drove the chrome once, at the *first* leg. See the
+  // `clearAddressBarEdit` call below.
+  //
   // `options.bzzLoadUrl` / `options.swarmHash` — set by the ENS resolution
   // path when an ENS name resolves to Swarm content: the recursive call
   // into the bzz branch carries the ENS-named load URL plus the resolved
@@ -1121,7 +1128,15 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
   // against — a scripted `location.href` to a custom scheme, which the main
   // process cancels and replays through here as `navigate-to-url`. Those must
   // leave a half-typed address alone, exactly like the `did-navigate` path.
-  if (!options.pageInitiated) {
+  //
+  // `options.continuesNavigation` marks loadTarget's own recursive calls (a
+  // name resolution settling, the search fallback). Those are not a second
+  // user action: for a page-driven navigation there was never an edit to end,
+  // and for a chrome-driven one the commit already ended it at the first leg —
+  // possibly seconds ago, before a slow name lookup, so anything in the bar
+  // now is a *new* draft the user started while the resolution was in flight.
+  // Ending it here is the same clobber, one hop later (#305).
+  if (!options.pageInitiated && !options.continuesNavigation) {
     clearAddressBarEdit(navState);
   }
 
@@ -1412,6 +1427,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
           pushDebug(`${systemLabel} resolved: ${ens.name} -> ${targetUri}`);
           loadTarget(targetUri, displayOverride || targetUri, capturedWebview, {
             nameResolutionDepth: resolutionDepth + 1,
+            continuesNavigation: true,
           });
           return;
         }
@@ -1476,7 +1492,10 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
         // rather than the resolved CID/hash. For Swarm the probe still
         // needs the actual hash to gate navigation on Bee warmth, so we
         // pass it separately as `swarmHash`.
-        const innerOptions = { nameResolutionDepth: resolutionDepth + 1 };
+        const innerOptions = {
+          nameResolutionDepth: resolutionDepth + 1,
+          continuesNavigation: true,
+        };
         if (result.protocol === 'bzz') {
           innerOptions.bzzLoadUrl = transportDisplay;
           innerOptions.swarmHash = result.decoded;
@@ -1514,7 +1533,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
       // the panel that explains the profile setting instead.
       pushDebug(RADICLE_DISABLED_MESSAGE);
       const disabledUrl = buildRadicleDisabledUrl(window.location.href, value.trim());
-      addressInput.value = value.trim();
+      setAddressDisplayForTab(value.trim(), targetTabId);
       navState.pendingNavigationUrl = disabledUrl;
       navState.hasNavigatedDuringCurrentLoad = false;
       webview.loadURL(disabledUrl);
@@ -1551,7 +1570,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
     const errorUrl = new URL('pages/rad-browser.html', window.location.href);
     errorUrl.searchParams.set('error', 'invalid-rid');
     errorUrl.searchParams.set('input', withoutScheme);
-    addressInput.value = value.trim();
+    setAddressDisplayForTab(value.trim(), targetTabId);
     navState.pendingNavigationUrl = errorUrl.toString();
     navState.hasNavigatedDuringCurrentLoad = false;
     webview.loadURL(errorUrl.toString());
@@ -1721,7 +1740,7 @@ export const loadTarget = (value, displayOverride = null, targetWebview = null, 
   const searchUrl = buildSearchUrl(value, state.searchProvider, state.customSearchProviders);
   if (searchUrl) {
     pushDebug(`[AddressBar] Searching for input via ${searchUrl}`);
-    loadTarget(searchUrl, null, webview);
+    loadTarget(searchUrl, null, webview, { continuesNavigation: true });
     return;
   }
 

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -2398,6 +2398,8 @@ describe('navigation', () => {
       ctx.state.ensUriByName.set('vitalik.eth', 'bzz://old-reference');
       ctx.elements.addressInput.value = 'bzz://vitalik.eth';
       ctx.elements.addressInput.dispatch('input');
+      // The refresh keys on the committed page, not on the live input.
+      ctx.activeRef.tab.navigationState.committedDisplayUrl = 'bzz://vitalik.eth';
       expect(ctx.elements.trustShield.hidden).toBe(false);
 
       ctx.electronAPI.resolveEns.mockReturnValue(new Promise(() => {}));
@@ -3401,6 +3403,132 @@ describe('navigation', () => {
       // committed URL again (`deriveSwitchedTabDisplay` is mocked here).
       expect(ctx.elements.addressInput.value).not.toBe('half-typed-url');
       expect(ctx.elements.addressInput.value).toBe('switched:https://active.example');
+    });
+
+    test('reloading an error/ENS page keeps the edit, like reloading a plain page does', async () => {
+      // Reload is not a commit of the address bar. On a plain page it is a
+      // bare `webview.reload()` and the draft survives by construction; the
+      // branches that have to route through `loadTarget` (error-page retry,
+      // ENS re-resolution, an unavailable dweb node) must behave the same.
+      const ctx = await loadNavigationModule();
+      ctx.pageUrlsMocks.parseEnsInput.mockImplementation((value) =>
+        /(^|\/\/)[^/]+\.eth/i.test(value) ? { name: 'vitalik.eth', suffix: '' } : null
+      );
+      await ctx.mod.initNavigation();
+
+      // 1. Error-page retry branch.
+      ctx.activeRef.tab.navigationState.committedDisplayUrl = 'https://failed.example/';
+      ctx.activeRef.tab.webview.getURL.mockReturnValue(
+        'file:///app/pages/error.html?url=https%3A%2F%2Ffailed.example%2F'
+      );
+      typeInAddressBar(ctx, 'half-typed-url');
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: false });
+      await flushMicrotasks();
+
+      expect(ctx.activeRef.tab.navigationState.addressBarPendingInput).toBe('half-typed-url');
+      expect(ctx.elements.addressInput.value).toBe('half-typed-url');
+
+      // …and the page committing underneath it still doesn't repaint the bar.
+      ctx.tabsMocks.webviewEventHandler('did-navigate', {
+        event: { url: 'https://failed.example/' },
+      });
+      expect(ctx.elements.addressInput.value).toBe('half-typed-url');
+
+      // 2. ENS re-resolution branch.
+      ctx.electronAPI.resolveEns.mockReturnValue(new Promise(() => {}));
+      ctx.activeRef.tab.navigationState.committedDisplayUrl = 'bzz://vitalik.eth/';
+      ctx.activeRef.tab.webview.getURL.mockReturnValue(`bzz://${'a'.repeat(64)}/`);
+      ctx.elements.reloadBtn.dispatch('click', { shiftKey: false });
+      await flushMicrotasks();
+
+      expect(ctx.electronAPI.resolveEns).toHaveBeenCalledWith('vitalik.eth');
+      expect(ctx.activeRef.tab.navigationState.addressBarPendingInput).toBe('half-typed-url');
+      expect(ctx.elements.addressInput.value).toBe('half-typed-url');
+
+      // The form submit is still what commits: it ends the edit.
+      ctx.elements.navForm.dispatch('submit', { preventDefault: jest.fn() });
+      expect(ctx.activeRef.tab.navigationState.addressBarPendingInput).toBeNull();
+    });
+
+    test('a settings refresh reloads the committed page, not a half-typed draft', async () => {
+      // A settings broadcast (e.g. a network config saved in another window)
+      // is not the user submitting the address bar: it must re-run the page
+      // the tab is on, and leave the draft alone.
+      const ctx = await loadNavigationModule();
+      ctx.pageUrlsMocks.parseEnsInput.mockImplementation((value) =>
+        /(^|\/\/)[^/]+\.eth/i.test(value) ? { name: 'vitalik.eth', suffix: '' } : null
+      );
+      await ctx.mod.initNavigation();
+      ctx.electronAPI.resolveEns.mockReturnValue(new Promise(() => {}));
+
+      ctx.activeRef.tab.navigationState.committedDisplayUrl = 'bzz://vitalik.eth/';
+      typeInAddressBar(ctx, 'half-typed.eth');
+
+      ctx.mod.onSettingsChanged({ networkConfigUpdated: true });
+      await flushMicrotasks();
+
+      expect(ctx.electronAPI.resolveEns).toHaveBeenCalledWith('vitalik.eth');
+      expect(ctx.activeRef.tab.navigationState.addressBarPendingInput).toBe('half-typed.eth');
+      expect(ctx.elements.addressInput.value).toBe('half-typed.eth');
+    });
+
+    test('Escape reverts to an empty page display in a single press (#310)', async () => {
+      // A new-tab page's display *is* the empty string. Gating the revert on
+      // snapshot truthiness left the typed fragment in the bar with nothing
+      // tracking it — neither the page URL nor a live edit.
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      ctx.activeRef.tab.navigationState.addressBarSnapshot = '';
+      ctx.activeRef.tab.navigationState.pendingTitleForUrl = '';
+      typeInAddressBar(ctx, 'half-typed');
+
+      ctx.elements.addressInput.dispatch('keydown', { key: 'Escape', preventDefault: jest.fn() });
+      expect(ctx.elements.addressInput.value).toBe('');
+      expect(ctx.activeRef.tab.navigationState.addressBarPendingInput).toBeNull();
+      expect(ctx.elements.addressInput.select).toHaveBeenCalled();
+      expect(ctx.elements.addressInput.blur).not.toHaveBeenCalled();
+
+      // Nothing left to revert: the second press moves focus to the page.
+      ctx.elements.addressInput.dispatch('keydown', { key: 'Escape', preventDefault: jest.fn() });
+      expect(ctx.elements.addressInput.blur).toHaveBeenCalled();
+      expect(ctx.elements.addressInput.value).toBe('');
+    });
+
+    test('a switch-to-tab suggestion does not write its URL into the tab it leaves', async () => {
+      // autocomplete.js clears the edit and switches; the bar at that moment
+      // holds the *target* tab's URL (a previewed row) or the leftover query,
+      // so the tab being left must not adopt it as its page display.
+      const tabB = createTab(2, 'https://second.example', {
+        title: 'Second Tab',
+        webview: createWebview('https://second.example', { webContentsId: 22 }),
+      });
+      const ctx = await loadNavigationModule();
+      const tabA = ctx.activeRef.tab;
+      ctx.tabsRef.list = [tabA, tabB];
+      await ctx.mod.initNavigation();
+
+      ctx.tabsMocks.webviewEventHandler('did-navigate', {
+        event: { url: 'https://page-a.example/' },
+      });
+      ctx.tabsMocks.webviewEventHandler('tab-switched', {
+        tabId: tabA.id,
+        tab: tabA,
+        isNewTab: false,
+      });
+      expect(tabA.navigationState.addressBarSnapshot).toBe('display:https://page-a.example/');
+
+      // The dropdown previewed tab B's URL into the bar and committed it.
+      ctx.elements.addressInput.value = 'https://second.example';
+      ctx.activeRef.tab = tabB;
+      ctx.tabsMocks.webviewEventHandler('tab-switched', {
+        tabId: tabB.id,
+        tab: tabB,
+        isNewTab: false,
+        fromAddressBarCommit: true,
+      });
+
+      expect(tabA.navigationState.addressBarSnapshot).toBe('display:https://page-a.example/');
     });
   });
 });

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -167,10 +167,10 @@ const loadNavigationModule = async (options = {}) => {
       loadUrl: `load:${value}`,
     })),
     deriveDisplayAddress: jest.fn(({ url }) => `display:${url}`),
-    deriveSwitchedTabDisplay: jest.fn(
-      ({ url, isLoading, addressBarSnapshot }) =>
-        (isLoading && addressBarSnapshot) || (url ? `switched:${url}` : '')
-    ),
+    deriveSwitchedTabDisplay: jest.fn(({ url, isLoading, addressBarSnapshot, addressBarPendingInput }) => {
+      if (typeof addressBarPendingInput === 'string') return addressBarPendingInput;
+      return (isLoading && addressBarSnapshot) || (url ? `switched:${url}` : '');
+    }),
     extractEnsResolutionMetadata: jest.fn(() => ({
       knownEnsPairs: [],
       resolvedProtocol: null,
@@ -3062,6 +3062,217 @@ describe('navigation', () => {
       expect(tabA.webview.reloadIgnoringCache).not.toHaveBeenCalled();
       expect(ctx.electronAPI.resolveEns).not.toHaveBeenCalled();
       expect(ctx.electronAPI.invalidateEnsContent).not.toHaveBeenCalled();
+    });
+  });
+  describe('uncommitted address-bar edits (Chrome omnibox parity)', () => {
+    // #305/#310/#314. The three behaviours share one concept: Chrome's
+    // "user input in progress". These assert it end-to-end through the
+    // renderer's own handlers rather than through the helper alone.
+
+    const typeInAddressBar = (ctx, value) => {
+      ctx.elements.addressInput.value = value;
+      ctx.elements.addressInput.dispatch('input');
+    };
+
+    test('a page commit does not overwrite text the user is typing (#305)', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      // The page settles once with its own URL, so the bar (and the page
+      // snapshot) start out truthful.
+      ctx.tabsMocks.webviewEventHandler('did-navigate', {
+        event: { url: 'https://page-a.example/' },
+      });
+      expect(ctx.elements.addressInput.value).toBe('display:https://page-a.example/');
+
+      typeInAddressBar(ctx, 'my-important-note.eth/deep/link');
+
+      // …and now the page redirects itself (client-side redirect, meta
+      // refresh, a slow load finishing — all arrive as navigation events).
+      ctx.tabsMocks.webviewEventHandler('did-navigate', {
+        event: { url: 'https://page-b.example/' },
+      });
+      ctx.tabsMocks.webviewEventHandler('did-navigate-in-page', {
+        event: { url: 'https://page-b.example/#frag' },
+      });
+
+      // The typed text survives; the page's own URL is kept as the snapshot
+      // so Escape and tab switches still have it.
+      expect(ctx.elements.addressInput.value).toBe('my-important-note.eth/deep/link');
+      expect(ctx.activeRef.tab.navigationState.addressBarSnapshot).toBe(
+        'display:https://page-b.example/#frag'
+      );
+
+      // Committing through the address bar ends the edit, so the next page
+      // commit paints normally again.
+      ctx.elements.navForm.dispatch('submit', { preventDefault: jest.fn() });
+      ctx.tabsMocks.webviewEventHandler('did-navigate', {
+        event: { url: 'https://page-c.example/' },
+      });
+      expect(ctx.elements.addressInput.value).toBe('display:https://page-c.example/');
+    });
+
+    test('an internal-page commit is held too, not just derived URLs (#305)', async () => {
+      // Every branch of handleNavigationEvent writes the address bar; the
+      // guard has to cover all of them, not only the one the report named.
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      typeInAddressBar(ctx, 'half-typed');
+
+      ctx.tabsMocks.webviewEventHandler('did-navigate', {
+        event: { url: 'file:///app/pages/history.html' },
+      });
+      expect(ctx.elements.addressInput.value).toBe('half-typed');
+      expect(ctx.activeRef.tab.navigationState.addressBarSnapshot).toBe('freedom://history');
+
+      ctx.tabsMocks.webviewEventHandler('did-navigate', {
+        event: { url: 'file:///app/pages/error.html?url=https%3A%2F%2Ffailed.example' },
+      });
+      expect(ctx.elements.addressInput.value).toBe('half-typed');
+    });
+
+    test('an in-page link click keeps the edit, a chrome-driven load ends it (#305)', async () => {
+      // A same-tab link click is replayed through `loadTarget` (the preload
+      // intercept, and the main process' will-navigate bounce for custom
+      // schemes — the exact route the #305 repro takes). Page-driven commits
+      // must leave a half-typed address alone; chrome-driven ones commit it.
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      typeInAddressBar(ctx, 'half-typed');
+      ctx.tabsMocks.webviewEventHandler('ipc-message', {
+        tabId: ctx.activeRef.tab.id,
+        channel: 'link:navigate',
+        args: [{ url: 'https://linked.example/', disposition: 'currentTab' }],
+      });
+      await flushMicrotasks();
+
+      expect(ctx.elements.addressInput.value).toBe('half-typed');
+      expect(ctx.activeRef.tab.navigationState.addressBarPendingInput).toBe('half-typed');
+
+      // The same call without the page-initiated flag (menu item, bookmark,
+      // address-bar submit) does commit.
+      ctx.mod.loadTarget('https://chrome-driven.example/');
+      await flushMicrotasks();
+      expect(ctx.activeRef.tab.navigationState.addressBarPendingInput).toBeNull();
+    });
+
+    test('Escape reverts to the page URL keeping focus, and blurs only on the next press (#310)', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      ctx.tabsMocks.webviewEventHandler('did-navigate', {
+        event: { url: 'https://page-a.example/' },
+      });
+      typeInAddressBar(ctx, 'bzz');
+
+      const first = { key: 'Escape', preventDefault: jest.fn() };
+      ctx.elements.addressInput.dispatch('keydown', first);
+
+      expect(first.preventDefault).toHaveBeenCalled();
+      expect(ctx.elements.addressInput.value).toBe('display:https://page-a.example/');
+      // Chrome keeps focus in the omnibox and selects the restored text.
+      expect(ctx.elements.addressInput.select).toHaveBeenCalled();
+      expect(ctx.elements.addressInput.blur).not.toHaveBeenCalled();
+
+      const second = { key: 'Escape', preventDefault: jest.fn() };
+      ctx.elements.addressInput.dispatch('keydown', second);
+      expect(ctx.elements.addressInput.blur).toHaveBeenCalled();
+      expect(ctx.elements.addressInput.value).toBe('display:https://page-a.example/');
+    });
+
+    test('Escape stands down while the dropdown previews a suggestion (#310)', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      ctx.tabsMocks.webviewEventHandler('did-navigate', {
+        event: { url: 'https://page-a.example/' },
+      });
+      typeInAddressBar(ctx, 'bzz');
+      // autocomplete.js previewed a row into the bar.
+      ctx.elements.addressInput.value = 'https://suggestion.example';
+      ctx.mod.setSuggestionPreviewProbe(() => true);
+
+      const escape = { key: 'Escape', preventDefault: jest.fn() };
+      ctx.elements.addressInput.dispatch('keydown', escape);
+
+      // autocomplete.js owns this press: no revert, no blur, no preventDefault
+      // from this handler.
+      expect(escape.preventDefault).not.toHaveBeenCalled();
+      expect(ctx.elements.addressInput.value).toBe('https://suggestion.example');
+      expect(ctx.elements.addressInput.blur).not.toHaveBeenCalled();
+
+      // With the dropdown closed again, this handler takes over.
+      ctx.mod.setSuggestionPreviewProbe(() => false);
+      ctx.elements.addressInput.dispatch('keydown', { key: 'Escape', preventDefault: jest.fn() });
+      expect(ctx.elements.addressInput.value).toBe('display:https://page-a.example/');
+    });
+
+    test('an unsubmitted edit survives switching tabs and back (#314)', async () => {
+      const tabB = createTab(2, 'https://second.example', {
+        title: 'Second Tab',
+        webview: createWebview('https://second.example', { webContentsId: 22 }),
+      });
+      const ctx = await loadNavigationModule();
+      const tabA = ctx.activeRef.tab;
+      ctx.tabsRef.list = [tabA, tabB];
+      await ctx.mod.initNavigation();
+
+      ctx.tabsMocks.webviewEventHandler('did-navigate', {
+        event: { url: 'https://page-a.example/' },
+      });
+      ctx.tabsMocks.webviewEventHandler('tab-switched', {
+        tabId: tabA.id,
+        tab: tabA,
+        isNewTab: false,
+      });
+      typeInAddressBar(ctx, 'half-typed-url');
+
+      // Switch away: the draft goes onto the tab we left, and the page
+      // snapshot is *not* replaced by it.
+      ctx.activeRef.tab = tabB;
+      ctx.tabsMocks.webviewEventHandler('tab-switched', {
+        tabId: tabB.id,
+        tab: tabB,
+        isNewTab: false,
+      });
+      expect(tabA.navigationState.addressBarPendingInput).toBe('half-typed-url');
+      expect(tabA.navigationState.addressBarSnapshot).toBe('display:https://page-a.example/');
+      expect(ctx.elements.addressInput.value).toBe('switched:https://second.example');
+
+      // …and back: the draft is restored and the bar regains focus, the way
+      // Chrome restores per-tab omnibox state.
+      ctx.elements.addressInput.focus.mockClear();
+      ctx.activeRef.tab = tabA;
+      ctx.tabsMocks.webviewEventHandler('tab-switched', {
+        tabId: tabA.id,
+        tab: tabA,
+        isNewTab: false,
+      });
+
+      expect(ctx.elements.addressInput.value).toBe('half-typed-url');
+      expect(ctx.elements.addressInput.focus).toHaveBeenCalled();
+
+      // Escape ends the edit, so a later switch away restores the page URL.
+      ctx.elements.addressInput.dispatch('keydown', { key: 'Escape', preventDefault: jest.fn() });
+      expect(tabA.navigationState.addressBarPendingInput).toBeNull();
+      ctx.activeRef.tab = tabB;
+      ctx.tabsMocks.webviewEventHandler('tab-switched', {
+        tabId: tabB.id,
+        tab: tabB,
+        isNewTab: false,
+      });
+      ctx.activeRef.tab = tabA;
+      ctx.tabsMocks.webviewEventHandler('tab-switched', {
+        tabId: tabA.id,
+        tab: tabA,
+        isNewTab: false,
+      });
+      // No draft left to restore: the display is derived from the tab's own
+      // committed URL again (`deriveSwitchedTabDisplay` is mocked here).
+      expect(ctx.elements.addressInput.value).not.toBe('half-typed-url');
+      expect(ctx.elements.addressInput.value).toBe('switched:https://active.example');
     });
   });
 });

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -3158,6 +3158,134 @@ describe('navigation', () => {
       expect(ctx.activeRef.tab.navigationState.addressBarPendingInput).toBeNull();
     });
 
+    // Bootstrap a module whose `parseEnsInput` recognises `<name>.eth` (bare
+    // or transport-prefixed) and whose resolver never settles on its own, so
+    // a test can hold a name resolution open across a user edit.
+    const setupDeferredEns = async () => {
+      const ctx = await loadNavigationModule();
+      ctx.pageUrlsMocks.parseEnsInput.mockImplementation((value) => {
+        const m = value.match(/^(?:(bzz|ipfs|ipns|ens):\/\/)?([^?/]+\.eth)(.*)?$/i);
+        if (!m) return null;
+        const scheme = m[1]?.toLowerCase();
+        return {
+          name: m[2].toLowerCase(),
+          suffix: m[3] || '',
+          assertedTransport: !scheme || scheme === 'ens' ? null : scheme,
+        };
+      });
+      await ctx.mod.initNavigation();
+      let settle;
+      ctx.electronAPI.resolveEns.mockReturnValue(
+        new Promise((resolve) => {
+          settle = resolve;
+        })
+      );
+      return {
+        ctx,
+        settle: async (result) => {
+          settle(result);
+          await flushMicrotasks();
+        },
+      };
+    };
+
+    const IPFS_RESOLUTION = {
+      type: 'ok',
+      name: 'name.eth',
+      protocol: 'ipfs',
+      uri: 'ipfs://QmResolved',
+      decoded: 'QmResolved',
+      trust: { level: 'verified', queried: ['a', 'b'], agreed: ['a', 'b'] },
+    };
+
+    test('a page-driven name resolution settling keeps the edit it was held for (#305)', async () => {
+      // The report's own repro: the page scripts `location.href` to a custom
+      // scheme, the main process bounces it back through `loadTarget` as
+      // page-initiated, and the name resolution finishes a second later. The
+      // resolution hop re-enters `loadTarget`; pre-fix that second entry ran
+      // the chrome-driven branch and cleared the edit the outer call had just
+      // held, so the resolved display painted straight over the typed text.
+      const { ctx, settle } = await setupDeferredEns();
+
+      typeInAddressBar(ctx, 'my-important-note.eth/deep/link');
+      ctx.mod.loadTarget('bzz://name.eth/', null, null, { pageInitiated: true });
+      await flushMicrotasks();
+      expect(ctx.elements.addressInput.value).toBe('my-important-note.eth/deep/link');
+
+      await settle({ ...IPFS_RESOLUTION, protocol: 'bzz', uri: `bzz://${'a'.repeat(64)}` });
+
+      expect(ctx.elements.addressInput.value).toBe('my-important-note.eth/deep/link');
+      expect(ctx.activeRef.tab.navigationState.addressBarPendingInput).toBe(
+        'my-important-note.eth/deep/link'
+      );
+      // The page's own display still lands in the snapshot, so Escape and a
+      // tab switch have the truthful URL to fall back to.
+      expect(ctx.activeRef.tab.navigationState.addressBarSnapshot).toBe('bzz://name.eth/');
+    });
+
+    test('a chrome-driven name resolution settling does not wipe a draft typed while it was in flight (#305)', async () => {
+      // Committing `name.eth` ends that edit at submit time. If the lookup
+      // takes a second and the user starts typing a new address meanwhile,
+      // the resolution hop must not end *that* edit — it is a new one the
+      // user has not committed.
+      const { ctx, settle } = await setupDeferredEns();
+
+      ctx.mod.loadTarget('name.eth');
+      await flushMicrotasks();
+      expect(ctx.activeRef.tab.navigationState.addressBarPendingInput).toBeNull();
+
+      typeInAddressBar(ctx, 'somewhere-else.example');
+      await settle(IPFS_RESOLUTION);
+
+      expect(ctx.elements.addressInput.value).toBe('somewhere-else.example');
+      expect(ctx.activeRef.tab.navigationState.addressBarPendingInput).toBe(
+        'somewhere-else.example'
+      );
+      expect(ctx.activeRef.tab.navigationState.addressBarSnapshot).toBe('ipfs://name.eth');
+      // …and the navigation itself still happened.
+      expect(ctx.activeRef.tab.webview.loadURL).toHaveBeenCalledWith('ipfs://name.eth');
+    });
+
+    test("loadTarget's rad: error branches hold the edit like every other branch (#305)", async () => {
+      // Both of these used to write `addressInput.value` directly, so they
+      // painted over a held edit (and over the foreground tab when the
+      // navigation targeted a background one). They go through the same
+      // per-tab helper as their siblings now.
+      const disabledCtx = await loadNavigationModule({
+        registry: { ipfs: { mode: 'bundled' }, radicle: { mode: 'disabled' } },
+      });
+      await disabledCtx.mod.initNavigation();
+      typeInAddressBar(disabledCtx, 'half-typed');
+      disabledCtx.mod.loadTarget('rad://zrepo123', null, null, { pageInitiated: true });
+      await flushMicrotasks();
+      expect(disabledCtx.elements.addressInput.value).toBe('half-typed');
+      expect(disabledCtx.activeRef.tab.navigationState.addressBarSnapshot).toBe('rad://zrepo123');
+
+      const invalidCtx = await loadNavigationModule();
+      await invalidCtx.mod.initNavigation();
+      typeInAddressBar(invalidCtx, 'half-typed');
+      invalidCtx.mod.loadTarget('rad:notarid', null, null, { pageInitiated: true });
+      await flushMicrotasks();
+      expect(invalidCtx.elements.addressInput.value).toBe('half-typed');
+      expect(invalidCtx.activeRef.tab.webview.loadURL.mock.calls.at(-1)[0]).toContain(
+        'error=invalid-rid'
+      );
+    });
+
+    test('the search fallback does not end an edit a page-driven navigation held (#305)', async () => {
+      // The tail of `loadTarget` re-enters itself with the built search URL.
+      // That inner call is the same navigation, not a second user action.
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      typeInAddressBar(ctx, 'half-typed');
+      ctx.mod.loadTarget('some free text query', null, null, { pageInitiated: true });
+      await flushMicrotasks();
+
+      expect(ctx.elements.addressInput.value).toBe('half-typed');
+      expect(ctx.activeRef.tab.navigationState.addressBarPendingInput).toBe('half-typed');
+    });
+
     test('Escape reverts to the page URL keeping focus, and blurs only on the next press (#310)', async () => {
       const ctx = await loadNavigationModule();
       await ctx.mod.initNavigation();

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -84,6 +84,10 @@ export const state = {
   // bar value on focusin and tab-switched. Do not key reload or other
   // commit-sensitive decisions on this field; use `committedDisplayUrl`.
   addressBarSnapshot: '',
+  // Uncommitted user edit of the address bar ("user input in progress" in
+  // Chrome's omnibox), or `null` when there is none. See address-bar-edit.js.
+  addressBarPendingInput: null,
+  addressBarPendingSelection: null,
   // User-facing identity of the last committed navigation. Written only by
   // tabs.js' per-webview did-navigate handler, so it stays stable when the
   // user is mid-typing or while a navigation is still in flight. Usually it

--- a/src/renderer/lib/tabs-ui.test.js
+++ b/src/renderer/lib/tabs-ui.test.js
@@ -528,7 +528,11 @@ describe('tabs ui behavior', () => {
       const { webview } = activeTab;
 
       electronHandlers.navigateToUrl('bzz://meinhard.eth');
-      expect(onLoadTarget).toHaveBeenCalledWith('bzz://meinhard.eth');
+      // Flagged page-initiated: a scripted/link navigation the main process
+      // bounced back here must not discard an address-bar edit (#305).
+      expect(onLoadTarget).toHaveBeenCalledWith('bzz://meinhard.eth', null, null, {
+        pageInitiated: true,
+      });
       // Simulate the `loadTarget` dispatch flipping the spinner on (the
       // ENS branch in navigation.js does this synchronously).
       activeTab.isLoading = true;
@@ -725,7 +729,11 @@ describe('tabs ui behavior', () => {
       // suppressNextStop (in case the paired did-stop-loading is still
       // in flight, which is exactly what's about to happen here).
       electronHandlers.navigateToUrl('bzz://meinhard.eth');
-      expect(onLoadTarget).toHaveBeenCalledWith('bzz://meinhard.eth');
+      // Flagged page-initiated: a scripted/link navigation the main process
+      // bounced back here must not discard an address-bar edit (#305).
+      expect(onLoadTarget).toHaveBeenCalledWith('bzz://meinhard.eth', null, null, {
+        pageInitiated: true,
+      });
       expect(activeTab.suppressNextStop).toBe(true);
       expect(activeTab.suppressNextStopTimer).not.toBeNull();
 
@@ -967,7 +975,9 @@ describe('tabs ui behavior', () => {
 
     electronHandlers.navigateToUrl('https://navigate.example');
     electronHandlers.loadUrl('https://load.example');
-    expect(onLoadTarget).toHaveBeenCalledWith('https://navigate.example');
+    expect(onLoadTarget).toHaveBeenCalledWith('https://navigate.example', null, null, {
+      pageInitiated: true,
+    });
     expect(onLoadTarget).toHaveBeenCalledWith('https://load.example');
 
     electronHandlers.focusAddressBar();

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -268,6 +268,13 @@ const createNavigationState = () => ({
   // names). Reload and other commit-keyed decisions must NOT key on it; use
   // `committedDisplayUrl` instead.
   addressBarSnapshot: '',
+  // Chrome's per-tab "user input in progress": the uncommitted address-bar
+  // edit for this tab (a string, possibly empty) or `null` when the user has
+  // no edit in flight. Owned by `address-bar-edit.js`. While it is a string,
+  // navigation commits leave the address input alone (#305) and a switch back
+  // to this tab restores the draft and its selection (#314).
+  addressBarPendingInput: null,
+  addressBarPendingSelection: null,
   // `committedDisplayUrl` is the user-facing identity of the URL Chromium
   // committed for this tab's last navigation. For most schemes it equals
   // `webview.getURL()`; onchain apps reverse-map their synthetic Chromium
@@ -1801,7 +1808,11 @@ export const initTabs = async () => {
           activeTab.suppressNextStopTimer = null;
         }, 200);
       }
-      onLoadTarget(url);
+      // The page navigated itself (a link click or a scripted `location`
+      // change to a custom scheme); the main process cancelled it and handed
+      // it back here. Flagged as page-initiated so it repaints the address
+      // bar only when the user isn't mid-edit. See #305.
+      onLoadTarget(url, null, null, { pageInitiated: true });
     }
   });
 

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -1523,9 +1523,17 @@ export const switchTab = (tabId, options = {}) => {
     electronAPI?.setWindowTitle?.(tab.title);
   }
 
-  // Notify navigation module
+  // Notify navigation module. `fromAddressBarCommit` marks a switch the
+  // address bar itself commanded (a picked "switch to tab" suggestion): the
+  // text in the bar at that moment is the *target* tab's URL or the leftover
+  // query, so the tab we're leaving must not adopt it as its display.
   if (onWebviewEvent) {
-    onWebviewEvent('tab-switched', { tabId, tab, isNewTab: options.isNewTab || false });
+    onWebviewEvent('tab-switched', {
+      tabId,
+      tab,
+      isNewTab: options.isNewTab || false,
+      fromAddressBarCommit: options.fromAddressBarCommit || false,
+    });
   }
 
   renderTabs();

--- a/test-e2e/address-bar.spec.js
+++ b/test-e2e/address-bar.spec.js
@@ -273,6 +273,56 @@ test('a page commit does not overwrite text the user is typing (#305)', async ({
   });
 });
 
+test('a page-driven name resolution does not overwrite text the user is typing (#305)', async ({
+  window,
+  harness,
+}) => {
+  // Same shape as the test above, but the page redirects to an *ENS name*.
+  // That route takes an extra hop: the will-navigate bounce enters
+  // `loadTarget` page-initiated (which holds the edit), the name resolves
+  // asynchronously, and the resolution re-enters `loadTarget` to load the
+  // content. The continuation must stay page-initiated — otherwise it ends
+  // the edit the outer call just held and repaints over the typed text.
+  const RESOLVED_HASH = 'c'.repeat(64);
+  await harness.setEnsFixture('name.eth', {
+    type: 'ok',
+    name: 'name.eth',
+    protocol: 'bzz',
+    decoded: RESOLVED_HASH,
+    uri: `bzz://${RESOLVED_HASH}`,
+    trust: { level: 'verified', queried: ['a.test', 'b.test'], agreed: ['a.test', 'b.test'] },
+  });
+  await harness.setProbeFixture(RESOLVED_HASH, { ok: true });
+  await harness.setContentFixture('bzz://name.eth/', {
+    body: '<!doctype html><title>ResolvedName</title><h1>resolved</h1>',
+  });
+  await harness.setContentFixture(PAGE_A, {
+    body: `<!doctype html><title>PageA</title><h1>Page A</h1><script>setTimeout(() => { location.href = 'bzz://name.eth/'; }, 1200);</script>`,
+  });
+
+  await goTo(window, PAGE_A);
+
+  const draft = 'my-important-note.eth/deep/link';
+  await typeInAddressBar(window, draft);
+  expect(await addressState(window)).toMatchObject({ value: draft, focused: true });
+
+  // Let the scripted navigation resolve and commit.
+  await expect(window.locator('[data-test="tab"] .tab-title').first()).toHaveText('ResolvedName', {
+    timeout: 15_000,
+  });
+
+  const afterResolution = await addressState(window);
+  expect(afterResolution).toMatchObject({ value: draft, focused: true });
+  expect(afterResolution.selectionStart).toBe(draft.length);
+
+  // The resolved page's own display URL was still tracked underneath.
+  await window.keyboard.press('Escape');
+  expect(await addressState(window)).toMatchObject({
+    value: 'bzz://name.eth/',
+    focused: true,
+  });
+});
+
 test('an unsubmitted address-bar edit survives switching tabs and back (#314)', async ({
   window,
   harness,

--- a/test-e2e/address-bar.spec.js
+++ b/test-e2e/address-bar.spec.js
@@ -162,3 +162,232 @@ test('a custom search engine added in Settings persists and handles address-bar 
   await expect(reloadedInput).toHaveValue(expectedUrl);
   await expectHarnessStubServed(window, expectedUrl);
 });
+
+// ---------------------------------------------------------------------------
+// Address-bar editing behaviours that have to match Chrome's omnibox.
+//
+// All four cases share one concept — Chrome's "user input in progress": an
+// uncommitted edit belongs to the tab, survives anything the page does, and
+// is ended only by the user (commit, Escape, or picking a suggestion).
+//   #305 a page commit must not overwrite text the user is typing
+//   #314 an unsubmitted edit survives switching tabs and back
+//   #310 Escape restores the page URL and keeps focus, in Chrome's stages
+//   #313 arrow keys stop at both ends and return to the typed text
+//
+// Asserted at the chrome layer (input value, focus, dropdown rows), which is
+// where the behaviour lives; the harness serves the page content in-process.
+
+const PAGE_A = `bzz://${SAMPLE_BZZ_HASH}/`;
+const HASH_B = 'b'.repeat(64);
+const PAGE_B = `bzz://${HASH_B}/`;
+
+const addressState = (window) =>
+  window.evaluate(() => {
+    const input = document.getElementById('address-input');
+    return {
+      value: input.value,
+      focused: document.activeElement === input,
+      selectionStart: input.selectionStart,
+      selectionEnd: input.selectionEnd,
+    };
+  });
+
+const suggestionRows = (window) =>
+  window.evaluate(() =>
+    Array.from(document.querySelectorAll('#autocomplete-dropdown .autocomplete-item')).map(
+      (item) => ({
+        url: item.dataset.url,
+        selected: item.classList.contains('selected'),
+      })
+    )
+  );
+
+// Navigate the active tab and wait for the address bar to settle on the
+// canonical display URL for the target.
+const goTo = async (window, url) => {
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(url);
+  await input.press('Enter');
+  await expect(input).toHaveValue(url);
+};
+
+// Type into the address bar the way a user does (real key events, so the
+// `input` listener that marks the edit as "in progress" actually fires).
+const typeInAddressBar = async (window, text) => {
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill('');
+  await window.keyboard.type(text);
+};
+
+// Open the suggestion dropdown for `query` and wait for at least `minRows`
+// rows. Suggestions come from open tabs, history and bookmarks; the specs
+// below seed history by actually visiting the fixtures first.
+const openSuggestions = async (window, query, minRows) => {
+  await typeInAddressBar(window, query);
+  await expect
+    .poll(async () => (await suggestionRows(window)).length, {
+      message: `Waiting for ${minRows}+ autocomplete rows for "${query}"`,
+      timeout: 10_000,
+    })
+    .toBeGreaterThanOrEqual(minRows);
+  return suggestionRows(window);
+};
+
+test('a page commit does not overwrite text the user is typing (#305)', async ({
+  window,
+  harness,
+}) => {
+  // Page A redirects itself a moment after load, like a login hop or a
+  // shortener — the exact shape that used to wipe a half-typed address.
+  await harness.setContentFixture(PAGE_A, {
+    body: `<!doctype html><title>PageA</title><h1>Page A</h1><script>setTimeout(() => { location.href = '${PAGE_B}'; }, 1200);</script>`,
+  });
+  await harness.setContentFixture(PAGE_B, {
+    body: '<!doctype html><title>PageB</title><h1>Page B</h1>',
+  });
+
+  await goTo(window, PAGE_A);
+
+  const draft = 'my-important-note.eth/deep/link';
+  await typeInAddressBar(window, draft);
+  expect(await addressState(window)).toMatchObject({ value: draft, focused: true });
+
+  // Let the page's redirect commit.
+  await expect(window.locator('[data-test="tab"] .tab-title').first()).toHaveText('PageB', {
+    timeout: 10_000,
+  });
+
+  // The typed text is still there, still focused, caret untouched.
+  const afterRedirect = await addressState(window);
+  expect(afterRedirect).toMatchObject({ value: draft, focused: true });
+  expect(afterRedirect.selectionStart).toBe(draft.length);
+
+  // …and the page's own URL was tracked underneath, so Escape still knows
+  // what the tab is actually showing.
+  await window.keyboard.press('Escape');
+  expect(await addressState(window)).toMatchObject({
+    value: PAGE_B,
+    focused: true,
+  });
+});
+
+test('an unsubmitted address-bar edit survives switching tabs and back (#314)', async ({
+  window,
+  harness,
+}) => {
+  await harness.setContentFixture(PAGE_A, {
+    body: '<!doctype html><title>PageA</title><p>alpha</p>',
+  });
+
+  await goTo(window, PAGE_A);
+  await typeInAddressBar(window, 'half-typed-url');
+  // Put the caret in the middle: Chrome restores the selection too.
+  await window.evaluate(() => document.getElementById('address-input').setSelectionRange(4, 9));
+
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(window.locator('[data-test="tab"][data-tab-id="2"]')).toHaveClass(/active/);
+  // The new tab shows its own (empty) address bar, not tab 1's draft.
+  expect((await addressState(window)).value).toBe('');
+
+  await window.locator('[data-test="tab"][data-tab-id="1"]').click();
+  await expect(window.locator('[data-test="tab"][data-tab-id="1"]')).toHaveClass(/active/);
+
+  const restored = await addressState(window);
+  expect(restored).toMatchObject({ value: 'half-typed-url', focused: true });
+  expect([restored.selectionStart, restored.selectionEnd]).toEqual([4, 9]);
+
+  // Escape ends the edit, so the tab goes back to showing its page URL and
+  // stops carrying a draft across switches.
+  await window.keyboard.press('Escape');
+  await window.locator('[data-test="tab"][data-tab-id="2"]').click();
+  await window.locator('[data-test="tab"][data-tab-id="1"]').click();
+  expect((await addressState(window)).value).toBe(PAGE_A);
+});
+
+test('Escape with the dropdown open restores the typed text, then the page URL, keeping focus (#310)', async ({
+  window,
+  harness,
+}) => {
+  await harness.setContentFixture(PAGE_A, {
+    body: '<!doctype html><title>PageA</title><p>alpha</p>',
+  });
+  await harness.setContentFixture(PAGE_B, {
+    body: '<!doctype html><title>PageB</title><p>beta</p>',
+  });
+
+  // Two visited pages give the dropdown something to show for "bzz".
+  await goTo(window, PAGE_B);
+  await goTo(window, PAGE_A);
+
+  await openSuggestions(window, 'bzz', 1);
+  await window.keyboard.press('ArrowDown');
+  const previewed = await addressState(window);
+  expect(previewed.value).not.toBe('bzz');
+
+  // First Escape: back to the text the user typed, dropdown closed, focus
+  // kept — never a blurred fragment that looks like a committed URL.
+  await window.keyboard.press('Escape');
+  expect(await addressState(window)).toMatchObject({ value: 'bzz', focused: true });
+  await expect(window.locator('#autocomplete-dropdown')).toHaveClass(/hidden/);
+
+  // Second Escape: revert to the URL of the page actually on screen, still
+  // focused, with the text selected.
+  await window.keyboard.press('Escape');
+  const reverted = await addressState(window);
+  expect(reverted).toMatchObject({ value: PAGE_A, focused: true });
+  expect([reverted.selectionStart, reverted.selectionEnd]).toEqual([0, reverted.value.length]);
+
+  // Third Escape: focus leaves the bar (Chrome's "move focus to the page").
+  await window.keyboard.press('Escape');
+  expect(await addressState(window)).toMatchObject({
+    value: PAGE_A,
+    focused: false,
+  });
+});
+
+test('arrow keys stop at both ends of the dropdown and return to the typed text (#313)', async ({
+  window,
+  harness,
+}) => {
+  await harness.setContentFixture(PAGE_A, {
+    body: '<!doctype html><title>PageA</title><p>alpha</p>',
+  });
+  await harness.setContentFixture(PAGE_B, {
+    body: '<!doctype html><title>PageB</title><p>beta</p>',
+  });
+
+  await goTo(window, PAGE_B);
+  await goTo(window, PAGE_A);
+
+  const rows = await openSuggestions(window, 'bzz', 2);
+
+  // Walk to the last row…
+  for (let i = 0; i < rows.length; i += 1) {
+    await window.keyboard.press('ArrowDown');
+  }
+  expect((await addressState(window)).value).toBe(rows[rows.length - 1].url);
+
+  // …one more ArrowDown stops there instead of wrapping to the first row.
+  await window.keyboard.press('ArrowDown');
+  expect((await addressState(window)).value).toBe(rows[rows.length - 1].url);
+
+  // Walk back up: the row above the first suggestion is the typed text.
+  for (let i = 0; i < rows.length; i += 1) {
+    await window.keyboard.press('ArrowUp');
+  }
+  expect((await addressState(window)).value).toBe('bzz');
+  expect((await suggestionRows(window)).some((row) => row.selected)).toBe(false);
+
+  // …and one more ArrowUp stays on the typed text rather than teleporting to
+  // the bottom of the list.
+  await window.keyboard.press('ArrowUp');
+  expect((await addressState(window)).value).toBe('bzz');
+
+  // Mouse hover moves the highlight, so Enter would commit the row under the
+  // cursor rather than the typed text.
+  await window.locator('#autocomplete-dropdown .autocomplete-item').last().hover();
+  const hovered = await suggestionRows(window);
+  expect(hovered[hovered.length - 1].selected).toBe(true);
+});


### PR DESCRIPTION
Fixes the four address-bar findings from the 2026-09 interaction audit
(`docs/audits/ui-interaction-2026-09.md`, PR #317) in one change, because they
are one missing concept, not four bugs.

## Why one PR

Chrome's omnibox tracks **"user input in progress"**: while the user has an
uncommitted edit, that text belongs to the *tab*, survives anything the page
does, and is replaced only when the user commits it, reverts it (Escape), or
picks a suggestion. Freedom had no such concept — `addressBarSnapshot` was
doing double duty as "the page's display URL" *and* "whatever is in the bar
right now", which is why a page commit could clobber a half-typed address
(#305), a draft was saved on tab switch but thrown away on the way back
(#314), and the two Escape handlers on the same input disagreed (#310).

## What changed

**New `src/renderer/lib/address-bar-edit.js`** — the edit lives on the tab as
`navigationState.addressBarPendingInput` (+ `addressBarPendingSelection`),
`null` when there is none. `addressBarSnapshot` goes back to meaning one
thing: the page's own display URL (Chrome's "permanent text"), so Escape and
tab switches always have something truthful to fall back to.

**#305 — a page commit no longer overwrites what you are typing.** Every
address-bar write in `handleNavigationEvent` — view-source, onchain
interstitial, internal page, Radicle, name interstitial, error page, derived
URL — now goes through `commitAddressDisplay`, which always updates the
snapshot and writes the input only when no edit is in flight. The two sibling
writers got the same treatment: `setAddressDisplayForTab` (a slow ENS
resolution settling on the foreground tab) and `stopLoadingAndRestore`
(clicking Stop mid-edit).

`loadTarget` is the choke point that *ends* an edit, since every chrome-driven
navigation funnels through it. Two callers are page-driven and now pass a new
`pageInitiated` option so they don't: an intercepted in-page link
(`link:navigate`), and the main process' `will-navigate` bounce for custom
schemes — which is the route the issue's own `location.href` repro takes, and
the reason the first fix attempt still failed its e2e.

**#314 — an unsubmitted edit survives a tab switch.**
`deriveSwitchedTabDisplay` returns the pending draft first, instead of only
returning the snapshot while the tab happens to be loading; the tab-switch
handler restores the caret/selection and returns focus to the bar, and the
save half now refreshes the draft rather than promoting it over the page
snapshot.

**#310 — Escape.** The dropdown owns the press while a suggestion is
previewed (back to the typed text, list closed, focus kept); navigation.js
takes the next press (revert to the page's URL with the text selected, focus
kept) and the one after that (focus leaves the bar). The bar never comes to
rest showing a fragment that is neither the page URL nor a live edit.
Ownership is a small probe wired in `index.js` rather than the
`stopPropagation()` the issue suggested: `initNavigation()` registers its
listener *before* `initAutocomplete()`, so the later listener cannot unwind
one that already ran.

**#313 — arrow keys.** Row −1 *is* the typed text: ArrowUp off the first
suggestion restores the string and its caret, ArrowDown stops on the last row,
and neither wraps. The two related gaps named in the issue are in as well:
mouse hover moves the highlight (so Enter commits the row under the cursor,
not the typed text), and returning to the typed row restores the caret.

## Verification

`npm run lint` clean. `npm test` — 3831 passed / 18 skipped, all green.
New/updated unit coverage: `address-bar-edit.test.js` (new), `navigation.test.js`
(5 new tests: held page commit, held internal-page commit, the Escape ladder,
Escape standing down for the dropdown, the tab-switch round trip, page- vs
chrome-initiated `loadTarget`), `navigation-utils-helpers.test.js`
(`deriveSwitchedTabDisplay` with a draft), `autocomplete.test.js` (arrow ends,
hover, Escape with a preview), `tabs-ui.test.js` (the `pageInitiated` flag).

Four new e2e in `test-e2e/address-bar.spec.js`, one per issue —
`xvfb-run -a npx playwright test --project=harness test-e2e/address-bar.spec.js`
→ **9 passed**. Mutation-tested: with `src/renderer` reverted to `main` and the
new specs kept, **all four fail** (so they carry the fix, not just the app).

Full harness project: 102 passed, 2 failed —
`settings-adblock.spec.js` "adblock section shows iOS-matching defaults"
(pre-existing: no filter lists bundled in a dev tree; fails identically on
`main`) and `chrome-input-focus.spec.js` "a mouse-clicked select gets the same
ring" (pre-existing flake: the click lands on a `<select>` overlaying the
webview; interleaved A/B of 5 runs each gave branch 0/5 failures vs base 1/5,
and it passes in isolation on both).

### Visual verification (run-freedom skill, real app under xvfb, both themes)

Typed text survives a `location.href` redirect — bar still reads
`my-important-note.eth/deep/link`, still focused, caret intact, while the page
below is Page B:

![305 typing survives a page redirect](https://raw.githubusercontent.com/solardev-xyz/alan-artifacts/main/solardev-xyz/freedom-browser/pr320/20260908-233339-shot305.png)

An unsubmitted edit (and its selection, chars 4–9) restored after switching to
another tab and back:

![314 draft restored on switch back](https://raw.githubusercontent.com/solardev-xyz/alan-artifacts/main/solardev-xyz/freedom-browser/pr320/20260908-233347-shot314.png)

ArrowUp past the first row returns to the typed text `bzz` with nothing
highlighted, instead of teleporting to the bottom of the list:

![313 arrow keys return to the typed text](https://raw.githubusercontent.com/solardev-xyz/alan-artifacts/main/solardev-xyz/freedom-browser/pr320/20260908-233351-shot313.png)

Second Escape reverts to the page's URL with the text selected and focus still
in the bar (light theme):

![310 escape restores the page URL, focus kept](https://raw.githubusercontent.com/solardev-xyz/alan-artifacts/main/solardev-xyz/freedom-browser/pr320/20260908-233354-shot310.png)

Closes #305
Closes #310
Closes #313
Closes #314
