### PR TITLE
chore(release): cut 0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Freedom will be documented in this file.
 
-## [Unreleased]
+## [0.8.5] - 2026-09-10
 
 ### Added
 

--- a/LICENSE_AUDIT.md
+++ b/LICENSE_AUDIT.md
@@ -2,7 +2,7 @@
 
 **Intended License:** MPL-2.0 (Mozilla Public License 2.0)
 **Audit Date:** 2026-09-10
-**Baseline:** `0.8.5-rc.8`
+**Baseline:** `0.8.5`
 **Auditor:** Automated analysis, re-derived from the installed tree
 
 > **DISCLAIMER:** This is a practical engineering audit, not legal advice. For final licensing decisions, consult a qualified attorney.
@@ -344,4 +344,4 @@ Freedom Browser can be released under MPL-2.0, with these conditions:
 
 ---
 
-_Re-derived from the installed tree on 2026-09-10 against `0.8.5-rc.8`. Kept honest by `licenses-audit.test.js`._
+_Re-derived from the installed tree on 2026-09-10 against `0.8.5`. Kept honest by `licenses-audit.test.js`._

--- a/licenses-audit.json
+++ b/licenses-audit.json
@@ -1,7 +1,7 @@
 {
   "project_license": "MPL-2.0",
   "generated_at": "2026-09-10T00:00:00.000Z",
-  "audit_baseline": "0.8.5-rc.8",
+  "audit_baseline": "0.8.5",
   "notes": "Regenerated for the 0.8.5 release. The 2026-08-19 revision of this file described a pre-0.8.5 tree (electron 39.2.7, ant v0.5.21, libradicle 0.3.0, no Myotis, no Arti) and reported zero copyleft dependencies, which was already untrue. Bundled-component inventory is derived from package.json build.extraResources and src/renderer/vendor/; licenses-audit.test.js fails if this file drifts from either.",
   "distribution_model": {
     "packaging": "electron-builder",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freedom-browser",
-  "version": "0.8.5-rc.8",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freedom-browser",
-      "version": "0.8.5-rc.8",
+      "version": "0.8.5",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freedom-browser",
-  "version": "0.8.5-rc.8",
+  "version": "0.8.5",
   "license": "MPL-2.0",
   "description": "Freedom – A browser for the decentralized web, with Swarm, IPFS, onchain apps, and ENS as first-class protocols.",
   "author": {


### PR DESCRIPTION
Final cut of 0.8.5 on the release branch, per release-process.md §1, §3 and §4. The tree is exactly v0.8.5-rc.8 (which passed manual testing) plus the version and changelog commits:

```
git diff v0.8.5-rc.8 --stat
 CHANGELOG.md        | 2 +-
 LICENSE_AUDIT.md    | 4 ++--
 licenses-audit.json | 2 +-
 package-lock.json   | 4 ++--
 package.json        | 2 +-
```

- `npm version 0.8.5 --no-git-tag-version`; the unrelated `binaries` array reformat it produced was reverted, so package.json changes only in `version`.
- Changelog heading `## [Unreleased]` → `## [0.8.5] - 2026-09-10`; no empty Unreleased section left behind.
- Licence audit re-stamped to `0.8.5` (`audit_baseline`, `**Baseline:**`, footer); `licenses-audit.test.js` passes (77 tests).

After merge: tag `v0.8.5` from the release branch head (draft release), then §7 publish, §8 merge back to main, §9 open the next dev cycle.