### PR TITLE
docs(changelog): headline the 0.8.5 blocks for scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,53 +6,67 @@ All notable changes to Freedom will be documented in this file.
 
 ### Added
 
-- Ad and tracker blocking, on by default, which also hides the empty spaces blocked ads leave:
+- Ad and tracker blocking:
+  - On by default
   - Settings > Ad Blocking with a per-site allowlist and live rule counts
-  - Blocked ads leave no empty gaps in the page
   - Cookie-banner and annoyance filtering, off by default
   - Filter lists refresh over Swarm without an app update
-- Find in page (`Cmd/Ctrl+F`, or Edit > Find in Page): per-tab overlay bar with a live match counter, `Enter` / `Shift+Enter` to cycle matches, `Esc` to close
-- Download manager covering every download source, including `bzz://` and `ipfs://` content:
+- Find in page:
+  - `Cmd/Ctrl+F`, or Edit > Find in Page
+  - Per-tab overlay bar with a live match counter
+  - `Enter` / `Shift+Enter` to cycle matches, `Esc` to close
+- Download manager:
+  - Covers every download source, including `bzz://` and `ipfs://` content
   - Shelf card with live progress and cancel; Open / Show in Folder on completion
   - `freedom://downloads` page (`Cmd/Ctrl+Shift+J`) with search, pause/resume, and Clear All
   - "Ask where to save each file" toggle under Settings > Downloads
-- Per-site permission prompts for camera, microphone, notifications, clipboard reading, location, and MIDI, replacing the previous silent denial:
+- Per-site permission prompts:
+  - For camera, microphone, notifications, clipboard reading, location, and MIDI, replacing the previous silent denial
   - Prompt under the address bar with Allow / Block and "Remember for this site"
   - Remembered decisions per profile under Settings > Site Permissions, with per-site and remove-all revocation
   - Indicator icon in the address bar with quick revoke on sites holding granted permissions
-- Private windows (`Cmd/Ctrl+Shift+N`, File > New Private Window): ephemeral browsing on a per-window in-memory session with dark, badged chrome
+- Private windows:
+  - `Cmd/Ctrl+Shift+N`, or File > New Private Window
+  - Ephemeral browsing on a per-window in-memory session with dark, badged chrome
   - No history, favicon-cache or autocomplete writes; cookies and site data end on close
   - Downloads leave the list on close and permission decisions are session-only; files stay on disk
   - Wallet and `window.ethereum` / `window.swarm` / `window.radicle` providers are unavailable; x402 payment interception is off
   - Start page listing what private windows do and do not protect
-- Remappable keyboard shortcuts under Settings > Shortcuts:
+- Remappable keyboard shortcuts:
+  - Under Settings > Shortcuts
   - Searchable list grouped by category; click a binding and press the new combination
   - Conflict warning with a one-click swap when a combination is already taken
   - Per-shortcut reset and a Restore defaults button; changes apply without a restart
 - Page zoom on `Cmd/Ctrl` with `=`, `-` and `0`, remappable like every other binding (thanks @alexwbend!)
 - Address-bar search for typed input that isn't a URL, with DuckDuckGo, Google, Bing, Brave Search, Ecosia, Startpage or a custom engine under Settings > Search
 - Audio indicator on tabs playing sound; click it or use "Mute Tab" in the tab context menu to mute/unmute (mute survives navigation)
-- Contract-hosted onchain apps on `web3://<address>[:<chainId>]/` — the app itself lives in the contract, not on a web server:
+- Contract-hosted onchain apps:
+  - On `web3://<address>[:<chainId>]/` — the app itself lives in the contract, not on a web server
   - Address-bar shield popover reporting the chain, block, contract and content hash behind the page
   - Unverified reads stop at a warning page you can pass once; disagreeing sources block the load
   - The wallet provider is pinned to the app's chain; a page cannot switch it
   - Reasoning: the page is a contract read, not a hosted file; the shield reports whether that read was verified
-- Radicle repositories are browsable and writable from the browser — open a `rad:` URL the way you would a web page:
+- Radicle repositories in the browser:
+  - Browsable and writable — open a `rad:` URL the way you would a web page
   - `rad:` as a fetchable scheme, plus a consented `window.radicle` provider for issues, comments and patches
   - Seed-to-browse reports per-peer clone phases, with retry and cancellation
   - Repository view pinned to any commit id, with commit, branch and contributor counts
   - Nodes menu in the toolbar shows Radicle's connected peers, seeded repositories and addon version
-- [Myotis](https://github.com/biafra23/myotis) 0.1.7, a peer-to-peer Ethereum and Gnosis light client, as an experimental verified source, off by default:
+- [Myotis](https://github.com/biafra23/myotis) 0.1.7, a peer-to-peer Ethereum and Gnosis light client:
+  - An experimental verified source, off by default
   - Draggable read and verification order per chain under Settings > Chains, alongside Colibri and RPC
   - Reasoning: reads are proven against a chain head Myotis syncs from peers itself, rather than trusted from an endpoint
 - `.tez` name resolution from the Tezos Domains contracts, for bare names and `ipfs://` / `ipns://` targets
 - Encrypted point-to-point messaging and topic broadcast for Swarm apps through `window.swarm`, behind its own consent tier
 - Swarm apps can ship a `freedom-manifest.json` so their permissions are one decision instead of a stream of prompts
-- Three new wallet account types, usable with the vault locked and across dApp signing and sends:
+- Three new wallet account types:
+  - All three usable with the vault locked and across dApp signing and sends
   - Ledger hardware accounts, confirmed on the device, including x402 payments
   - Phone accounts over Open Lavatory: QR pairing, signing on the phone, including x402 payments
   - Safe multi-owner accounts on Gnosis, with a signing board owners sign in any order
-- Tor for `.onion` addresses through a bundled [Arti](https://gitlab.torproject.org/tpo/core/arti) 2.6.0 client, off by default under Settings > Experimental (clearnet traffic keeps connecting directly)
+- Tor for `.onion` addresses, through a bundled [Arti](https://gitlab.torproject.org/tpo/core/arti) 2.6.0 client:
+  - Off by default under Settings > Experimental
+  - Clearnet traffic keeps connecting directly
   - Prompt to use a system Tor client, such as Tor Browser, instead of Arti
 
 ### Changed


### PR DESCRIPTION
Re-cuts the `[Unreleased]` (0.8.5) section on `release/0.8.5` so every multi-line block opens with a crisp headline: the lead line is the feature name in a few words, and the qualifiers that used to trail it are short sub-bullets. Touches `CHANGELOG.md` only; base is the release branch, per `release-process.md` §3 — the merge is the approval.

## The rule applied

Lead line = feature name, no trailing clause (`Ad and tracker blocking:`, not `Ad and tracker blocking, on by default, which also hides the empty spaces blocked ads leave:`). Displaced qualifiers, invocation hints and click paths become short sub-bullets (`On by default`, `Under Settings > Shortcuts`, `` `Cmd/Ctrl+Shift+N`, or File > New Private Window``). Ordering (the daily-driver run from #265), all links, both `Reasoning:` sub-bullets and every UI hint are preserved; no editorial framing added.

**Note on sourcing the rule:** the task pointed at an *open* PR on `main` adding this rule to `docs/agent-playbooks/changelog-process.md`. There isn't one — no open PR in this repo touches that file (checked all 14 open PRs' file lists), and title/body search for "headline" / "lead line" returns only merged work: #220 (`lead with the headline`, the nearest in-repo precedent, already in the playbook as the `Lead Added with the release's defining feature` structure rule) and #265. So I applied the rule as stated in the task rather than from a diff. If a playbook PR does land later with different wording, this section may need a second pass.

## Lead lines only — the scan view

```
### Added
- Ad and tracker blocking:
- Find in page:
- Download manager:
- Per-site permission prompts:
- Private windows:
- Remappable keyboard shortcuts:
- Page zoom on `Cmd/Ctrl` with `=`, `-` and `0`, remappable like every other binding (thanks @alexwbend!)
- Address-bar search for typed input that isn't a URL, with DuckDuckGo, Google, Bing, Brave Search, Ecosia, Startpage or a custom engine under Settings > Search
- Audio indicator on tabs playing sound; click it or use "Mute Tab" in the tab context menu to mute/unmute (mute survives navigation)
- Contract-hosted onchain apps:
- Radicle repositories in the browser:
- [Myotis](https://github.com/biafra23/myotis) 0.1.7, a peer-to-peer Ethereum and Gnosis light client:
- `.tez` name resolution from the Tezos Domains contracts, for bare names and `ipfs://` / `ipns://` targets
- Encrypted point-to-point messaging and topic broadcast for Swarm apps through `window.swarm`, behind its own consent tier
- Swarm apps can ship a `freedom-manifest.json` so their permissions are one decision instead of a stream of prompts
- Three new wallet account types:
- Tor for `.onion` addresses, through a bundled [Arti](https://gitlab.torproject.org/tpo/core/arti) 2.6.0 client:

### Changed
- Radicle runs as an embedded [libradicle](https://github.com/solardev-xyz/libradicle) 0.7.1 addon instead of separate daemon, HTTP and CLI processes, and takes no local port
- Swarm peers count up from launch instead of sitting at 0 during startup
- Installers are about 15 MB smaller: each build now ships only the `better-sqlite3` native addon for its own platform and architecture instead of all eight upstream prebuilds
- The Windows installer is named `Freedom-Setup-<version>.exe`, previously `Freedom Setup <version>.exe`

### Removed
- Adopting a system Radicle node found on its default port as an external node — the embedded Radicle node takes no local port, so there is nothing to adopt

### Fixed
- (23 entries, untouched — each already opens with its subject)

### Security
- Escape repository-supplied names and identifiers in the Radicle repository viewer's HTML attributes, blocking script execution from a crafted file name
- `window.ethereum` responses reach only the document that made the request, so a reply arriving after a navigation cannot land in the next page
- A remote page that mimics Freedom's error page can no longer choose what the address bar shows when you switch back to its tab
- Updated bundled nodes:
- Updated runtime dependencies:
```

Eleven `Added` blocks now scan as a feature list. The six lines still carrying their own prose are the single-line entries (below).

## Which lines moved where

| Block | Old lead line | New lead line | Where the rest went |
| --- | --- | --- | --- |
| Ad blocking | `Ad and tracker blocking, on by default, which also hides the empty spaces blocked ads leave:` | `Ad and tracker blocking:` | `On by default`; gap-hiding claim **dropped** (below) |
| Find in page | *(one line: name, hints and three details after a colon)* | `Find in page:` | 3 sub-bullets: shortcut/menu path, overlay bar and counter, cycle/close keys |
| Downloads | `Download manager covering every download source, including bzz:// and ipfs:// content:` | `Download manager:` | `Covers every download source, including bzz:// and ipfs:// content` |
| Permissions | `Per-site permission prompts for camera, …, and MIDI, replacing the previous silent denial:` | `Per-site permission prompts:` | `For camera, …, and MIDI, replacing the previous silent denial` |
| Private windows | `Private windows (Cmd/Ctrl+Shift+N, File > New Private Window): ephemeral browsing …` | `Private windows:` | 2 sub-bullets: the shortcut/menu path, and the ephemeral-session line |
| Shortcuts | `Remappable keyboard shortcuts under Settings > Shortcuts:` | `Remappable keyboard shortcuts:` | `Under Settings > Shortcuts` |
| Onchain apps | `Contract-hosted onchain apps on web3://… — the app itself lives in the contract, not on a web server:` | `Contract-hosted onchain apps:` | `On web3://<address>[:<chainId>]/ — the app itself lives in the contract, not on a web server` |
| Radicle | `Radicle repositories are browsable and writable from the browser — open a rad: URL …:` | `Radicle repositories in the browser:` | `Browsable and writable — open a rad: URL the way you would a web page` |
| Myotis | `…0.1.7, a peer-to-peer Ethereum and Gnosis light client, as an experimental verified source, off by default:` | `[Myotis](…) 0.1.7, a peer-to-peer Ethereum and Gnosis light client:` | `An experimental verified source, off by default` |
| Wallet accounts | `Three new wallet account types, usable with the vault locked and across dApp signing and sends:` | `Three new wallet account types:` | `All three usable with the vault locked and across dApp signing and sends` |
| Tor | `Tor for .onion addresses through a bundled [Arti](…) 2.6.0 client, off by default under Settings > Experimental (clearnet traffic keeps connecting directly)` | `Tor for .onion addresses, through a bundled [Arti](…) 2.6.0 client:` | `Off by default under Settings > Experimental`; `Clearnet traffic keeps connecting directly` |

Version + upstream link stay on the parent for Myotis and Arti, as the playbook's first-shipped-component rule requires. The Tor parent also gains the `:` it was missing.

## Dropped, so it isn't dropped silently

One claim leaves the file, per the maintainer's call that it is arguable:

- parent clause `…which also hides the empty spaces blocked ads leave` — **dropped** (not moved to a sub-bullet)
- sub-bullet `Blocked ads leave no empty gaps in the page` — **dropped** as too fine-grained for a scanning reader

Both said the same thing; #265 split the clause into that sub-bullet and `1b983357` restored the clause without removing the sub-bullet, so the section has been carrying it twice. Nothing else is removed: a word-level token diff of the whole `Added` section before/after shows the only content tokens lost are `hides / empty / spaces / blocked / ads / leave / gaps`, plus punctuation and connectives from the rewritten lead lines.

## Single-line entries: kept single-line

Six `Added` entries and all of `Changed` / `Removed` / `Fixed` are single-line and already open with the feature name or subject, so they stand unchanged — `Page zoom on Cmd/Ctrl …`, `Address-bar search for typed input …`, `Audio indicator on tabs playing sound; …`, `.tez name resolution …`, `Encrypted point-to-point messaging …`, `Swarm apps can ship a freedom-manifest.json …`. Only one single-line entry was a block in disguise — `Find in page`, which packed the name, both invocation hints and three details behind a colon on one 26-word line — and it is now a block. `Security`'s two update lines (`Updated bundled nodes:`, `Updated runtime dependencies:`) were already headlines.

## Judgement call for the releaser: three parents now carry more than 4 sub-bullets

The playbook's density budget says no parent should carry more than 4. Moving lead-line facts down pushes three over: `Private windows` (6), `Contract-hosted onchain apps` (5, one of them the `Reasoning:` line), `Radicle repositories in the browser` (5). The alternative is leaving the invocation hint on the lead (`Private windows (Cmd/Ctrl+Shift+N, File > New Private Window):`), which costs the crisp one-name headline. I went with the headline, since that is what this pass is for — say the word and I'll fold the hints back up instead.

## Side-by-side against 0.8.0 (playbook § Review gate)

Measured on the file at this commit:

| | 0.8.5 before | 0.8.5 after | 0.8.0 shipped |
| --- | --- | --- | --- |
| Added: top / sub | 17 / 31 | 17 / 45 | 7 / 9 |
| Changed / Removed / Fixed (top) | 4 / 1 / 23 | 4 / 1 / 23 | 2 / 1 / 5 |
| Security: top / sub | 5 / 11 | 5 / 11 | 3 / 16 |
| **Added** top-bullet words: med / max / over 25 | 17 / 27 / 1 | **5** / 25 / **0** | 16 / 23 / 0 |
| Sub-bullet words: med / max / over 15 | 12 / 19 / 3 | 12 / 19 / 3 | 4 / 18 / 1 |
| Words in the whole section | 1302 | **1285** | 451 |

Reading:

- **The rule does what it is for.** The median `Added` top-level bullet drops from 17 words to 5, and the section no longer has a top-level bullet over 25 words (it had one at 27). Total words go *down* by 17 — this is redistribution plus the dropped duplicate claim, not new prose.
- **The cost is sub-bullet count**: `Added` goes 31 → 45, which widens the gap to 0.8.0 (9) and to the playbook's "0.8.5 about 30" aim. That is inherent to the rule — every qualifier that left a lead line became a line of its own. Flagging rather than acting on it; trimming further would drop facts this task says to keep.
- **Lead patterns hold per section**: `Added` noun phrases, `Changed` noun/subject-led, `Removed` with its dash clause, `Fixed` subject-led, `Security` imperative. Sub-bullet register is unchanged (median 12 words before and after) — no sub-bullet was rewritten, only relocated.

## Verification

- **Formatting**: `npm run format:check` on this branch — `CHANGELOG.md` is clean. The repo script (`prettier --check .`) exits non-zero here for an unrelated reason: this is a fresh clone with no `node_modules`, and running the lockfile's prettier (3.9.6) over the whole tree warns on **295 JS files**. That warn set is **byte-identical before and after this commit** (captured with the change stashed and unstashed, then `diff`ed) and contains no Markdown file. `npx prettier@3.9.6 --check CHANGELOG.md` → *All matched files use Prettier code style!*
- **Nothing lost**: word-level token diff of the `Added` section, base `311be1d6` vs head — only the gap-hiding tokens and rewritten-lead connectives are absent; every entry, sub-bullet, code span and link is present. Both `Reasoning:` sub-bullets intact. Ordering unchanged (17 top-level entries in the same daily-driver sequence).
- **Markdown renders as intended**: posted the section to GitHub's `/markdown` API and checked the HTML — every new block nests as a real `<ul>` under its parent `<li>`, including the three whose first sub-bullet starts with a code span.
- **Hints re-verified against the tree at this head** (not carried over on faith), since several moved lines: `shortcuts.js` — `page.findInPage` `CmdOrCtrl+F`, `window.newPrivate` `CmdOrCtrl+Shift+N`, `downloads.show` `CmdOrCtrl+Shift+J`; `menu.js` — `Find in Page…` under Edit, `New Private Window` under File; `settings.html` nav labels — Ad Blocking, Site Permissions, Search, Shortcuts, Downloads, Chains, Experimental. All exact as written.
- **No app run**: nothing in `src/` or `scripts/` reads `CHANGELOG.md`, so this text has no rendered surface in the app — the rendered-Markdown check above is the visual layer.
- `## [Unreleased]` stays the heading; 0.8.5 is still at `rc.5`.

Single commit, `056535e8`, no bot commits on this branch.
