### PR TITLE
test(licenses): let a -dev cycle keep the shipped release's audit baseline

### DIFF
--- a/docs/agent-playbooks/release-process.md
+++ b/docs/agent-playbooks/release-process.md
@@ -185,7 +185,7 @@ What the guard cannot check, and you must do by hand before tagging:
 
 - **Upstream licenses are unchanged at the pinned versions.** The guard knows a component is attributed; it cannot know whether upstream relicensed. Re-read the license for anything whose pin moved this cycle: Ant (`MIT OR Apache-2.0`, `LICENSE-MIT` / `LICENSE-APACHE`), freedom-ipfs and Arti (same), libradicle (`license` field in its `Cargo.toml` — it publishes no license file), Myotis (`Apache-2.0`).
 - **Myotis's upstream `NOTICE`.** Apache-2.0 §4(d) obliges us to reproduce it verbatim, and `NOTICES` does. Re-read `https://github.com/biafra23/myotis/blob/<pinned tag>/NOTICE` on every bump and copy across any change — the guard checks that Myotis is attributed, not that the notice text still matches.
-- **Re-stamp the audit at the final cut.** `licenses-audit.json`'s `audit_baseline` and `LICENSE_AUDIT.md`'s `**Baseline:**` and footer must name `package.json`'s version, so `npm version 0.8.5` turns the suite red until you update all three and refresh `Audit Date`. That is the reminder; it is not evidence the audit was re-derived, so re-read what changed since the last candidate before re-stamping.
+- **Re-stamp the audit at the final cut.** `licenses-audit.json`'s `audit_baseline` and `LICENSE_AUDIT.md`'s `**Baseline:**` and footer must name `package.json`'s version, so `npm version 0.8.5` turns the suite red until you update all three and refresh `Audit Date`. That is the reminder; it is not evidence the audit was re-derived, so re-read what changed since the last candidate before re-stamping. The one exception is the `<next>-dev` bump of §9, which ships nothing: there the guard accepts the audit still naming the release just shipped (a bare version below the dev number), so do not re-stamp it to `0.8.6-dev`.
 - **The OpenLV bundle is still relinkable.** `src/renderer/vendor/openlv.esm.js` is LGPL-3.0 and ships only because it is one standalone generated file containing no Freedom code, which is what makes LGPL §4 relinking possible. If a change inlines it into an app bundle or mixes Freedom code into it, that stops being true.
 
 The 0.8.5 cycle is why this is written down: Myotis and Arti reached the artifacts with no attribution at all, the audit files still described a pre-0.8.5 inventory, and a GPL-3.0 QR library (`qrious.min.js`) had been shipping unreferenced inside `app.asar` — all while this step was passing.
@@ -351,6 +351,8 @@ Update the same two files as §1:
 
 - `package.json` — top-level `"version"`.
 - `package-lock.json` — both top-level `"version"` entries.
+
+Leave `licenses-audit.json` and `LICENSE_AUDIT.md` alone: `licenses-audit.test.js` accepts a `-dev` version whose audit baseline still names the release just shipped, because the tree is what that release was audited against. Re-stamping to `<next>-dev` would claim a re-derivation that did not happen. The next candidate cut (§4) is where the audit gets re-derived and re-stamped.
 
 Commit on `main` (not on the release branch):
 

--- a/licenses-audit.test.js
+++ b/licenses-audit.test.js
@@ -706,9 +706,48 @@ describe('audit files agree with each other', () => {
     // would have carried an rc-stamped audit with the whole suite green —
     // exactly the undetected staleness (`generated_at: 2026-08-19` against a
     // moved tree) this file exists to stop, one release later.
+    //
+    // A `-dev` cycle is the one version bump that ships nothing: §9 of the
+    // playbook opens it by moving `package.json` alone, on the tree the
+    // previous release was audited against. Re-stamping the audit to
+    // `0.8.6-dev` would record a re-derivation that never happened, so on a
+    // dev version the baseline must instead still name a shipped release —
+    // a bare version strictly below the cycle's number. Every candidate and
+    // final cut must match `package.json` exactly, as before.
+    const triple = (v) =>
+      String(v)
+        .match(/^(\d+)\.(\d+)\.(\d+)$/)
+        ?.slice(1)
+        .map(Number);
+    const devCycle = pkg.version.match(/^(\d+\.\d+\.\d+)-dev$/);
+    let expectedBaseline = pkg.version;
+    if (devCycle) {
+      const shipped = triple(audit.audit_baseline);
+      expect({
+        field: 'audit_baseline',
+        version: audit.audit_baseline,
+        bareRelease: Boolean(shipped),
+      }).toEqual({
+        field: 'audit_baseline',
+        version: audit.audit_baseline,
+        bareRelease: true,
+      });
+      const cycle = triple(devCycle[1]);
+      const order = shipped.map((n, i) => Math.sign(n - cycle[i])).find(Boolean) ?? 0;
+      expect({
+        field: 'audit_baseline',
+        version: audit.audit_baseline,
+        belowDevCycle: order < 0,
+      }).toEqual({
+        field: 'audit_baseline',
+        version: audit.audit_baseline,
+        belowDevCycle: true,
+      });
+      expectedBaseline = audit.audit_baseline;
+    }
     expect({ field: 'audit_baseline', version: audit.audit_baseline }).toEqual({
       field: 'audit_baseline',
-      version: pkg.version,
+      version: expectedBaseline,
     });
     const documented = auditDoc.match(/^\*\*Baseline:\*\* `([^`]+)`$/m);
     expect({ field: 'LICENSE_AUDIT.md Baseline', found: Boolean(documented) }).toEqual({
@@ -717,12 +756,12 @@ describe('audit files agree with each other', () => {
     });
     expect({ field: 'LICENSE_AUDIT.md Baseline', version: documented[1] }).toEqual({
       field: 'LICENSE_AUDIT.md Baseline',
-      version: pkg.version,
+      version: expectedBaseline,
     });
     const footer = auditDoc.match(/Re-derived from the installed tree on [\d-]+ against `([^`]+)`/);
     expect({ field: 'LICENSE_AUDIT.md footer', version: footer?.[1] }).toEqual({
       field: 'LICENSE_AUDIT.md footer',
-      version: pkg.version,
+      version: expectedBaseline,
     });
   });
 


### PR DESCRIPTION
## Why

`main` has been red since [03fac64c](https://github.com/solardev-xyz/freedom-browser/commit/03fac64c) opened the 0.8.6-dev cycle. The `test` job fails one assertion:

```
● audit files agree with each other › is baselined against the version being released
    -   "version": "0.8.6-dev",
    +   "version": "0.8.5",
```

`licenses-audit.test.js` holds `audit_baseline`, `LICENSE_AUDIT.md`'s `**Baseline:**` and its footer to `package.json`'s version exactly. The dev bump moved `package.json` alone, as §9 of `release-process.md` says to.

## What changed

Not a re-stamp. §9 opens the cycle on the very tree 0.8.5 was audited against, so the audit is still accurate, and stamping it `0.8.6-dev` would record a re-derivation that never happened.

Instead, on a `<x.y.z>-dev` version the guard now requires the baseline to name a **shipped release**: a bare `x.y.z` strictly below the cycle number. Release candidates and final cuts still have to match `package.json` exactly, so the property the test exists for (no rc-stamped or stale audit at a cut) is unchanged.

`release-process.md`: the §4 re-stamp bullet and §9 now say the dev bump is the one version change that must not touch the audit files.

## Verification

Ran the `baselined` test with `package.json` temporarily set to each version:

| version | result |
| --- | --- |
| `0.8.6-dev` (main today) | pass |
| `0.8.5` | pass |
| `0.9.0-dev` | pass |
| `0.8.6-rc.1` | fail: expects `0.8.6-rc.1`, got `0.8.5` |
| `0.8.5-dev` | fail: `belowDevCycle: false` |
| `0.8.4-dev` | fail: `belowDevCycle: false` |

Full `licenses-audit.test.js` suite passes (77 tests), `eslint` and `prettier --check` clean.
