### PR TITLE
docs(agents): require issue search before filing and vendor-neutral rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ This file defines mandatory constraints for automated agents and contributors. I
 7. Match existing naming and file conventions in nearby code. Do not reformat or change behavior outside the requested scope.
 8. Run `npm test` after modifying files that have corresponding `.test.js` files.
 9. Do not add or upgrade dependencies without user approval.
+10. Before opening a GitHub issue, search open and closed issues and PRs with several synonyms (for example `gh issue list --state all --search "<term>"`). If one already covers the topic, comment there instead of filing a new one; if a duplicate was already filed, close it and move its content to the older issue.
+11. Process rules for agents live in this file, `docs/agent-playbooks/`, or repo-side automation (CI, GitHub Actions). Do not put them in vendor-specific agent configuration such as hooks or per-tool settings files; every agent and contributor must be bound by the same rules.
 
 ## Task Routing (Read On Demand)
 


### PR DESCRIPTION
## Summary

Adds two core rules to `AGENTS.md`:

- **Rule 10:** search open and closed issues and PRs with several synonyms before opening a GitHub issue; comment on the existing one instead, and consolidate duplicates into the older issue.
- **Rule 11:** agent process rules live in `AGENTS.md`, `docs/agent-playbooks/`, or repo-side automation, never in vendor-specific agent configuration such as hooks or per-tool settings files.

## Why

#347 was filed on 2026-09-11 as a duplicate of #5, which had been open since February. `CONTRIBUTING.md` already asks humans to search first, but that file is not on the agent read path. Rule 11 records the decision that fixes like this must bind every agent and contributor equally, not just one tool.

## Follow-up (not in this PR)

A GitHub Action on `issues: opened` that comments a "possible duplicates" list, so the check also fires for issues opened through the web UI.
