### PR TITLE
chore(release): cut 0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Freedom will be documented in this file.
 
-## [Unreleased]
+## [0.8.5] - 2026-09-09
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freedom-browser",
-  "version": "0.8.5-rc.5",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freedom-browser",
-      "version": "0.8.5-rc.5",
+      "version": "0.8.5",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freedom-browser",
-  "version": "0.8.5-rc.5",
+  "version": "0.8.5",
   "license": "MPL-2.0",
   "description": "Freedom – A browser for the decentralized web, with Swarm, IPFS, onchain apps, and ENS as first-class protocols.",
   "author": {


### PR DESCRIPTION
Final 0.8.5 on top of the rc.5 tree. `git diff --stat v0.8.5-rc.5` shows only CHANGELOG.md (the headline re-cut from #333 plus the released heading), package.json and package-lock.json (version 0.8.5).

## Changelog
- `## [Unreleased]` became `## [0.8.5] - 2026-09-09` (same format as 0.8.0); no empty Unreleased section left behind.

## Dependency table (unchanged from rc.5, verified against the tag on 2026-09-09)
| component | version | changelog line |
| --- | --- | --- |
| Electron | 44.3.0 (Chromium 152) | yes |
| @ethersphere/bee-js | 13.0.0 | yes |
| @corpus-core/colibri-stateless | 2.0.6 (pinned) | yes |
| @openlv/core, @openlv/session | 0.2.0 | yes |
| @ledgerhq/hw-app-eth | 7.8.17 | yes |
| @x402/core, @x402/evm | 2.25.0 | yes |
| @scure/bip39 | 2.4.0 | yes |
| better-sqlite3 | 13.0.3 | yes |
| micro-key-producer | 0.10.2 | yes |
| Ant | 0.5.44 | yes |
| freedom-ipfs | 0.4.3 | (bundled, unchanged since 0.8.0) |
| libradicle | 0.7.1 | yes |
| Myotis | 0.1.7 | yes |
| Arti | 2.6.0 | yes |

## Verification
Tree identical to `v0.8.5-rc.5` apart from the files above; CI runs on this PR. Prepared by hand because alan's runs were limit-blocked at the time.