### PR TITLE
fix(chrome): Escape-closable menus, bookmark-bar gestures, non-stale context menus, sticky download dismiss (#306, #307, #308, #309, #316)

### DIFF
--- a/.claude/skills/run-freedom/SKILL.md
+++ b/.claude/skills/run-freedom/SKILL.md
@@ -65,8 +65,9 @@ with `FB_ROOT=/tmp/fb-base`. Remove the worktree afterwards.
 
 ## Gotchas (all hit in practice)
 
-- The Nodes and hamburger menus leave `#menu-backdrop` open; `Escape` does
-  not close them. Use `closeMenus(win)`.
+- The Nodes and hamburger menus close on `Escape` (#306), which also drops
+  `#menu-backdrop`. `closeMenus(win)` presses it and falls back to clicking the
+  backdrop, so it works on older checkouts too.
 - Clicking the sidebar's "Get Started" opens the onboarding modal, which then
   blocks every sidebar click. `dismissOnboarding(win)` clicks "Skip for now".
 - dApp/Swarm approval prompts are `.sidebar-modal` subscreens covering the

--- a/.claude/skills/run-freedom/lib.js
+++ b/.claude/skills/run-freedom/lib.js
@@ -78,8 +78,15 @@ function evalInWebview(win, code) {
   }, code);
 }
 
-// The Nodes/app menus leave #menu-backdrop open; Escape does not close them.
+// Dismiss the Nodes/app menus and whatever else is holding #menu-backdrop up.
+// Escape closes them since #306 (two presses: an open Profiles flyout takes the
+// first one); the backdrop click stays as the fallback, both for surfaces that
+// only dismiss on a click-out and for older checkouts.
 async function closeMenus(win) {
+  for (let i = 0; i < 2; i++) {
+    await win.keyboard.press('Escape');
+    await win.waitForTimeout(150);
+  }
   for (let i = 0; i < 3; i++) {
     const backdrop = await win.$('#menu-backdrop');
     if (backdrop && (await backdrop.isVisible())) {
@@ -89,7 +96,6 @@ async function closeMenus(win) {
       break;
     }
   }
-  await win.keyboard.press('Escape');
 }
 
 // Close the sidebar, dismissing whatever it is showing first. A no-op when the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,10 +506,16 @@ jobs:
   # Tab activation, link dispositions and menu dismissal are all about *focus*
   # — which of the shell and the guest `<webview>` owns the keyboard — and no
   # unit test can see that: it is decided by the real Chromium focus tree.
-  # These two specs are the only place it is asserted, and they ran locally
+  # These specs are the only place it is asserted, and they ran locally
   # only until a focus regression in one shipped green through the curated
   # list above (the `<webview>` holding focus after a tab switch swallowed the
   # Escape that dismisses the page context menu; caught by hand, not by CI).
+  #
+  # `menus.spec.js` and `bookmarks.spec.js` are here for the same reason: the
+  # first asserts Escape hands focus back to the button that opened a menu
+  # (#306), the second drives modified/middle clicks and a real HTML5 drag on
+  # the bookmarks bar (#307) — dispositions and drag gestures a synthetic DOM
+  # dispatch cannot exercise.
   e2e-tabs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -533,8 +539,13 @@ jobs:
       - name: Install Playwright system dependencies
         uses: ./.github/actions/install-playwright-deps
 
-      - name: Run tabs + onchain-apps E2E
-        run: xvfb-run -a npm run test:e2e -- test-e2e/tabs.spec.js test-e2e/onchain-apps.spec.js
+      - name: Run tabs + onchain-apps + menus + bookmarks E2E
+        run: |
+          xvfb-run -a npm run test:e2e -- \
+            test-e2e/tabs.spec.js \
+            test-e2e/onchain-apps.spec.js \
+            test-e2e/menus.spec.js \
+            test-e2e/bookmarks.spec.js
 
       - name: Upload Playwright traces and screenshots
         if: failure()

--- a/docs/features.md
+++ b/docs/features.md
@@ -172,7 +172,7 @@ See [contract-hosted applications](protocols/onchain-apps.md) for the origin mod
   - `Cmd+Shift+W` / `Ctrl+Shift+W`: Toggle wallet sidebar
   - `F11`: Toggle fullscreen
   - `Cmd+Alt+I` / `Ctrl+Shift+I` / `F12`: Developer Tools (listed for reference; all three are locked, not remappable)
-- **Fixed Keys**: Not part of the registry above and not remappable — `Escape` stops loading or restores the address bar, and in the find bar `Enter` jumps to the next match, `Shift+Enter` to the previous, and `Esc` closes it.
+- **Fixed Keys**: Not part of the registry above and not remappable — `Escape` stops loading or restores the address bar, closes any open menu or popover (the hamburger and Nodes menus included; an open Profiles flyout closes first, the hamburger on a second press) and returns focus to the control that opened it, and in the find bar `Enter` jumps to the next match, `Shift+Enter` to the previous, and `Esc` closes it.
 - **Zoom**: The zoom bindings above act on the active page (the same target and 10% step as the hamburger menu's − / + controls, which stay in sync with them), not on the browser chrome. Only the first binding on each row is remappable; the rest are fixed aliases that always stay active, listed as "Also …" in Settings > Shortcuts. Zoom In carries them because `=` sits behind Shift on many layouts (German, Spanish, Italian, Swiss and the Nordic ones all put it on `Shift+0`), where `Cmd`/`Ctrl` + `=` alone can never fire. All three actions additionally answer to the numeric keypad — `Num +`, `Num -` and `Num 0` — which the accelerator parser treats as keys distinct from the main row. Each action appears once under View > Zoom In / Zoom Out / Actual Size; the alias rows are hidden.
 - **No Keyboard Binding**: Print has no shortcut; use the hamburger menu's Print entry.
 
@@ -181,6 +181,8 @@ See [contract-hosted applications](protocols/onchain-apps.md) for the origin mod
 - **Address Bar Star**: Click the star icon to bookmark or unbookmark the current page.
 - **Supported Protocols**: Bookmark any `bzz://`, `ipfs://`, `ipns://`, `web3://`, `rad://`, `freedom://`, `http://`, or `https://` URL. The legacy `ens://` form is bookmarkable too, so older bookmarks and the seeded `ens://` defaults keep working.
 - **Named Bookmarks**: Name and edit bookmarks via modal or right-click.
+- **Open Where You Want**: A plain click opens the bookmark in the current tab; `Cmd`/`Ctrl`+click or middle-click opens it in a background tab and leaves the page you are on alone (add `Shift` to switch to the new tab); `Shift`+click opens it in a new window.
+- **Reorder by Drag**: Drag an entry along the bookmarks bar to move it; the new order is saved and is the order the bar shows on the next launch.
 - **Bookmarks Bar**: Quick access below the toolbar, with an overflow menu when bookmarks don't fit. Always visible on the new tab page; toggle visibility on other pages with `Cmd+Shift+B` / `Ctrl+Shift+B` (persisted across sessions).
 
 ## Browsing History

--- a/src/main/bookmarks-store.js
+++ b/src/main/bookmarks-store.js
@@ -88,6 +88,29 @@ function registerBookmarksIpc() {
     return saveBookmarks(current);
   });
 
+  // Reorder the bar. The renderer sends the full list of targets in their new
+  // order (a bookmarks-bar drag, #307); anything the renderer did not name —
+  // an entry added by another window since it read the list — keeps its
+  // relative order at the end rather than being dropped.
+  ipcMain.handle(IPC.BOOKMARKS_REORDER, (_event, targets) => {
+    if (!Array.isArray(targets)) return false;
+    const current = loadBookmarks();
+    const byTarget = new Map(current.map((bookmark) => [bookmark.target, bookmark]));
+    const seen = new Set();
+    const ordered = [];
+    for (const target of targets) {
+      const bookmark = byTarget.get(target);
+      if (!bookmark || seen.has(target)) continue;
+      seen.add(target);
+      ordered.push(bookmark);
+    }
+    for (const bookmark of current) {
+      if (!seen.has(bookmark.target)) ordered.push(bookmark);
+    }
+    if (ordered.length !== current.length) return false;
+    return saveBookmarks(ordered);
+  });
+
   ipcMain.handle(IPC.BOOKMARKS_REMOVE, (_event, target) => {
     const current = loadBookmarks();
     const updated = current.filter((b) => b.target !== target);

--- a/src/main/bookmarks-store.test.js
+++ b/src/main/bookmarks-store.test.js
@@ -132,4 +132,91 @@ describe('bookmarks-store', () => {
       JSON.parse(fs.readFileSync(getUserBookmarksPath(userDataDir), 'utf-8'))
     ).toEqual([{ label: 'Two', target: 'https://two.example' }]);
   });
+
+  // #307: the bar reorders by drag, and the store is the order it renders.
+  describe('reorder', () => {
+    const seed = (userDataDir, bookmarks) =>
+      fs.writeFileSync(
+        getUserBookmarksPath(userDataDir),
+        JSON.stringify(bookmarks, null, 2),
+        'utf-8'
+      );
+
+    const initialBookmarks = [
+      { label: 'One', target: 'https://one.example' },
+      { label: 'Two', target: 'https://two.example' },
+      { label: 'Three', target: 'https://three.example' },
+    ];
+
+    test('writes the bar order the renderer sends', async () => {
+      const ipcMain = createIpcMainMock();
+      seed(userDataDir, initialBookmarks);
+
+      const { mod } = loadBookmarksStore({ userDataDir, ipcMain });
+      mod.registerBookmarksIpc();
+
+      await expect(
+        ipcMain.invoke(IPC.BOOKMARKS_REORDER, [
+          'https://three.example',
+          'https://one.example',
+          'https://two.example',
+        ])
+      ).resolves.toBe(true);
+
+      expect(
+        JSON.parse(fs.readFileSync(getUserBookmarksPath(userDataDir), 'utf-8')).map(
+          (bookmark) => bookmark.target
+        )
+      ).toEqual(['https://three.example', 'https://one.example', 'https://two.example']);
+      // The entries themselves are untouched — only their order moved.
+      await expect(ipcMain.invoke(IPC.BOOKMARKS_GET)).resolves.toEqual([
+        { label: 'Three', target: 'https://three.example' },
+        { label: 'One', target: 'https://one.example' },
+        { label: 'Two', target: 'https://two.example' },
+      ]);
+    });
+
+    test('keeps an entry the renderer never saw rather than dropping it', async () => {
+      const ipcMain = createIpcMainMock();
+      seed(userDataDir, initialBookmarks);
+
+      const { mod } = loadBookmarksStore({ userDataDir, ipcMain });
+      mod.registerBookmarksIpc();
+
+      // The renderer's list predates "Three" (added from another window).
+      await expect(
+        ipcMain.invoke(IPC.BOOKMARKS_REORDER, ['https://two.example', 'https://one.example'])
+      ).resolves.toBe(true);
+
+      expect(
+        JSON.parse(fs.readFileSync(getUserBookmarksPath(userDataDir), 'utf-8')).map(
+          (bookmark) => bookmark.target
+        )
+      ).toEqual(['https://two.example', 'https://one.example', 'https://three.example']);
+    });
+
+    test('refuses a payload that is not a list of known targets', async () => {
+      const ipcMain = createIpcMainMock();
+      seed(userDataDir, initialBookmarks);
+
+      const { mod } = loadBookmarksStore({ userDataDir, ipcMain });
+      mod.registerBookmarksIpc();
+
+      await expect(ipcMain.invoke(IPC.BOOKMARKS_REORDER, 'not-a-list')).resolves.toBe(false);
+      // A duplicate cannot be used to push a bookmark out of the list.
+      await expect(
+        ipcMain.invoke(IPC.BOOKMARKS_REORDER, [
+          'https://one.example',
+          'https://one.example',
+          'https://two.example',
+        ])
+      ).resolves.toBe(true);
+
+      expect(
+        JSON.parse(fs.readFileSync(getUserBookmarksPath(userDataDir), 'utf-8')).map(
+          (bookmark) => bookmark.target
+        )
+      ).toEqual(['https://one.example', 'https://two.example', 'https://three.example']);
+    });
+  });
 });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -67,6 +67,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   updateBookmark: (originalTarget, bookmark) =>
     ipcRenderer.invoke('bookmarks:update', { originalTarget, bookmark }),
   removeBookmark: (target) => ipcRenderer.invoke('bookmarks:remove', target),
+  // New bar order after a drag, as the full list of targets (#307).
+  reorderBookmarks: (targets) => ipcRenderer.invoke('bookmarks:reorder', targets),
   resolveEns: (name) => ipcRenderer.invoke('ens:resolve', { name }),
   resolveEnsAddress: (name) => ipcRenderer.invoke('ens:resolve-address', { name }),
   resolveEnsReverse: (address) => ipcRenderer.invoke('ens:resolve-reverse', { address }),

--- a/src/main/preload.test.js
+++ b/src/main/preload.test.js
@@ -139,6 +139,7 @@ describe('preload', () => {
       [exposures.electronAPI, 'addBookmark', [{ label: 'Example', target: 'https://example.com' }], IPC.BOOKMARKS_ADD, [{ label: 'Example', target: 'https://example.com' }]],
       [exposures.electronAPI, 'updateBookmark', ['https://old.example', { label: 'New', target: 'https://new.example' }], IPC.BOOKMARKS_UPDATE, [{ originalTarget: 'https://old.example', bookmark: { label: 'New', target: 'https://new.example' } }]],
       [exposures.electronAPI, 'removeBookmark', ['https://example.com'], IPC.BOOKMARKS_REMOVE, ['https://example.com']],
+      [exposures.electronAPI, 'reorderBookmarks', [['https://b.example', 'https://a.example']], IPC.BOOKMARKS_REORDER, [['https://b.example', 'https://a.example']]],
       [exposures.electronAPI, 'resolveEns', ['myname.box'], IPC.ENS_RESOLVE, [{ name: 'myname.box' }]],
       [exposures.electronAPI, 'resolveEnsAddress', ['vitalik.eth'], IPC.ENS_RESOLVE_ADDRESS, [{ name: 'vitalik.eth' }]],
       [exposures.electronAPI, 'resolveEnsReverse', ['0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'], IPC.ENS_RESOLVE_REVERSE, [{ address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' }]],

--- a/src/main/test-harness.js
+++ b/src/main/test-harness.js
@@ -122,6 +122,13 @@ function notFoundResponse(url) {
   });
 }
 
+// `delayMs` holds the response open before answering, so a spec can act while
+// the tab is genuinely still loading — the stop/reload button in its `stop`
+// state, `webview.stop()` still meaningful. Without it there is no way to
+// observe an in-flight load in the harness project at all.
+const holdOpen = (ms) =>
+  ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+
 function makeProtocolHandler(scheme) {
   return async (request) => {
     const fixture = pickContentFixture(request.url);
@@ -129,6 +136,7 @@ function makeProtocolHandler(scheme) {
       log.info(`[test-harness] ${scheme}: 404 (no fixture) for ${redactUrlForLog(request.url)}`);
       return notFoundResponse(request.url);
     }
+    await holdOpen(fixture.delayMs);
     return buildResponse(fixture);
   };
 }

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -65,6 +65,7 @@ import { initPageContextMenu, hidePageContextMenu } from './lib/page-context-men
 import {
   initChromeInputContextMenu,
   hideChromeInputContextMenu,
+  CHROME_INPUT_IDS,
 } from './lib/chrome-input-context-menu.js';
 import { pushDebug } from './lib/debug.js';
 import { initOnboarding } from './lib/onboarding.js';
@@ -779,7 +780,14 @@ window.addEventListener('DOMContentLoaded', async () => {
   initTabs(); // Creates first tab and starts loading home page
   initAutocomplete(); // Address bar autocomplete
   initPageContextMenu(); // Page context menu for webviews
-  initChromeInputContextMenu({ onOpening: onAnyMenuOpening }); // Address bar edit menu
+  // Cut/Copy/Paste/Select All for every editable chrome text field — the
+  // address bar, the find bar and the bookmark-edit dialog (#316). Passed in
+  // explicitly rather than left to the module's fallback so the list of chrome
+  // inputs is visible at the one call site that owns it.
+  initChromeInputContextMenu({
+    onOpening: onAnyMenuOpening,
+    inputs: CHROME_INPUT_IDS.map((id) => document.getElementById(id)),
+  });
   initOnboarding(); // Identity onboarding wizard
   initSidebar(); // Identity & wallet sidebar
   initWalletUi(); // Wallet & identity display in sidebar

--- a/src/renderer/lib/autocomplete.js
+++ b/src/renderer/lib/autocomplete.js
@@ -459,7 +459,6 @@ const handleMouseMove = (e) => {
 export const initAutocomplete = () => {
   dropdown = document.getElementById('autocomplete-dropdown');
   addressInput = document.getElementById('address-input');
-  const webviewElement = document.getElementById('bzz-webview');
 
   if (!dropdown || !addressInput) {
     console.error('[Autocomplete] Required elements not found');
@@ -475,8 +474,11 @@ export const initAutocomplete = () => {
   dropdown.addEventListener('mousemove', handleMouseMove);
 
   // Close on webview interaction or window blur
-  webviewElement?.addEventListener('focus', hide);
-  webviewElement?.addEventListener('mousedown', hide);
+  // (The `focus`/`mousedown` dismissal that used to hang off
+  // `document.getElementById('bzz-webview')` is gone: webviews are created
+  // id-less, so that lookup was always null and the listeners never existed.
+  // `#menu-backdrop` covers the window while the dropdown is open, so a click into
+  // the page dismisses it through the document listener above. See #306.)
   window.addEventListener('blur', hide);
 
   // Load initial cache

--- a/src/renderer/lib/autocomplete.test.js
+++ b/src/renderer/lib/autocomplete.test.js
@@ -685,11 +685,15 @@ describe('autocomplete', () => {
       },
     });
 
-    webviewElement.handlers.focus();
-    webviewElement.handlers.mousedown();
     windowHandlers.blur();
 
     expect(dropdown.classList.add).toHaveBeenCalledWith('hidden');
+    // The `#bzz-webview` focus/mousedown dismissal is gone: webviews are
+    // created id-less, so the lookup was always null and those listeners never
+    // existed (#306). The fake DOM does resolve that id, so this asserts they
+    // are really gone rather than merely never firing.
+    expect(webviewElement.handlers.focus).toBeUndefined();
+    expect(webviewElement.handlers.mousedown).toBeUndefined();
 
     electronAPI.getHistory.mockRejectedValueOnce(new Error('history unavailable'));
     await mod.refreshCache();

--- a/src/renderer/lib/bookmarks-ui.js
+++ b/src/renderer/lib/bookmarks-ui.js
@@ -1,6 +1,6 @@
 // Bookmarks bar and modal UI
 import { pushDebug } from './debug.js';
-import { getActiveTab, hideTabContextMenu } from './tabs.js';
+import { getActiveTab, hideTabContextMenu, openInNewTabWithTarget } from './tabs.js';
 import { closeMenus } from './menus.js';
 import { showMenuBackdrop, hideMenuBackdrop } from './menu-backdrop.js';
 import { normalizeLegacyEnsBookmarkUrl } from './url-utils.js';
@@ -69,12 +69,39 @@ const BOOKMARK_GLOBE_SVG = `<svg class="bookmark-icon-default" viewBox="0 0 24 2
 // Store all bookmarks for overflow calculation
 let allBookmarks = [];
 
+// Which tab a bookmark activation should land in, from the mouse event that
+// triggered it — Chrome's dispositions, and the same rules the tab strip and
+// page links already follow (#303, #307):
+//
+//   Ctrl/Cmd+click, middle-click  -> background tab, current page untouched
+//   +Shift                        -> the same tab, but foregrounded
+//   Shift+click                   -> new window
+//   plain click                   -> this tab
+export const bookmarkDisposition = (event) => {
+  const middle = event?.type === 'auxclick' && event.button === 1;
+  if (middle || event?.ctrlKey || event?.metaKey) {
+    return event?.shiftKey ? 'foreground-tab' : 'background-tab';
+  }
+  if (event?.shiftKey) return 'new-window';
+  return 'current-tab';
+};
+
+// Drag state for bookmark reordering (mirrors the tab strip's, tabs.js).
+let draggedBookmarkTarget = null;
+let isDraggingBookmark = false;
+
 // Create a bookmark button element
 const createBookmarkButton = (item, isOverflowItem = false) => {
   const button = document.createElement('button');
   button.className = isOverflowItem ? 'bookmarks-overflow-item' : 'bookmark';
   button.dataset.hash = item.target;
   button.dataset.test = isOverflowItem ? 'bookmark-overflow-item' : 'bookmark-item';
+  // Bar entries reorder by drag, like Chrome's bookmarks bar (#307). The
+  // overflow menu is a transient popup — dragging inside it is not offered.
+  if (!isOverflowItem) {
+    button.draggable = true;
+    attachBookmarkDragHandlers(button, item.target);
+  }
 
   // Create icon container
   const iconContainer = document.createElement('span');
@@ -212,6 +239,96 @@ const renderBookmarks = async (items = []) => {
   });
 };
 
+// Persist the bar's order after a drag. The store keeps bookmarks as an
+// ordered list, so reordering is a single write of the new target order; the
+// renderer paints the new order first (a drag that visibly snaps back while an
+// IPC round-trips reads as a failed drag) and re-reads from the store if the
+// write is refused.
+const persistBookmarkOrder = async (ordered) => {
+  try {
+    const saved = await electronAPI?.reorderBookmarks?.(ordered.map((item) => item.target));
+    if (saved === false) {
+      pushDebug('Failed to save the new bookmark order');
+      await loadBookmarks();
+    }
+  } catch (err) {
+    console.error('Failed to save bookmark order', err);
+    pushDebug(`Failed to save bookmark order: ${err.message}`);
+    await loadBookmarks();
+  }
+};
+
+// Move `fromTarget` next to `toTarget` and save. Insert semantics match the
+// tab strip: the dragged item lands before the drop target when the pointer is
+// on its left half, after it otherwise.
+const moveBookmark = async (fromTarget, toTarget, insertBefore) => {
+  if (!fromTarget || !toTarget || fromTarget === toTarget) return;
+  const next = allBookmarks.map((item) => ({ ...item }));
+  const fromIndex = next.findIndex((item) => item.target === fromTarget);
+  if (fromIndex === -1) return;
+  const [moved] = next.splice(fromIndex, 1);
+  const targetIndex = next.findIndex((item) => item.target === toTarget);
+  if (targetIndex === -1) return;
+  next.splice(insertBefore ? targetIndex : targetIndex + 1, 0, moved);
+  await renderBookmarks(next);
+  await persistBookmarkOrder(next);
+  pushDebug(`Reordered bookmark ${fromTarget}`);
+};
+
+// The tab strip's four drag handlers (tabs.js), applied to a bar entry.
+const attachBookmarkDragHandlers = (button, target) => {
+  const clearDropIndicators = () => {
+    for (const el of bookmarksInner?.querySelectorAll('.bookmark') || []) {
+      el.classList.remove('drag-over-left', 'drag-over-right');
+    }
+  };
+
+  button.addEventListener('dragstart', (event) => {
+    isDraggingBookmark = true;
+    draggedBookmarkTarget = target;
+    button.classList.add('dragging');
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('text/plain', target);
+    }
+  });
+
+  button.addEventListener('dragend', () => {
+    draggedBookmarkTarget = null;
+    button.classList.remove('dragging');
+    clearDropIndicators();
+    // Let the click that ends the drag gesture pass before re-arming
+    // navigation, so a reorder never also opens the bookmark.
+    setTimeout(() => {
+      isDraggingBookmark = false;
+    }, 0);
+  });
+
+  button.addEventListener('dragover', (event) => {
+    if (draggedBookmarkTarget === null || draggedBookmarkTarget === target) return;
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+    const rect = button.getBoundingClientRect();
+    const isLeft = event.clientX < rect.left + rect.width / 2;
+    button.classList.toggle('drag-over-left', isLeft);
+    button.classList.toggle('drag-over-right', !isLeft);
+  });
+
+  button.addEventListener('dragleave', () => {
+    button.classList.remove('drag-over-left', 'drag-over-right');
+  });
+
+  button.addEventListener('drop', (event) => {
+    event.preventDefault();
+    const dragged = draggedBookmarkTarget;
+    button.classList.remove('drag-over-left', 'drag-over-right');
+    if (dragged === null || dragged === target) return;
+    const rect = button.getBoundingClientRect();
+    const insertBefore = event.clientX < rect.left + rect.width / 2;
+    void moveBookmark(dragged, target, insertBefore);
+  });
+};
+
 export const loadBookmarks = async () => {
   if (!bookmarksBar) return;
   try {
@@ -332,7 +449,9 @@ export const initBookmarks = () => {
     }
   };
 
-  // Handle click on bookmarks (both bar and overflow menu)
+  // Handle activation of a bookmark (both bar and overflow menu). `event` is
+  // the click/auxclick that triggered it; its modifiers pick the disposition,
+  // exactly as they do on a link in the page (#307).
   const handleBookmarkClick = async (event) => {
     try {
       const eventTarget = event.target;
@@ -341,12 +460,35 @@ export const initBookmarks = () => {
       // Find the bookmark button (could be clicked on child elements)
       const bookmarkBtn = eventTarget.closest('.bookmark, .bookmarks-overflow-item');
       const storedTarget = bookmarkBtn?.dataset?.hash;
-      if (storedTarget && onLoadTarget) {
-        // Rewrite legacy ens://name.eth bookmarks to bare-name form so they
-        // re-enter the same ENS resolution flow as a typed name and pick up
-        // the new transport-aware display (e.g. bzz://name.eth, ipfs://name.eth).
-        // Non-ENS bookmark targets pass through unchanged.
-        const navigationTarget = normalizeLegacyEnsBookmarkUrl(storedTarget);
+      if (!storedTarget) return;
+      // A drag that ends over the bar also fires a click; that gesture was a
+      // reorder, not an activation.
+      if (isDraggingBookmark) return;
+
+      // Rewrite legacy ens://name.eth bookmarks to bare-name form so they
+      // re-enter the same ENS resolution flow as a typed name and pick up
+      // the new transport-aware display (e.g. bzz://name.eth, ipfs://name.eth).
+      // Non-ENS bookmark targets pass through unchanged.
+      const navigationTarget = normalizeLegacyEnsBookmarkUrl(storedTarget);
+      const disposition = bookmarkDisposition(event);
+
+      if (disposition === 'new-window') {
+        electronAPI?.openUrlInNewWindow?.(navigationTarget);
+        hideOverflowMenu();
+        return;
+      }
+
+      if (disposition !== 'current-tab') {
+        // Background/foreground tab: the page the user is on is untouched, so
+        // the address bar must keep showing it rather than the bookmark.
+        openInNewTabWithTarget(navigationTarget, null, {
+          background: disposition === 'background-tab',
+        });
+        hideOverflowMenu();
+        return;
+      }
+
+      if (onLoadTarget) {
         addressInput.value = navigationTarget;
         onLoadTarget(navigationTarget);
         hideOverflowMenu();
@@ -357,8 +499,18 @@ export const initBookmarks = () => {
     }
   };
 
+  // Middle-click arrives as `auxclick`, never as `click` — without this the
+  // gesture did nothing at all.
+  const handleBookmarkAuxClick = (event) => {
+    if (event.button !== 1) return;
+    event.preventDefault();
+    void handleBookmarkClick(event);
+  };
+
   bookmarksInner?.addEventListener('click', handleBookmarkClick);
   overflowMenu?.addEventListener('click', handleBookmarkClick);
+  bookmarksInner?.addEventListener('auxclick', handleBookmarkAuxClick);
+  overflowMenu?.addEventListener('auxclick', handleBookmarkAuxClick);
 
   // Create context menu
   contextMenu = document.createElement('div');
@@ -400,10 +552,11 @@ export const initBookmarks = () => {
       hideAllBookmarkMenus();
     }
   });
-  // Close when webview gets focus or is clicked
-  const webviewElement = document.getElementById('bzz-webview');
-  webviewElement?.addEventListener('focus', hideAllBookmarkMenus);
-  webviewElement?.addEventListener('mousedown', hideAllBookmarkMenus);
+  // (The `focus`/`mousedown` dismissal that used to hang off
+  // `document.getElementById('bzz-webview')` is gone: webviews are created
+  // id-less, so that lookup was always null and the listeners never existed.
+  // `#menu-backdrop` covers the window while one of these menus is open, so a click into
+  // the page dismisses it through the document listener above. See #306.)
   window.addEventListener('blur', hideAllBookmarkMenus);
 
   // Handle context menu actions

--- a/src/renderer/lib/bookmarks-ui.js
+++ b/src/renderer/lib/bookmarks-ui.js
@@ -3,6 +3,7 @@ import { pushDebug } from './debug.js';
 import { getActiveTab, hideTabContextMenu, openInNewTabWithTarget } from './tabs.js';
 import { closeMenus } from './menus.js';
 import { showMenuBackdrop, hideMenuBackdrop } from './menu-backdrop.js';
+import { isModalDialogOpen } from './modal-dialog.js';
 import { normalizeLegacyEnsBookmarkUrl } from './url-utils.js';
 
 const electronAPI = window.electronAPI;
@@ -560,6 +561,9 @@ export const initBookmarks = () => {
   document.addEventListener('keydown', (event) => {
     if (event.key !== 'Escape') return;
     if (!anyBookmarkMenuOpen()) return;
+    // A modal <dialog> raised over one of these menus owns the press and
+    // cannot mark it — see `isModalDialogOpen`.
+    if (isModalDialogOpen()) return;
     event.preventDefault();
     hideAllBookmarkMenus();
   });

--- a/src/renderer/lib/bookmarks-ui.js
+++ b/src/renderer/lib/bookmarks-ui.js
@@ -531,6 +531,12 @@ export const initBookmarks = () => {
     }
   };
 
+  const anyBookmarkMenuOpen = () =>
+    Boolean(
+      (contextMenu && !contextMenu.classList.contains('hidden')) ||
+        (overflowMenu && !overflowMenu.classList.contains('hidden'))
+    );
+
   const hideAllBookmarkMenus = () => {
     hideBookmarkContextMenu();
     hideOverflowMenu();
@@ -547,10 +553,15 @@ export const initBookmarks = () => {
       hideBookmarkContextMenu();
     }
   });
+  // A press that actually closes one of these menus is consumed
+  // (`preventDefault`), so navigation.js's window-level Escape doesn't also
+  // stop an in-flight page load — Chrome closes the innermost surface only.
+  // See #306.
   document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
-      hideAllBookmarkMenus();
-    }
+    if (event.key !== 'Escape') return;
+    if (!anyBookmarkMenuOpen()) return;
+    event.preventDefault();
+    hideAllBookmarkMenus();
   });
   // (The `focus`/`mousedown` dismissal that used to hang off
   // `document.getElementById('bzz-webview')` is gone: webviews are created

--- a/src/renderer/lib/bookmarks-ui.test.js
+++ b/src/renderer/lib/bookmarks-ui.test.js
@@ -149,6 +149,16 @@ const loadBookmarksModule = async (options = {}) => {
         storedBookmarks = storedBookmarks.filter((item) => item.target !== target);
         return true;
       }),
+    reorderBookmarks:
+      options.reorderBookmarks ||
+      jest.fn().mockImplementation(async (targets) => {
+        if (options.reorderBookmarksResult === false) return false;
+        storedBookmarks = targets
+          .map((target) => storedBookmarks.find((item) => item.target === target))
+          .filter(Boolean);
+        return true;
+      }),
+    openUrlInNewWindow: options.openUrlInNewWindow || jest.fn(),
   };
   const debugMocks = {
     pushDebug: jest.fn(),
@@ -156,6 +166,7 @@ const loadBookmarksModule = async (options = {}) => {
   const tabsMocks = {
     getActiveTab: jest.fn(() => activeTabRef.current),
     hideTabContextMenu: jest.fn(),
+    openInNewTabWithTarget: jest.fn(),
   };
   const menuMocks = {
     closeMenus: jest.fn(),
@@ -494,5 +505,273 @@ describe('bookmarks-ui', () => {
     expect(ctx.electronAPI.removeBookmark).toHaveBeenCalledWith('https://renamed.example');
     expect(ctx.getStoredBookmarks()).toHaveLength(0);
     expect(ctx.menuBackdropMocks.hideMenuBackdrop).toHaveBeenCalled();
+  });
+
+  // #307: the bar handled a plain left click and nothing else. Ctrl/Cmd+click
+  // navigated the page the user was reading away, and middle-click did nothing
+  // at all — the two gestures Chrome uses for "open that in the background and
+  // leave me where I am".
+  describe('activation dispositions', () => {
+    const setupBar = async (extra = {}) => {
+      const onLoadTarget = jest.fn();
+      const ctx = await loadBookmarksModule({
+        initialBookmarks: [
+          { label: 'Alpha', target: 'https://alpha.example' },
+          { label: 'Beta', target: 'https://beta.example' },
+        ],
+        ...extra,
+      });
+      ctx.mod.setOnLoadTarget(onLoadTarget);
+      ctx.mod.initBookmarks();
+      await ctx.mod.loadBookmarks();
+      await flushMicrotasks();
+      const inner = ctx.helpers.getBookmarksInner();
+      return { ctx, onLoadTarget, inner, first: inner.children[0] };
+    };
+
+    test('Ctrl+click opens a background tab and leaves the current page alone', async () => {
+      const { ctx, onLoadTarget, inner, first } = await setupBar();
+      ctx.elements.addressInput.value = 'https://reading.example';
+
+      inner.dispatch('click', { target: first.children[1], ctrlKey: true });
+      await flushMicrotasks();
+
+      expect(ctx.tabsMocks.openInNewTabWithTarget).toHaveBeenCalledWith(
+        'https://alpha.example',
+        null,
+        { background: true }
+      );
+      expect(onLoadTarget).not.toHaveBeenCalled();
+      // The address bar still describes the page the user is on.
+      expect(ctx.elements.addressInput.value).toBe('https://reading.example');
+    });
+
+    test('Cmd+click does the same on macOS', async () => {
+      const { ctx, onLoadTarget, inner, first } = await setupBar();
+
+      inner.dispatch('click', { target: first.children[1], metaKey: true });
+      await flushMicrotasks();
+
+      expect(ctx.tabsMocks.openInNewTabWithTarget).toHaveBeenCalledWith(
+        'https://alpha.example',
+        null,
+        { background: true }
+      );
+      expect(onLoadTarget).not.toHaveBeenCalled();
+    });
+
+    test('middle-click opens a background tab', async () => {
+      const { ctx, onLoadTarget, inner, first } = await setupBar();
+      const preventDefault = jest.fn();
+
+      inner.dispatch('auxclick', {
+        type: 'auxclick',
+        button: 1,
+        target: first.children[1],
+        preventDefault,
+      });
+      await flushMicrotasks();
+
+      expect(preventDefault).toHaveBeenCalled();
+      expect(ctx.tabsMocks.openInNewTabWithTarget).toHaveBeenCalledWith(
+        'https://alpha.example',
+        null,
+        { background: true }
+      );
+      expect(onLoadTarget).not.toHaveBeenCalled();
+    });
+
+    test('a right-button auxclick is not an activation', async () => {
+      const { ctx, inner, first } = await setupBar();
+
+      inner.dispatch('auxclick', {
+        type: 'auxclick',
+        button: 2,
+        target: first.children[1],
+        preventDefault: jest.fn(),
+      });
+      await flushMicrotasks();
+
+      expect(ctx.tabsMocks.openInNewTabWithTarget).not.toHaveBeenCalled();
+    });
+
+    test('Ctrl+Shift+click foregrounds the new tab', async () => {
+      const { ctx, inner, first } = await setupBar();
+
+      inner.dispatch('click', { target: first.children[1], ctrlKey: true, shiftKey: true });
+      await flushMicrotasks();
+
+      expect(ctx.tabsMocks.openInNewTabWithTarget).toHaveBeenCalledWith(
+        'https://alpha.example',
+        null,
+        { background: false }
+      );
+    });
+
+    test('Shift+click opens a new window', async () => {
+      const { ctx, onLoadTarget, inner, first } = await setupBar();
+
+      inner.dispatch('click', { target: first.children[1], shiftKey: true });
+      await flushMicrotasks();
+
+      expect(ctx.electronAPI.openUrlInNewWindow).toHaveBeenCalledWith('https://alpha.example');
+      expect(ctx.tabsMocks.openInNewTabWithTarget).not.toHaveBeenCalled();
+      expect(onLoadTarget).not.toHaveBeenCalled();
+    });
+
+    test('a plain click still navigates this tab', async () => {
+      const { ctx, onLoadTarget, inner, first } = await setupBar();
+
+      inner.dispatch('click', { target: first.children[1] });
+      await flushMicrotasks();
+
+      expect(onLoadTarget).toHaveBeenCalledWith('https://alpha.example');
+      expect(ctx.elements.addressInput.value).toBe('https://alpha.example');
+      expect(ctx.tabsMocks.openInNewTabWithTarget).not.toHaveBeenCalled();
+    });
+
+    test('the modifiers work from the overflow menu too', async () => {
+      const { ctx } = await setupBar({
+        initialBookmarks: [
+          { label: 'Alpha', target: 'https://alpha.example' },
+          { label: 'Beta', target: 'https://beta.example' },
+          { label: 'Gamma', target: 'https://gamma.example' },
+        ],
+      });
+      const overflowMenu = ctx.helpers.getOverflowMenu();
+      const overflowItem = overflowMenu.children[0];
+
+      overflowMenu.dispatch('click', { target: overflowItem.children[1], ctrlKey: true });
+      await flushMicrotasks();
+
+      expect(ctx.tabsMocks.openInNewTabWithTarget).toHaveBeenCalledWith(
+        expect.any(String),
+        null,
+        { background: true }
+      );
+      expect(overflowMenu.classList.contains('hidden')).toBe(true);
+    });
+  });
+
+  // #307: the bar had no drag handlers at all (`draggable === false`), while
+  // the tab strip next to it has had them all along.
+  describe('drag reordering', () => {
+    const dragTo = (fromEl, toEl, { clientX }) => {
+      const dataTransfer = { setData: jest.fn(), effectAllowed: null, dropEffect: null };
+      fromEl.dispatch('dragstart', { dataTransfer });
+      toEl.dispatch('dragover', { preventDefault: jest.fn(), dataTransfer, clientX });
+      toEl.dispatch('drop', { preventDefault: jest.fn(), dataTransfer, clientX });
+    };
+
+    const setupBar = async () => {
+      const onLoadTarget = jest.fn();
+      const ctx = await loadBookmarksModule({
+        initialBookmarks: [
+          { label: 'Alpha', target: 'https://alpha.example' },
+          { label: 'Beta', target: 'https://beta.example' },
+        ],
+      });
+      ctx.mod.setOnLoadTarget(onLoadTarget);
+      ctx.mod.initBookmarks();
+      await ctx.mod.loadBookmarks();
+      await flushMicrotasks();
+      return { ctx, onLoadTarget, inner: ctx.helpers.getBookmarksInner() };
+    };
+
+    test('bar entries are draggable and a drop persists the new order', async () => {
+      const { ctx, inner } = await setupBar();
+      const [alpha, beta] = inner.children;
+      expect(alpha.draggable).toBe(true);
+
+      // Drop Alpha on the right half of Beta: Alpha lands after Beta.
+      dragTo(alpha, beta, { clientX: 55 });
+      await flushMicrotasks();
+
+      expect(ctx.electronAPI.reorderBookmarks).toHaveBeenCalledWith([
+        'https://beta.example',
+        'https://alpha.example',
+      ]);
+      expect(ctx.getStoredBookmarks().map((item) => item.target)).toEqual([
+        'https://beta.example',
+        'https://alpha.example',
+      ]);
+      // The bar repaints in the new order without waiting for a reload.
+      expect(
+        ctx.helpers.getBookmarksInner().children.map((el) => el.dataset.hash)
+      ).toEqual(['https://beta.example', 'https://alpha.example']);
+    });
+
+    test('dropping on the left half inserts before the target', async () => {
+      const { ctx, inner } = await setupBar();
+      const [alpha, beta] = inner.children;
+
+      // Beta dropped on Alpha's left half moves it to the front.
+      dragTo(beta, alpha, { clientX: 5 });
+      await flushMicrotasks();
+
+      expect(ctx.electronAPI.reorderBookmarks).toHaveBeenCalledWith([
+        'https://beta.example',
+        'https://alpha.example',
+      ]);
+    });
+
+    test('the click that ends a drag does not also open the bookmark', async () => {
+      const { ctx, onLoadTarget, inner } = await setupBar();
+      const [alpha, beta] = inner.children;
+      const dataTransfer = { setData: jest.fn(), effectAllowed: null, dropEffect: null };
+
+      alpha.dispatch('dragstart', { dataTransfer });
+      beta.dispatch('drop', { preventDefault: jest.fn(), dataTransfer, clientX: 55 });
+      inner.dispatch('click', { target: alpha });
+      await flushMicrotasks();
+
+      expect(onLoadTarget).not.toHaveBeenCalled();
+      expect(ctx.tabsMocks.openInNewTabWithTarget).not.toHaveBeenCalled();
+    });
+
+    test('a refused save re-reads the stored order', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const onLoadTarget = jest.fn();
+      const ctx = await loadBookmarksModule({
+        initialBookmarks: [
+          { label: 'Alpha', target: 'https://alpha.example' },
+          { label: 'Beta', target: 'https://beta.example' },
+        ],
+        reorderBookmarks: jest.fn().mockResolvedValue(false),
+      });
+      ctx.mod.setOnLoadTarget(onLoadTarget);
+      ctx.mod.initBookmarks();
+      await ctx.mod.loadBookmarks();
+      await flushMicrotasks();
+
+      const inner = ctx.helpers.getBookmarksInner();
+      const [alpha, beta] = inner.children;
+      dragTo(alpha, beta, { clientX: 55 });
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(ctx.debugMocks.pushDebug).toHaveBeenCalledWith(
+        'Failed to save the new bookmark order'
+      );
+      // Back to the order the store still holds.
+      expect(
+        ctx.helpers.getBookmarksInner().children.map((el) => el.dataset.hash)
+      ).toEqual(['https://alpha.example', 'https://beta.example']);
+      consoleError.mockRestore();
+    });
+  });
+
+  // The `#bzz-webview` focus/mousedown dismissal is gone from this module too:
+  // webviews are created id-less, so the lookup was always null and those
+  // listeners never existed (#306). The fake DOM does resolve that id, so this
+  // asserts they are really gone rather than merely never firing.
+  test('no dismissal hangs off the id-less webview element', async () => {
+    const ctx = await loadBookmarksModule({
+      initialBookmarks: [{ label: 'Alpha', target: 'https://alpha.example' }],
+    });
+    ctx.mod.initBookmarks();
+
+    expect(ctx.elements.webviewElement.handlers.focus).toBeUndefined();
+    expect(ctx.elements.webviewElement.handlers.mousedown).toBeUndefined();
   });
 });

--- a/src/renderer/lib/bookmarks-ui.test.js
+++ b/src/renderer/lib/bookmarks-ui.test.js
@@ -343,6 +343,47 @@ describe('bookmarks-ui', () => {
     expect(escape.preventDefault).toHaveBeenCalled();
   });
 
+  // #306, dialog sibling: a modal <dialog> raised over one of these menus is
+  // the top layer, so the press is its close request — and it cannot mark the
+  // press the way a menu handler does. Consuming it here would cancel that
+  // close outright, leaving the dialog open (and taking a menu down that the
+  // user could not even see).
+  test('a modal dialog above the menu owns the Escape', async () => {
+    const ctx = await loadBookmarksModule({
+      initialBookmarks: [{ label: 'Alpha', target: 'https://alpha.example' }],
+    });
+
+    ctx.mod.initBookmarks();
+    await ctx.mod.loadBookmarks();
+    await flushMicrotasks();
+
+    const contextMenu = ctx.helpers.getContextMenu();
+    const bookmarksInner = ctx.helpers.getBookmarksInner();
+    bookmarksInner.dispatch('contextmenu', {
+      preventDefault: jest.fn(),
+      clientX: 20,
+      clientY: 30,
+      target: bookmarksInner.children[0].children[1],
+    });
+    expect(contextMenu.classList.contains('hidden')).toBe(false);
+
+    const dialog = createElement('dialog');
+    dialog.setAttribute('open', '');
+    global.document.body.appendChild(dialog);
+
+    const escape = { key: 'Escape', preventDefault: jest.fn() };
+    global.document.handlers.keydown(escape);
+    expect(contextMenu.classList.contains('hidden')).toBe(false);
+    expect(escape.preventDefault).not.toHaveBeenCalled();
+
+    // The dialog gone, the menu is innermost again and takes the next press.
+    dialog.remove();
+    const next = { key: 'Escape', preventDefault: jest.fn() };
+    global.document.handlers.keydown(next);
+    expect(contextMenu.classList.contains('hidden')).toBe(true);
+    expect(next.preventDefault).toHaveBeenCalled();
+  });
+
   test('updates add bookmark button visibility and bookmark state', async () => {
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
     const ctx = await loadBookmarksModule({

--- a/src/renderer/lib/bookmarks-ui.test.js
+++ b/src/renderer/lib/bookmarks-ui.test.js
@@ -308,6 +308,41 @@ describe('bookmarks-ui', () => {
     expect(ctx.menuBackdropMocks.hideMenuBackdrop).toHaveBeenCalled();
   });
 
+  // #306: Escape closes only the innermost open surface, as in Chrome. The
+  // press is consumed while doing it, so navigation.js's window-level Escape
+  // (stop loading + restore the address bar) stands down on `defaultPrevented`
+  // and closing a bookmark menu over a loading page can't cancel that load.
+  test('Escape closes an open bookmark menu and consumes the press', async () => {
+    const ctx = await loadBookmarksModule({
+      initialBookmarks: [{ label: 'Alpha', target: 'https://alpha.example' }],
+    });
+
+    ctx.mod.initBookmarks();
+    await ctx.mod.loadBookmarks();
+    await flushMicrotasks();
+
+    // Nothing open: the press belongs to whatever is behind the bar.
+    const idle = { key: 'Escape', preventDefault: jest.fn() };
+    global.document.handlers.keydown(idle);
+    expect(idle.preventDefault).not.toHaveBeenCalled();
+
+    const contextMenu = ctx.helpers.getContextMenu();
+    const bookmarksInner = ctx.helpers.getBookmarksInner();
+    contextMenu.setRect({ right: 520, bottom: 420, width: 120, height: 50 });
+    bookmarksInner.dispatch('contextmenu', {
+      preventDefault: jest.fn(),
+      clientX: 20,
+      clientY: 30,
+      target: bookmarksInner.children[0].children[1],
+    });
+    expect(contextMenu.classList.contains('hidden')).toBe(false);
+
+    const escape = { key: 'Escape', preventDefault: jest.fn() };
+    global.document.handlers.keydown(escape);
+    expect(contextMenu.classList.contains('hidden')).toBe(true);
+    expect(escape.preventDefault).toHaveBeenCalled();
+  });
+
   test('updates add bookmark button visibility and bookmark state', async () => {
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
     const ctx = await loadBookmarksModule({

--- a/src/renderer/lib/chrome-input-context-menu.js
+++ b/src/renderer/lib/chrome-input-context-menu.js
@@ -3,7 +3,22 @@ import { showMenuBackdrop, hideMenuBackdrop } from './menu-backdrop.js';
 
 const electronAPI = window.electronAPI;
 
+// Every editable text field in the browser chrome, in DOM order. Chrome gives
+// all of them the same Cut/Copy/Paste/Select All menu — the omnibox, the find
+// bar and the bookmark-edit dialog's fields alike (#316). index.js passes the
+// resolved elements in explicitly; this list is the fallback so the module is
+// still correct on its own, and the single place a new chrome input is added.
+export const CHROME_INPUT_IDS = [
+  'address-input',
+  'find-bar-input',
+  'bookmark-label',
+  'bookmark-target',
+];
+
 let contextMenu = null;
+// Where the menu lives in the document when it is not borrowed by a modal
+// <dialog> (see showChromeInputContextMenu).
+let menuHome = null;
 let activeInput = null;
 let savedSelection = null;
 // Serializes async edit actions so a slow Paste cannot overlap a
@@ -26,6 +41,11 @@ const clearPointerSelection = () => {
 export const hideChromeInputContextMenu = () => {
   if (!contextMenu || contextMenu.classList.contains('hidden')) return;
   contextMenu.classList.add('hidden');
+  // Hand the menu back to its own place in the document if a modal dialog
+  // borrowed it (see showChromeInputContextMenu).
+  if (menuHome && contextMenu.parentElement && contextMenu.parentElement !== menuHome) {
+    menuHome.appendChild(contextMenu);
+  }
   activeInput = null;
   savedSelection = null;
   clearPointerSelection();
@@ -67,6 +87,18 @@ function showChromeInputContextMenu(input, clientX, clientY, selection) {
   savedSelection = selection ?? captureSelection(input);
   updateActionStates(input, savedSelection);
   showMenuBackdrop();
+
+  // A `showModal()` dialog puts itself in the top layer and makes everything
+  // outside it inert — the menu would render *under* the dialog's backdrop and
+  // ignore clicks. Move it inside the dialog for as long as it is up (and back
+  // out in hideChromeInputContextMenu), so the bookmark-edit fields get the
+  // same working menu as the address bar rather than a dead one. Positioning is
+  // `position: fixed`, so the new parent doesn't move the menu.
+  const modalHost = input.closest?.('dialog[open]') || null;
+  const host = modalHost || menuHome;
+  if (host && contextMenu.parentElement !== host) {
+    host.appendChild(contextMenu);
+  }
 
   contextMenu.style.left = `${clientX}px`;
   contextMenu.style.top = `${clientY}px`;
@@ -174,10 +206,11 @@ async function runEditAction(action, input, selection) {
 export const initChromeInputContextMenu = (options = {}) => {
   contextMenu = document.getElementById('chrome-input-context-menu');
   if (!contextMenu) return;
+  menuHome = contextMenu.parentElement || null;
 
   const inputs =
     options.inputs?.filter(Boolean) ??
-    [document.getElementById('address-input')].filter(Boolean);
+    CHROME_INPUT_IDS.map((id) => document.getElementById(id)).filter(Boolean);
 
   for (const input of inputs) {
     input.addEventListener('mousedown', (event) => {
@@ -244,10 +277,35 @@ export const initChromeInputContextMenu = (options = {}) => {
       });
   });
 
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
+  // An open menu is the innermost surface, so Escape belongs to it alone:
+  // capture the key before the find bar's own Escape (which would close the
+  // bar under the menu) and before a modal <dialog>'s built-in cancel (which
+  // would close the bookmark editor). Both are what Chrome does — the first
+  // Escape closes the menu, the second one the surface behind it. When no menu
+  // is up this listener does nothing at all.
+  document.addEventListener(
+    'keydown',
+    (event) => {
+      if (event.key !== 'Escape') return;
+      if (!contextMenu || contextMenu.classList.contains('hidden')) return;
+      event.preventDefault();
+      event.stopPropagation();
       hideChromeInputContextMenu();
-    }
+    },
+    true
+  );
+
+  // Click-away dismissal. `#menu-backdrop` covers this for the toolbar inputs,
+  // but it is inert while a modal dialog is open, so the bookmark editor needs
+  // its own path. Clicks inside a registered input are left alone: the input's
+  // own right-mousedown snapshot must survive to the contextmenu event that
+  // re-opens the menu.
+  document.addEventListener('mousedown', (event) => {
+    if (!contextMenu || contextMenu.classList.contains('hidden')) return;
+    if (contextMenu.contains?.(event.target)) return;
+    if (inputs.some((input) => input === event.target || input.contains?.(event.target))) return;
+    hideChromeInputContextMenu();
   });
+
   window.addEventListener('blur', hideChromeInputContextMenu);
 };

--- a/src/renderer/lib/chrome-input-context-menu.test.js
+++ b/src/renderer/lib/chrome-input-context-menu.test.js
@@ -89,7 +89,15 @@ const createContextMenu = () => {
   };
 };
 
-const loadModule = async ({ input, contextMenu, electronAPI } = {}) => {
+const loadModule = async ({
+  input,
+  contextMenu,
+  electronAPI,
+  // Extra chrome inputs by id (the find bar, the bookmark dialog fields), so a
+  // test can drive the same menu from a second registered input.
+  extraInputs = {},
+  initOptions,
+} = {}) => {
   jest.resetModules();
 
   const addressInput = input ?? createInput();
@@ -100,6 +108,7 @@ const loadModule = async ({ input, contextMenu, electronAPI } = {}) => {
     getElementById: jest.fn((id) => {
       if (id === 'address-input') return addressInput;
       if (id === 'chrome-input-context-menu') return menu;
+      if (extraInputs[id]) return extraInputs[id];
       return null;
     }),
     addEventListener: jest.fn((event, handler) => {
@@ -142,7 +151,7 @@ const loadModule = async ({ input, contextMenu, electronAPI } = {}) => {
   }));
 
   const mod = await import('./chrome-input-context-menu.js');
-  mod.initChromeInputContextMenu();
+  mod.initChromeInputContextMenu(initOptions);
   return { mod, input: addressInput, menu, documentHandlers, windowHandlers };
 };
 
@@ -448,13 +457,87 @@ describe('chrome-input-context-menu', () => {
     expect(input.dispatchEvent).not.toHaveBeenCalled();
   });
 
-  test('Escape hides the menu', async () => {
+  test('Escape hides the menu, and only the menu', async () => {
     const { input, menu, documentHandlers } = await loadModule();
     openContextMenu(input);
     expect(menu.classList.contains('hidden')).toBe(false);
 
-    documentHandlers.keydown({ key: 'Escape' });
+    const event = { key: 'Escape', preventDefault: jest.fn(), stopPropagation: jest.fn() };
+    documentHandlers.keydown(event);
     expect(menu.classList.contains('hidden')).toBe(true);
+    // The menu is the innermost surface, so it consumes the key: the find bar
+    // underneath must not close too, and a modal <dialog> hosting the input
+    // must not cancel (#316).
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+  });
+
+  test('Escape is left alone when no menu is open', async () => {
+    const { documentHandlers } = await loadModule();
+
+    const event = { key: 'Escape', preventDefault: jest.fn(), stopPropagation: jest.fn() };
+    documentHandlers.keydown(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  // #316: every editable chrome text field gets this menu, not just the
+  // address bar — the find bar and the bookmark-edit dialog had none at all.
+  describe('registered inputs', () => {
+    test('the default list covers every chrome text input', async () => {
+      const { mod } = await loadModule();
+      expect(mod.CHROME_INPUT_IDS).toEqual([
+        'address-input',
+        'find-bar-input',
+        'bookmark-label',
+        'bookmark-target',
+      ]);
+    });
+
+    test('the find-bar input opens the same menu as the address bar', async () => {
+      const findInput = createInput('needle');
+      const { menu } = await loadModule({ extraInputs: { 'find-bar-input': findInput } });
+
+      openContextMenu(findInput);
+
+      expect(menu.classList.contains('hidden')).toBe(false);
+      expect(menu.items.copy.disabled).toBe(false);
+    });
+
+    test('an explicit inputs list wins over the default', async () => {
+      const findInput = createInput('needle');
+      const { input, menu } = await loadModule({
+        extraInputs: { 'find-bar-input': findInput },
+        initOptions: { inputs: [findInput] },
+      });
+
+      expect(input.handlers.contextmenu).toBeUndefined();
+      openContextMenu(findInput);
+      expect(menu.classList.contains('hidden')).toBe(false);
+    });
+
+    test('a modal dialog borrows the menu so it is not left inert behind it', async () => {
+      const dialog = { appendChild: jest.fn() };
+      const home = { appendChild: jest.fn() };
+      const menu = createContextMenu();
+      menu.parentElement = home;
+      const labelInput = createInput('My bookmark');
+      labelInput.closest = jest.fn((selector) => (selector === 'dialog[open]' ? dialog : null));
+
+      const { mod } = await loadModule({
+        contextMenu: menu,
+        extraInputs: { 'bookmark-label': labelInput },
+      });
+
+      openContextMenu(labelInput);
+      expect(dialog.appendChild).toHaveBeenCalledWith(menu);
+
+      // ...and handed back when it closes, so the toolbar inputs keep it.
+      menu.parentElement = dialog;
+      mod.hideChromeInputContextMenu();
+      expect(home.appendChild).toHaveBeenCalledWith(menu);
+    });
   });
 
   test('Window blur hides the menu', async () => {

--- a/src/renderer/lib/downloads-ui.js
+++ b/src/renderer/lib/downloads-ui.js
@@ -16,6 +16,15 @@ const AUTO_DISMISS_MS = 5000;
 // id -> { el, nameEl, statusEl, barEl, fillEl, actionsEl, actionsKey, dismissTimer }
 const cards = new Map();
 
+// Downloads the user dismissed by hand. A dismiss on a running download used
+// to last until the next progress tick (250 ms, downloads-manager.js) and then
+// the card came straight back, over and over for the length of the transfer;
+// Chrome never resurrects an item the user closed. Ids are store rowids
+// (SQLite AUTOINCREMENT, or the private store's monotonic negative sequence),
+// so an id is never handed to a second download and a remembered dismissal
+// cannot leak onto an unrelated card. The set lives as long as the window.
+const dismissed = new Set();
+
 let shelfEl = null;
 
 // Human-readable byte count: 999 B, 1.2 KB, 34.5 MB, ...
@@ -70,7 +79,12 @@ export const downloadStatusText = (download) => {
 export const isSettledState = (state) =>
   state === 'completed' || state === 'cancelled' || state === 'interrupted';
 
-const dismissCard = (id) => {
+// `byUser` marks the dismissals the shelf must remember: the × and the
+// completed-file actions are the user saying "I'm done with this card", so no
+// later update may re-create it. The auto-dismiss timer is not one of those —
+// it fires on a settled download that will send no further updates anyway.
+const dismissCard = (id, { byUser = false } = {}) => {
+  if (byUser) dismissed.add(id);
   const card = cards.get(id);
   if (!card) return;
   if (card.dismissTimer) clearTimeout(card.dismissTimer);
@@ -115,7 +129,9 @@ const buildCard = (id) => {
   const actionsEl = document.createElement('div');
   actionsEl.className = 'download-card-actions';
 
-  const closeBtn = makeButton('×', 'download-card-close', 'download-close', () => dismissCard(id));
+  const closeBtn = makeButton('×', 'download-card-close', 'download-close', () =>
+    dismissCard(id, { byUser: true })
+  );
   closeBtn.setAttribute('aria-label', 'Dismiss');
 
   el.appendChild(main);
@@ -155,7 +171,7 @@ const runFileAction = async (downloadId, label, invoke) => {
     pushDebug(`[downloads] ${label} failed for ${downloadId}: ${error}`);
     return;
   }
-  dismissCard(downloadId);
+  dismissCard(downloadId, { byUser: true });
 };
 
 const renderActions = (card, download) => {
@@ -202,6 +218,10 @@ const actionsKey = (download) => {
 // Apply one `downloads:updated` payload to the shelf. Exported for tests.
 export const handleDownloadUpdate = (download) => {
   if (!shelfEl || !download || typeof download.id !== 'number') return;
+  // A card the user closed stays closed, however many more updates main sends
+  // for it. The download itself is untouched — it keeps running, and
+  // freedom://downloads still lists it; only the shelf card is gone.
+  if (dismissed.has(download.id)) return;
 
   let card = cards.get(download.id);
   const isNew = !card;
@@ -253,5 +273,6 @@ export const initDownloadsUi = () => {
 // Test-only: reset module state between specs.
 export const _resetForTest = () => {
   for (const id of [...cards.keys()]) dismissCard(id);
+  dismissed.clear();
   shelfEl = null;
 };

--- a/src/renderer/lib/downloads-ui.test.js
+++ b/src/renderer/lib/downloads-ui.test.js
@@ -195,8 +195,8 @@ describe('downloads-ui', () => {
       await Promise.resolve();
       await Promise.resolve();
 
-      // The open click dismissed the card; a fresh completed update spawns a
-      // new card which auto-dismisses after the timeout.
+      // The open click dismissed the card, and a repeat of the same update
+      // does not bring it back (#309).
       expect(shelfEl.children).toHaveLength(0);
       updateHandler({
         id: 3,
@@ -205,9 +205,79 @@ describe('downloads-ui', () => {
         received_bytes: 10,
         total_bytes: 10,
       });
+      expect(shelfEl.children).toHaveLength(0);
+    });
+
+    test('an untouched settled card auto-dismisses after the timeout', async () => {
+      await loadModule();
+
+      updateHandler({
+        id: 33,
+        filename: 'done.pdf',
+        state: 'completed',
+        received_bytes: 10,
+        total_bytes: 10,
+      });
       expect(shelfEl.children).toHaveLength(1);
       jest.advanceTimersByTime(5000);
       expect(shelfEl.children).toHaveLength(0);
+    });
+
+    // #309: main emits a progress tick every 250 ms, so a dismiss that is not
+    // remembered is undone almost immediately — the card blinked out and came
+    // back for the length of the transfer.
+    test('a card dismissed mid-download stays dismissed across later updates', async () => {
+      await loadModule();
+
+      updateHandler({
+        id: 4,
+        filename: 'big.iso',
+        state: 'progressing',
+        received_bytes: 1000,
+        total_bytes: 100000,
+      });
+      expect(shelfEl.children).toHaveLength(1);
+
+      const closeBtn = shelfEl.children[0].querySelector('[data-test="download-close"]');
+      closeBtn.dispatch('click');
+      expect(shelfEl.children).toHaveLength(0);
+
+      // The next progress tick, and every one after it, is ignored...
+      updateHandler({
+        id: 4,
+        filename: 'big.iso',
+        state: 'progressing',
+        received_bytes: 2000,
+        total_bytes: 100000,
+      });
+      updateHandler({
+        id: 4,
+        filename: 'big.iso',
+        state: 'progressing',
+        received_bytes: 90000,
+        total_bytes: 100000,
+      });
+      expect(shelfEl.children).toHaveLength(0);
+
+      // ...as is the terminal update when the download finishes.
+      updateHandler({
+        id: 4,
+        filename: 'big.iso',
+        state: 'completed',
+        received_bytes: 100000,
+        total_bytes: 100000,
+      });
+      expect(shelfEl.children).toHaveLength(0);
+
+      // The dismissal is scoped to that download: another one still shows.
+      updateHandler({
+        id: 5,
+        filename: 'other.iso',
+        state: 'progressing',
+        received_bytes: 10,
+        total_bytes: 100,
+      });
+      expect(shelfEl.children).toHaveLength(1);
     });
 
     test('a failed Open keeps the card and surfaces the error', async () => {

--- a/src/renderer/lib/github-bridge-ui.js
+++ b/src/renderer/lib/github-bridge-ui.js
@@ -419,9 +419,12 @@ export function initGithubBridgeUi() {
     }
   });
 
-  // Close panel on Escape
+  // Close panel on Escape. Consumed (`preventDefault`) so navigation.js's
+  // window-level Escape doesn't also stop an in-flight page load — Chrome
+  // closes the innermost surface only. See #306.
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && panelOpen) {
+      e.preventDefault();
       closePanel();
     }
   });

--- a/src/renderer/lib/github-bridge-ui.js
+++ b/src/renderer/lib/github-bridge-ui.js
@@ -1,4 +1,5 @@
 import { state } from './state.js';
+import { isModalDialogOpen } from './modal-dialog.js';
 
 // DOM references
 let bridgeBtn = null;
@@ -424,6 +425,9 @@ export function initGithubBridgeUi() {
   // closes the innermost surface only. See #306.
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && panelOpen) {
+      // A modal <dialog> over the panel owns the press and cannot mark it —
+      // see `isModalDialogOpen`.
+      if (isModalDialogOpen()) return;
       e.preventDefault();
       closePanel();
     }

--- a/src/renderer/lib/github-bridge-ui.test.js
+++ b/src/renderer/lib/github-bridge-ui.test.js
@@ -351,4 +351,33 @@ describe('github-bridge-ui', () => {
     });
     expect(ctx.elements.panel.classList.contains('hidden')).toBe(true);
   });
+
+  // #306, dialog sibling: a modal <dialog> raised over the panel is the top
+  // layer, so the press is its own close request — and consuming it here would
+  // cancel that close outright, leaving the dialog open.
+  test('a modal dialog above the panel owns the Escape', async () => {
+    const ctx = await loadGithubBridgeModule();
+
+    ctx.mod.initGithubBridgeUi();
+    await ctx.mod.updateGithubBridgeIcon();
+
+    ctx.elements.bridgeBtn.dispatch('click', { stopPropagation: jest.fn() });
+    await flushMicrotasks();
+    expect(ctx.elements.panel.classList.contains('hidden')).toBe(false);
+
+    const dialog = createElement('dialog');
+    dialog.setAttribute('open', '');
+    global.document.body.appendChild(dialog);
+
+    const escape = { key: 'Escape', preventDefault: jest.fn() };
+    ctx.documentHandlers.keydown(escape);
+    expect(ctx.elements.panel.classList.contains('hidden')).toBe(false);
+    expect(escape.preventDefault).not.toHaveBeenCalled();
+
+    dialog.remove();
+    const next = { key: 'Escape', preventDefault: jest.fn() };
+    ctx.documentHandlers.keydown(next);
+    expect(ctx.elements.panel.classList.contains('hidden')).toBe(true);
+    expect(next.preventDefault).toHaveBeenCalled();
+  });
 });

--- a/src/renderer/lib/github-bridge-ui.test.js
+++ b/src/renderer/lib/github-bridge-ui.test.js
@@ -327,10 +327,19 @@ describe('github-bridge-ui', () => {
     await flushMicrotasks();
     expect(ctx.electronAPI.copyText).toHaveBeenCalledWith('rad:zexisting');
 
-    ctx.documentHandlers.keydown({
-      key: 'Escape',
-    });
+    const escape = { key: 'Escape', preventDefault: jest.fn() };
+    ctx.documentHandlers.keydown(escape);
     expect(ctx.elements.panel.classList.contains('hidden')).toBe(true);
+    // Closing the panel consumes the press — navigation.js's window-level
+    // Escape (stop loading) stands down on `defaultPrevented`, so dismissing
+    // this panel over a loading page doesn't also cancel the load (#306).
+    expect(escape.preventDefault).toHaveBeenCalled();
+
+    // With the panel already closed the press is left alone for the surfaces
+    // behind it.
+    const escapeAgain = { key: 'Escape', preventDefault: jest.fn() };
+    ctx.documentHandlers.keydown(escapeAgain);
+    expect(escapeAgain.preventDefault).not.toHaveBeenCalled();
 
     ctx.elements.bridgeBtn.classList.remove('hidden');
     ctx.elements.bridgeBtn.dispatch('click', {

--- a/src/renderer/lib/menus.js
+++ b/src/renderer/lib/menus.js
@@ -7,6 +7,7 @@ import { startRadicleInfoUpdates, stopRadicleInfoUpdates } from './radicle-ui.js
 import { hideTabContextMenu, getActiveWebview } from './tabs.js';
 import { hideBookmarkContextMenu, hideOverflowMenu } from './bookmarks-ui.js';
 import { showMenuBackdrop, hideMenuBackdrop } from './menu-backdrop.js';
+import { isModalDialogOpen } from './modal-dialog.js';
 import { formatAccelerator, matchesShortcut } from './shortcuts.js';
 import { SUBMENU_CLOSE_DELAY_MS } from './submenu-hover.js';
 
@@ -358,6 +359,12 @@ export const initMenus = () => {
   // users zoom in, which is what they pressed. menus.test.js pins it.
   window.addEventListener('keydown', (event) => {
     if (event.key === 'Escape') {
+      // A modal <dialog> raised over these menus (the profile-create prompt
+      // the flyout itself opens, the external-node prompt main can send at
+      // any moment) is above them in the top layer and cannot mark the press
+      // — see `isModalDialogOpen`. Its close comes first; the next press
+      // reaches the menu behind it.
+      if (isModalDialogOpen()) return;
       if (isProfileFlyoutOpen()) {
         event.preventDefault();
         hideProfileFlyout();

--- a/src/renderer/lib/menus.js
+++ b/src/renderer/lib/menus.js
@@ -337,6 +337,13 @@ export const initMenus = () => {
   // permission prompt, find bar); these two were the exception, and left the
   // full-window `#menu-backdrop` swallowing clicks with no keyboard way out.
   //
+  // Closing a surface *consumes* the press: `preventDefault()` marks it, and
+  // navigation.js's window-level Escape stands down on `defaultPrevented`.
+  // Chrome only ever closes the innermost surface, so dismissing a menu over a
+  // still-loading page must not also stop that load, repaint the address bar
+  // and blur the focus we just handed back. `stopPropagation()` cannot do this
+  // job: both listeners sit on `window`, and same-node listeners still run.
+  //
   // Keyboard fallback for the zoom accelerators, resolved through the shared
   // shortcut registry so user remaps apply live. Needed on the Linux
   // frameless setups where menu accelerators never reach the app — the same
@@ -352,12 +359,15 @@ export const initMenus = () => {
   window.addEventListener('keydown', (event) => {
     if (event.key === 'Escape') {
       if (isProfileFlyoutOpen()) {
+        event.preventDefault();
         hideProfileFlyout();
         document.getElementById('profile-menu-btn')?.focus?.();
       } else if (state.menuOpen) {
+        event.preventDefault();
         setMenuOpen(false);
         menuButton?.focus?.();
       } else if (state.antMenuOpen) {
+        event.preventDefault();
         setAntMenuOpen(false);
         beeMenuButton?.focus?.();
       }

--- a/src/renderer/lib/menus.js
+++ b/src/renderer/lib/menus.js
@@ -47,7 +47,6 @@ export const setOnMenuOpening = (callback) => {
 };
 let beeMenuButton = null;
 let beeMenuDropdown = null;
-let webviewElement = null;
 let profileMenuWrap = null;
 
 // --- Profiles flyout dismissal ---------------------------------------------
@@ -257,7 +256,6 @@ export const initMenus = () => {
   checkUpdatesBtn = document.getElementById('check-updates-btn');
   beeMenuButton = document.getElementById('bee-menu-button');
   beeMenuDropdown = document.getElementById('bee-menu-dropdown');
-  webviewElement = document.getElementById('bzz-webview');
   profileMenuWrap = document.getElementById('profile-menu-wrap');
 
   // One submenu at a time: hovering or focusing any other hamburger row closes
@@ -327,6 +325,18 @@ export const initMenus = () => {
     zoomReset();
   });
 
+  // Keyboard handling for the menus. Escape shares this listener with the zoom
+  // fallback below rather than adding a second one (#306).
+  //
+  // Escape dismisses the innermost open surface first, exactly like Chrome's
+  // menus: the Profiles flyout, then the hamburger it hangs off, then the Nodes
+  // menu — and hands the keyboard back to the control that opened it, so the
+  // next Tab continues from the toolbar rather than from the top of the
+  // document. Every other dismissible surface in the chrome already closed on
+  // Escape (tab and page context menus, bookmark menu, trust popover,
+  // permission prompt, find bar); these two were the exception, and left the
+  // full-window `#menu-backdrop` swallowing clicks with no keyboard way out.
+  //
   // Keyboard fallback for the zoom accelerators, resolved through the shared
   // shortcut registry so user remaps apply live. Needed on the Linux
   // frameless setups where menu accelerators never reach the app — the same
@@ -340,6 +350,19 @@ export const initMenus = () => {
   // the `-` its physical code implies). Zoom In is tested first so those
   // users zoom in, which is what they pressed. menus.test.js pins it.
   window.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      if (isProfileFlyoutOpen()) {
+        hideProfileFlyout();
+        document.getElementById('profile-menu-btn')?.focus?.();
+      } else if (state.menuOpen) {
+        setMenuOpen(false);
+        menuButton?.focus?.();
+      } else if (state.antMenuOpen) {
+        setAntMenuOpen(false);
+        beeMenuButton?.focus?.();
+      }
+      return;
+    }
     if (matchesShortcut(event, 'page.zoomIn')) {
       event.preventDefault();
       zoomIn();
@@ -411,8 +434,11 @@ export const initMenus = () => {
     }
   });
 
-  webviewElement?.addEventListener('focus', closeMenus);
-  webviewElement?.addEventListener('mousedown', closeMenus);
+  // (The `focus`/`mousedown` dismissal that used to hang off
+  // `document.getElementById('bzz-webview')` is gone: webviews are created
+  // id-less, so that lookup was always null and the listeners never existed.
+  // `#menu-backdrop` covers the window while a menu is open, so a click into
+  // the page dismisses it through the document listener above. See #306.)
 
   // Close menus when window loses focus (switching windows or backgrounding app)
   window.addEventListener('blur', closeMenus);

--- a/src/renderer/lib/menus.test.js
+++ b/src/renderer/lib/menus.test.js
@@ -804,6 +804,34 @@ describe('menus', () => {
       expect(second.preventDefault).toHaveBeenCalled();
     });
 
+    // Dialog sibling: the profile-create prompt the flyout itself opens, and
+    // the external-node prompt main can send at any moment, are modal
+    // <dialog>s — the top layer, above these menus. The press is the dialog's
+    // own close request and it cannot mark it the way these handlers do, so
+    // consuming it here would cancel that close outright.
+    test('a modal dialog above the menus owns the Escape', async () => {
+      const { menus, state, elements, handlers } = await loadMenusModule();
+      menus.initMenus();
+      menus.setMenuOpen(true);
+      elements.profileFlyout.hidden = false;
+
+      const dialog = { tagName: 'DIALOG' };
+      global.document.querySelector.mockImplementation((selector) =>
+        selector === 'dialog[open]' ? dialog : null
+      );
+
+      const blocked = pressEscape(handlers);
+      expect(elements.profileFlyout.hidden).toBe(false);
+      expect(state.menuOpen).toBe(true);
+      expect(blocked.preventDefault).not.toHaveBeenCalled();
+
+      // The dialog closed, the flyout is innermost again.
+      global.document.querySelector.mockImplementation(() => null);
+      const next = pressEscape(handlers);
+      expect(elements.profileFlyout.hidden).toBe(true);
+      expect(next.preventDefault).toHaveBeenCalled();
+    });
+
     test('does nothing when no menu is open', async () => {
       const { menus, state, elements, handlers } = await loadMenusModule();
       menus.initMenus();

--- a/src/renderer/lib/menus.test.js
+++ b/src/renderer/lib/menus.test.js
@@ -747,7 +747,16 @@ describe('menus', () => {
   // these two menus were the exception, and left the modal backdrop up with no
   // keyboard way out.
   describe('Escape', () => {
-    const pressEscape = (handlers) => handlers.windowHandlers.keydown({ key: 'Escape' });
+    // Returns the event so callers can assert on `preventDefault`: closing a
+    // surface consumes the press, and navigation.js's window-level Escape
+    // (stop loading + restore the address bar + blur) stands down on
+    // `defaultPrevented`. Both listeners sit on `window`, so `stopPropagation`
+    // could never have done this job — same-node listeners still run.
+    const pressEscape = (handlers) => {
+      const event = { key: 'Escape', preventDefault: jest.fn() };
+      handlers.windowHandlers.keydown(event);
+      return event;
+    };
 
     test('closes the hamburger and returns focus to its button', async () => {
       const { menus, state, elements, handlers } = await loadMenusModule();
@@ -755,10 +764,11 @@ describe('menus', () => {
       menus.setMenuOpen(true);
       expect(state.menuOpen).toBe(true);
 
-      pressEscape(handlers);
+      const event = pressEscape(handlers);
 
       expect(state.menuOpen).toBe(false);
       expect(elements.menuButton.focus).toHaveBeenCalled();
+      expect(event.preventDefault).toHaveBeenCalled();
     });
 
     test('closes the Nodes menu and returns focus to its button', async () => {
@@ -767,10 +777,11 @@ describe('menus', () => {
       menus.setAntMenuOpen(true);
       expect(state.antMenuOpen).toBe(true);
 
-      pressEscape(handlers);
+      const event = pressEscape(handlers);
 
       expect(state.antMenuOpen).toBe(false);
       expect(elements.beeMenuButton.focus).toHaveBeenCalled();
+      expect(event.preventDefault).toHaveBeenCalled();
     });
 
     test('closes the Profiles flyout first, the hamburger on the second press', async () => {
@@ -779,28 +790,33 @@ describe('menus', () => {
       menus.setMenuOpen(true);
       elements.profileFlyout.hidden = false;
 
-      pressEscape(handlers);
+      const first = pressEscape(handlers);
       expect(elements.profileFlyout.hidden).toBe(true);
       // The hamburger the flyout hangs off stays up, as in Chrome: the
       // innermost surface closes first.
       expect(state.menuOpen).toBe(true);
       expect(elements.profileMenuBtn.focus).toHaveBeenCalled();
+      expect(first.preventDefault).toHaveBeenCalled();
 
-      pressEscape(handlers);
+      const second = pressEscape(handlers);
       expect(state.menuOpen).toBe(false);
       expect(elements.menuButton.focus).toHaveBeenCalled();
+      expect(second.preventDefault).toHaveBeenCalled();
     });
 
     test('does nothing when no menu is open', async () => {
       const { menus, state, elements, handlers } = await loadMenusModule();
       menus.initMenus();
 
-      pressEscape(handlers);
+      const event = pressEscape(handlers);
 
       expect(state.menuOpen).toBe(false);
       expect(state.antMenuOpen).toBe(false);
       expect(elements.menuButton.focus).not.toHaveBeenCalled();
       expect(elements.beeMenuButton.focus).not.toHaveBeenCalled();
+      // Nothing was consumed, so the press stays available to the surfaces
+      // behind these menus — notably navigation.js's stop-loading Escape.
+      expect(event.preventDefault).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/renderer/lib/menus.test.js
+++ b/src/renderer/lib/menus.test.js
@@ -24,6 +24,7 @@ const createElement = () => {
     }),
     contains: jest.fn(() => false),
     blur: jest.fn(),
+    focus: jest.fn(),
     print: jest.fn(),
   };
 };
@@ -722,7 +723,7 @@ describe('menus', () => {
     });
   });
 
-  test('closes menus on outside clicks, webview interaction, and window blur', async () => {
+  test('closes menus on outside clicks and window blur', async () => {
     const { menus, state, elements, handlers } = await loadMenusModule();
 
     menus.initMenus();
@@ -730,10 +731,76 @@ describe('menus', () => {
     menus.setAntMenuOpen(true);
 
     handlers.documentHandlers.click({ target: {} });
-    elements.webviewElement.handlers.focus();
     handlers.windowHandlers.blur();
 
     expect(state.menuOpen).toBe(false);
     expect(state.antMenuOpen).toBe(false);
+
+    // The `#bzz-webview` focus/mousedown dismissal is gone: webviews are
+    // created id-less, so that element never existed and the listeners were
+    // never registered. Nothing may go back to hanging behaviour off it
+    // (#306) — `#menu-backdrop` covers the window while a menu is open.
+    expect(elements.webviewElement.addEventListener).not.toHaveBeenCalled();
+  });
+
+  // #306: Escape is how every other dismissible surface in the chrome closes;
+  // these two menus were the exception, and left the modal backdrop up with no
+  // keyboard way out.
+  describe('Escape', () => {
+    const pressEscape = (handlers) => handlers.windowHandlers.keydown({ key: 'Escape' });
+
+    test('closes the hamburger and returns focus to its button', async () => {
+      const { menus, state, elements, handlers } = await loadMenusModule();
+      menus.initMenus();
+      menus.setMenuOpen(true);
+      expect(state.menuOpen).toBe(true);
+
+      pressEscape(handlers);
+
+      expect(state.menuOpen).toBe(false);
+      expect(elements.menuButton.focus).toHaveBeenCalled();
+    });
+
+    test('closes the Nodes menu and returns focus to its button', async () => {
+      const { menus, state, elements, handlers } = await loadMenusModule();
+      menus.initMenus();
+      menus.setAntMenuOpen(true);
+      expect(state.antMenuOpen).toBe(true);
+
+      pressEscape(handlers);
+
+      expect(state.antMenuOpen).toBe(false);
+      expect(elements.beeMenuButton.focus).toHaveBeenCalled();
+    });
+
+    test('closes the Profiles flyout first, the hamburger on the second press', async () => {
+      const { menus, state, elements, handlers } = await loadMenusModule();
+      menus.initMenus();
+      menus.setMenuOpen(true);
+      elements.profileFlyout.hidden = false;
+
+      pressEscape(handlers);
+      expect(elements.profileFlyout.hidden).toBe(true);
+      // The hamburger the flyout hangs off stays up, as in Chrome: the
+      // innermost surface closes first.
+      expect(state.menuOpen).toBe(true);
+      expect(elements.profileMenuBtn.focus).toHaveBeenCalled();
+
+      pressEscape(handlers);
+      expect(state.menuOpen).toBe(false);
+      expect(elements.menuButton.focus).toHaveBeenCalled();
+    });
+
+    test('does nothing when no menu is open', async () => {
+      const { menus, state, elements, handlers } = await loadMenusModule();
+      menus.initMenus();
+
+      pressEscape(handlers);
+
+      expect(state.menuOpen).toBe(false);
+      expect(state.antMenuOpen).toBe(false);
+      expect(elements.menuButton.focus).not.toHaveBeenCalled();
+      expect(elements.beeMenuButton.focus).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/renderer/lib/modal-dialog.js
+++ b/src/renderer/lib/modal-dialog.js
@@ -1,0 +1,22 @@
+// Is a modal `<dialog>` up? (The bookmark add/edit editor, the profile-create
+// and external-node prompts, onboarding — every `<dialog>` in the chrome is
+// shown with `showModal()`.)
+//
+// A modal dialog puts itself in the top layer and makes everything outside it
+// inert, so while one is open it *is* the innermost surface: the Escape
+// belongs to it, and a click that lands on it (or on its backdrop) is aimed at
+// it, never at whatever chrome surface is stranded behind it. Chrome's order,
+// the same rule the menus follow — this press closes the dialog, the next one
+// reaches the surface behind.
+//
+// The dialog cannot claim the press the way a menu handler does. Its Escape
+// *is* the platform's own close request, dispatched only after every keydown
+// listener has run and cancelled outright by a `preventDefault()` from any of
+// them. So the other surfaces stand down on this probe instead, leaving the
+// press uncancelled — a `preventDefault()` from one of them both keeps the
+// dialog open and dismisses a surface the user cannot even see. See #306.
+//
+// The one deliberate exception is `chrome-input-context-menu.js`: it reparents
+// itself *into* the open dialog, so it really is above it, and keeps its
+// capture-phase Escape.
+export const isModalDialogOpen = () => !!document.querySelector?.('dialog[open]');

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -108,6 +108,18 @@ export const setSuggestionPreviewProbe = (probe) => {
   isSuggestionPreviewActive = typeof probe === 'function' ? probe : () => false;
 };
 
+// True while a modal `<dialog>` is up (the bookmark add/edit editor, the
+// profile-create and external-node prompts, onboarding). Those are innermost
+// surfaces exactly like the menus, but they cannot mark the press with
+// `preventDefault()` the way the menus do: their Escape is the platform's own
+// close request, dispatched *after* every keydown listener has run and
+// cancelled outright by a `preventDefault()` from one of them. So the
+// stop-loading branch stands down while one is open instead — Chrome's order
+// again: this press belongs to the dialog (closing it, or being swallowed by
+// it, as onboarding's `cancel` handler chooses), and only the next one stops
+// the load. Every `<dialog>` in the chrome is shown with `showModal()`.
+const isModalDialogOpen = () => !!document.querySelector?.('dialog[open]');
+
 // Write a page-derived display value into the address bar, unless the user is
 // mid-edit. Chrome's omnibox keeps "user input in progress" text through any
 // navigation committing in the tab — a slow page finishing, a client-side
@@ -2807,6 +2819,10 @@ export const initNavigation = () => {
       // `window`, so their mark is already set by the time this runs;
       // `stopPropagation()` on a same-node listener could not have done it.
       if (event.defaultPrevented) return;
+      // A modal <dialog> owns the press the same way, but marks nothing — see
+      // `isModalDialogOpen`. Standing down here is what leaves its own
+      // Escape-to-cancel intact; a `preventDefault()` below would kill it.
+      if (isModalDialogOpen()) return;
       if (stopLoadingAndRestore()) {
         event.preventDefault();
         if (

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -32,6 +32,7 @@ import {
   looksLikeOnchainAppInput,
 } from './url-utils.js';
 import { buildSearchUrl } from './search-utils.js';
+import { isModalDialogOpen } from './modal-dialog.js';
 import {
   applyInputSelection,
   captureInputSelection,
@@ -107,18 +108,6 @@ let isSuggestionPreviewActive = () => false;
 export const setSuggestionPreviewProbe = (probe) => {
   isSuggestionPreviewActive = typeof probe === 'function' ? probe : () => false;
 };
-
-// True while a modal `<dialog>` is up (the bookmark add/edit editor, the
-// profile-create and external-node prompts, onboarding). Those are innermost
-// surfaces exactly like the menus, but they cannot mark the press with
-// `preventDefault()` the way the menus do: their Escape is the platform's own
-// close request, dispatched *after* every keydown listener has run and
-// cancelled outright by a `preventDefault()` from one of them. So the
-// stop-loading branch stands down while one is open instead — Chrome's order
-// again: this press belongs to the dialog (closing it, or being swallowed by
-// it, as onboarding's `cancel` handler chooses), and only the next one stops
-// the load. Every `<dialog>` in the chrome is shown with `showModal()`.
-const isModalDialogOpen = () => !!document.querySelector?.('dialog[open]');
 
 // Write a page-derived display value into the address bar, unless the user is
 // mid-edit. Chrome's omnibox keeps "user input in progress" text through any
@@ -2234,6 +2223,10 @@ export const initNavigation = () => {
   });
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && trustPopover && !trustPopover.hidden) {
+      // A modal <dialog> is above this popover in the top layer, so the press
+      // is the dialog's — and consuming it here would cancel the dialog's own
+      // close request. See `isModalDialogOpen`.
+      if (isModalDialogOpen()) return;
       // Consumed: the window-level Escape below must not also stop the load.
       e.preventDefault();
       setTrustPopoverOpen(false);

--- a/src/renderer/lib/navigation.js
+++ b/src/renderer/lib/navigation.js
@@ -2222,6 +2222,8 @@ export const initNavigation = () => {
   });
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && trustPopover && !trustPopover.hidden) {
+      // Consumed: the window-level Escape below must not also stop the load.
+      e.preventDefault();
       setTrustPopoverOpen(false);
     }
   });
@@ -2793,6 +2795,18 @@ export const initNavigation = () => {
       event.preventDefault();
       reloadPage();
     } else if (event.key === 'Escape') {
+      // Stop-loading is Escape's *last* meaning, the way it is in Chrome: one
+      // press closes only the innermost open surface. Every dismissible
+      // surface in the chrome (the hamburger and Nodes menus, the tab and page
+      // context menus, the bookmark menus, the trust popover, a permission
+      // prompt, the chrome-input context menu) calls `preventDefault()` when
+      // it consumes the press, and this handler stands down for it — otherwise
+      // closing a menu over a still-loading page would also cancel that load,
+      // repaint the address bar and blur the focus the menu just handed back.
+      // Those handlers all sit on `document` or, for menus.js, earlier on
+      // `window`, so their mark is already set by the time this runs;
+      // `stopPropagation()` on a same-node listener could not have done it.
+      if (event.defaultPrevented) return;
       if (stopLoadingAndRestore()) {
         event.preventDefault();
         if (

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -681,6 +681,76 @@ describe('navigation', () => {
     expect(ctx.activeRef.tab.webview.loadURL).toHaveBeenCalledTimes(1);
   });
 
+  // #306: Escape means "close the innermost open surface" first and
+  // "stop loading" only last, as it does in Chrome. Every surface that
+  // consumes the press marks it with `preventDefault()`; this handler must
+  // stand down for that mark, or closing a menu over a still-loading page
+  // also cancels the load, repaints the address bar and blurs the focus the
+  // menu just handed back. `stopPropagation()` cannot substitute: menus.js's
+  // listener sits on the same `window` node, and same-node listeners still run.
+  describe('Escape stop-loading yields to a surface that consumed the press', () => {
+    test('a consumed Escape leaves an in-flight load alone', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      ctx.activeRef.tab.navigationState.isWebviewLoading = true;
+      ctx.activeRef.tab.navigationState.currentPageUrl = 'https://slow.example';
+      ctx.elements.addressInput.value = 'https://slow.example';
+      ctx.elements.reloadBtn.dataset.state = 'stop';
+
+      const blurTarget = createElement('button');
+      blurTarget.blur = jest.fn();
+      global.document.activeElement = blurTarget;
+
+      ctx.windowHandlers.keydown({
+        key: 'Escape',
+        defaultPrevented: true,
+        preventDefault: jest.fn(),
+      });
+
+      expect(ctx.activeRef.tab.webview.stop).not.toHaveBeenCalled();
+      expect(ctx.elements.reloadBtn.dataset.state).toBe('stop');
+      // The menu handed the keyboard back to its own button; this handler must
+      // not take it away again.
+      expect(blurTarget.blur).not.toHaveBeenCalled();
+    });
+
+    test('an unconsumed Escape still stops the load', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      ctx.activeRef.tab.navigationState.isWebviewLoading = true;
+      ctx.activeRef.tab.navigationState.currentPageUrl = 'https://slow.example';
+      ctx.elements.reloadBtn.dataset.state = 'stop';
+
+      const blurTarget = createElement('button');
+      blurTarget.blur = jest.fn();
+      global.document.activeElement = blurTarget;
+
+      ctx.windowHandlers.keydown({
+        key: 'Escape',
+        defaultPrevented: false,
+        preventDefault: jest.fn(),
+      });
+
+      expect(ctx.activeRef.tab.webview.stop).toHaveBeenCalled();
+      expect(ctx.elements.reloadBtn.dataset.state).toBe('reload');
+      expect(blurTarget.blur).toHaveBeenCalled();
+    });
+
+    test('the trust popover consumes the Escape that closes it', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      ctx.elements.trustPopover.hidden = false;
+      const event = { key: 'Escape', preventDefault: jest.fn() };
+      global.document.handlers.keydown(event);
+
+      expect(ctx.elements.trustPopover.hidden).toBe(true);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+  });
+
   test('processes webview lifecycle events and records history', async () => {
     const ctx = await loadNavigationModule({
       initialSettings: { showBookmarkBar: true, showIpfsProgressStatus: true },

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -738,6 +738,66 @@ describe('navigation', () => {
       expect(blurTarget.blur).toHaveBeenCalled();
     });
 
+    // A modal <dialog> (the bookmark add/edit editor, the profile-create and
+    // external-node prompts, onboarding) is the innermost surface too, but it
+    // has no listener to mark the press with: Escape reaches it as the
+    // platform's own close request, dispatched after every keydown listener
+    // has run. So this handler must stand down on "a dialog is open" and, just
+    // as importantly, leave the press *uncancelled* — a `preventDefault()`
+    // here cancels the close request outright, which is what left the bookmark
+    // editor needing a second Escape while it stopped the load on the first.
+    test('an open modal dialog owns the Escape, load and press both untouched', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      const dialog = createElement('dialog');
+      dialog.setAttribute('open', '');
+      global.document.querySelector = jest.fn((selector) =>
+        selector === 'dialog[open]' ? dialog : null
+      );
+
+      ctx.activeRef.tab.navigationState.isWebviewLoading = true;
+      ctx.activeRef.tab.navigationState.currentPageUrl = 'https://slow.example';
+      ctx.elements.addressInput.value = 'https://slow.example';
+      ctx.elements.reloadBtn.dataset.state = 'stop';
+
+      // The dialog's own focused field: the editor's Name input.
+      const labelInput = createElement('input');
+      labelInput.blur = jest.fn();
+      global.document.activeElement = labelInput;
+
+      const event = { key: 'Escape', defaultPrevented: false, preventDefault: jest.fn() };
+      ctx.windowHandlers.keydown(event);
+
+      expect(ctx.activeRef.tab.webview.stop).not.toHaveBeenCalled();
+      expect(ctx.elements.reloadBtn.dataset.state).toBe('stop');
+      expect(ctx.elements.addressInput.value).toBe('https://slow.example');
+      expect(labelInput.blur).not.toHaveBeenCalled();
+      // Cancelling the press here would suppress the dialog's built-in cancel.
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    test('once the dialog is closed the next Escape stops the load', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      // No `dialog[open]` in the document — the editor has closed.
+      global.document.querySelector = jest.fn(() => null);
+
+      ctx.activeRef.tab.navigationState.isWebviewLoading = true;
+      ctx.activeRef.tab.navigationState.currentPageUrl = 'https://slow.example';
+      ctx.elements.reloadBtn.dataset.state = 'stop';
+
+      ctx.windowHandlers.keydown({
+        key: 'Escape',
+        defaultPrevented: false,
+        preventDefault: jest.fn(),
+      });
+
+      expect(ctx.activeRef.tab.webview.stop).toHaveBeenCalled();
+      expect(ctx.elements.reloadBtn.dataset.state).toBe('reload');
+    });
+
     test('the trust popover consumes the Escape that closes it', async () => {
       const ctx = await loadNavigationModule();
       await ctx.mod.initNavigation();

--- a/src/renderer/lib/navigation.test.js
+++ b/src/renderer/lib/navigation.test.js
@@ -809,6 +809,32 @@ describe('navigation', () => {
       expect(ctx.elements.trustPopover.hidden).toBe(true);
       expect(event.preventDefault).toHaveBeenCalled();
     });
+
+    // …unless a modal <dialog> is above it in the top layer: the press is the
+    // dialog's own close request then, and consuming it here would cancel it.
+    test('a modal dialog above the trust popover owns the Escape', async () => {
+      const ctx = await loadNavigationModule();
+      await ctx.mod.initNavigation();
+
+      const dialog = createElement('dialog');
+      dialog.setAttribute('open', '');
+      global.document.querySelector = jest.fn((selector) =>
+        selector === 'dialog[open]' ? dialog : null
+      );
+
+      ctx.elements.trustPopover.hidden = false;
+      const blocked = { key: 'Escape', preventDefault: jest.fn() };
+      global.document.handlers.keydown(blocked);
+
+      expect(ctx.elements.trustPopover.hidden).toBe(false);
+      expect(blocked.preventDefault).not.toHaveBeenCalled();
+
+      global.document.querySelector = jest.fn(() => null);
+      const next = { key: 'Escape', preventDefault: jest.fn() };
+      global.document.handlers.keydown(next);
+      expect(ctx.elements.trustPopover.hidden).toBe(true);
+      expect(next.preventDefault).toHaveBeenCalled();
+    });
   });
 
   test('processes webview lifecycle events and records history', async () => {

--- a/src/renderer/lib/page-context-menu.js
+++ b/src/renderer/lib/page-context-menu.js
@@ -2,6 +2,7 @@
 import { state } from './state.js';
 import { pushDebug } from './debug.js';
 import { showMenuBackdrop, hideMenuBackdrop } from './menu-backdrop.js';
+import { isModalDialogOpen } from './modal-dialog.js';
 import { deriveDisplayValue, applyEnsNamePreservation } from './url-utils.js';
 import { isTrustInterstitialPageUrl } from './page-urls.js';
 
@@ -397,6 +398,9 @@ export const initPageContextMenu = async () => {
   document.addEventListener('keydown', (e) => {
     if (e.key !== 'Escape') return;
     if (!pageContextMenu || pageContextMenu.classList.contains('hidden')) return;
+    // A modal <dialog> raised over the menu owns the press and cannot mark it
+    // — see `isModalDialogOpen`.
+    if (isModalDialogOpen()) return;
     e.preventDefault();
     hidePageContextMenu();
   });

--- a/src/renderer/lib/page-context-menu.js
+++ b/src/renderer/lib/page-context-menu.js
@@ -390,11 +390,15 @@ export const initPageContextMenu = async () => {
     }
   });
 
-  // Hide on escape
+  // Hide on escape. A press that actually closes the menu is consumed
+  // (`preventDefault`), so navigation.js's window-level Escape doesn't also
+  // stop an in-flight page load — Chrome closes the innermost surface only.
+  // See #306.
   document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') {
-      hidePageContextMenu();
-    }
+    if (e.key !== 'Escape') return;
+    if (!pageContextMenu || pageContextMenu.classList.contains('hidden')) return;
+    e.preventDefault();
+    hidePageContextMenu();
   });
 
   // Hide when window loses focus — without the focus hand-back, which would

--- a/src/renderer/lib/page-context-menu.js
+++ b/src/renderer/lib/page-context-menu.js
@@ -18,6 +18,20 @@ let currentContext = null;
 // to a different tab an action opened in the meantime.
 let menuWebview = null;
 
+// The URL that webview was showing when the menu was raised. A context menu
+// describes one document: every item on it (the link, the image, the
+// selection, even Back/Forward's enabled state) was read off that page, so the
+// moment the page changes underneath, the whole menu is stale. #308.
+let menuPageUrl = null;
+
+const currentUrlOf = (webview) => {
+  try {
+    return webview?.getURL?.() || null;
+  } catch {
+    return null;
+  }
+};
+
 // The active (foreground) guest, or null.
 const getActiveWebview = () =>
   document.getElementById('webview-container')?.querySelector('webview:not(.hidden)') || null;
@@ -91,6 +105,7 @@ export const showPageContextMenu = (x, y, context) => {
   // Get the webview from the active tab
   const activeWebview = getActiveWebview();
   menuWebview = activeWebview;
+  menuPageUrl = currentUrlOf(activeWebview) || context.pageUrl || null;
 
   if (backBtn && activeWebview) {
     try {
@@ -169,6 +184,31 @@ export const hidePageContextMenu = ({ restoreFocus = true } = {}) => {
   }
   currentContext = null;
   menuWebview = null;
+  menuPageUrl = null;
+};
+
+// True when the menu is up but the page it describes is gone — the tab
+// navigated (a redirect, a slow load finishing, Back, a reload) or the
+// foreground moved to another tab. Chrome's context menu never outlives its
+// document; this is the belt to the navigation braces below, so even a
+// navigation nobody reported to us can't be acted on. #308.
+const contextIsStale = () => {
+  if (!menuWebview) return false;
+  if (menuWebview !== getActiveWebview()) return true;
+  const url = currentUrlOf(menuWebview);
+  return Boolean(menuPageUrl && url && url !== menuPageUrl);
+};
+
+// A navigation in `webview` (or in whichever tab owns the menu, when called
+// without one) dismisses the menu. Wired from the same per-tab navigation path
+// the find bar uses, tabs.js — a menu raised on page A must not still be
+// offering "Open Link in New Tab" over page B. #308.
+export const notifyPageContextMenuNavigated = (webview) => {
+  if (!pageContextMenu || pageContextMenu.classList.contains('hidden')) return;
+  if (webview && menuWebview && webview !== menuWebview) return;
+  // The page the keyboard would go back to is the one that just went away, so
+  // let the incoming document take focus on its own terms.
+  hidePageContextMenu({ restoreFocus: false });
 };
 
 // Handle context menu action
@@ -179,6 +219,17 @@ const handleAction = async (action) => {
   // still live.
   if (!currentContext) {
     hidePageContextMenu();
+    return;
+  }
+
+  // The page moved on since the menu was raised (a navigation that reached us
+  // through no event, a tab switch). Every item here refers to a document that
+  // is no longer on screen — opening its link, copying its address or
+  // view-sourcing it would act on a page the user is no longer looking at, so
+  // take the menu down and do nothing. #308.
+  if (contextIsStale()) {
+    pushDebug('[PageContextMenu] Dropping an action for a page that has navigated away');
+    hidePageContextMenu({ restoreFocus: false });
     return;
   }
 

--- a/src/renderer/lib/page-context-menu.test.js
+++ b/src/renderer/lib/page-context-menu.test.js
@@ -605,6 +605,113 @@ describe('page-context-menu', () => {
     expect(backdrop.hideMenuBackdrop).toHaveBeenCalled();
   });
 
+  // #308: a context menu describes one document. A navigation in the tab it
+  // was raised on takes it down, and an action that somehow still reaches a
+  // navigated-away page is dropped rather than applied to the old page's link.
+  describe('navigation', () => {
+    const withUrl = (url) => ({
+      canGoBack: jest.fn(() => true),
+      canGoForward: jest.fn(() => false),
+      goBack: jest.fn(),
+      goForward: jest.fn(),
+      reloadIgnoringCache: jest.fn(),
+      openDevTools: jest.fn(),
+      send: jest.fn(),
+      focus: jest.fn(),
+      getURL: jest.fn(() => url),
+    });
+
+    test('a navigation in the menu\u2019s own tab dismisses it', async () => {
+      const activeWebview = withUrl('bzz://page-a/');
+      const { mod, pageContextMenu, backdrop } = await loadPageContextMenuModule({ activeWebview });
+      await mod.initPageContextMenu();
+
+      mod.showPageContextMenu(20, 30, {
+        pageUrl: 'bzz://page-a/',
+        linkUrl: 'bzz://page-c/',
+      });
+      pageContextMenu.classList.add.mockClear();
+      backdrop.hideMenuBackdrop.mockClear();
+
+      mod.notifyPageContextMenuNavigated(activeWebview);
+
+      expect(pageContextMenu.classList.add).toHaveBeenCalledWith('hidden');
+      expect(backdrop.hideMenuBackdrop).toHaveBeenCalled();
+      // The document the keyboard would go back to is the one that just went
+      // away, so the incoming page is left to take focus on its own terms.
+      expect(activeWebview.focus).not.toHaveBeenCalled();
+    });
+
+    test('a navigation in another tab leaves it alone', async () => {
+      const activeWebview = withUrl('bzz://page-a/');
+      const { mod, pageContextMenu } = await loadPageContextMenuModule({ activeWebview });
+      await mod.initPageContextMenu();
+
+      mod.showPageContextMenu(20, 30, { pageUrl: 'bzz://page-a/' });
+      pageContextMenu.classList.add.mockClear();
+
+      mod.notifyPageContextMenuNavigated(withUrl('bzz://other-tab/'));
+
+      expect(pageContextMenu.classList.add).not.toHaveBeenCalledWith('hidden');
+    });
+
+    test('a tab switch (no webview named) dismisses it', async () => {
+      const activeWebview = withUrl('bzz://page-a/');
+      const { mod, pageContextMenu } = await loadPageContextMenuModule({ activeWebview });
+      await mod.initPageContextMenu();
+
+      mod.showPageContextMenu(20, 30, { pageUrl: 'bzz://page-a/' });
+      pageContextMenu.classList.add.mockClear();
+
+      mod.notifyPageContextMenuNavigated();
+
+      expect(pageContextMenu.classList.add).toHaveBeenCalledWith('hidden');
+    });
+
+    test('an item clicked after the page moved on acts on nothing', async () => {
+      const activeWebview = withUrl('bzz://page-a/');
+      const { mod, pageContextMenu, pushDebug } = await loadPageContextMenuModule({
+        activeWebview,
+      });
+      await mod.initPageContextMenu();
+
+      mod.showPageContextMenu(20, 30, {
+        pageUrl: 'bzz://page-a/',
+        linkUrl: 'bzz://page-c/',
+      });
+
+      // The page redirected itself and nothing told the menu — the belt to the
+      // navigation braces above.
+      activeWebview.getURL.mockReturnValue('bzz://page-b/');
+      document.dispatchEvent.mockClear();
+      pageContextMenu.classList.add.mockClear();
+
+      await triggerMenuAction(pageContextMenu, 'open-link-new-tab');
+
+      expect(document.dispatchEvent).not.toHaveBeenCalled();
+      expect(pageContextMenu.classList.add).toHaveBeenCalledWith('hidden');
+      expect(pushDebug).toHaveBeenCalledWith(expect.stringContaining('navigated away'));
+    });
+
+    test('an item clicked on the page it was raised on still acts', async () => {
+      const activeWebview = withUrl('bzz://page-a/');
+      const { mod, pageContextMenu } = await loadPageContextMenuModule({ activeWebview });
+      await mod.initPageContextMenu();
+
+      mod.showPageContextMenu(20, 30, {
+        pageUrl: 'bzz://page-a/',
+        linkUrl: 'bzz://page-c/',
+      });
+      document.dispatchEvent.mockClear();
+
+      await triggerMenuAction(pageContextMenu, 'open-link-new-tab');
+
+      expect(document.dispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'open-url-new-tab', detail: { url: 'bzz://page-c/' } })
+      );
+    });
+  });
+
   test('closes on outside interactions and wires webview ipc context-menu events', async () => {
     const { mod, pageContextMenu, documentHandlers, windowHandlers, backdrop } =
       await loadPageContextMenuModule();

--- a/src/renderer/lib/page-context-menu.test.js
+++ b/src/renderer/lib/page-context-menu.test.js
@@ -558,9 +558,20 @@ describe('page-context-menu', () => {
     // Escape dismisses and returns the keyboard to the page it was opened over.
     global.document.activeElement = pageContextMenu;
     pageContextMenu.contains.mockImplementation((el) => el === pageContextMenu);
-    documentHandlers.keydown({ key: 'Escape' });
+    const escape = { key: 'Escape', preventDefault: jest.fn() };
+    documentHandlers.keydown(escape);
     expect(pageContextMenu.classList.add).toHaveBeenCalledWith('hidden');
     expect(activeWebview.focus).toHaveBeenCalledTimes(1);
+    // Closing the menu consumes the press — navigation.js's window-level
+    // Escape (stop loading + restore the address bar) stands down on
+    // `defaultPrevented`, so dismissing a context menu raised over a loading
+    // page doesn't also cancel that load (#306).
+    expect(escape.preventDefault).toHaveBeenCalled();
+
+    // With the menu already down the press belongs to whatever is behind it.
+    const escapeAgain = { key: 'Escape', preventDefault: jest.fn() };
+    documentHandlers.keydown(escapeAgain);
+    expect(escapeAgain.preventDefault).not.toHaveBeenCalled();
 
     // A click that moved focus elsewhere in chrome (the address bar) dismisses
     // the menu too — and must not yank focus back to the page.
@@ -582,7 +593,7 @@ describe('page-context-menu', () => {
     mod.showPageContextMenu(20, 30, { pageUrl: 'https://example.com/page' });
     global.document.activeElement = pageContextMenu;
     webviewContainer.querySelector.mockReturnValue({ focus: jest.fn() });
-    documentHandlers.keydown({ key: 'Escape' });
+    documentHandlers.keydown({ key: 'Escape', preventDefault: jest.fn() });
     expect(activeWebview.focus).toHaveBeenCalledTimes(1);
   });
 

--- a/src/renderer/lib/page-context-menu.test.js
+++ b/src/renderer/lib/page-context-menu.test.js
@@ -597,6 +597,35 @@ describe('page-context-menu', () => {
     expect(activeWebview.focus).toHaveBeenCalledTimes(1);
   });
 
+  // #306, dialog sibling: a modal <dialog> raised over the menu is the top
+  // layer, so the press is its own close request — and it cannot mark the
+  // press the way this handler does. Consuming it here would cancel that close
+  // outright, leaving the dialog open.
+  test('a modal dialog above the menu owns the Escape', async () => {
+    const { mod, pageContextMenu, documentHandlers } = await loadPageContextMenuModule();
+
+    await mod.initPageContextMenu();
+    mod.showPageContextMenu(20, 30, { pageUrl: 'https://example.com/page' });
+    pageContextMenu.classList.add.mockClear();
+
+    const dialog = { tagName: 'DIALOG' };
+    global.document.querySelector = jest.fn((selector) =>
+      selector === 'dialog[open]' ? dialog : null
+    );
+
+    const escape = { key: 'Escape', preventDefault: jest.fn() };
+    documentHandlers.keydown(escape);
+    expect(pageContextMenu.classList.add).not.toHaveBeenCalledWith('hidden');
+    expect(escape.preventDefault).not.toHaveBeenCalled();
+
+    // The dialog gone, the menu is innermost again and takes the next press.
+    global.document.querySelector = jest.fn(() => null);
+    const next = { key: 'Escape', preventDefault: jest.fn() };
+    documentHandlers.keydown(next);
+    expect(pageContextMenu.classList.add).toHaveBeenCalledWith('hidden');
+    expect(next.preventDefault).toHaveBeenCalled();
+  });
+
   test('still dismisses when the context went away before the action ran', async () => {
     const { mod, pageContextMenu, windowHandlers, backdrop } = await loadPageContextMenuModule();
 

--- a/src/renderer/lib/site-permissions-ui.js
+++ b/src/renderer/lib/site-permissions-ui.js
@@ -386,10 +386,16 @@ export const initSitePermissionsUi = () => {
     }
   });
 
+  // A press that actually dismisses the prompt or closes the indicator
+  // popover is consumed (`preventDefault`), so navigation.js's window-level
+  // Escape doesn't also stop an in-flight page load — Chrome closes the
+  // innermost surface only. See #306.
   document.addEventListener('keydown', (e) => {
     if (e.key !== 'Escape') return;
+    const popoverOpen = Boolean(popoverEl && !popoverEl.hidden);
+    if (activePrompt || popoverOpen) e.preventDefault();
     dismissActivePrompt('escape');
-    if (popoverEl && !popoverEl.hidden) setPopoverOpen(false);
+    if (popoverOpen) setPopoverOpen(false);
   });
 
   // Focus loss only closes the indicator popover — never the prompt.

--- a/src/renderer/lib/site-permissions-ui.js
+++ b/src/renderer/lib/site-permissions-ui.js
@@ -24,6 +24,7 @@
 
 import { getActiveWebview, getDisplayUrlForWebview } from './tabs.js';
 import { getPermissionKey } from './origin-utils.js';
+import { isModalDialogOpen } from './modal-dialog.js';
 import { pushDebug } from './debug.js';
 
 // Storage-key → human noun (indicator popover, settings mirror this).
@@ -375,7 +376,20 @@ export const initSitePermissionsUi = () => {
   });
 
   // Click-away / Esc dismissal, mirroring the trust popover's handlers.
+  //
+  // Both stand down while a modal <dialog> is up. A page can request a
+  // permission at any moment — including while the bookmark editor, the
+  // profile-create/external-node prompt or onboarding is open — and the
+  // prompt then renders behind the dialog's top layer, inert and
+  // un-answerable. Every gesture in that state is aimed at the dialog: a
+  // click lands inside it (or on its backdrop), and the Escape is its own
+  // close request. Acting on either would deny the page's request from a
+  // press or click the user never aimed at the prompt, and the Escape's
+  // `preventDefault()` would additionally cancel the dialog's close outright,
+  // leaving it open. The prompt is held instead and becomes answerable the
+  // moment the dialog is gone. See `isModalDialogOpen` and #306.
   document.addEventListener('click', (e) => {
+    if (isModalDialogOpen()) return;
     if (activePrompt && !promptEl.hidden && !promptEl.contains(e.target)) {
       dismissActivePrompt('click-away');
     }
@@ -392,6 +406,7 @@ export const initSitePermissionsUi = () => {
   // innermost surface only. See #306.
   document.addEventListener('keydown', (e) => {
     if (e.key !== 'Escape') return;
+    if (isModalDialogOpen()) return;
     const popoverOpen = Boolean(popoverEl && !popoverEl.hidden);
     if (activePrompt || popoverOpen) e.preventDefault();
     dismissActivePrompt('escape');

--- a/src/renderer/lib/site-permissions-ui.test.js
+++ b/src/renderer/lib/site-permissions-ui.test.js
@@ -256,6 +256,29 @@ describe('site-permissions-ui prompt tab-scoping', () => {
     expect(promptVisible()).toBe(false);
     expect(api.respondToPrompt).not.toHaveBeenCalled();
   });
+
+  // #306: Escape closes only the innermost open surface, as in Chrome, and
+  // consumes the press while doing it — navigation.js's window-level Escape
+  // (stop loading + restore the address bar) stands down on `defaultPrevented`,
+  // so dismissing a prompt over a still-loading page can't cancel that load.
+  test('Escape consumes the press only when it actually dismisses the prompt', () => {
+    const idle = { key: 'Escape', preventDefault: jest.fn() };
+    doc.handlers.keydown(idle);
+    expect(idle.preventDefault).not.toHaveBeenCalled();
+
+    sendRequest({ id: 16, origin: 'https://a.example', keys: ['camera'], guestId: 1 });
+    expect(promptVisible()).toBe(true);
+
+    const escape = { key: 'Escape', preventDefault: jest.fn() };
+    doc.handlers.keydown(escape);
+    expect(promptVisible()).toBe(false);
+    expect(api.respondToPrompt).toHaveBeenCalledWith({
+      id: 16,
+      decision: 'dismiss',
+      remember: false,
+    });
+    expect(escape.preventDefault).toHaveBeenCalled();
+  });
 });
 
 describe('site-permissions-ui popover revoke label', () => {

--- a/src/renderer/lib/site-permissions-ui.test.js
+++ b/src/renderer/lib/site-permissions-ui.test.js
@@ -279,6 +279,71 @@ describe('site-permissions-ui prompt tab-scoping', () => {
     });
     expect(escape.preventDefault).toHaveBeenCalled();
   });
+
+  // #306, dialog sibling: a page can request a permission at any moment,
+  // including while a modal <dialog> (the bookmark editor, the profile-create
+  // or external-node prompt, onboarding) is up. The prompt then sits behind
+  // the dialog's top layer, inert and un-answerable, and every gesture in that
+  // state belongs to the dialog. Answering the prompt from one of them denies
+  // the page's request behind the user's back — and the Escape's
+  // `preventDefault()` additionally cancels the dialog's own close request, so
+  // the dialog stays open too.
+  const openModalDialog = () => {
+    const dialog = createElement('dialog');
+    dialog.setAttribute('open', '');
+    doc.body.appendChild(dialog);
+    return dialog;
+  };
+
+  test('a modal dialog owns the Escape: the prompt behind it is neither dismissed nor consumed', () => {
+    sendRequest({ id: 17, origin: 'https://a.example', keys: ['notifications'], guestId: 1 });
+    expect(promptVisible()).toBe(true);
+
+    const dialog = openModalDialog();
+    const escape = { key: 'Escape', preventDefault: jest.fn() };
+    doc.handlers.keydown(escape);
+
+    expect(promptVisible()).toBe(true);
+    expect(api.respondToPrompt).not.toHaveBeenCalled();
+    // Cancelling the press here would suppress the dialog's built-in cancel.
+    expect(escape.preventDefault).not.toHaveBeenCalled();
+
+    // Once the dialog is gone the prompt is the innermost surface again, and
+    // the next press dismisses it as a deny-once.
+    dialog.remove();
+    const next = { key: 'Escape', preventDefault: jest.fn() };
+    doc.handlers.keydown(next);
+    expect(promptVisible()).toBe(false);
+    expect(api.respondToPrompt).toHaveBeenCalledWith({
+      id: 17,
+      decision: 'dismiss',
+      remember: false,
+    });
+    expect(next.preventDefault).toHaveBeenCalled();
+  });
+
+  test('a click inside a modal dialog is not a click-away from the prompt behind it', () => {
+    sendRequest({ id: 18, origin: 'https://a.example', keys: ['camera'], guestId: 1 });
+    expect(promptVisible()).toBe(true);
+
+    const dialog = openModalDialog();
+    const field = createElement('input');
+    dialog.appendChild(field);
+    doc.handlers.click({ target: field });
+
+    expect(promptVisible()).toBe(true);
+    expect(api.respondToPrompt).not.toHaveBeenCalled();
+
+    // With the dialog closed, an ordinary click-away still dismisses.
+    dialog.remove();
+    doc.handlers.click({ target: doc.body });
+    expect(promptVisible()).toBe(false);
+    expect(api.respondToPrompt).toHaveBeenCalledWith({
+      id: 18,
+      decision: 'dismiss',
+      remember: false,
+    });
+  });
 });
 
 describe('site-permissions-ui popover revoke label', () => {

--- a/src/renderer/lib/tabs-audio-mute.test.js
+++ b/src/renderer/lib/tabs-audio-mute.test.js
@@ -147,7 +147,10 @@ const loadTabsModule = async (options = {}) => {
     showMenuBackdrop: jest.fn(),
     hideMenuBackdrop: jest.fn(),
   }));
-  jest.doMock('./page-context-menu.js', () => ({ setupWebviewContextMenu: jest.fn() }));
+  jest.doMock('./page-context-menu.js', () => ({
+    setupWebviewContextMenu: jest.fn(),
+    notifyPageContextMenuNavigated: jest.fn(),
+  }));
   jest.doMock('./link-status.js', () => ({
     clearLinkStatus: jest.fn(),
     clearHoverStatus: jest.fn(),

--- a/src/renderer/lib/tabs-find-nav.test.js
+++ b/src/renderer/lib/tabs-find-nav.test.js
@@ -92,7 +92,10 @@ const loadModules = async () => {
     showMenuBackdrop: jest.fn(),
     hideMenuBackdrop: jest.fn(),
   }));
-  jest.doMock('./page-context-menu.js', () => ({ setupWebviewContextMenu: jest.fn() }));
+  jest.doMock('./page-context-menu.js', () => ({
+    setupWebviewContextMenu: jest.fn(),
+    notifyPageContextMenuNavigated: jest.fn(),
+  }));
   jest.doMock('./link-status.js', () => ({
     clearLinkStatus: jest.fn(),
     clearHoverStatus: jest.fn(),

--- a/src/renderer/lib/tabs-ui.test.js
+++ b/src/renderer/lib/tabs-ui.test.js
@@ -1548,6 +1548,40 @@ describe('tabs ui behavior', () => {
     expect(elements.tabContextMenu.classList.contains('hidden')).toBe(true);
   });
 
+  // #306, dialog sibling: a modal <dialog> raised over the tab menu (the
+  // external-node prompt arrives from main on its own schedule) is the top
+  // layer, so the press is its close request — and it cannot mark the press
+  // the way this handler does. Consuming it here would cancel that close.
+  test('a modal dialog above the tab context menu owns the Escape', async () => {
+    const { mod, elements, documentHandlers } = await loadTabsModule();
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    const firstTabEl = findTabElement(elements.tabBar, firstTab.id);
+    firstTabEl.dispatch('contextmenu', {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      clientX: 20,
+      clientY: 30,
+    });
+    expect(elements.tabContextMenu.classList.contains('hidden')).toBe(false);
+
+    const dialog = createElement('dialog');
+    dialog.setAttribute('open', '');
+    global.document.body.appendChild(dialog);
+
+    const escape = { key: 'Escape', preventDefault: jest.fn() };
+    documentHandlers.keydown(escape);
+    expect(elements.tabContextMenu.classList.contains('hidden')).toBe(false);
+    expect(escape.preventDefault).not.toHaveBeenCalled();
+
+    dialog.remove();
+    const next = { key: 'Escape', preventDefault: jest.fn() };
+    documentHandlers.keydown(next);
+    expect(elements.tabContextMenu.classList.contains('hidden')).toBe(true);
+    expect(next.preventDefault).toHaveBeenCalled();
+  });
+
   // #308: the page context menu belongs to the document it was raised on, so
   // tabs.js reports every navigation (and every tab activation) to it — the
   // same hook the find bar already had. Without it the menu floated over the

--- a/src/renderer/lib/tabs-ui.test.js
+++ b/src/renderer/lib/tabs-ui.test.js
@@ -139,6 +139,7 @@ const loadTabsModule = async (options = {}) => {
   };
   const pageContextMenuMocks = {
     setupWebviewContextMenu: jest.fn(),
+    notifyPageContextMenuNavigated: jest.fn(),
   };
   const linkStatusMocks = {
     clearLinkStatus: jest.fn(),
@@ -1525,6 +1526,42 @@ describe('tabs ui behavior', () => {
     expect(elements.tabContextMenu.classList.contains('hidden')).toBe(false);
     mod.closeTab(secondTab.id);
     expect(elements.tabContextMenu.classList.contains('hidden')).toBe(true);
+  });
+
+  // #308: the page context menu belongs to the document it was raised on, so
+  // tabs.js reports every navigation (and every tab activation) to it — the
+  // same hook the find bar already had. Without it the menu floated over the
+  // next page still offering the previous page's link.
+  test('a navigation and a tab switch both report to the page context menu', async () => {
+    const { mod, pageContextMenuMocks } = await loadTabsModule();
+    await mod.initTabs();
+
+    const firstTab = mod.getActiveTab();
+    const secondTab = mod.createTab('https://second.example');
+    mod.switchTab(firstTab.id);
+    pageContextMenuMocks.notifyPageContextMenuNavigated.mockClear();
+
+    // A committed navigation names the webview it happened in, so a menu
+    // raised over another tab is left alone.
+    firstTab.webview.dispatch('did-navigate', { url: 'https://redirected.example' });
+    expect(pageContextMenuMocks.notifyPageContextMenuNavigated).toHaveBeenCalledWith(
+      firstTab.webview
+    );
+
+    // A same-document navigation is a navigation too.
+    pageContextMenuMocks.notifyPageContextMenuNavigated.mockClear();
+    firstTab.webview.dispatch('did-navigate-in-page', {
+      url: 'https://redirected.example#section',
+    });
+    expect(pageContextMenuMocks.notifyPageContextMenuNavigated).toHaveBeenCalledWith(
+      firstTab.webview
+    );
+
+    // A tab switch dismisses it outright: the page it describes is no longer
+    // the one on screen.
+    pageContextMenuMocks.notifyPageContextMenuNavigated.mockClear();
+    mod.switchTab(secondTab.id);
+    expect(pageContextMenuMocks.notifyPageContextMenuNavigated).toHaveBeenCalledWith();
   });
 
   // #315: re-activating the tab that is already foreground (Ctrl+1 on tab 1

--- a/src/renderer/lib/tabs-ui.test.js
+++ b/src/renderer/lib/tabs-ui.test.js
@@ -958,6 +958,26 @@ describe('tabs ui behavior', () => {
     documentHandlers.click({ target: createElement('div') });
     expect(backdropMocks.hideMenuBackdrop).toHaveBeenCalled();
 
+    // Escape takes the menu down, and consumes the press while doing it:
+    // navigation.js's window-level Escape (stop loading + restore the address
+    // bar) stands down on `defaultPrevented`, so dismissing this menu over a
+    // still-loading page doesn't also cancel that load (#306).
+    firstTabEl.dispatch('contextmenu', {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      clientX: 20,
+      clientY: 30,
+    });
+    const escape = { key: 'Escape', preventDefault: jest.fn() };
+    documentHandlers.keydown(escape);
+    expect(elements.tabContextMenu.classList.contains('hidden')).toBe(true);
+    expect(escape.preventDefault).toHaveBeenCalled();
+
+    // With the menu already down the press is left for the surfaces behind it.
+    const escapeAgain = { key: 'Escape', preventDefault: jest.fn() };
+    documentHandlers.keydown(escapeAgain);
+    expect(escapeAgain.preventDefault).not.toHaveBeenCalled();
+
     firstTabEl.dispatch('contextmenu', {
       preventDefault: jest.fn(),
       stopPropagation: jest.fn(),

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -22,6 +22,7 @@ import {
   notifyFindBarTabSwitched,
 } from './find-bar.js';
 import { matchesShortcut } from './shortcuts.js';
+import { isModalDialogOpen } from './modal-dialog.js';
 import {
   clearLinkStatus,
   clearHoverStatus,
@@ -1940,6 +1941,10 @@ export const initTabs = async () => {
   document.addEventListener('keydown', (e) => {
     if (e.key !== 'Escape') return;
     if (!tabContextMenu || tabContextMenu.classList.contains('hidden')) return;
+    // A modal <dialog> raised over the menu (the external-node or
+    // profile-create prompt arrives on its own schedule) owns the press and
+    // cannot mark it — see `isModalDialogOpen`.
+    if (isModalDialogOpen()) return;
     e.preventDefault();
     hideTabContextMenu();
   });

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -3,7 +3,7 @@ import { pushDebug } from './debug.js';
 import { closeMenus } from './menus.js';
 import { hideBookmarkContextMenu } from './bookmarks-ui.js';
 import { showMenuBackdrop, hideMenuBackdrop } from './menu-backdrop.js';
-import { setupWebviewContextMenu } from './page-context-menu.js';
+import { setupWebviewContextMenu, notifyPageContextMenuNavigated } from './page-context-menu.js';
 import {
   homeUrl,
   getInternalPageName,
@@ -667,11 +667,20 @@ const createWebview = (tabId, initialUrl) => {
       // per tab, so a background tab that navigates must not keep a bar or
       // a match count that no longer describes its page.
       notifyFindBarNavigated(webview);
+      // ...and any page context menu raised on the document that just went
+      // away. Chrome's context menu never outlives its page: leaving it up
+      // meant Open Link in New Tab / Copy Link Address still acting on the
+      // previous page's link, over a document that no longer has it (#308).
+      notifyPageContextMenuNavigated(webview);
       if (tabId === tabState.activeTabId && onWebviewEvent) {
         onWebviewEvent('did-navigate', { tabId, event });
       }
     },
     'did-navigate-in-page': (event) => {
+      // A same-document navigation (an in-page anchor, a history.pushState
+      // route change) is still a navigation: the menu's link/selection context
+      // was read off the pre-navigation DOM. #308.
+      notifyPageContextMenuNavigated(webview);
       if (tabId === tabState.activeTabId && onWebviewEvent) {
         onWebviewEvent('did-navigate-in-page', { tabId, event });
       }
@@ -1593,6 +1602,10 @@ export const switchTab = (tabId, options = {}) => {
   // Hiding an already-hidden menu is a no-op, so this costs nothing on the
   // ordinary path.
   hideTabContextMenu();
+  // Same for the page context menu: it belongs to the document it was raised
+  // on, so a switch to another tab takes it down rather than leaving it
+  // floating over a page it knows nothing about (#308).
+  notifyPageContextMenuNavigated();
 
   // Already foreground — nothing to swap, and running the swap anyway has
   // real side effects (closing an open find bar, re-hiding webviews).

--- a/src/renderer/lib/tabs.js
+++ b/src/renderer/lib/tabs.js
@@ -1933,11 +1933,15 @@ export const initTabs = async () => {
     }
   });
 
-  // Hide context menu on escape or when window loses focus
+  // Hide context menu on escape or when window loses focus. A press that
+  // actually closes the menu is consumed (`preventDefault`), so navigation.js's
+  // window-level Escape doesn't also stop an in-flight page load — Chrome
+  // closes the innermost surface only. See #306.
   document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') {
-      hideTabContextMenu();
-    }
+    if (e.key !== 'Escape') return;
+    if (!tabContextMenu || tabContextMenu.classList.contains('hidden')) return;
+    e.preventDefault();
+    hideTabContextMenu();
   });
   window.addEventListener('blur', hideTabContextMenu);
   // (The `focus`/`mousedown` dismissal that used to hang off

--- a/src/renderer/styles/bookmarks.css
+++ b/src/renderer/styles/bookmarks.css
@@ -104,6 +104,8 @@
   flex-shrink: 0;
   transition: background-color 0.2s ease;
   margin: 0 1px;
+  /* Anchor for the drag insertion caret below. */
+  position: relative;
 }
 
 .bookmark:hover {
@@ -112,6 +114,31 @@
 
 .bookmark.overflow-hidden {
   display: none;
+}
+
+/* Bookmark drag-and-drop styles — the same insertion caret the tab strip
+   draws (tabs.css), so a reorder reads the same way on both bars (#307). */
+.bookmark.dragging {
+  opacity: 0.5;
+}
+
+.bookmark.drag-over-left::before,
+.bookmark.drag-over-right::after {
+  content: '';
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+}
+
+.bookmark.drag-over-left::before {
+  left: -2px;
+}
+
+.bookmark.drag-over-right::after {
+  right: -2px;
 }
 
 .bookmark-icon-container {

--- a/src/shared/ipc-channels.js
+++ b/src/shared/ipc-channels.js
@@ -6,6 +6,7 @@ module.exports = {
   BOOKMARKS_ADD: 'bookmarks:add',
   BOOKMARKS_UPDATE: 'bookmarks:update',
   BOOKMARKS_REMOVE: 'bookmarks:remove',
+  BOOKMARKS_REORDER: 'bookmarks:reorder',
   BOOKMARKS_BAR_TOGGLE: 'bookmarks-bar:toggle',
 
   // Ant node management

--- a/test-e2e/bookmarks.spec.js
+++ b/test-e2e/bookmarks.spec.js
@@ -1,7 +1,7 @@
 // Bookmarks bar — add via the IPC the address-bar star uses, and assert
 // the bar reflects the new entry. Removal goes through the same IPC.
 
-const { test, expect } = require('./fixtures');
+const { test, expect, SAMPLE_BZZ_HASH } = require('./fixtures');
 
 // Force the bookmarks bar to be visible on every page. Without this the
 // bar is only shown on the home page, which complicates assertions when
@@ -137,4 +137,68 @@ test('bookmarks can be dragged into a new order, and the order survives a restar
   await window.reload();
   await window.waitForSelector('[data-test="address-input"]');
   await expect.poll(() => barOrder(window)).toEqual([BOOKMARK_TWO, BOOKMARK_ONE]);
+});
+
+// #306, dialog sibling: the bookmark add/edit editor is a modal <dialog>, and
+// a modal dialog is an innermost surface exactly like the menus — one Escape
+// closes it and nothing else. It cannot mark the press with
+// `preventDefault()` the way a menu handler does (its Escape is the
+// platform's own close request, dispatched after every keydown listener), so
+// navigation.js's window-level Escape has to stand down while one is open.
+// Before that guard the first Escape over an in-flight load stopped the load,
+// repainted the address bar, blurred the focused field *and* — because it
+// cancelled the press — left the dialog itself open, needing a second Escape.
+const editorLoadState = (window) =>
+  window.evaluate(() => ({
+    dialogOpen: !!document.getElementById('add-bookmark-modal')?.open,
+    reload: document.getElementById('reload-btn')?.dataset?.state || '',
+    address: document.getElementById('address-input')?.value || '',
+    focused: document.activeElement?.id || '',
+  }));
+
+test('Escape in the bookmark editor closes only the editor, not the load behind it', async ({
+  window,
+  harness,
+}) => {
+  await seedBookmarks(window);
+
+  // A fixture that holds its response open, so the tab is genuinely still
+  // loading while the editor is up (dweb pages routinely take seconds).
+  await harness.setContentFixture(`bzz://${SAMPLE_BZZ_HASH}/`, {
+    body: '<!doctype html><title>slow</title><h1>slow</h1>',
+    delayMs: 30000,
+  });
+
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(SAMPLE_BZZ_HASH);
+  await input.press('Enter');
+
+  // The stop/reload button in its `stop` state is the app's own signal that a
+  // load is in flight.
+  await expect.poll(() => editorLoadState(window)).toMatchObject({ reload: 'stop' });
+  const loading = await editorLoadState(window);
+
+  // Right-click a bookmark → Edit… is the editor's reachable entry point over a
+  // loading page (the address-bar star hides itself while the tab loads).
+  await window.locator('[data-test="bookmark-item"]').first().click({ button: 'right' });
+  await window.locator('.context-menu-item[data-action="edit"]').click();
+  await expect
+    .poll(() => editorLoadState(window))
+    .toMatchObject({ dialogOpen: true, focused: 'bookmark-label' });
+
+  await window.keyboard.press('Escape');
+
+  // One press: the editor is gone, and the load behind it is untouched — still
+  // in flight, with the address bar not repainted from the page snapshot.
+  await expect.poll(() => editorLoadState(window)).toMatchObject({ dialogOpen: false });
+  expect(await editorLoadState(window)).toMatchObject({
+    reload: 'stop',
+    address: loading.address,
+  });
+
+  // With nothing open, the very next Escape reaches the stop-loading handler —
+  // the behaviour the guard must not have removed.
+  await window.keyboard.press('Escape');
+  await expect.poll(() => editorLoadState(window)).toMatchObject({ reload: 'reload' });
 });

--- a/test-e2e/bookmarks.spec.js
+++ b/test-e2e/bookmarks.spec.js
@@ -45,3 +45,96 @@ test('adding a bookmark via IPC shows it in the bookmarks bar', async ({ window 
     )
   ).toHaveCount(0);
 });
+
+// #307: the bar handled a plain left click and nothing else — Ctrl/Cmd+click
+// navigated the page you were reading away, middle-click did nothing at all,
+// and the entries could not be dragged into a new order.
+const BOOKMARK_ONE = 'https://one.example/freedom-e2e';
+const BOOKMARK_TWO = 'https://two.example/freedom-e2e';
+
+// Replace the bar's contents with a known pair, in a known order.
+async function seedBookmarks(window) {
+  await window.evaluate(
+    async ({ one, two }) => {
+      for (const existing of await window.electronAPI.getBookmarks()) {
+        await window.electronAPI.removeBookmark(existing.target);
+      }
+      await window.electronAPI.addBookmark({ label: 'One', target: one });
+      await window.electronAPI.addBookmark({ label: 'Two', target: two });
+    },
+    { one: BOOKMARK_ONE, two: BOOKMARK_TWO }
+  );
+  await window.reload();
+  await window.waitForSelector('[data-test="address-input"]');
+  await expect(window.locator('[data-test="bookmark-item"]')).toHaveCount(2);
+}
+
+const barOrder = (window) =>
+  window.evaluate(() =>
+    [...document.querySelectorAll('[data-test="bookmark-item"]')].map((el) => el.dataset.hash)
+  );
+
+test('Ctrl+click and middle-click on a bookmark open a background tab', async ({ window }) => {
+  await seedBookmarks(window);
+
+  const tabs = window.locator('[data-test="tab"]');
+  await expect(tabs).toHaveCount(1);
+  const addressBefore = await window.locator('[data-test="address-input"]').inputValue();
+  const first = window.locator('[data-test="bookmark-item"]').first();
+  const box = await first.boundingBox();
+
+  await window.keyboard.down('Control');
+  await window.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+  await window.keyboard.up('Control');
+
+  await expect(tabs).toHaveCount(2);
+  // The tab that was in front still is, and the address bar still describes it.
+  await expect(window.locator('[data-test="tab"].active')).toHaveAttribute('data-tab-id', '1');
+  await expect(window.locator('[data-test="address-input"]')).toHaveValue(addressBefore);
+
+  await window.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await window.mouse.down({ button: 'middle' });
+  await window.mouse.up({ button: 'middle' });
+
+  await expect(tabs).toHaveCount(3);
+  await expect(window.locator('[data-test="tab"].active')).toHaveAttribute('data-tab-id', '1');
+  await expect(window.locator('[data-test="address-input"]')).toHaveValue(addressBefore);
+});
+
+test('a plain click still opens the bookmark in the current tab', async ({ window }) => {
+  await seedBookmarks(window);
+
+  const tabs = window.locator('[data-test="tab"]');
+  await window.locator('[data-test="bookmark-item"]').first().click();
+
+  await expect(tabs).toHaveCount(1);
+  await expect(window.locator('[data-test="address-input"]')).toHaveValue(BOOKMARK_ONE);
+});
+
+test('bookmarks can be dragged into a new order, and the order survives a restart', async ({
+  window,
+}) => {
+  await seedBookmarks(window);
+  expect(await barOrder(window)).toEqual([BOOKMARK_ONE, BOOKMARK_TWO]);
+
+  const items = window.locator('[data-test="bookmark-item"]');
+  await expect(items.first()).toHaveJSProperty('draggable', true);
+
+  // Drag the first entry onto the right half of the second one.
+  const source = await items.first().boundingBox();
+  const target = await items.nth(1).boundingBox();
+  await window.mouse.move(source.x + source.width / 2, source.y + source.height / 2);
+  await window.mouse.down();
+  await window.mouse.move(target.x + target.width * 0.9, target.y + target.height / 2, {
+    steps: 12,
+  });
+  await window.mouse.up();
+
+  await expect.poll(() => barOrder(window)).toEqual([BOOKMARK_TWO, BOOKMARK_ONE]);
+
+  // The new order is the stored order, not just a repaint: the reload re-reads
+  // it from the bookmark store through the same IPC the bar loads with.
+  await window.reload();
+  await window.waitForSelector('[data-test="address-input"]');
+  await expect.poll(() => barOrder(window)).toEqual([BOOKMARK_TWO, BOOKMARK_ONE]);
+});

--- a/test-e2e/downloads.spec.js
+++ b/test-e2e/downloads.spec.js
@@ -144,3 +144,72 @@ test('shelf cards dismiss manually and Clear All empties the downloads page', as
     )
     .toBe(0);
 });
+
+// #309: the × on a running download used to last exactly one progress tick —
+// main emits one every 250 ms, so the card blinked out and came straight back
+// for the length of the transfer. A data: URI download settles in one chunk,
+// so the in-flight payloads are fed to the shelf directly: this is the exact
+// `downloads:updated` shape main sends, applied through the real card UI.
+test('a card dismissed mid-download stays dismissed', async ({ window }) => {
+  const feed = (download) =>
+    window.evaluate(async (payload) => {
+      const mod = await import('./lib/downloads-ui.js');
+      mod.handleDownloadUpdate(payload);
+    }, download);
+
+  // Counted with a one-shot read, never a polling locator: a settled card
+  // auto-dismisses after 5 s, so a *retrying* "no cards" assertion would go
+  // green on the timer alone even with the card resurrected (it did, before
+  // this was written this way).
+  const cardCount = () =>
+    window.evaluate(() => document.querySelectorAll('#download-shelf .download-card').length);
+  const cardNames = () =>
+    window.evaluate(() =>
+      [...document.querySelectorAll('#download-shelf .download-card-name')].map(
+        (el) => el.textContent
+      )
+    );
+
+  const cards = window.locator('#download-shelf .download-card');
+  const tick = (received) => ({
+    id: 4242,
+    filename: 'big.iso',
+    state: 'progressing',
+    received_bytes: received,
+    total_bytes: 100_000,
+  });
+
+  await feed(tick(1_000));
+  await expect(cards).toHaveCount(1);
+  await expect(cards.locator('[data-test="download-cancel"]')).toBeVisible();
+
+  await cards.locator('[data-test="download-close"]').click();
+  expect(await cardCount()).toBe(0);
+
+  // The next progress ticks are ignored — this is the quarter-second the card
+  // used to come back in.
+  await feed(tick(2_000));
+  expect(await cardCount()).toBe(0);
+  await feed(tick(90_000));
+  expect(await cardCount()).toBe(0);
+
+  // ...as is the terminal update when the transfer finishes.
+  await feed({
+    id: 4242,
+    filename: 'big.iso',
+    state: 'completed',
+    received_bytes: 100_000,
+    total_bytes: 100_000,
+  });
+  expect(await cardCount()).toBe(0);
+
+  // Another download still shows: the dismissal is per item, not a mute.
+  await feed({
+    id: 4243,
+    filename: 'other.iso',
+    state: 'progressing',
+    received_bytes: 10,
+    total_bytes: 100,
+  });
+  expect(await cardNames()).toEqual(['other.iso']);
+});

--- a/test-e2e/find-in-page.spec.js
+++ b/test-e2e/find-in-page.spec.js
@@ -518,3 +518,47 @@ test('a download link with the bar closed does not keep the bar open across the 
   await expect(window.locator('[data-test="find-bar"]')).toBeHidden();
   await expect(window.locator('[data-test="find-bar-count"]')).toHaveText('');
 });
+
+// #316: every editable text field in the browser chrome gets the same
+// Cut/Copy/Paste/Select All menu on right-click. The find bar had none at all,
+// one row below an address bar that did.
+test('right-clicking the find input gives the same edit menu as the address bar', async ({
+  window,
+  harness,
+  electronApp,
+}) => {
+  await loadFixturePage(window, harness);
+  await openFindBar(window);
+
+  const input = window.locator('[data-test="find-bar-input"]');
+  const menu = window.locator('[data-test="chrome-input-context-menu"]');
+  await input.fill('needle');
+  await expect(window.locator('[data-test="find-bar-count"]')).toHaveText('1/3');
+
+  await input.click({ button: 'right' });
+  await expect(menu).toBeVisible();
+  await expect(menu.getByRole('button', { name: 'Cut' })).toBeVisible();
+  await expect(menu.getByRole('button', { name: 'Copy' })).toBeVisible();
+  await expect(menu.getByRole('button', { name: 'Paste' })).toBeVisible();
+  await expect(menu.getByRole('button', { name: 'Select All' })).toBeVisible();
+
+  // Select All then Copy puts the query on the real clipboard — the menu acts
+  // on the find input, not on whatever the address bar happens to hold.
+  await menu.getByRole('button', { name: 'Select All' }).click();
+  await expect(menu).toBeHidden();
+  await input.click({ button: 'right' });
+  await menu.getByRole('button', { name: 'Copy' }).click();
+  await expect
+    .poll(() => electronApp.evaluate(({ clipboard }) => clipboard.readText()))
+    .toBe('needle');
+
+  // Escape closes the menu and leaves the bar itself up (innermost first);
+  // a second Escape then closes the bar, as it always did.
+  await input.click({ button: 'right' });
+  await expect(menu).toBeVisible();
+  await window.keyboard.press('Escape');
+  await expect(menu).toBeHidden();
+  await expect(window.locator('[data-test="find-bar"]')).toBeVisible();
+  await window.keyboard.press('Escape');
+  await expect(window.locator('[data-test="find-bar"]')).toBeHidden();
+});

--- a/test-e2e/menus.spec.js
+++ b/test-e2e/menus.spec.js
@@ -7,7 +7,7 @@
 // the mouse. Chrome closes the open menu on Escape, innermost submenu first,
 // and gives the keyboard back to the button that opened it.
 
-const { test, expect } = require('./fixtures');
+const { test, expect, SAMPLE_BZZ_HASH } = require('./fixtures');
 
 const menuState = (window) =>
   window.evaluate(() => ({
@@ -73,4 +73,58 @@ test('the backdrop stops swallowing clicks once Escape has closed the menu', asy
   // bar — the concrete cost of a menu with no keyboard way out.
   await window.locator('[data-test="address-input"]').click();
   await expect(window.locator('[data-test="address-input"]')).toBeFocused();
+});
+
+// Chrome closes only the *innermost* surface on one Escape press: dismissing a
+// menu never also cancels whatever the page is doing behind it. The menu
+// handler consumes the press with `preventDefault()`, and navigation.js's
+// window-level Escape (stop loading + repaint the address bar + blur) stands
+// down on `defaultPrevented`. `stopPropagation()` could not have done this —
+// both listeners sit on `window`, and same-node listeners still run.
+const loadState = (window) =>
+  window.evaluate(() => ({
+    reload: document.getElementById('reload-btn')?.dataset?.state || '',
+    address: document.getElementById('address-input')?.value || '',
+    focused: document.activeElement?.id || '',
+  }));
+
+test('Escape closing a menu leaves an in-flight page load running', async ({ window, harness }) => {
+  // A fixture that holds its response open, so the tab is genuinely still
+  // loading while the menu is up.
+  await harness.setContentFixture(`bzz://${SAMPLE_BZZ_HASH}/`, {
+    body: '<!doctype html><title>slow</title><h1>slow</h1>',
+    delayMs: 8000,
+  });
+
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(SAMPLE_BZZ_HASH);
+  await input.press('Enter');
+
+  // The stop/reload button in its `stop` state is the app's own signal that a
+  // load is in flight.
+  await expect.poll(() => loadState(window)).toMatchObject({ reload: 'stop' });
+  const loading = await loadState(window);
+
+  await window.locator('#menu-button').click();
+  await expect.poll(() => menuState(window)).toMatchObject({ hamburger: true, backdrop: true });
+
+  await window.keyboard.press('Escape');
+
+  await expect
+    .poll(() => menuState(window))
+    .toMatchObject({ hamburger: false, backdrop: false, focused: 'menu-button' });
+
+  // The load is untouched: still in flight, the address bar was not repainted,
+  // and the focus the menu handed back to its button is still there.
+  expect(await loadState(window)).toEqual({
+    reload: 'stop',
+    address: loading.address,
+    focused: 'menu-button',
+  });
+
+  // With no menu open, the very next Escape reaches the stop-loading handler —
+  // the behaviour the guard above must not have removed.
+  await window.keyboard.press('Escape');
+  await expect.poll(() => loadState(window)).toMatchObject({ reload: 'reload' });
 });

--- a/test-e2e/menus.spec.js
+++ b/test-e2e/menus.spec.js
@@ -1,0 +1,76 @@
+// Hamburger and Nodes menus — dismissal.
+//
+// #306: Escape is how every other dismissible surface in the chrome closes
+// (tab and page context menus, the bookmark menu, the trust popover, the
+// permission prompt, the find bar). These two did not close on it at all, and
+// they raise `#menu-backdrop` over the whole window — so the only way out was
+// the mouse. Chrome closes the open menu on Escape, innermost submenu first,
+// and gives the keyboard back to the button that opened it.
+
+const { test, expect } = require('./fixtures');
+
+const menuState = (window) =>
+  window.evaluate(() => ({
+    hamburger: document.getElementById('menu-dropdown')?.classList.contains('open') === true,
+    nodes: document.getElementById('bee-menu-dropdown')?.classList.contains('open') === true,
+    flyout: document.getElementById('profile-menu')?.hidden === false,
+    backdrop: document.getElementById('menu-backdrop')?.classList.contains('hidden') === false,
+    focused: document.activeElement?.id || '',
+  }));
+
+test('Escape closes the hamburger menu and returns focus to its button', async ({ window }) => {
+  await window.locator('#menu-button').click();
+  await expect.poll(() => menuState(window)).toMatchObject({ hamburger: true, backdrop: true });
+
+  await window.keyboard.press('Escape');
+
+  await expect
+    .poll(() => menuState(window))
+    .toMatchObject({ hamburger: false, backdrop: false, focused: 'menu-button' });
+});
+
+test('Escape closes the Nodes menu and returns focus to its button', async ({ window }) => {
+  await window.locator('#bee-menu-button').click();
+  await expect.poll(() => menuState(window)).toMatchObject({ nodes: true, backdrop: true });
+
+  await window.keyboard.press('Escape');
+
+  await expect
+    .poll(() => menuState(window))
+    .toMatchObject({ nodes: false, backdrop: false, focused: 'bee-menu-button' });
+});
+
+test('Escape closes the Profiles flyout first, the hamburger on the second press', async ({
+  window,
+}) => {
+  await window.locator('#menu-button').click();
+  await expect.poll(() => menuState(window)).toMatchObject({ hamburger: true });
+
+  // A click on the Profiles row opens the flyout immediately (the hover delay
+  // is for the pointer path).
+  await window.locator('#profile-menu-btn').click();
+  await expect.poll(() => menuState(window)).toMatchObject({ hamburger: true, flyout: true });
+
+  await window.keyboard.press('Escape');
+  await expect
+    .poll(() => menuState(window))
+    .toMatchObject({ flyout: false, hamburger: true, focused: 'profile-menu-btn' });
+
+  await window.keyboard.press('Escape');
+  await expect
+    .poll(() => menuState(window))
+    .toMatchObject({ hamburger: false, backdrop: false, focused: 'menu-button' });
+});
+
+test('the backdrop stops swallowing clicks once Escape has closed the menu', async ({ window }) => {
+  await window.locator('#menu-button').click();
+  await expect.poll(() => menuState(window)).toMatchObject({ hamburger: true, backdrop: true });
+
+  await window.keyboard.press('Escape');
+  await expect.poll(() => menuState(window)).toMatchObject({ backdrop: false });
+
+  // With the backdrop up this click would land on it instead of the address
+  // bar — the concrete cost of a menu with no keyboard way out.
+  await window.locator('[data-test="address-input"]').click();
+  await expect(window.locator('[data-test="address-input"]')).toBeFocused();
+});

--- a/test-e2e/permissions.spec.js
+++ b/test-e2e/permissions.spec.js
@@ -205,6 +205,76 @@ test('Escape dismisses the prompt as deny-once and the site can ask again', asyn
   await expect(prompt).toBeVisible();
 });
 
+// #306, permission-prompt sibling: a modal <dialog> (here the bookmark
+// editor) is the top layer — everything behind it, including a prompt the
+// page raised in the meantime, is inert and un-answerable. So the prompt's
+// Escape handler has to stand down while one is up: consuming the press
+// (`preventDefault()`) cancels the dialog's own close request outright, so
+// the editor stayed open AND the un-answerable prompt was dismissed as a
+// deny-once, on a press the user aimed at the editor. Same for a click
+// landing inside the dialog — it is not a click-away from the prompt.
+test.describe('with the bookmarks bar pinned', () => {
+  test.use({ seedSettings: { showBookmarkBar: true } });
+
+  const editorState = (window) =>
+    window.evaluate(() => ({
+      dialogOpen: !!document.getElementById('add-bookmark-modal')?.open,
+      promptShown: !!document.getElementById('permission-prompt')?.hidden === false,
+    }));
+
+  async function openBookmarkEditor(window) {
+    await window.evaluate(async () => {
+      for (const existing of await window.electronAPI.getBookmarks()) {
+        await window.electronAPI.removeBookmark(existing.target);
+      }
+      await window.electronAPI.addBookmark({
+        label: 'One',
+        target: 'https://one.example/freedom-e2e',
+      });
+    });
+    await window.reload();
+    await window.waitForSelector('[data-test="address-input"]');
+    await expect(window.locator('[data-test="bookmark-item"]')).toHaveCount(1);
+  }
+
+  test('a prompt raised behind the bookmark editor leaves the editor its Escape', async ({
+    window,
+    harness,
+  }) => {
+    await openBookmarkEditor(window);
+    await navigateToFixture(window, harness);
+
+    const prompt = window.locator('[data-test="permission-prompt"]');
+
+    // Right-click a bookmark → Edit… puts the modal editor up.
+    await window.locator('[data-test="bookmark-item"]').first().click({ button: 'right' });
+    await window.locator('.context-menu-item[data-action="edit"]').click();
+    await expect.poll(() => editorState(window)).toMatchObject({ dialogOpen: true });
+
+    // The page asks for a permission while the editor is up — the prompt
+    // renders behind the dialog's top layer, inert.
+    await clickAsk(window);
+    await expect.poll(() => editorState(window)).toMatchObject({ promptShown: true });
+
+    // Typing in the editor's own fields must not click-away/deny it either.
+    await window.locator('#bookmark-label').click();
+    await window.waitForTimeout(300);
+    expect(await readOut(window)).toBe('none');
+
+    // One Escape: the editor closes, the prompt survives unanswered.
+    await window.keyboard.press('Escape');
+    await expect.poll(() => editorState(window)).toMatchObject({ dialogOpen: false });
+    expect(await editorState(window)).toMatchObject({ promptShown: true });
+    expect(await readOut(window)).toBe('none');
+
+    // And now that it is the innermost surface, it is answerable again —
+    // by Escape (deny-once) as well as by its buttons.
+    await window.keyboard.press('Escape');
+    await expect(prompt).toBeHidden();
+    await expect.poll(() => readOut(window), { timeout: 5_000 }).toBe('denied');
+  });
+});
+
 test('clicking a background tab surfaces its held prompt instead of dismissing it', async ({
   window,
   harness,

--- a/test-e2e/tabs.spec.js
+++ b/test-e2e/tabs.spec.js
@@ -628,3 +628,125 @@ test('the tab context menu closes on a keyboard tab switch and on a tab close', 
   await expect(window.locator('[data-test="tab"]')).toHaveCount(1);
   await expect(menu).toBeHidden();
 });
+
+// #308: a context menu describes one document. Raise a link menu on page A,
+// let page A navigate itself to page B, and the menu used to still be up over
+// B — with Open Link in New Tab / Copy Link Address still bound to A's link.
+test('the page context menu closes when the page navigates under it', async ({
+  window,
+  harness,
+}) => {
+  const PAGE_C = `bzz://${'c'.repeat(64)}/`;
+
+  await harness.setContentFixture(PAGE_A, {
+    body:
+      '<!doctype html><title>Page A</title><style>body{margin:0;padding:40px}' +
+      'a{display:inline-block;padding:20px;font-size:24px}</style>' +
+      `<a id="lnk" href="${PAGE_C}">link to C</a>`,
+  });
+  await harness.setContentFixture(PAGE_B, {
+    body: '<!doctype html><title>Page B</title><h1>Page B - no links here</h1>',
+  });
+  await harness.setContentFixture(PAGE_C, {
+    body: '<!doctype html><title>Page C</title><h1>Page C</h1>',
+  });
+
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(PAGE_A);
+  await input.press('Enter');
+
+  let point;
+  await expect
+    .poll(
+      async () => {
+        point = await window.evaluate(async () => {
+          const wv = document.querySelector('webview:not(.hidden)');
+          if (!wv || typeof wv.executeJavaScript !== 'function') return null;
+          try {
+            const box = await wv.executeJavaScript(
+              "(() => { const a = document.getElementById('lnk'); if (!a) return null;" +
+                'const r = a.getBoundingClientRect();' +
+                'return { x: r.x + r.width / 2, y: r.y + r.height / 2 }; })()'
+            );
+            if (!box) return null;
+            const rect = wv.getBoundingClientRect();
+            return { x: rect.x + box.x, y: rect.y + box.y };
+          } catch {
+            return null;
+          }
+        });
+        return !!point;
+      },
+      { message: 'Waiting for the link fixture to render', timeout: 15_000 }
+    )
+    .toBe(true);
+
+  // Right-click page A's link.
+  await wakeGuest(window);
+  await window.mouse.click(point.x, point.y, { button: 'right' });
+  const menu = window.locator('#page-context-menu');
+  await expect(menu).toBeVisible();
+  await expect(menu.locator('[data-group="link"]')).toHaveClass(/visible/);
+
+  // Page A navigates itself out from under the open menu — the client-side
+  // redirect from the bug report, driven deterministically rather than on a
+  // timer so the right-click above can't race it.
+  await window.evaluate(
+    (url) =>
+      document
+        .querySelector('webview:not(.hidden)')
+        .executeJavaScript(`location.href = ${JSON.stringify(url)}`),
+    PAGE_B
+  );
+  await expect
+    .poll(
+      () => window.evaluate(() => document.querySelector('webview:not(.hidden)')?.getURL?.() || ''),
+      { message: 'Waiting for the navigation to commit', timeout: 15_000 }
+    )
+    .toContain('bbbb');
+
+  // The menu is gone, so nothing of page A's is left to click...
+  await expect(menu).toBeHidden();
+  await expect(window.locator('#menu-backdrop')).toBeHidden();
+  // ...and no tab was opened for page A's link.
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(1);
+});
+
+// #308: the same rule for a tab switch — the menu belongs to the document it
+// was raised on, not to whichever tab is in front.
+test('the page context menu closes on a tab switch', async ({ window, harness, electronApp }) => {
+  await harness.setContentFixture(PAGE_A, {
+    body: '<!doctype html><title>Page A</title><p>page a</p>',
+  });
+
+  const input = window.locator('[data-test="address-input"]');
+  await input.click();
+  await input.fill(PAGE_A);
+  await input.press('Enter');
+
+  // A second tab to switch to, opened before the menu goes up: while the menu
+  // is open `#menu-backdrop` covers the window, so any *mouse* path would
+  // dismiss it through the click-away listener and prove nothing.
+  await window.locator('[data-test="new-tab-btn"]').click();
+  await expect(window.locator('[data-test="tab"]')).toHaveCount(2);
+  await window.locator('[data-test="tab"][data-tab-id="1"]').click();
+  await expectActiveTab(window, 1);
+
+  await wakeGuest(window);
+  const spot = await window.evaluate(() => {
+    const rect = document.querySelector('webview:not(.hidden)').getBoundingClientRect();
+    return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+  });
+  await window.mouse.click(spot.x, spot.y, { button: 'right' });
+  const menu = window.locator('#page-context-menu');
+  await expect(menu).toBeVisible();
+
+  // Keyboard switch (Ctrl+Tab), driven through the application menu item the
+  // accelerator maps to — see `clickMenuItem`.
+  await clickMenuItem(electronApp, 'next-tab');
+  await expectActiveTab(window, 2);
+
+  await expect(menu).toBeHidden();
+  await expect(window.locator('#menu-backdrop')).toBeHidden();
+});

--- a/test/helpers/fake-dom.js
+++ b/test/helpers/fake-dom.js
@@ -69,6 +69,17 @@ const matchesSingleSelector = (element, selector) => {
     return element.dataset[dataAttr.key] === dataAttr.value;
   }
 
+  // Tag name plus a bare attribute-presence check, e.g. `dialog[open]` — the
+  // probe every chrome surface uses to spot an open modal dialog above it.
+  // Matches the attribute or the matching IDL property a real <dialog> keeps
+  // in sync with it.
+  const tagWithAttr = selector.match(/^([a-z]+)\[([a-z-]+)\]$/);
+  if (tagWithAttr) {
+    const [, tag, attr] = tagWithAttr;
+    if (element.tagName !== tag.toUpperCase()) return false;
+    return element.attributes?.[attr] !== undefined || element[attr] === true;
+  }
+
   const bareDataAttr = selector.match(/^\[data-([a-z-]+)\]$/);
   if (bareDataAttr) {
     const key = bareDataAttr[1].replace(/-([a-z])/g, (_, char) => char.toUpperCase());


### PR DESCRIPTION
Five Chrome-behaviour bugs from the 2026-09 interaction audit (`docs/audits/ui-interaction-2026-09.md`, PR #317), all in the browser chrome, fixed together because they share the audit's "dismissal is wired per surface" theme.

Closes #306
Closes #307
Closes #308
Closes #309
Closes #316

## What changed

**#306 — Escape closes the hamburger and Nodes menus.** `src/renderer/lib/menus.js` had no `keydown` handler at all, so the two menus that raise the full-window `#menu-backdrop` were the only dismissible surfaces in the chrome with no keyboard way out. Escape now closes the innermost surface first (Profiles flyout → hamburger → Nodes) and hands focus back to the button that opened it, from the module's existing `window` keydown chain rather than a second listener. The dead `#bzz-webview` `focus`/`mousedown` listeners the issue calls out are removed from `menus.js`, `bookmarks-ui.js` and `autocomplete.js` (`tabs.js` lost its copy in #319); each of the three suites now asserts they stay gone, so nothing quietly hangs behaviour off a lookup that is always `null`.

**#307 — Bookmarks bar gestures and drag reorder.** `handleBookmarkClick` now resolves the disposition the same way a link click does (#303): `Ctrl`/`Cmd`+click and middle-click (`auxclick`) open a **background** tab and leave the current page and the address bar alone, `+Shift` foregrounds it, `Shift`+click opens a new window, a plain click still navigates this tab. Bar entries are `draggable` and carry the tab strip's four DnD handlers plus its insertion-caret styling; the new order is persisted through a `bookmarks:reorder` IPC that rewrites the store's list. An entry the renderer never saw (added from another window) keeps its place at the end rather than being dropped, and a non-list payload is refused.

**#308 — The page context menu no longer outlives its document.** `tabs.js` reports every committed *and* same-document navigation to `page-context-menu.js` (the hook `notifyFindBarNavigated` already used), and `switchTab` dismisses the menu outright. As a belt to those braces, an action clicked against a page that has navigated away — or a menu whose webview is no longer the foreground one — is refused with a `pushDebug` instead of acting on the previous page's link.

**#309 — A dismissed in-progress download stays dismissed.** The × recorded nothing, so main's 250 ms progress tick rebuilt the card immediately, for the length of the transfer. Dismissals the user drives (the × and the completed-file actions) are now remembered; the auto-dismiss timer is not. Ids are store rowids (SQLite `AUTOINCREMENT`, or the private store's monotonic negative sequence) and never reused, so a remembered dismissal cannot land on an unrelated download. Cancel remains the way to stop the transfer itself, and `freedom://downloads` still lists it.

**#316 — Edit menu for every chrome text field.** `initChromeInputContextMenu` is given the list explicitly at the call site (`address-input`, `find-bar-input`, `bookmark-label`, `bookmark-target`), with the same list as the module's fallback so a new chrome input has one place to be added. Two things were needed to make it work in the bookmark dialog: a `showModal()` dialog puts itself in the top layer and makes everything outside inert, so the menu is moved into the dialog while it is up (and back out on hide); and an open menu now consumes Escape in the capture phase, so the first press closes the menu and the second the surface behind it (the find bar, the dialog) — Chrome's order. A click-away `mousedown` covers the dialog case, where `#menu-backdrop` is inert.

## Verification

- `npm run lint` clean; `npm test` — 3919 passed, 203 suites.
- Affected e2e under xvfb (`--project=harness`): `menus.spec.js` (new, 4 tests), `bookmarks.spec.js`, `downloads.spec.js`, `tabs.spec.js`, `find-in-page.spec.js`, plus `address-bar-clipboard.spec.js`, `chrome-input-focus.spec.js` and `shortcuts.spec.js` as neighbours — 52 passed, 1 pre-existing flake (see below).
- **Every new e2e test was run against the branch with `src/` reverted and confirmed to fail there** — the first draft of the #309 spec passed on unfixed code (a retrying `toHaveCount(0)` was satisfied by the 5 s auto-dismiss timer rather than by the fix), so that spec now counts cards with one-shot reads; the comment in the file says why.
- Pre-existing flake, not caused by this PR: `chrome-input-focus.spec.js › a mouse-clicked select gets the same ring as a text field` fails roughly 1 run in 3 **with this branch's `src/` changes stashed** as well (verified 1/3 failures on unmodified source, 1/3 on the branch). Not filed here; worth its own issue.
- Docs kept in sync: `docs/features.md` (Fixed Keys + two new Bookmarks bullets) and the `run-freedom` skill, whose Gotchas list and `closeMenus()` helper both documented "Escape does not close them".

## Visual verification

Driven with the `run-freedom` skill under xvfb, in dark and light. Observed state printed alongside each shot:

```
hamburger open    : {"hamburger":true,"backdrop":true,"focused":"menu-button"}
after Escape      : {"hamburger":false,"backdrop":false,"focused":"menu-button"}
nodes after Esc   : {"nodes":false,"backdrop":false,"focused":"bee-menu-button"}
ctrl+click        : before {"tabs":1} -> after {"tabs":2}, address bar unchanged
after drag        : ["One","Two","Three"] -> ["Two","Three","One"]
download card     : ["big.iso 1000 B of 97.7 KB Cancel ×"]
after dismiss+2 ticks : []
find input menu   : true      (Escape -> {"menu":false,"findBar":true})
dialog input menu : { visible: true, parent: 'DIALOG' }   (Escape -> dialog still open)
link menu open    : {"vis":true,"url":"bzz://aaaa…"}
after navigation  : {"vis":false,"url":"bzz://bbbb…","tabs":2}
```

Screenshots in the first comment below.
