### PR TITLE
build: fetch electron's dist before insisting on Chromium's notices; cut 0.8.5-rc.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freedom-browser",
-  "version": "0.8.5-rc.6",
+  "version": "0.8.5-rc.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freedom-browser",
-      "version": "0.8.5-rc.6",
+      "version": "0.8.5-rc.7",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freedom-browser",
-  "version": "0.8.5-rc.6",
+  "version": "0.8.5-rc.7",
   "license": "MPL-2.0",
   "description": "Freedom – A browser for the decentralized web, with Swarm, IPFS, onchain apps, and ENS as first-class protocols.",
   "author": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -90,13 +90,31 @@ if (dist && process.env.FREEDOM_ALLOW_INTERIM_BRIDGE !== '1') {
 // carry Freedom.app, so `build.mac.extraResources` copies it out of the same
 // dist into Contents/Resources instead. NOTICES points users at that file; a
 // missing one would ship Chromium with a dangling attribution reference.
+//
+// The dist is populated by electron's postinstall (`node install.js`), which
+// npm on the CI runners no longer runs for dependencies unless approved, and
+// which ELECTRON_SKIP_BINARY_DOWNLOAD skips locally. electron-builder never
+// needs that dist (it fetches its own zip), so a missing one only surfaces
+// here: run electron's own installer once, then insist on the file.
 const CHROMIUM_NOTICES = 'node_modules/electron/dist/LICENSES.chromium.html';
-if (!fs.existsSync(path.join(__dirname, '..', CHROMIUM_NOTICES))) {
+const chromiumNoticesPath = path.join(__dirname, '..', CHROMIUM_NOTICES);
+if (!fs.existsSync(chromiumNoticesPath)) {
+  console.log(`\n→ ${CHROMIUM_NOTICES} is missing; running electron's installer to fetch the dist\n`);
+  try {
+    execSync('node node_modules/electron/install.js', {
+      stdio: 'inherit',
+      cwd: path.join(__dirname, '..'),
+      env: { ...process.env, ELECTRON_SKIP_BINARY_DOWNLOAD: '' },
+    });
+  } catch (err) {
+    console.error(`electron's installer failed: ${err.message}`);
+  }
+}
+if (!fs.existsSync(chromiumNoticesPath)) {
   console.error(
-    `Error: ${CHROMIUM_NOTICES} is missing, so this build would ship Chromium with no ` +
-      `third-party license notices. It comes from electron's postinstall download — reinstall ` +
-      `without ELECTRON_SKIP_BINARY_DOWNLOAD (\`npm ci\`, or \`npm rebuild electron\`) and ` +
-      `build again.`
+    `Error: ${CHROMIUM_NOTICES} is still missing, so this build would ship Chromium with no ` +
+      `third-party license notices. It comes from electron's postinstall download — run ` +
+      `\`node node_modules/electron/install.js\` (or \`npm rebuild electron\`) and build again.`
   );
   process.exit(1);
 }


### PR DESCRIPTION
The v0.8.5-rc.6 release run (34435490264) failed on mac-arm64, linux-x64, linux-arm64 and windows-x64 at the Chromium-notices guard that #340 added to `scripts/build.js`: `node_modules/electron/dist/LICENSES.chromium.html` does not exist on the runners.

Root cause: npm on the CI image (Node 24.20) does not run dependency install scripts unless approved (`npm warn install-scripts: 8 packages have install scripts not yet covered by allowScripts`), so electron's postinstall never downloads its dist there. electron-builder fetches its own Electron zip and never needed that dist, which is why rc.5 built.

Fix: when the file is absent, run `node node_modules/electron/install.js` once (the same download electron's postinstall performs), then insist on the file. This also makes the macOS `extraResources` copy from #340 work on CI, since it reads the same dist. Version bumped to 0.8.5-rc.7 for the re-cut.

Verified locally by removing `node_modules/electron/dist` and running the installer: the dist comes back with `LICENSES.chromium.html` (19.9 MB) in place. The CI proof is the v0.8.5-rc.7 release run itself.